### PR TITLE
List handling performance fixes

### DIFF
--- a/src/lib/preprocess.ml
+++ b/src/lib/preprocess.ml
@@ -146,101 +146,97 @@ let wrap_include l file = function
   | [] -> []
   | defs -> [DEF_aux (DEF_pragma ("include_start", file), l)] @ defs @ [DEF_aux (DEF_pragma ("include_end", file), l)]
 
-let rec preprocess dir target opts =
+let preprocess dir target opts =
   let module P = Parse_ast in
-  function
-  | [] -> []
-  | DEF_aux (DEF_pragma ("define", symbol), _) :: defs ->
-      symbols := StringSet.add symbol !symbols;
-      preprocess dir target opts defs
-  | (DEF_aux (DEF_pragma ("option", command), l) as opt_pragma) :: defs ->
-      begin
-        let first_line err_msg =
-          match String.split_on_char '\n' err_msg with line :: _ -> "\n" ^ line | [] -> ("" [@coverage off])
-          (* Don't expect this should ever happen, but we are fine if it does *)
-        in
-        try
-          let args = Str.split (Str.regexp " +") command in
-          let file_arg file =
-            raise (Reporting.err_general l ("Anonymous argument '" ^ file ^ "' cannot be passed via $option directive"))
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | DEF_aux (DEF_pragma ("define", symbol), _) :: defs ->
+        symbols := StringSet.add symbol !symbols;
+        aux acc defs
+    | (DEF_aux (DEF_pragma ("option", command), l) as opt_pragma) :: defs ->
+        begin
+          let first_line err_msg =
+            match String.split_on_char '\n' err_msg with line :: _ -> "\n" ^ line | [] -> ("" [@coverage off])
+            (* Don't expect this should ever happen, but we are fine if it does *)
           in
-          Arg.parse_argv ~current:(ref 0) (Array.of_list ("sail" :: args)) opts file_arg ""
-        with
-        | Arg.Help msg -> raise (Reporting.err_general l "-help flag passed to $option directive")
-        | Arg.Bad msg -> raise (Reporting.err_general l ("Invalid flag passed to $option directive" ^ first_line msg))
-      end;
-      opt_pragma :: preprocess dir target opts defs
-  | DEF_aux (DEF_pragma ("ifndef", symbol), l) :: defs ->
-      let then_defs, else_defs, defs = cond_pragma l defs in
-      if not (StringSet.mem symbol !symbols) then preprocess dir target opts (then_defs @ defs)
-      else preprocess dir target opts (else_defs @ defs)
-  | DEF_aux (DEF_pragma ("ifdef", symbol), l) :: defs ->
-      let then_defs, else_defs, defs = cond_pragma l defs in
-      if StringSet.mem symbol !symbols then preprocess dir target opts (then_defs @ defs)
-      else preprocess dir target opts (else_defs @ defs)
-  | DEF_aux (DEF_pragma ("iftarget", t), l) :: defs ->
-      let then_defs, else_defs, defs = cond_pragma l defs in
-      begin
-        match target with
-        | Some t' when t = t' -> preprocess dir target opts (then_defs @ defs)
-        | _ -> preprocess dir target opts (else_defs @ defs)
+          try
+            let args = Str.split (Str.regexp " +") command in
+            let file_arg file =
+              raise
+                (Reporting.err_general l ("Anonymous argument '" ^ file ^ "' cannot be passed via $option directive"))
+            in
+            Arg.parse_argv ~current:(ref 0) (Array.of_list ("sail" :: args)) opts file_arg ""
+          with
+          | Arg.Help msg -> raise (Reporting.err_general l "-help flag passed to $option directive")
+          | Arg.Bad msg -> raise (Reporting.err_general l ("Invalid flag passed to $option directive" ^ first_line msg))
+        end;
+        aux (opt_pragma :: acc) defs
+    | DEF_aux (DEF_pragma ("ifndef", symbol), l) :: defs ->
+        let then_defs, else_defs, defs = cond_pragma l defs in
+        if not (StringSet.mem symbol !symbols) then aux acc (then_defs @ defs) else aux acc (else_defs @ defs)
+    | DEF_aux (DEF_pragma ("ifdef", symbol), l) :: defs ->
+        let then_defs, else_defs, defs = cond_pragma l defs in
+        if StringSet.mem symbol !symbols then aux acc (then_defs @ defs) else aux acc (else_defs @ defs)
+    | DEF_aux (DEF_pragma ("iftarget", t), l) :: defs ->
+        let then_defs, else_defs, defs = cond_pragma l defs in
+        begin
+          match target with Some t' when t = t' -> aux acc (then_defs @ defs) | _ -> aux acc (else_defs @ defs)
+        end
+    | DEF_aux (DEF_pragma ("include", file), l) :: defs ->
+        let len = String.length file in
+        if len = 0 then (
+          Reporting.warn "" l "Skipping bad $include. No file argument.";
+          aux acc defs
+        )
+        else if file.[0] = '"' && file.[len - 1] = '"' then (
+          let relative =
+            match l with
+            | Parse_ast.Range (pos, _) -> Filename.dirname Lexing.(pos.pos_fname)
+            | _ -> failwith "Couldn't figure out relative path for $include. This really shouldn't ever happen."
+          in
+          let file = String.sub file 1 (len - 2) in
+          let include_file = Filename.concat relative file in
+          let include_defs = Initial_check.parse_file ~loc:l (Filename.concat relative file) |> snd |> aux [] in
+          aux (List.rev (wrap_include l include_file include_defs) @ acc) defs
+        )
+        else if file.[0] = '<' && file.[len - 1] = '>' then (
+          let file = String.sub file 1 (len - 2) in
+          let sail_dir = Reporting.get_sail_dir dir in
+          let file = Filename.concat sail_dir ("lib/" ^ file) in
+          let include_defs = Initial_check.parse_file ~loc:l file |> snd |> aux [] in
+          aux (List.rev (wrap_include l file include_defs) @ acc) defs
+        )
+        else (
+          let help = "Make sure the filename is surrounded by quotes or angle brackets" in
+          Reporting.warn "" l ("Skipping bad $include " ^ file ^ ". " ^ help);
+          aux acc defs
+        )
+    | DEF_aux (DEF_pragma ("suppress_warnings", _), l) :: defs ->
+        begin
+          match Reporting.simp_loc l with
+          | None -> () (* This shouldn't happen, but if it does just continue *)
+          | Some (p, _) -> Reporting.suppress_warnings_for_file p.pos_fname
+        end;
+        aux acc defs
+    (* Filter file_start and file_end out of the AST so when we
+       round-trip files through the compiler we don't end up with
+       incorrect start/end annotations *)
+    | (DEF_aux (DEF_pragma ("file_start", _), _) | DEF_aux (DEF_pragma ("file_end", _), _)) :: defs -> aux acc defs
+    | DEF_aux (DEF_pragma (p, arg), l) :: defs ->
+        if not (StringSet.mem p all_pragmas) then Reporting.warn "" l ("Unrecognised directive: " ^ p);
+        aux (DEF_aux (DEF_pragma (p, arg), l) :: acc) defs
+    | DEF_aux (DEF_outcome (outcome_spec, inner_defs), l) :: defs ->
+        aux (DEF_aux (DEF_outcome (outcome_spec, aux [] inner_defs), l) :: acc) defs
+    | (DEF_aux (DEF_default (DT_aux (DT_order (_, ATyp_aux (atyp, _)), _)), l) as def) :: defs -> begin
+        match atyp with
+        | Parse_ast.ATyp_inc ->
+            symbols := StringSet.add "_DEFAULT_INC" !symbols;
+            aux (def :: acc) defs
+        | Parse_ast.ATyp_dec ->
+            symbols := StringSet.add "_DEFAULT_DEC" !symbols;
+            aux (def :: acc) defs
+        | _ -> aux (def :: acc) defs
       end
-  | DEF_aux (DEF_pragma ("include", file), l) :: defs ->
-      let len = String.length file in
-      if len = 0 then (
-        Reporting.warn "" l "Skipping bad $include. No file argument.";
-        preprocess dir target opts defs
-      )
-      else if file.[0] = '"' && file.[len - 1] = '"' then (
-        let relative =
-          match l with
-          | Parse_ast.Range (pos, _) -> Filename.dirname Lexing.(pos.pos_fname)
-          | _ -> failwith "Couldn't figure out relative path for $include. This really shouldn't ever happen."
-        in
-        let file = String.sub file 1 (len - 2) in
-        let include_file = Filename.concat relative file in
-        let include_defs =
-          Initial_check.parse_file ~loc:l (Filename.concat relative file) |> snd |> preprocess dir target opts
-        in
-        wrap_include l include_file include_defs @ preprocess dir target opts defs
-      )
-      else if file.[0] = '<' && file.[len - 1] = '>' then (
-        let file = String.sub file 1 (len - 2) in
-        let sail_dir = Reporting.get_sail_dir dir in
-        let file = Filename.concat sail_dir ("lib/" ^ file) in
-        let include_defs = Initial_check.parse_file ~loc:l file |> snd |> preprocess dir target opts in
-        wrap_include l file include_defs @ preprocess dir target opts defs
-      )
-      else (
-        let help = "Make sure the filename is surrounded by quotes or angle brackets" in
-        Reporting.warn "" l ("Skipping bad $include " ^ file ^ ". " ^ help);
-        preprocess dir target opts defs
-      )
-  | DEF_aux (DEF_pragma ("suppress_warnings", _), l) :: defs ->
-      begin
-        match Reporting.simp_loc l with
-        | None -> () (* This shouldn't happen, but if it does just continue *)
-        | Some (p, _) -> Reporting.suppress_warnings_for_file p.pos_fname
-      end;
-      preprocess dir target opts defs
-  (* Filter file_start and file_end out of the AST so when we
-     round-trip files through the compiler we don't end up with
-     incorrect start/end annotations *)
-  | (DEF_aux (DEF_pragma ("file_start", _), _) | DEF_aux (DEF_pragma ("file_end", _), _)) :: defs ->
-      preprocess dir target opts defs
-  | DEF_aux (DEF_pragma (p, arg), l) :: defs ->
-      if not (StringSet.mem p all_pragmas) then Reporting.warn "" l ("Unrecognised directive: " ^ p);
-      DEF_aux (DEF_pragma (p, arg), l) :: preprocess dir target opts defs
-  | DEF_aux (DEF_outcome (outcome_spec, inner_defs), l) :: defs ->
-      DEF_aux (DEF_outcome (outcome_spec, preprocess dir target opts inner_defs), l) :: preprocess dir target opts defs
-  | (DEF_aux (DEF_default (DT_aux (DT_order (_, ATyp_aux (atyp, _)), _)), l) as def) :: defs -> begin
-      match atyp with
-      | Parse_ast.ATyp_inc ->
-          symbols := StringSet.add "_DEFAULT_INC" !symbols;
-          def :: preprocess dir target opts defs
-      | Parse_ast.ATyp_dec ->
-          symbols := StringSet.add "_DEFAULT_DEC" !symbols;
-          def :: preprocess dir target opts defs
-      | _ -> def :: preprocess dir target opts defs
-    end
-  | def :: defs -> def :: preprocess dir target opts defs
+    | def :: defs -> aux (def :: acc) defs
+  in
+  aux []

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -6013,13 +6013,15 @@ and check_def : Env.t -> uannot def -> tannot def list * Env.t =
 
 and check_defs_progress : int -> int -> Env.t -> uannot def list -> tannot def list * Env.t =
  fun n total env defs ->
-  match defs with
-  | [] -> ([], env)
-  | def :: defs ->
-      Util.progress "Type check " (string_of_int n ^ "/" ^ string_of_int total) n total;
-      let def, env = check_def env def in
-      let defs, env = check_defs_progress (n + 1) total env defs in
-      (def @ defs, env)
+  let rec aux n total acc env defs =
+    match defs with
+    | [] -> (List.rev acc, env)
+    | def :: defs ->
+        Util.progress "Type check " (string_of_int n ^ "/" ^ string_of_int total) n total;
+        let def, env = check_def env def in
+        aux (n + 1) total (List.rev def @ acc) env defs
+  in
+  aux n total [] env defs
 
 and check_defs : Env.t -> uannot def list -> tannot def list * Env.t =
  fun env defs ->


### PR DESCRIPTION
Makes Sail happier with large models, mostly by tail calling recursive functions over all top level syntax, but also by avoiding snocs when sorting.