### PR TITLE
Load ELF: pass pointer to g_elf_entry to get the ELF entry

### DIFF
--- a/lib/rts.c
+++ b/lib/rts.c
@@ -589,7 +589,7 @@ int process_arguments(int argc, char *argv[])
       break;
 
     case 'e':
-      load_elf(optarg, NULL, NULL);
+      load_elf(optarg, NULL, &g_elf_entry);
       break;
 
     case 'n':


### PR DESCRIPTION
I've been working with the C emulators generated using Sail, but noticed that the ELF entry was always 0. The pointer to the g_elf_entry variable was not passed to the load_elf function.

It's a very small change that needs to happen in the Sail lib but it does make it easier to work with ELF files passed using the -e flag to the C emulator.