### PR TITLE
Add CD for nightly docker images

### DIFF
--- a/.github/workflows/docker_imge_nightly.yml
+++ b/.github/workflows/docker_imge_nightly.yml
@@ -1,0 +1,38 @@
+name: Docker Nightly
+
+on:
+  push:
+    # Publish `master` as Docker `nightly` image.
+    branches:
+      - master
+
+env:
+  IMAGE_NAME: sail
+
+jobs:
+  # Push image to GitHub Packages.
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file ./Dockerfile.nightly --tag sail:nightly
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u USERNAME --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          
+          echo IMAGE_NAME=$IMAGE_NAME
+          echo IMAGE_ID=$IMAGE_ID
+          
+          docker tag $IMAGE_NAME:nightly $IMAGE_ID:nightly
+          docker push $IMAGE_ID


### PR DESCRIPTION
Nightly images that are automatically pushed to ghcr

Things you have to do yourself (once):
- decide which branch is the master branch (if sail2 is the master branch, replace master with sail2)
- create a [PAT](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) which can push public and private images
- put that PAT into a github actions secret called `CR_PAT`
- replace USERNAME with the PAT's owner
- ensure that users has the permission to push to rems-project
- set the image visibility to public once the first version is published (you **must** login as the PAT's owner, being an owner of rems-project does not suffice)

Fixes #107 
