### PR TITLE
Fix build path in sailcov make

### DIFF
--- a/sailcov/Makefile
+++ b/sailcov/Makefile
@@ -1,4 +1,4 @@
 
 sailcov: *.ml dune
 	dune build main.exe
-	cp -f _build/default/main.exe sailcov
+	cp -f ../_build/default/sailcov/main.exe sailcov


### PR DESCRIPTION
Without this patch I get the following error when I try to make:
```
﻿﻿﻿dune build main.exe
Entering directory '/local/scratch/mv380/sail'
cp -f _build/default/main.exe sailcov
cp: cannot stat '_build/default/main.exe': No such file or directory
make: *** [Makefile:4: sailcov] Error 1
```