### PR TITLE
README: add a link to my RISC-V implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Sail is currently being used for ARM, RISC-V, MIPS, CHERI-MIPS, IBM Power, and x
 
 * [Sail x86 ISA model, handwritten](https://github.com/rems-project/sail/tree/sail2/x86). This is a handwritten user-mode fragment. 
 
+* [Sail 32-bit RISC-V model, partially handwritten and partially generated](https://github.com/thoughtpolice/rv32-sail). This currently implements a fragment of the machine mode (-M) specification for RV32IM. (Developed independently of the full RISC-V model for the REMS project.)
+
 The hand-written ARMv8-A, IBM POWER, and x86 models are currently not in sync
 with the latest version of Sail, which is the (default) sail2 branch
 on Github.  These and the RISC-V model are integrated with our [RMEM](http://www.cl.cam.ac.uk/users/pes20/rmem) tool for concurrency semantics. 


### PR DESCRIPTION
This adds a link to my RISC-V implementation which I open sourced earlier. It is an independent development from the official REMS RISC-V specification, though I did lift some helpful code (and insights) from the original project. (Notably it is intended to only target 32-bit U/M mode, though it's a young project.)

It can also be run online, in a web browser, by compiling the C code emitted from Sail to WebAssembly -- although it currently only works on Chrome: https://riscv.ls0f.pw

I plan on inevitably extending this to full RV32GC support, and CHERI extensions -- making it a sketch of the design outlined in [the CheriRTOS paper](https://www.cl.cam.ac.uk/research/security/ctsrd/pdfs/201810-iccd2018-cheri-rtos.pdf), but for now it only implements a subset of Machine Mode for RV32IM.

---

As an aside, this only took me about 2-3 weeks to write this, from inception to now, after I found out about the new version of Sail -- and overall I like Sail quite a bit, and think it's excellent for its purpose, even if it's rough. I have a list of a few bugs I probably need to submit still, but, thank you for the wonderful project!