### PR TITLE
Add coq-sail.opam to the root

### DIFF
--- a/coq-sail.opam
+++ b/coq-sail.opam
@@ -1,0 +1,1 @@
+lib/coq/coq-sail.opam


### PR DESCRIPTION
This PR adds a symlink to coq-sail.opam to the root of the repository such that the package can be pinned directory from github.