### PR TITLE
Add base64 package constraint

### DIFF
--- a/opam
+++ b/opam
@@ -35,7 +35,7 @@ depends: [
   "omd"
   "conf-gmp"
   "conf-zlib"
-  "base64"
+  "base64" {< "3.0.0"}
   "yojson"
 ]
 available: [ocaml-version >= "4.06.1"]


### PR DESCRIPTION
Sail currently uses base64 2.x API. If we don't add constraint, opam will install latest 3.x version.