### PR TITLE
Add new hex_bits_of_prefix function to C/OCaml/Lem libraries

### DIFF
--- a/lib/mapping.sail
+++ b/lib/mapping.sail
@@ -60,11 +60,20 @@ mapping sep : unit <-> string = {
 $ifdef _DEFAULT_DEC
 $include <vector_dec.sail>
 
+val "hex_bits_of_prefix" : forall 'n. (implicit('n), string) -> (bits('n), nat)
+
+val hex_bits_matches_prefix : forall 'n. (implicit('n), string) -> option((bits('n), nat))
+function hex_bits_matches_prefix (n, s) = {
+  let (bs, 'len) = hex_bits_of_prefix(n, s);
+  if (len == 0) then None() else Some(bs, 'len)
+}
+
 val hex_bits_20 : bits(20) <-> string
 val hex_bits_20_forwards = "decimal_string_of_bits" : bits(20) -> string
 val hex_bits_20_forwards_matches : bits(20) -> bool
 function hex_bits_20_forwards_matches bv = true
-val "hex_bits_20_matches_prefix" : string -> option((bits(20), nat))
+val hex_bits_20_matches_prefix : string -> option((bits(20), nat))
+function hex_bits_20_matches_prefix s = hex_bits_matches_prefix(s)
 val hex_bits_20_backwards_matches : string -> bool
 function hex_bits_20_backwards_matches s = match s {
   s if match hex_bits_20_matches_prefix(s) {

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include<assert.h>
+#include<ctype.h>
 #include<inttypes.h>
 #include<stdbool.h>
 #include<stdio.h>
@@ -172,6 +173,42 @@ void string_take(sail_string *dst, sail_string s, sail_int ns)
   *dst = realloc(*dst, to_copy + 1);
   memcpy(*dst, s, to_copy);
   *dst[to_copy] = '\0';
+}
+
+// struct tuple_(%lb, %i)
+struct ztuple_z8z5lbzCz0z5iz9 {
+  lbits ztup0;
+  sail_int ztup1;
+};
+
+void hex_bits_of_prefix(struct ztuple_z8z5lbzCz0z5iz9 *tuple, sail_int bits, const sail_string str)
+{
+  /*
+   * Stop at whitespace, not just NUL, since mpz_set_str frustratingly ignores
+   * all whitespace within a string.
+   */
+  mach_int len = 0;
+  while (str[len] && !isspace(str[len]))
+    ++len;
+
+  char *substr = (char *) sail_malloc(len + 1);
+  memcpy(substr, str, len);
+
+  for (; len > 0; --len) {
+    substr[len] = '\0';
+    if (mpz_set_str(*tuple->ztup0.bits, substr, 0) == 0)
+      break;
+  }
+
+  sail_free(substr);
+  tuple->ztup0.len = CONVERT_OF(mach_int, sail_int)(bits);
+  if (len > 0 && mpz_sgn(*tuple->ztup0.bits) >= 0 &&
+      mpz_sizeinbase(*tuple->ztup0.bits, 2) <= tuple->ztup0.len) {
+    CONVERT_OF(sail_int, mach_int)(&tuple->ztup1, len);
+  } else {
+    mpz_set_ui(*tuple->ztup0.bits, 0);
+    CONVERT_OF(sail_int, mach_int)(&tuple->ztup1, 0);
+  }
 }
 
 /* ***** Sail integers ***** */

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -400,6 +400,8 @@ void string_length(sail_int *len, sail_string s);
 void string_drop(sail_string *dst, sail_string s, sail_int len);
 void string_take(sail_string *dst, sail_string s, sail_int len);
 
+struct ztuple_z8z5lbzCz0z5iz9;
+void hex_bits_of_prefix(struct ztuple_z8z5lbzCz0z5iz9 *tuple, sail_int bits, const sail_string str);
 
 /* ***** Printing ***** */
 

--- a/src/gen_lib/sail2_string.lem
+++ b/src/gen_lib/sail2_string.lem
@@ -82,6 +82,18 @@ let spc_matches_prefix s =
   (* | n -> *) Just ((), n)
   (* end *)
 
+let hex_bits_of_prefix bits s =
+  let (n, len) =
+    match maybe_int_of_prefix s with
+    | Nothing -> (0, 0)
+    | Just (n, len) ->
+      if 0 <= n && n < (2 ** (natFromInteger bits)) then
+        (n, len)
+      else
+        (0, 0)
+    end
+  in (of_int bits n, len)
+
 (* Python:
 f = """let hex_bits_{0}_matches_prefix s =
   match maybe_int_of_prefix s with

--- a/src/sail_lib.ml
+++ b/src/sail_lib.ml
@@ -774,6 +774,19 @@ let speculate_conditional_success () = true
 (* Return nanoseconds since epoch. Truncates to ocaml int but will be OK for next 100 years or so... *)
 let get_time_ns () = Big_int.of_int (int_of_float (1e9 *. Unix.gettimeofday ()))
 
+let hex_bits_of_prefix (bits, s) =
+  let bits = Big_int.to_int bits in
+  let n, len =
+    match maybe_int_of_prefix s with
+    | ZNone () -> (Big_int.zero, Big_int.zero)
+    | ZSome (n, len) ->
+       if Big_int.less_equal Big_int.zero n
+          && Big_int.less n (Big_int.pow_int_positive 2 bits) then
+         (n, len)
+       else
+         (Big_int.zero, Big_int.zero)
+  in (bits_of_big_int bits n, len)
+
 (* Python:
 f = """let hex_bits_{0}_matches_prefix s =
   match maybe_int_of_prefix s with


### PR DESCRIPTION
This is intended to replace the hex_bits_N_matches_prefix functions,
providing a polymorphic version in its place. More importantly, it
removes the surrounding option type, as the C library is unable to
determine the right integer value to use for the option's kind, as it
varies based on what option type instantiations are used by the user's
input Sail. Instead, force the caller to turn it into an option type, if
desired, based on the length returned.