### PR TITLE
Adjust spacing before comments when formatting

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -343,8 +343,8 @@ let run_sail_format (config : Yojson.Basic.t option) =
         let formatted = Formatter.format_defs f source comments parse_ast in
         begin
           match !opt_format_backup with
-          | Some backup_file ->
-              let out_chan = open_out backup_file in
+          | Some suffix ->
+              let out_chan = open_out (f ^ "." ^ suffix) in
               output_string out_chan source;
               close_out out_chan
           | None -> ()

--- a/test/format/default/test_if_comment_1.expect
+++ b/test/format/default/test_if_comment_1.expect
@@ -1,0 +1,28 @@
+
+function foo () = {
+    if cond then {
+        2 /* comment */
+    } else {
+        3 /* comment */
+    }
+}
+
+function foo () = {
+    if cond then {
+        2 // comment
+    } else {
+        3 // comment
+    }
+}
+
+function foo () = {
+    if cond then {
+        if cond2 then {
+            2 // comment
+        } else {
+            4 /* comment */
+        }
+    } else {
+        3 // comment
+    }
+}

--- a/test/format/test_if_comment_1.sail
+++ b/test/format/test_if_comment_1.sail
@@ -1,0 +1,23 @@
+
+function foo() = {
+    if cond
+    then 2 /* comment */
+    else { 3 /* comment */ }
+}
+
+function foo() = {
+    if cond
+    then 2// comment
+    else { 3   // comment
+}
+}
+
+function foo() = {
+    if cond
+    then {
+      if cond2
+      then 2// comment
+      else { 4 /* comment */ }}
+    else { 3   // comment
+}
+}


### PR DESCRIPTION
Makes sure `sail -fmt` never generates a comment like `expression/*comment*/` where there is no space between the comment and the expression.