### PR TITLE
Use output file for generated branch information.

### DIFF
--- a/src/jib/c_backend.mli
+++ b/src/jib/c_backend.mli
@@ -88,7 +88,7 @@ val opt_prefix : string ref
 val opt_extra_params : string option ref
 val opt_extra_arguments : string option ref
 
-val opt_branch_coverage : bool ref
+val opt_branch_coverage : out_channel option ref
   
 (** Optimization flags *)
 

--- a/src/jib/jib_compile.mli
+++ b/src/jib/jib_compile.mli
@@ -113,7 +113,7 @@ module type Config = sig
   (** Allow real literals *)
   val use_real : bool
   (** Insert branch coverage operations *)
-  val branch_coverage : bool
+  val branch_coverage : out_channel option
   (** If true track the location of the last exception thrown, useful
      for debugging C but we want to turn it off for SMT generation
      where we can't use strings *)

--- a/src/jib/jib_smt.ml
+++ b/src/jib/jib_smt.ml
@@ -1584,7 +1584,7 @@ let unroll_static_foreach ctx = function
   let unroll_loops = Some Opts.unroll_limit
   let struct_value = true
   let use_real = true
-  let branch_coverage = false
+  let branch_coverage = None
   let track_throw = false
 end
 

--- a/src/sail.ml
+++ b/src/sail.ml
@@ -233,8 +233,8 @@ let options = Arg.align ([
     Arg.String (fun str -> Constant_fold.opt_fold_to_unit := Util.split_on_char ',' str),
     " remove comma separated list of functions from C output, replacing them with unit");
   ( "-c_coverage",
-    Arg.Set C_backend.opt_branch_coverage,
-    " instrument C code to track branch coverage");
+    Arg.String (fun str -> C_backend.opt_branch_coverage := Some (open_out str)),
+    " output file for C code instrumention to track branch coverage");
   ( "-elf",
     Arg.String (fun elf -> opt_process_elf := Some elf),
     " process an ELF file so that it can be executed by compiled C code");


### PR DESCRIPTION
This changes the meaning of the `c_coverage` cli option, making it not backwards compatible if this option ended up in the released opam package.