### PR TITLE
Add a IR->IR rewrite that removes unstructured control flow

### DIFF
--- a/src/lib/jib_optimize.mli
+++ b/src/lib/jib_optimize.mli
@@ -96,3 +96,5 @@ val remove_dead_after_goto : instr list -> instr list
 val remove_dead_code : instr list -> instr list
 
 val remove_tuples : cdef list -> Jib_compile.ctx -> cdef list * Jib_compile.ctx
+
+val structure_control_flow_block : instr list -> instr list


### PR DESCRIPTION
For now we assume the IR is flat, but in theory we can preserve more structure. There must be no backwards jumps so loops are not supported - we need cleverer unrolling or to preserve loops in the IR longer.

If used for Sail->C this rewrite will leak memory, as it doesn't won't necessarily ensure that all the clear instructions are in the right place. We could fix this, or maybe a better way would be to not emit any clear instructions in jib_compile and insert them later when we need them.