### PR TITLE
Add new files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ lib/hol/sail-heap
 /src/sail.docdir
 /src/ast.lem
 /src/ast.ml
+/src/jib.lem
+/src/jib.ml
+/src/manifest.ml
 
 /test/typecheck/rtpass*/
 /test/typecheck/tests.xml


### PR DESCRIPTION
When I run `make` from the sail2 branch, I get a successful build, but `git status` shows these three untracked files.

Shouldn't these be in the .gitignore?