### PR TITLE
Fix Coq bindings (Coq version 8.12.0)

### DIFF
--- a/lib/coq/Operators_mwords.v
+++ b/lib/coq/Operators_mwords.v
@@ -256,7 +256,6 @@ Lemma concat_eq {a b} : a >= 0 -> b >= 0 -> Z.of_nat (Z.to_nat b + Z.to_nat a)%n
 intros.
 rewrite Nat2Z.inj_add.
 rewrite Z2Nat.id; auto with zarith.
-rewrite Z2Nat.id; auto with zarith.
 Qed.
 
 
@@ -490,8 +489,6 @@ Lemma replicate_ok {n a} `{ArithFact (n >=? 0)} `{ArithFact (a >=? 0)} :
    Z.of_nat (Z.to_nat n * Z.to_nat a) = a * n.
 destruct H. destruct H0. unbool_comparisons.
 rewrite <- Z2Nat.id; auto with zarith.
-rewrite Z2Nat.inj_mul; auto with zarith.
-rewrite Nat.mul_comm. reflexivity.
 Qed.
 Definition replicate_bits {a} (w : mword a) (n : Z) `{ArithFact (n >=? 0)} : mword (a * n) :=
  cast_to_mword (replicate_bits_aux (get_word w) (Z.to_nat n)) replicate_ok.


### PR DESCRIPTION
This is a haphazard patch to the Coq-files, to make them compile, because there are some problems in them which makes them unusable on Coq v8.12.

The Coq-functions `foreach_Z_up'` and `foreach_Z_down'` caused
Anomalies and thus Value.v wouldn’t compile. This commit defines the
functions as "proofs" and makes the definitions work. I haven’t found an explicit (i.e. non-proof) formulation for these functions, because somehow Coq doesn’t accept it if I do `Print foreach_Z_up'` and use the output of that as the new definition of `foreach_Z_up'`.

The other changes are required, because `auto with zarith` can solve
more proofs than before and because `omega with Z` somehow doesn’t work anymore.

All tests except type_pow_zero.sail did pass on my computer. The problem with type_pow_zero.sail probably lies elsewhere, because that one also fails for the "typecheck" set of tests.

P.S. : I haven’t checked whether this patch works with older/other versions of Coq.