### PR TITLE
C codegen: remove an unnecessary declaration in the header file

### DIFF
--- a/src/jib/c_codegen.ml
+++ b/src/jib/c_codegen.ml
@@ -1261,7 +1261,7 @@ let codegen_vector_header ctx id (direction, ctyp) =
   if is_stack_ctyp ctyp then
     string (Printf.sprintf "%s vector_access_%s(%s op, sail_int n);" (sgen_ctyp ctyp) (sgen_id id) (sgen_id id))
   else
-    string (Printf.sprintf "static void vector_access_%s(%s *rop, %s op, sail_int n);" (sgen_id id) (sgen_ctyp ctyp) (sgen_id id))
+    string "" (* Not needed in the header file at the moment *)
   ^^ twice hardline
 
 let codegen_vector_body ctx id (direction, ctyp) =


### PR DESCRIPTION
This is a follow up of one of my previous patches. vector_access is marked as static for non-stack types. But, the function was forwarded declared in the header which serves no purposes (it will not be used in the header file)