### PR TITLE
Add github actions to build on macOS and ubuntu

### DIFF
--- a/.github/workflows/macOS_build.yml
+++ b/.github/workflows/macOS_build.yml
@@ -1,0 +1,16 @@
+name: CI macOS-latest
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build on macOS
+      run: |
+        brew install gpatch gmp z3 pkg-config
+        brew install opam
+        etc/ci_opam_build.sh

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -1,0 +1,16 @@
+name: CI ubuntu-latest
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build on ubuntu
+      run: |
+        sudo apt install build-essential libgmp-dev z3
+        sudo apt install opam
+        etc/ci_opam_build.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ sudo apt-get install build-essential libgmp-dev z3
 ```
 or MacOS homebrew:
 ```
-brew install gmp z3
+brew install gmp z3 pkg-config
 ```
 Finally, install sail and its dependencies:
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 The Sail ISA specification language
 ===================================
 
+![](https://github.com/rems-project/sail/workflows/CI%20ubuntu-latest/badge.svg)
+![](https://github.com/rems-project/sail/workflows/CI%20macOS-latest/badge.svg)
+
 Overview
 ========
 

--- a/etc/ci_opam_build.sh
+++ b/etc/ci_opam_build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+opam init -y --no-setup --compiler=4.06.1 --shell=sh
+
+eval `opam config env`
+
+opam repository -y add rems https://github.com/rems-project/opam-repository.git
+opam pin -y add sail .
+opam install -y -v sail
+sail -v


### PR DESCRIPTION
This commit adds two github action to build Sail on macOS and ubuntu (both using the latest version
of each for now). These just build and don't run any tests, as we run those on our own Jenkins
server which is much faster than the github build runners.

I also fixed INSTALL.md to include brew installing pkg-config on macOS as this seems to be required.

From testing on a personal fork it seems quite email happy when it fails. Maybe that's what we want
though.

There's also a windows option but I leave that as future work...