### PR TITLE
Check pattern completeness for scattered functions

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -285,8 +285,7 @@ let register_default_target () =
 let run_sail tgt =
   Target.run_pre_parse_hook tgt ();
   let ast, env, effect_info = Frontend.load_files ~target:tgt Manifest.dir !options Type_check.initial_env !opt_file_arguments in
-  Target.run_pre_descatter_hook tgt ast env;
-  let ast, env = Frontend.descatter effect_info env ast in
+  let ast, env = Frontend.initial_rewrite effect_info env ast in
   let ast, env =
     List.fold_right (fun file (ast, _) -> Splice.splice ast file)
       (!opt_splice) (ast, env)

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -93,7 +93,14 @@ let mk_def_annot l = {
     attrs = [];
     loc = l;
   }
- 
+
+let add_def_attribute l attr arg (annot : def_annot) =
+  { annot with attrs = (attr, arg, l) :: annot.attrs }
+
+let get_def_attribute attr (annot : def_annot) =
+  List.find_opt (fun (attr', arg, l) -> attr = attr') annot.attrs
+  |> Option.map (fun (_, arg, l) -> (l, arg))
+
 type mut = Immutable | Mutable
 
 type 'a lvar = Register of 'a | Enum of 'a | Local of mut * 'a | Unbound of id

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -94,7 +94,11 @@ val get_attribute : string -> uannot -> (l * string) option
 val get_attributes : uannot -> (l * string * string) list
 
 val mk_def_annot : l -> def_annot
-  
+
+val add_def_attribute : l -> string -> string -> def_annot -> def_annot
+
+val get_def_attribute : string -> def_annot -> (l * string) option
+
 (** The empty annotation (as a location + uannot pair). Should be used
    carefully because it can result in unhelpful error messgaes. However
    a common pattern is generating code with [no_annot], then adding location

--- a/src/lib/effects.ml
+++ b/src/lib/effects.ml
@@ -208,16 +208,10 @@ let infer_def_direct_effects asserts_termination def =
   begin match def with
   | DEF_aux (DEF_val (VS_aux (VS_val_spec (_, id, Some { pure = false; _ }, _), _)), _) ->
      effects := EffectSet.add External !effects
-  | DEF_aux (DEF_fundef (FD_aux (FD_function (_, _, funcls), (l, _))), _) ->
+  | DEF_aux (DEF_fundef (FD_aux (FD_function (_, _, funcls), (l, _))), def_annot) ->
      begin match funcls_info funcls with
      | Some (id, typ, env) ->
-        let cases = funcls_to_pexps funcls in
-        let ctx = {
-            Pattern_completeness.variants = Env.get_variants env;
-            Pattern_completeness.enums = Env.get_enums env;
-            Pattern_completeness.constraints = Env.get_constraints env;
-          } in
-        if not (PC.is_complete l ctx cases typ) then (
+        if Option.is_some (get_def_attribute "incomplete" def_annot) then (
           effects := EffectSet.add IncompleteMatch !effects
         )
      | None ->

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -76,6 +76,7 @@ let opt_reformat : string option ref = ref None
 let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : uannot ast) : Type_check.tannot ast * Type_check.Env.t * Effects.side_effect_info =
   let env = if !opt_dno_cast then Type_check.Env.no_casts env else env in
   let ast, env = Type_error.check env ast in
+  let ast = Scattered.descatter ast in
   let side_effects = Effects.infer_side_effects asserts_termination ast in
   Effects.check_side_effects side_effects ast;
   let () = if !opt_ddump_tc_ast then Pretty_print_sail.pp_ast stdout (Type_check.strip_ast ast) else () in
@@ -115,8 +116,7 @@ let load_files ?target:target default_sail_dir options type_envs files =
 
 let rewrite_ast_initial effect_info env = Rewrites.rewrite effect_info env [("initial", fun effect_info env ast -> Rewriter.rewrite_ast ast, effect_info, env)]
   
-let descatter effect_info type_envs ast =
-  let ast = Scattered.descatter ast in
+let initial_rewrite effect_info type_envs ast =
   let ast, _, type_envs = rewrite_ast_initial effect_info type_envs ast in
   (* Recheck after descattering so that the internal type environments
      always have complete variant types *)

--- a/src/lib/frontend.mli
+++ b/src/lib/frontend.mli
@@ -83,4 +83,4 @@ val load_files :
   string list ->
   (Type_check.tannot ast * Type_check.Env.t * Effects.side_effect_info)
 
-val descatter : Effects.side_effect_info -> Type_check.Env.t -> Type_check.tannot ast -> Type_check.tannot ast * Type_check.Env.t
+val initial_rewrite : Effects.side_effect_info -> Type_check.Env.t -> Type_check.tannot ast -> Type_check.tannot ast * Type_check.Env.t

--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -829,6 +829,15 @@ module Make(C: Config) = struct
     (* For now, if any error occurs just report the pattern match is incomplete *)
     | exn -> None
 
+  let is_complete_funcls_wildcarded l ctx funcls head_exp_typ =
+    let destruct_funcl (FCL_aux (FCL_funcl (id, pexp), annot)) = ((id, annot), pexp) in
+    let cases = List.map destruct_funcl funcls in
+    match is_complete_wildcarded l ctx (List.map snd cases) head_exp_typ with
+    | Some pexps ->
+       Some (List.map2 (fun ((id, annot), _) pexp -> FCL_aux (FCL_funcl (id, pexp), annot)) cases pexps)
+    | None ->
+       None
+
   let is_complete l ctx cases head_exp_typ = Option.is_some (is_complete_wildcarded l ctx cases head_exp_typ)
 
 end

--- a/src/lib/pattern_completeness.mli
+++ b/src/lib/pattern_completeness.mli
@@ -89,5 +89,6 @@ module type Config =
 
 module Make(C: Config) : sig
   val is_complete_wildcarded : Parse_ast.l -> ctx -> C.t pexp list -> typ -> C.t pexp list option
+  val is_complete_funcls_wildcarded : Parse_ast.l -> ctx -> C.t funcl list -> typ -> C.t funcl list option
   val is_complete : Parse_ast.l -> ctx -> C.t pexp list -> typ -> bool
 end

--- a/src/lib/scattered.ml
+++ b/src/lib/scattered.ml
@@ -102,19 +102,34 @@ let rec filter_union_clauses id = function
      def :: filter_union_clauses id defs
   | [] -> []
 
+module PC_config = struct
+  type t = Type_check.tannot
+  let typ_of_t = Type_check.typ_of_tannot
+  let add_attribute l attr arg = Type_check.map_uannot (add_attribute l attr arg)
+end
+
+module PC = Pattern_completeness.Make(PC_config)
+
 let rec descatter' funcls mapcls = function
   (* For scattered functions we collect all the seperate function
      clauses until we find the last one, then we turn that function
      clause into a DEF_fundef containing all the clauses. *)
-  | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, (l, _))), _) :: defs
+  | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, (l, tannot))), _) :: defs
        when last_scattered_funcl (funcl_id funcl) defs ->
      let clauses = match Bindings.find_opt (funcl_id funcl) funcls with
        | Some clauses -> List.rev (funcl :: clauses)
        | None -> [funcl]
      in
