### PR TITLE
C codegen: add an option to skip generating the body of the selected functions

### DIFF
--- a/etc/default_config.json
+++ b/etc/default_config.json
@@ -26,10 +26,15 @@
         // of primops, which are specified via the "foo" string from
         // val id = "foo" : ... in Sail.
         "state_primops": [],
-        // Control which sail_state variables accessors will be implemented
-        // by the consumer of the library. This is a list of regular expressions,
+        // control which sail_state variables accessors will be implemented
+        // by the consumer of the library. this is a list of regular expressions,
         // if one of those regular expression matches the name of a sail_state variable,
         // only the declaration of the accessors will be generated.
-        "external_state_api" : []
+        "external_state_api" : [],
+        // control which functions will provided as an external defintion
+        // by the consumer of the library. this is a list of regular expressions,
+        // if one of those regular expression matches the name of a Sail function,
+        // the function body will be omitted.
+        "external_fun_definition" : []
     }
 }


### PR DESCRIPTION
This patch introduces a new configuration parameter that allows the user to decide if a function body should be generated or skipped.
I found this pretty useful to replace some generated functions with a hand-written/custom implementation that is provided externally. To give an example: it may be desirable to replace the TLB or cache operations with actual TLB/cache ops when Sail is used to emulate instructions on actual hardware.