### PR TITLE
Various formatting improvments

### DIFF
--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -465,7 +465,7 @@ and to_ast_exp ctx (P.E_aux (exp, l) : P.exp) =
           )
         | P.E_app_infix (left, op, right) -> E_app_infix (to_ast_exp ctx left, to_ast_id ctx op, to_ast_exp ctx right)
         | P.E_tuple exps -> E_tuple (List.map (to_ast_exp ctx) exps)
-        | P.E_if (e1, e2, e3) -> E_if (to_ast_exp ctx e1, to_ast_exp ctx e2, to_ast_exp ctx e3)
+        | P.E_if (e1, e2, e3, _) -> E_if (to_ast_exp ctx e1, to_ast_exp ctx e2, to_ast_exp ctx e3)
         | P.E_for (id, e1, e2, e3, atyp, e4) ->
             E_for
               ( to_ast_id ctx id,

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -217,6 +217,8 @@ and fpat = FP_aux of fpat_aux * l
 
 type loop = While | Until
 
+type if_loc = { if_loc : l; then_loc : l; else_loc : l option }
+
 type measure_aux = (* optional termination measure for a loop *)
   | Measure_none | Measure_some of exp
 
@@ -233,7 +235,7 @@ and exp_aux =
   | E_app of id * exp list (* function application *)
   | E_app_infix of exp * id * exp (* infix function application *)
   | E_tuple of exp list (* tuple *)
-  | E_if of exp * exp * exp (* conditional *)
+  | E_if of exp * exp * exp * if_loc (* conditional *)
   | E_loop of loop * measure * exp * exp
   | E_for of id * exp * exp * exp * atyp * exp (* loop *)
   | E_vector of exp list (* vector (indexed from 0) *)

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -845,9 +845,17 @@ exp:
   | Throw exp
     { mk_exp (E_throw $2) $startpos $endpos }
   | If_ exp Then exp Else exp
-    { mk_exp (E_if ($2, $4, $6)) $startpos $endpos }
+    { let keywords = { if_loc = loc $startpos($1) $endpos($1);
+                       then_loc = loc $startpos($3) $endpos($3);
+                       else_loc = Some (loc $startpos($5) $endpos($5))
+                     } in
+      mk_exp (E_if ($2, $4, $6, keywords)) $startpos $endpos }
   | If_ exp Then exp
-    { mk_exp (E_if ($2, $4, mk_lit_exp L_unit $endpos($4) $endpos($4))) $startpos $endpos }
+    { let keywords = { if_loc = loc $startpos($1) $endpos($1);
+                       then_loc = loc $startpos($3) $endpos($3);
+                       else_loc = None
+                     } in
+      mk_exp (E_if ($2, $4, mk_lit_exp L_unit $endpos($4) $endpos($4), keywords)) $startpos $endpos }
   | Match exp Lcurly case_list Rcurly
     { mk_exp (E_match ($2, $4)) $startpos $endpos }
   | Try exp Catch Lcurly case_list Rcurly

--- a/test/format/default/block.expect
+++ b/test/format/default/block.expect
@@ -25,4 +25,3 @@ function foo () = {
 
     print_endline("string3")
 }
-

--- a/test/format/default/can_hang.expect
+++ b/test/format/default/can_hang.expect
@@ -18,4 +18,3 @@ function bar () = {
         unit => (),
     }
 }
-

--- a/test/format/default/function_quant.expect
+++ b/test/format/default/function_quant.expect
@@ -26,4 +26,3 @@ function foo forall 'very_long_identifier_that_will_cause_a_line_break 'm, 'n >=
 (x : int('very_long_identifier_that_will_cause_a_line_break), y : int('m)) -> unit = {
     ()
 }
-

--- a/test/format/default/patterns.expect
+++ b/test/format/default/patterns.expect
@@ -14,4 +14,3 @@ function foo(ys : bits(6), xs : bits(6)) -> unit = {
     let _ = xs[3..1] @ xs[0..0] @ xs[5..4];
     ()
 }
-

--- a/test/format/default/struct_update.expect
+++ b/test/format/default/struct_update.expect
@@ -64,4 +64,3 @@ function has_loops () = {
 }
 
 type foo = bar
-

--- a/test/format/default/val.expect
+++ b/test/format/default/val.expect
@@ -15,4 +15,3 @@ val bar = monadic { c: "foo_c", _: "foo" } : (
 
 val baz : unit -> unit // baz
 val quuz : unit -> unit
-


### PR DESCRIPTION
Improve formatting of comments around if-then-else

Fix a bug with indentation after line comments

Make sure formatted files are always terminated by exactly one newline