+     let typ_arg, _, env = Type_check.(bind_funcl_arg_typ l (env_of_tannot tannot) (typ_of_tannot tannot)) in
+     let ctx = Type_check.pattern_completeness_ctx env in
+     let clauses, attr = match PC.is_complete_funcls_wildcarded l ctx clauses typ_arg with
+       | Some clauses -> clauses, "complete"
+       | None -> clauses, "incomplete"
+     in
+     let def_annot = mk_def_annot (gen_loc l) |> add_def_attribute (gen_loc l) attr "" in
      DEF_aux (DEF_fundef (FD_aux (FD_function (fake_rec_opt l, no_tannot_opt l, clauses),
-                                  (gen_loc l, Type_check.empty_tannot))),
-              mk_def_annot (gen_loc l))
+                                  (gen_loc l, tannot))),
+              def_annot)
      :: descatter' funcls mapcls defs
 
   | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, _)), _) :: defs ->

--- a/src/lib/target.ml
+++ b/src/lib/target.ml
@@ -74,7 +74,6 @@ type target = {
     name : string;
     options : (Arg.key * Arg.spec * Arg.doc) list;
     pre_parse_hook : (unit -> unit);
-    pre_descatter_hook : (tannot ast -> Env.t -> unit);
     pre_rewrites_hook : (tannot ast -> Effects.side_effect_info -> Env.t -> unit);
     rewrites : (string * Rewrites.rewriter_arg list) list;
     action : string -> string option -> tannot ast -> Effects.side_effect_info -> Env.t -> unit;
@@ -85,8 +84,6 @@ let name tgt = tgt.name
 
 let run_pre_parse_hook tgt = tgt.pre_parse_hook
 
-let run_pre_descatter_hook tgt = tgt.pre_descatter_hook
-                           
 let run_pre_rewrites_hook tgt = tgt.pre_rewrites_hook
                               
 let action tgt = tgt.action
@@ -105,7 +102,6 @@ let register
       ?description:desc
       ?options:(options = [])
       ?pre_parse_hook:(pre_parse_hook = (fun () -> ()))
-      ?pre_descatter_hook:(pre_descatter_hook = (fun _ _ -> ()))
       ?pre_rewrites_hook:(pre_rewrites_hook = (fun _ _ _ -> ()))
       ?rewrites:(rewrites = [])
       ?asserts_termination:(asserts_termination = false)
@@ -128,7 +124,6 @@ let register
       name = name;
       options = ("-" ^ flag, Arg.Unit set_target, desc) :: options;
       pre_parse_hook = pre_parse_hook;
-      pre_descatter_hook = pre_descatter_hook;
       pre_rewrites_hook = pre_rewrites_hook;
       rewrites = rewrites;
       action = action;

--- a/src/lib/target.mli
+++ b/src/lib/target.mli
@@ -84,8 +84,6 @@ val name : target -> string
 
 val run_pre_parse_hook : target -> unit -> unit
 
-val run_pre_descatter_hook : target -> tannot ast -> Env.t -> unit
-  
 val run_pre_rewrites_hook : target -> tannot ast -> Effects.side_effect_info -> Env.t -> unit
 
 val rewrites : target -> Rewrites.rewrite_sequence
@@ -123,7 +121,6 @@ val register :
   ?description:string ->
   ?options:(Arg.key * Arg.spec * Arg.doc) list ->
   ?pre_parse_hook:(unit -> unit) ->
-  ?pre_descatter_hook:(tannot ast -> Env.t -> unit) ->
   ?pre_rewrites_hook:(tannot ast -> Effects.side_effect_info -> Env.t -> unit) ->
   ?rewrites:(string * Rewrites.rewriter_arg list) list ->
   ?asserts_termination:bool ->

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -3143,7 +3143,13 @@ module PC_config = struct
   let add_attribute l attr arg = map_uannot (add_attribute l attr arg)
 end
 
-module PC = Pattern_completeness.Make(PC_config);;
+module PC = Pattern_completeness.Make(PC_config)
+
+let pattern_completeness_ctx env = {
+  Pattern_completeness.variants = Env.get_variants env;
+  Pattern_completeness.enums = Env.get_enums env;
+  Pattern_completeness.constraints = Env.get_constraints env;
+}
        
 let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_aux (typ_aux, _) as typ) : tannot exp =
   let annot_exp exp typ' = E_aux (exp, (l, mk_expected_tannot ~uannot:uannot env typ' (Some typ))) in
