### PR TITLE
c2: make the global state API configurable for externally defined get/set functions

### DIFF
--- a/etc/default_config.json
+++ b/etc/default_config.json
@@ -25,6 +25,11 @@
         // The sail_state struct will be passed to the following array
         // of primops, which are specified via the "foo" string from
         // val id = "foo" : ... in Sail.
-        "state_primops": []
+        "state_primops": [],
+        // Control which sail_state variables accessors will be implemented
+        // by the consumer of the library. This is a list of regular expressions,
+        // if one of those regular expression matches the name of a sail_state variable,
+        // only the declaration of the accessors will be generated.
+        "external_state_api" : []
     }
 }


### PR DESCRIPTION
This change builds up on my previous change that added the ability to intercept read and writes to variables in the sail_state. I made this feature configurable via the json configuration file. external_state_api accepts a list of regex that can be used to select which get/set functions will get a body and which will only get a declaration (externally provided).

That way users can decide to instruments read to GPR only for example. Or only to TTBRX registers, etc.. 