### PR TITLE
Add scattered enums

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -711,6 +711,10 @@ scattered_def :: 'SD_' ::=
 
   | mapping clause id = mapcl :: :: mapcl
 
+  | scattered enum id :: :: enum
+
+  | enum clause id1 = id2 :: :: enumcl
+
   | end id  :: :: end
 {{ texlong }} {{ com scattered definition end }}
 

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -766,6 +766,8 @@ and map_scattered_annot_aux f = function
   | SD_mapping (id, tannot_opt) -> SD_mapping (id, tannot_opt)
   | SD_mapcl (id, mcl) -> SD_mapcl (id, map_mapcl_annot f mcl)
   | SD_end id -> SD_end id
+  | SD_enum id -> SD_enum id
+  | SD_enumcl (id, member) -> SD_enumcl (id, member)
 
 and map_register_annot f = function DEC_aux (dec_aux, annot) -> DEC_aux (map_register_annot_aux f dec_aux, f annot)
 
@@ -1098,7 +1100,9 @@ let id_of_scattered (SD_aux (sdef, _)) =
   | SD_variant (id, _)
   | SD_unioncl (id, _)
   | SD_mapping (id, _)
-  | SD_mapcl (id, _) ->
+  | SD_mapcl (id, _)
+  | SD_enum id
+  | SD_enumcl (id, _) ->
       id
 
 let ids_of_def (DEF_aux (aux, _)) =
@@ -1136,6 +1140,12 @@ let rec get_scattered_union_clauses id = function
   | DEF_aux (DEF_scattered (SD_aux (SD_unioncl (uid, tu), _)), _) :: defs when Id.compare id uid = 0 ->
       tu :: get_scattered_union_clauses id defs
   | _ :: defs -> get_scattered_union_clauses id defs
+  | [] -> []
+
+let rec get_scattered_enum_clauses id = function
+  | DEF_aux (DEF_scattered (SD_aux (SD_enumcl (uid, member), _)), _) :: defs when Id.compare id uid = 0 ->
+      member :: get_scattered_enum_clauses id defs
+  | _ :: defs -> get_scattered_enum_clauses id defs
   | [] -> []
 
 let order_compare (Ord_aux (o1, _)) (Ord_aux (o2, _)) =

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -528,6 +528,7 @@ val val_spec_ids : 'a def list -> IdSet.t
 val record_ids : 'a def list -> IdSet.t
 
 val get_scattered_union_clauses : id -> 'a def list -> type_union list
+val get_scattered_enum_clauses : id -> 'a def list -> id list
 
 val pat_ids : 'a pat -> IdSet.t
 

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -68,6 +68,8 @@
 open Ast_util
 open Ast_defs
 
+module StringMap = Map.Make (String)
+
 let opt_ddump_initial_ast = ref false
 let opt_ddump_tc_ast = ref false
 let opt_dno_cast = ref true

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -395,6 +395,8 @@ type scattered_def_aux =
      a file. Each one must end in $_$ *)
   | SD_function of rec_opt * tannot_opt * effect_opt * id (* scattered function definition header *)
   | SD_funcl of funcl (* scattered function definition clause *)
+  | SD_enum of id (* scattered enumeration definition header *)
+  | SD_enumcl of id * id (* scattered enumeration member clause *)
   | SD_variant of id * typquant (* scattered union definition header *)
   | SD_unioncl of id * type_union (* scattered union definition member *)
   | SD_mapping of id * tannot_opt

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -1511,6 +1511,8 @@ default_def:
     { mk_default (DT_order ($2, mk_typ ATyp_dec $startpos($3) $endpos)) $startpos $endpos }
 
 scattered_def:
+  | Scattered Enum id
+    { mk_sd (SD_enum $3) $startpos $endpos }
   | Scattered Union id typaram
     { mk_sd (SD_variant($3, $4)) $startpos $endpos }
   | Scattered Union id
@@ -1521,6 +1523,8 @@ scattered_def:
     { mk_sd (SD_mapping ($3, mk_tannotn)) $startpos $endpos }
   | Scattered Mapping id Colon funcl_typ
     { mk_sd (SD_mapping ($3, $5)) $startpos $endpos }