@@ -3159,11 +3165,7 @@ let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_au
        if Option.is_some (get_attribute "complete" uannot) || Option.is_some (get_attribute "incomplete" uannot) then (
          checked_cases, (fun attrs -> attrs)
        ) else (
-         let ctx = {
-             Pattern_completeness.variants = Env.get_variants env;
-             Pattern_completeness.enums = Env.get_enums env;
-             Pattern_completeness.constraints = Env.get_constraints env;
-           } in
+         let ctx = pattern_completeness_ctx env in
          match PC.is_complete_wildcarded l ctx checked_cases inferred_typ with
          | Some wildcarded -> wildcarded, add_attribute (gen_loc l) "complete" ""
          | None -> checked_cases, add_attribute (gen_loc l) "incomplete" ""
@@ -5028,36 +5030,36 @@ let check_letdef orig_env def_annot (LB_aux (letbind, (l, _))) =
      [DEF_aux (DEF_let (LB_aux (LB_val (tpat, inferred_bind), (l, empty_tannot))), def_annot)],
      Env.add_toplevel_lets (pat_ids tpat) env
 
-let check_funcl env (FCL_aux (FCL_funcl (id, pexp), (l, _))) typ =
+let bind_funcl_arg_typ l env typ =
   match typ with
   | Typ_aux (Typ_fn (typ_args, typ_ret), _) ->
      begin
-       let typ_args = List.map implicit_to_int typ_args in
        let env = Env.add_ret_typ typ_ret env in
-       (* We want to forbid polymorphic undefined values in all cases,
-          except when type checking the specific undefined_(type)
-          functions created by the -undefined_gen functions in
-          initial_check.ml. Only in these functions will the rewriter
-          be able to correctly re-write the polymorphic undefineds
-          (due to the specific form the functions have *)
-       let env =
-         if Str.string_match (Str.regexp_string "undefined_") (string_of_id id) 0
-         then Env.allow_polymorphic_undefineds env
-         else env
-       in
-       (* This is one of the cases where we are allowed to treat
-          function arguments as like a tuple, and maybe we
-          shouldn't. *)
-       let typed_pexp =
-         match List.map implicit_to_int typ_args with
-         | [typ_arg] ->
-            check_case env typ_arg pexp typ_ret
-         | typ_args ->
-            check_case env (Typ_aux (Typ_tuple typ_args, l)) pexp typ_ret
-       in
-       FCL_aux (FCL_funcl (id, typed_pexp), (l, mk_expected_tannot env typ (Some typ)))
+       match List.map implicit_to_int typ_args with
+       | [typ_arg] ->
+         typ_arg, typ_ret, env
+       | typ_args ->
+         (* This is one of the cases where we are allowed to treat
+            function arguments as like a tuple, normally we can't. *)
+         Typ_aux (Typ_tuple typ_args, l), typ_ret, env
      end
   | _ -> typ_error env l ("Function clause must have function type: " ^ string_of_typ typ ^ " is not a function type")
+
+let check_funcl env (FCL_aux (FCL_funcl (id, pexp), (l, _))) typ =
+  let typ_arg, typ_ret, env = bind_funcl_arg_typ l env typ in
+  (* We want to forbid polymorphic undefined values in all cases,
+     except when type checking the specific undefined_(type) functions
+     created by the -undefined_gen functions in initial_check.ml. Only
+     in these functions will the rewriter be able to correctly
+     re-write the polymorphic undefineds (due to the specific form the
+     functions have *)
+  let env =
+    if Str.string_match (Str.regexp_string "undefined_") (string_of_id id) 0
+    then Env.allow_polymorphic_undefineds env
+    else env
+  in
+  let typed_pexp = check_case env typ_arg pexp typ_ret in
+  FCL_aux (FCL_funcl (id, typed_pexp), (l, mk_expected_tannot env typ (Some typ)))
 
 let check_mapcl : Env.t -> uannot mapcl -> typ -> tannot mapcl =
   fun env (MCL_aux (cl, (l, _))) typ ->
@@ -5389,7 +5391,7 @@ let rec check_typedef : Env.t -> def_annot -> uannot type_def -> (tannot def) li
      end
 
 and check_scattered : Env.t -> def_annot -> uannot scattered_def -> (tannot def) list * Env.t =
-  fun env def_annot (SD_aux (sdef, (l, _))) ->
+  fun env def_annot (SD_aux (sdef, (l, uannot))) ->
   match sdef with
   | SD_function _ | SD_end _ | SD_mapping _ ->
      [], env
@@ -5414,7 +5416,7 @@ and check_scattered : Env.t -> def_annot -> uannot scattered_def -> (tannot def)
      let typq, typ = Env.get_val_spec id env in
      let funcl_env = Env.add_typquant l typq env in
      let funcl = check_funcl funcl_env funcl typ in
-     [DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, (l, empty_tannot))), def_annot)],
+     [DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, (l, mk_tannot ~uannot:uannot funcl_env typ))), def_annot)],
      env
 
   | SD_mapcl (id, mapcl) ->

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -347,6 +347,10 @@ val strip_n_constraint_aux : n_constraint_aux -> n_constraint_aux
 val strip_n_constraint : n_constraint -> n_constraint
 val strip_typ_aux : typ_aux -> typ_aux
 
+val bind_funcl_arg_typ : Parse_ast.l -> Env.t -> typ -> (typ * typ * Env.t)
+
+val pattern_completeness_ctx : Env.t -> Pattern_completeness.ctx
+
 (** {2 Checking expressions and patterns} *)
 
 (** Check an expression has some type. Returns a fully annotated


### PR DESCRIPTION
Do this during descattering so we can modify the clauses the same way we do for match statements

Requires refactoring the frontend.ml flow a bit, in a way that makes it no longer fully make sense. So this should be modified a bit more.

Currently causes some tests to break, so should not be merged as is.