### PR TITLE
Add some more information to scattered enum type error

### DIFF
--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1390,7 +1390,9 @@ end = struct
           typ_error env (id_loc id) ("Enumeration " ^ string_of_id id ^ " already has a member " ^ string_of_id member)
         else { env with enums = Bindings.add id (true, IdSet.add member members) env.enums }
     | Some (false, _) ->
-        typ_error env (id_loc id)
+        let prev_id, _ = Bindings.find_first (fun prev_id -> Id.compare id prev_id = 0) env.enums in
+        typ_error env
+          (Parse_ast.Hint ("Declared as regular enumeration here", id_loc prev_id, id_loc id))
           ("Enumeration " ^ string_of_id id ^ " is not scattered - cannot add a new member with 'enum clause'")
     | None -> typ_error env (id_loc id) ("Enumeration " ^ string_of_id id ^ " does not exist")
 

--- a/test/typecheck/pass/scattered_enum/v2.expect
+++ b/test/typecheck/pass/scattered_enum/v2.expect
@@ -1,4 +1,7 @@
 [93mType error[0m:
+[96mpass/scattered_enum/v2.sail[0m:2.5-6:
+2[96m |[0menum E = D | E | F
+ [92m |[0m     [92m^[0m [92mDeclared as regular enumeration here[0m
 [96mpass/scattered_enum/v2.sail[0m:4.12-13:
 4[96m |[0menum clause E = A
  [91m |[0m            [91m^[0m


### PR DESCRIPTION
If we add a enum clause to a regular enum it will print the location of the regular enum