+  | Enum Clause id Eq id
+    { mk_sd (SD_enumcl ($3, $5)) $startpos $endpos }
   | Function_ Clause funcl
     { mk_sd (SD_funcl $3) $startpos $endpos }
   | Union Clause id Eq type_union

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -751,6 +751,8 @@ let doc_scattered (SD_aux (sd_aux, _)) =
   | SD_mapping (id, Typ_annot_opt_aux (Typ_annot_opt_some (typq, typ), _)) ->
       separate space [string "scattered mapping"; doc_id id; colon; doc_binding (typq, typ)]
   | SD_unioncl (id, tu) -> separate space [string "union clause"; doc_id id; equals; doc_union tu]
+  | SD_enum id -> separate space [string "scattered enum"; doc_id id]
+  | SD_enumcl (id, member) -> separate space [string "enum clause"; doc_id id; equals; doc_id member]
 
 let doc_filter = function
   | DEF_aux ((DEF_pragma ("file_start", _, _) | DEF_pragma ("file_end", _, _)), _) -> false
@@ -761,6 +763,16 @@ let rec doc_def_no_hardline ?(comment = false) (DEF_aux (aux, def_annot)) =
   | Some str when comment -> string "/*! " ^^ string str ^^ string " */" ^^ hardline
   | _ -> empty
   )
+  ^^ ( match def_annot.attrs with
+     | [] -> empty
+     | attrs ->
+         separate_map hardline
+           (fun (_, attr, arg) ->
+             if arg = "" then Printf.ksprintf string "$[%s]" attr else Printf.ksprintf string "$[%s %s]" attr arg
+           )
+           attrs
+         ^^ hardline
+     )
   ^^
   match aux with
   | DEF_default df -> doc_default df

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -283,7 +283,7 @@ let rewrite_scattered rewriters (SD_aux (sd, (l, annot))) =
     match sd with
     | SD_funcl funcl -> SD_funcl (rewrite_funcl rewriters funcl)
     | SD_mapcl (id, mapcl) -> SD_mapcl (id, rewrite_mapcl rewriters mapcl)
-    | SD_variant _ | SD_unioncl _ | SD_mapping _ | SD_function _ | SD_end _ -> sd
+    | SD_variant _ | SD_unioncl _ | SD_mapping _ | SD_function _ | SD_end _ | SD_enum _ | SD_enumcl _ -> sd
   in
   SD_aux (sd, (l, annot))
 

--- a/test/typecheck/pass/scattered_enum.sail
+++ b/test/typecheck/pass/scattered_enum.sail
@@ -1,0 +1,6 @@
+
+scattered enum E
+
+enum clause E = A
+enum clause E = B
+enum clause E = C

--- a/test/typecheck/pass/scattered_enum/v1.expect
+++ b/test/typecheck/pass/scattered_enum/v1.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/scattered_enum/v1.sail[0m:5.12-13:
+5[96m |[0menum clause E = A
+ [91m |[0m            [91m^[0m
+ [91m |[0m Enumeration E already has a member A

--- a/test/typecheck/pass/scattered_enum/v1.sail
+++ b/test/typecheck/pass/scattered_enum/v1.sail
@@ -1,0 +1,6 @@
+
+scattered enum E
+
+enum clause E = A
+enum clause E = A
+enum clause E = C

--- a/test/typecheck/pass/scattered_enum/v2.expect
+++ b/test/typecheck/pass/scattered_enum/v2.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/scattered_enum/v2.sail[0m:4.12-13:
+4[96m |[0menum clause E = A
+ [91m |[0m            [91m^[0m
+ [91m |[0m Enumeration E is not scattered - cannot add a new member with 'enum clause'

--- a/test/typecheck/pass/scattered_enum/v2.sail
+++ b/test/typecheck/pass/scattered_enum/v2.sail
@@ -1,0 +1,6 @@
+
+enum E = D | E | F
+
+enum clause E = A
+enum clause E = B
+enum clause E = C

--- a/test/typecheck/pass/scattered_enum/v3.expect
+++ b/test/typecheck/pass/scattered_enum/v3.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/scattered_enum/v3.sail[0m:2.12-13:
+2[96m |[0menum clause E = A
+ [91m |[0m            [91m^[0m
+ [91m |[0m Enumeration E does not exist

--- a/test/typecheck/pass/scattered_enum/v3.sail
+++ b/test/typecheck/pass/scattered_enum/v3.sail
@@ -1,0 +1,4 @@
+
+enum clause E = A
+enum clause E = B
+enum clause E = C


### PR DESCRIPTION
Was always a bit odd that we allowed scattered unions, but not enumerations, despite the two having basically the same implementation