### PR TITLE
Fix missing undefined reference generation in C backend

### DIFF
--- a/src/jib/c_backend.ml
+++ b/src/jib/c_backend.ml
@@ -1645,6 +1645,7 @@ let rec codegen_instr fid ctx (I_aux (instr, (_, l))) =
           sgen_name gs,
           [Printf.sprintf "struct %s %s = { " (sgen_ctyp_name ctyp) (sgen_name gs)
            ^ Util.string_of_list ", " (fun x -> x) inits ^ " };"] @ prev
+       | CT_ref _ -> "NULL", []
        | ctyp -> c_error ("Cannot create undefined value for type: " ^ string_of_ctyp ctyp)
      in
      let ret, prev = codegen_exn_return ctyp in

--- a/test/c/return_register_ref.expect
+++ b/test/c/return_register_ref.expect
@@ -1,0 +1,1 @@
+register value = 0xA

--- a/test/c/return_register_ref.sail
+++ b/test/c/return_register_ref.sail
@@ -1,0 +1,15 @@
+default Order dec
+
+$include <prelude.sail>
+
+register X : bits(4)
+
+function get_X() -> register(bits(4)) = {
+    ref X
+}
+
+function main() -> unit = {
+    (*get_X()) = 0xA;
+
+    print_bits("register value = ", X);
+}


### PR DESCRIPTION
Prior to this fix, the Sail compiler generated the following error message for the test case included in this PR when invoking `./run_tests.py` in `test/c`:
```
C backend: Cannot create undefined value for type: &(%bv4)
```
