### PR TITLE
latex: Prefix label names with the specified -latex_prefix

### DIFF
--- a/src/latex.ml
+++ b/src/latex.ml
@@ -360,9 +360,6 @@ let rec latex_command cat id no_loc ((l, _) as annot) =
       ^^ ksprintf string "\\lstinputlisting[language=sail]{%s}}}}" (Filename.concat !opt_directory code_file)
     end
 
-let latex_label str id =
-  string (Printf.sprintf "\\label{%s:%s}" str (Util.zencode_string (string_of_id id)))
-
 let counter = ref 0
 
 let rec app_code (E_aux (exp, _)) =

--- a/src/latex.ml
+++ b/src/latex.ml
@@ -208,7 +208,8 @@ let rec app_code (E_aux (exp, _)) =
   | _ -> ""
 
 let refcode_cat_string cat str =
-  category_name_val cat ^ Str.global_replace (Str.regexp "_") "zy" (Util.zencode_string str)
+  let refcode_str = Str.global_replace (Str.regexp "_") "zy" (Util.zencode_string str) in
+  !opt_prefix ^ category_name_val cat ^ refcode_str
 
 let refcode_cat_id prefix id = refcode_cat_string prefix (string_of_id id)
 

--- a/src/latex.ml
+++ b/src/latex.ml
@@ -197,7 +197,7 @@ let latex_id_raw id =
     state.generated_names <- Bindings.add id str state.generated_names;
     str
 
-let latex_cat_id cat id = category_name cat ^ latex_id_raw id
+let latex_cat_id cat id = !opt_prefix ^ category_name cat ^ latex_id_raw id
 
 let rec app_code (E_aux (exp, _)) =
   match exp with
@@ -358,7 +358,7 @@ let rec latex_command cat id no_loc ((l, _) as annot) =
   let doc = if cat = Val then no_loc else latex_loc no_loc l in
   output_string chan (Pretty_print_sail.to_string doc);
   close_out chan;
-  let command = sprintf "\\%s%s" !opt_prefix (latex_cat_id cat id) in
+  let command = sprintf "\\%s" (latex_cat_id cat id) in
   if StringSet.mem command state.commands then
     (Reporting.warn "" l ("Multiple instances of " ^ string_of_id id ^ " only generating latex for the first"); empty)
   else
@@ -495,7 +495,7 @@ let defs (Defs defs) =
      identifiers then outputs the correct mangled command. *)
   let id_command cat ids =
     sprintf "\\newcommand{\\%s%s}[1]{\n  " !opt_prefix (category_name cat)
-    ^ Util.string_of_list "%\n  " (fun id -> sprintf "\\ifstrequal{#1}{%s}{\\%s%s}{}" (string_of_id id) !opt_prefix (latex_cat_id cat id))
+    ^ Util.string_of_list "%\n  " (fun id -> sprintf "\\ifstrequal{#1}{%s}{\\%s}{}" (string_of_id id) (latex_cat_id cat id))
                           (IdSet.elements ids)
     ^ "}"
     |> string

--- a/src/sail.ml
+++ b/src/sail.ml
@@ -162,7 +162,7 @@ let options = Arg.align ([
     " pretty print the input to LaTeX");
   ( "-latex_prefix",
     Arg.String (fun prefix -> Latex.opt_prefix := prefix),
-    "<prefix> set a custom prefix for generated LaTeX macro command (default sail)");
+    "<prefix> set a custom prefix for generated LaTeX labels and macro commands (default sail)");
   ( "-latex_full_valspecs",
     Arg.Clear Latex.opt_simple_val,
     " print full valspecs in LaTeX output");


### PR DESCRIPTION
This ensures names shared between multiple projects don't collide if included in a common LaTeX document; cheri-architecture using both sail-cheri-mips and sail-cheri-riscv runs into this.

Includes a series of NFC commits such that the commit with actual functional changes is trivial, and that we can be sure everything is prefixed both now and with any future changes.

Closes: #88
