### PR TITLE
Allow compiling generated C code with a C++ compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all isail sail install coverage clean docker test
+.PHONY: all isail sail install coverage clean docker test core-tests c-tests
 
 all: sail
 
@@ -25,3 +25,6 @@ test:
 
 core-tests:
 	SAIL_DIR=`pwd` SAIL=`pwd`/sail test/run_core_tests.sh
+
+c-tests:
+	SAIL_DIR=`pwd` SAIL=`pwd`/sail test/c/run_tests.py

--- a/lib/elf.c
+++ b/lib/elf.c
@@ -77,6 +77,10 @@
 // Use the zlib library to uncompress ELF.gz files
 #include <zlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Define ELF constants/types. These come from the
 // Tool Interface Standard Executable and Linking Format Specification 1.2
 
@@ -628,3 +632,6 @@ fail:
 // ELF Loader
 ////////////////////////////////////////////////////////////////
 
+#ifdef __cplusplus
+}
+#endif

--- a/lib/elf.h
+++ b/lib/elf.h
@@ -71,5 +71,13 @@
 #include<stdbool.h>
 #include<stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void load_elf(char *filename, bool *is32bit_p, uint64_t *entry);
 int  lookup_sym(const char *filename, const char *symname, uint64_t *value);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/int128/rts.c
+++ b/lib/int128/rts.c
@@ -10,13 +10,13 @@ static uint64_t g_elf_entry;
 uint64_t g_cycle_count = 0;
 static uint64_t g_cycle_limit;
 
-void sail_match_failure(sail_string msg)
+void sail_match_failure(const_sail_string msg)
 {
   fprintf(stderr, "Pattern match failure in %s\n", msg);
   exit(EXIT_FAILURE);
 }
 
-unit sail_assert(bool b, sail_string msg)
+unit sail_assert(bool b, const_sail_string msg)
 {
   if (b) return UNIT;
   fprintf(stderr, "Assertion failed: %s\n", msg);

--- a/lib/int128/rts.c
+++ b/lib/int128/rts.c
@@ -297,7 +297,7 @@ void read_ram(lbits *data,
   }
 }
 
-unit load_raw(fbits addr, const sail_string file)
+unit load_raw(fbits addr, const_sail_string file)
 {
   FILE *fp = fopen(file, "r");
 

--- a/lib/int128/rts.h
+++ b/lib/int128/rts.h
@@ -10,13 +10,13 @@
  * This function should be called whenever a pattern match failure
  * occurs. Pattern match failures are always fatal.
  */
-void sail_match_failure(sail_string msg);
+void sail_match_failure(const_sail_string msg);
 
 /*
  * sail_assert implements the assert construct in Sail. If any
  * assertion fails we immediately exit the model.
  */
-unit sail_assert(bool b, sail_string msg);
+unit sail_assert(bool b, const_sail_string msg);
 
 unit sail_exit(unit);
 
@@ -104,5 +104,5 @@ int process_arguments(int, char**);
 void setup_rts(void);
 void cleanup_rts(void);
 
-unit z__SetConfig(sail_string, sail_int);
+unit z__SetConfig(const_sail_string, sail_int);
 unit z__ListConfig(const unit u);

--- a/lib/int128/rts.h
+++ b/lib/int128/rts.h
@@ -71,7 +71,7 @@ sbits fast_read_ram(const int64_t data_size,
 unit write_tag_bool(const fbits, const bool);
 bool read_tag_bool(const fbits);
 
-unit load_raw(fbits addr, const sail_string file);
+unit load_raw(fbits addr, const_sail_string file);
 
 void load_image(char *);
 

--- a/lib/int128/sail.c
+++ b/lib/int128/sail.c
@@ -48,10 +48,6 @@ bool eq_bit(const fbits a, const fbits b)
 
 /* ***** Sail booleans ***** */
 
-bool not(const bool b) {
-  return !b;
-}
-
 bool EQUAL(bool)(const bool a, const bool b) {
   return a == b;
 }

--- a/lib/int128/sail.c
+++ b/lib/int128/sail.c
@@ -125,17 +125,17 @@ void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str
   strcat(*stro, str2);
 }
 
-bool string_startswith(sail_string s, sail_string prefix)
+bool string_startswith(const_sail_string s, const_sail_string prefix)
 {
   return strstr(s, prefix) == s;
 }
 
-sail_int string_length(sail_string s)
+sail_int string_length(const_sail_string s)
 {
   return (sail_int) strlen(s);
 }
 
-void string_drop(sail_string *dst, sail_string s, sail_int ns)
+void string_drop(sail_string *dst, const_sail_string s, sail_int ns)
 {
   size_t len = strlen(s);
   mach_int n = CREATE_OF(mach_int, sail_int)(ns);
@@ -149,7 +149,7 @@ void string_drop(sail_string *dst, sail_string s, sail_int ns)
   }
 }
 
-void string_take(sail_string *dst, sail_string s, sail_int ns)
+void string_take(sail_string *dst, const_sail_string s, sail_int ns)
 {
   size_t len = strlen(s);
   mach_int n = CREATE_OF(mach_int, sail_int)(ns);

--- a/lib/int128/sail.c
+++ b/lib/int128/sail.c
@@ -73,7 +73,7 @@ void RECREATE(sail_string)(sail_string *str)
   *str = istr;
 }
 
-void COPY(sail_string)(sail_string *str1, const sail_string str2)
+void COPY(sail_string)(sail_string *str1, const_sail_string str2)
 {
   size_t len = strlen(str2);
   *str1 = realloc(*str1, len + 1);
@@ -105,19 +105,19 @@ void hex_str(sail_string *str, const sail_int n)
   //gmp_asprintf(str, "0x%Zx", n);
 }
 
-bool eq_string(const sail_string str1, const sail_string str2)
+bool eq_string(const_sail_string str1, const_sail_string str2)
 {
   return strcmp(str1, str2) == 0;
 }
 
-bool EQUAL(sail_string)(const sail_string str1, const sail_string str2)
+bool EQUAL(sail_string)(const_sail_string str1, const_sail_string str2)
 {
   return strcmp(str1, str2) == 0;
 }
 
 void undefined_string(sail_string *str, const unit u) {}
 
-void concat_str(sail_string *stro, const sail_string str1, const sail_string str2)
+void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2)
 {
   *stro = realloc(*stro, strlen(str1) + strlen(str2) + 1);
   (*stro)[0] = '\0';
@@ -196,7 +196,7 @@ sail_int CONVERT_OF(sail_int, mach_int)(const mach_int op)
   return (sail_int) op;
 }
 
-sail_int CONVERT_OF(sail_int, sail_string)(const sail_string str)
+sail_int CONVERT_OF(sail_int, sail_string)(const_sail_string str)
 {
   mpz_t tmp;
   mpz_init(tmp);
@@ -1323,13 +1323,13 @@ void real_power(real *rop, const real base, const sail_int exp)
   mpq_clear(b);
 }
 
-void CREATE_OF(real, sail_string)(real *rop, const sail_string op)
+void CREATE_OF(real, sail_string)(real *rop, const_sail_string op)
 {
   mpq_init(*rop);
   CONVERT_OF(real, sail_string)(rop, op);
 }
 
-void CONVERT_OF(real, sail_string)(real *rop, const sail_string op)
+void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op)
 {
   int decimal;
   int total;
@@ -1359,13 +1359,13 @@ void CONVERT_OF(real, sail_string)(real *rop, const sail_string op)
   mpq_clear(tmp_real);
 }
 
-unit print_real(const sail_string str, const real op)
+unit print_real(const_sail_string str, const real op)
 {
   gmp_printf("%s%Qd\n", str, op);
   return UNIT;
 }
 
-unit prerr_real(const sail_string str, const real op)
+unit prerr_real(const_sail_string str, const real op)
 {
   gmp_fprintf(stderr, "%s%Qd\n", str, op);
   return UNIT;
@@ -1431,9 +1431,9 @@ void decimal_string_of_lbits(sail_string *str, const lbits op)
   gmp_asprintf(str, "%Z", *op.bits);
 }
 
-void fprint_bits(const sail_string pre,
+void fprint_bits(const_sail_string pre,
 		 const lbits op,
-		 const sail_string post,
+		 const_sail_string post,
 		 FILE *stream)
 {
   fputs(pre, stream);
@@ -1467,43 +1467,43 @@ void fprint_bits(const sail_string pre,
   fputs(post, stream);
 }
 
-unit print_bits(const sail_string str, const lbits op)
+unit print_bits(const_sail_string str, const lbits op)
 {
   fprint_bits(str, op, "\n", stdout);
   return UNIT;
 }
 
-unit prerr_bits(const sail_string str, const lbits op)
+unit prerr_bits(const_sail_string str, const lbits op)
 {
   fprint_bits(str, op, "\n", stderr);
   return UNIT;
 }
 
-unit print(const sail_string str)
+unit print(const_sail_string str)
 {
   printf("%s", str);
   return UNIT;
 }
 
-unit print_endline(const sail_string str)
+unit print_endline(const_sail_string str)
 {
   printf("%s\n", str);
   return UNIT;
 }
 
-unit prerr(const sail_string str)
+unit prerr(const_sail_string str)
 {
   fprintf(stderr, "%s", str);
   return UNIT;
 }
 
-unit prerr_endline(const sail_string str)
+unit prerr_endline(const_sail_string str)
 {
   fprintf(stderr, "%s\n", str);
   return UNIT;
 }
 
-unit print_int(const sail_string str, const sail_int op)
+unit print_int(const_sail_string str, const sail_int op)
 {
   mpz_t op_mpz;
   mpz_init_set_si128(op_mpz, op);
@@ -1516,7 +1516,7 @@ unit print_int(const sail_string str, const sail_int op)
   return UNIT;
 }
 
-unit prerr_int(const sail_string str, const sail_int op)
+unit prerr_int(const_sail_string str, const sail_int op)
 {
   fputs(str, stderr);
   //mpz_out_str(stderr, 10, op);

--- a/lib/int128/sail.h
+++ b/lib/int128/sail.h
@@ -67,15 +67,16 @@ bool UNDEFINED(bool)(const unit);
  * Sail strings are just C strings.
  */
 typedef char *sail_string;
+typedef const char *const_sail_string;
 
 SAIL_BUILTIN_TYPE(sail_string);
 
 void undefined_string(sail_string *str, const unit u);
 
-bool eq_string(const sail_string, const sail_string);
-bool EQUAL(sail_string)(const sail_string, const sail_string);
+bool eq_string(const_sail_string, const_sail_string);
+bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 
-void concat_str(sail_string *stro, const sail_string str1, const sail_string str2);
+void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
 bool string_startswith(sail_string s, sail_string prefix);
 
 /* ***** Sail integers ***** */
@@ -100,7 +101,7 @@ mach_int CREATE_OF(mach_int, sail_int)(const sail_int);
 
 mach_int CONVERT_OF(mach_int, sail_int)(const sail_int);
 sail_int CONVERT_OF(sail_int, mach_int)(const mach_int);
-sail_int CONVERT_OF(sail_int, sail_string)(const sail_string);
+sail_int CONVERT_OF(sail_int, sail_string)(const_sail_string);
 
 /*
  * Comparison operators for integers
@@ -334,8 +335,8 @@ typedef mpq_t real;
 
 SAIL_BUILTIN_TYPE(real);
 
-void CREATE_OF(real, sail_string)(real *rop, const sail_string op);
-void CONVERT_OF(real, sail_string)(real *rop, const sail_string op);
+void CREATE_OF(real, sail_string)(real *rop, const_sail_string op);
+void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op);
 
 void UNDEFINED(real)(real *rop, unit u);
 
@@ -363,8 +364,8 @@ bool gteq_real(const real op1, const real op2);
 
 void real_power(real *rop, const real base, const sail_int exp);
 
-unit print_real(const sail_string, const real);
-unit prerr_real(const sail_string, const real);
+unit print_real(const_sail_string, const real);
+unit prerr_real(const_sail_string, const real);
 
 void random_real(real *rop, unit);
 
@@ -385,22 +386,22 @@ void decimal_string_of_fbits(sail_string *str, const fbits op);
 /*
  * Utility function not callable from Sail!
  */
-void fprint_bits(const sail_string pre,
+void fprint_bits(const_sail_string pre,
 		 const lbits op,
-		 const sail_string post,
+		 const_sail_string post,
 		 FILE *stream);
 
-unit print_bits(const sail_string str, const lbits op);
-unit prerr_bits(const sail_string str, const lbits op);
+unit print_bits(const_sail_string str, const lbits op);
+unit prerr_bits(const_sail_string str, const lbits op);
 
-unit print(const sail_string str);
-unit print_endline(const sail_string str);
+unit print(const_sail_string str);
+unit print_endline(const_sail_string str);
 
-unit prerr(const sail_string str);
-unit prerr_endline(const sail_string str);
+unit prerr(const_sail_string str);
+unit prerr_endline(const_sail_string str);
 
-unit print_int(const sail_string str, const sail_int op);
-unit prerr_int(const sail_string str, const sail_int op);
+unit print_int(const_sail_string str, const sail_int op);
+unit prerr_int(const_sail_string str, const sail_int op);
 
 unit sail_putchar(const sail_int op);
 

--- a/lib/int128/sail.h
+++ b/lib/int128/sail.h
@@ -52,7 +52,12 @@ unit skip(const unit);
  * and_bool and or_bool are special-cased by the compiler to ensure
  * short-circuiting evaluation.
  */
-bool not(const bool);
+#ifndef __cplusplus
+static inline bool not(bool b)
+{
+     return !b;
+}
+#endif
 bool EQUAL(bool)(const bool, const bool);
 bool UNDEFINED(bool)(const unit);
 

--- a/lib/int128/sail.h
+++ b/lib/int128/sail.h
@@ -77,7 +77,7 @@ bool eq_string(const_sail_string, const_sail_string);
 bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 
 void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
-bool string_startswith(sail_string s, sail_string prefix);
+bool string_startswith(const_sail_string s, const_sail_string prefix);
 
 /* ***** Sail integers ***** */
 
@@ -372,8 +372,8 @@ void random_real(real *rop, unit);
 /* ***** String utilities ***** */
 
 SAIL_INT_FUNCTION(string_length, sail_int, sail_string);
-void string_drop(sail_string *dst, sail_string s, sail_int len);
-void string_take(sail_string *dst, sail_string s, sail_int len);
+void string_drop(sail_string *dst, const_sail_string s, sail_int len);
+void string_take(sail_string *dst, const_sail_string s, sail_int len);
 
 /* ***** Printing ***** */
 

--- a/lib/nostd/sail.c
+++ b/lib/nostd/sail.c
@@ -29,7 +29,7 @@ void RECREATE(sail_string)(sail_string *str)
      *str = istr;
 }
 
-size_t sail_strlen(const sail_string str)
+size_t sail_strlen(const_sail_string str)
 {
      size_t i = 0;
      while (true) {
@@ -71,7 +71,7 @@ char *sail_strcat(char *dest, const char *src)
      return sail_strcpy(dest + i, src);
 }
 
-void COPY(sail_string)(sail_string *str1, const sail_string str2)
+void COPY(sail_string)(sail_string *str1, const_sail_string str2)
 {
      size_t len = sail_strlen(str2);
      *str1 = sail_realloc(*str1, len + 1);
@@ -83,19 +83,19 @@ void KILL(sail_string)(sail_string *str)
      sail_free(*str);
 }
 
-bool eq_string(const sail_string str1, const sail_string str2)
+bool eq_string(const_sail_string str1, const_sail_string str2)
 {
      return sail_strcmp(str1, str2) == 0;
 }
 
-bool EQUAL(sail_string)(const sail_string str1, const sail_string str2)
+bool EQUAL(sail_string)(const_sail_string str1, const_sail_string str2)
 {
      return sail_strcmp(str1, str2) == 0;
 }
 
 void undefined_string(sail_string *str, const unit u) {}
 
-void concat_str(sail_string *stro, const sail_string str1, const sail_string str2)
+void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2)
 {
      *stro = sail_realloc(*stro, sail_strlen(str1) + sail_strlen(str2) + 1);
      (*stro)[0] = '\0';

--- a/lib/nostd/sail.h
+++ b/lib/nostd/sail.h
@@ -74,10 +74,12 @@ static inline bool EQUAL(unit)(const unit u1, const unit u2)
  * proper short-circuiting evaluation.
  */
 
-static inline bool not(const bool b)
+#ifndef __cplusplus
+static inline bool not(bool b)
 {
      return !b;
 }
+#endif
 
 static inline bool EQUAL(bool)(const bool a, const bool b)
 {

--- a/lib/nostd/sail.h
+++ b/lib/nostd/sail.h
@@ -99,15 +99,16 @@ static inline bool UNDEFINED(bool)(const unit u)
  * Sail strings are just C strings.
  */
 typedef char *sail_string;
+typedef const char *const_sail_string;
 
 SAIL_BUILTIN_TYPE(sail_string)
 
 void undefined_string(sail_string *str, const unit u);
 
-bool eq_string(const sail_string, const sail_string);
-bool EQUAL(sail_string)(const sail_string, const sail_string);
+bool eq_string(const_sail_string, const_sail_string);
+bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 
-void concat_str(sail_string *stro, const sail_string str1, const sail_string str2);
+void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
 bool string_startswith(sail_string s, sail_string prefix);
 
 /* ********************************************************************** */
@@ -163,11 +164,11 @@ static inline uint64_t sail_int_get_ui(const sail_int op)
 #endif
 
 SAIL_INT_FUNCTION(CREATE_OF(sail_int, mach_int), const mach_int);
-SAIL_INT_FUNCTION(CREATE_OF(sail_int, sail_string), const sail_string);
+SAIL_INT_FUNCTION(CREATE_OF(sail_int, sail_string), const_sail_string);
 mach_int CREATE_OF(mach_int, sail_int)(const sail_int);
 
 SAIL_INT_FUNCTION(CONVERT_OF(sail_int, mach_int), const mach_int);
-SAIL_INT_FUNCTION(CONVERT_OF(sail_int, sail_string), const sail_string);
+SAIL_INT_FUNCTION(CONVERT_OF(sail_int, sail_string), const_sail_string);
 mach_int CONVERT_OF(mach_int, sail_int)(const sail_int);
 
 /*
@@ -361,8 +362,8 @@ typedef mpq_t real;
 
 SAIL_BUILTIN_TYPE(real)
 
-void CREATE_OF(real, sail_string)(real *rop, const sail_string op);
-void CONVERT_OF(real, sail_string)(real *rop, const sail_string op);
+void CREATE_OF(real, sail_string)(real *rop, const_sail_string op);
+void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op);
 
 void UNDEFINED(real)(real *rop, unit u);
 

--- a/lib/nostd/sail.h
+++ b/lib/nostd/sail.h
@@ -109,7 +109,7 @@ bool eq_string(const_sail_string, const_sail_string);
 bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 
 void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
-bool string_startswith(sail_string s, sail_string prefix);
+bool string_startswith(const_sail_string s, const_sail_string prefix);
 
 /* ********************************************************************** */
 /* Sail integers                                                          */

--- a/lib/rts.c
+++ b/lib/rts.c
@@ -73,6 +73,10 @@
 #include "rts.h"
 #include "elf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static uint64_t g_elf_entry;
 uint64_t g_cycle_count = 0;
 static uint64_t g_cycle_limit;
@@ -707,3 +711,7 @@ void cleanup_rts(void)
   cleanup_library();
   kill_mem();
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/rts.c
+++ b/lib/rts.c
@@ -386,7 +386,7 @@ unit platform_barrier()
 }
 
 
-unit load_raw(fbits addr, const sail_string file)
+unit load_raw(fbits addr, const_sail_string file)
 {
   FILE *fp = fopen(file, "r");
 
@@ -472,7 +472,7 @@ void trace_unit(const unit u) {
   if (g_trace_enabled) fputs("()", stderr);
 }
 
-void trace_sail_string(const sail_string str) {
+void trace_sail_string(const_sail_string str) {
   if (g_trace_enabled) fputs(str, stderr);
 }
 

--- a/lib/rts.c
+++ b/lib/rts.c
@@ -163,9 +163,9 @@ void write_mem(uint64_t address, uint64_t byte)
    * If we couldn't find a block matching the mask, allocate a new
    * one, write the byte, and put it at the front of the block list.
    */
-  struct block *new_block = malloc(sizeof(struct block));
+  struct block *new_block = (struct block *)malloc(sizeof(struct block));
   new_block->block_id = mask;
-  new_block->mem = calloc(MASK + 1, sizeof(uint8_t));
+  new_block->mem = (uint8_t *)calloc(MASK + 1, sizeof(uint8_t));
   new_block->mem[offset] = (uint8_t) byte;
   new_block->next = sail_memory;
   sail_memory = new_block;
@@ -209,9 +209,9 @@ unit write_tag_bool(const uint64_t address, const bool tag)
    * If we couldn't find a block matching the mask, allocate a new
    * one, write the byte, and put it at the front of the block list.
    */
-  struct tag_block *new_block = malloc(sizeof(struct tag_block));
+  struct tag_block *new_block = (struct tag_block *)malloc(sizeof(struct tag_block));
   new_block->block_id = mask;
-  new_block->mem = calloc(MASK + 1, sizeof(bool));
+  new_block->mem = (bool *)calloc(MASK + 1, sizeof(bool));
   new_block->mem[offset] = tag;
   new_block->next = sail_tags;
   sail_tags = new_block;

--- a/lib/rts.c
+++ b/lib/rts.c
@@ -297,7 +297,7 @@ sbits fast_read_ram(const int64_t data_size,
     r = r << 8;
     r = r + byte;
   }
-  sbits res = {.len = data_size * 8, .bits = r };
+  sbits res = {.len = (uint64_t)data_size * 8, .bits = r };
   return res;
 }
 

--- a/lib/rts.h
+++ b/lib/rts.h
@@ -147,7 +147,7 @@ unit platform_barrier();
 
 
 
-unit load_raw(fbits addr, const sail_string file);
+unit load_raw(fbits addr, const_sail_string file);
 
 void load_image(char *);
 
@@ -184,7 +184,7 @@ bool is_tracing(const unit);
 void trace_sail_int(const sail_int);
 void trace_bool(const bool);
 void trace_unit(const unit);
-void trace_sail_string(const sail_string);
+void trace_sail_string(const_sail_string);
 void trace_fbits(const fbits);
 void trace_lbits(const lbits);
 

--- a/lib/rts.h
+++ b/lib/rts.h
@@ -75,6 +75,10 @@
 #include "sail.h"
 #include "sail_failure.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 unit sail_exit(unit);
 
 /*
@@ -226,5 +230,9 @@ void cleanup_rts(void);
 
 unit z__SetConfig(sail_string, sail_int);
 unit z__ListConfig(const unit u);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/rts.h
+++ b/lib/rts.h
@@ -228,7 +228,7 @@ int process_arguments(int, char**);
 void setup_rts(void);
 void cleanup_rts(void);
 
-unit z__SetConfig(sail_string, sail_int);
+unit z__SetConfig(const_sail_string, sail_int);
 unit z__ListConfig(const unit u);
 
 #ifdef __cplusplus

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -78,6 +78,10 @@
 
 #include"sail.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // zero bits from high index, same semantics as bzhi intrinsic
 uint64_t bzhi_u64(uint64_t bits, uint64_t len)
 {
@@ -1770,3 +1774,7 @@ void size_itself_int(sail_int *rop, const sail_int op)
 {
   mpz_set(*rop, op);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -260,7 +260,6 @@ uint64_t sail_int_get_ui(const mpz_t op)
   return mpz_get_ui(op);
 }
 
-inline
 bool EQUAL(mach_int)(const mach_int op1, const mach_int op2)
 {
   return op1 == op2;
@@ -268,109 +267,91 @@ bool EQUAL(mach_int)(const mach_int op1, const mach_int op2)
 
 #ifndef USE_INT128
 
-inline
 void COPY(sail_int)(sail_int *rop, const sail_int op)
 {
   mpz_set(*rop, op);
 }
 
-inline
 void CREATE(sail_int)(sail_int *rop)
 {
   mpz_init(*rop);
 }
 
-inline
 void RECREATE(sail_int)(sail_int *rop)
 {
   mpz_set_ui(*rop, 0);
 }
 
-inline
 void KILL(sail_int)(sail_int *rop)
 {
   mpz_clear(*rop);
 }
 
-inline
 void CREATE_OF(sail_int, mach_int)(sail_int *rop, mach_int op)
 {
   mpz_init_set_si(*rop, op);
 }
 
-inline
 mach_int CREATE_OF(mach_int, sail_int)(const sail_int op)
 {
   return mpz_get_ui(op);
 }
 
-inline
 void RECREATE_OF(sail_int, mach_int)(sail_int *rop, mach_int op)
 {
   mpz_set_si(*rop, op);
 }
 
-inline
-void CREATE_OF(sail_int, sail_string)(sail_int *rop, sail_string str)
+void CREATE_OF(sail_int, sail_string)(sail_int *rop, const_sail_string str)
 {
   mpz_init_set_str(*rop, str, 10);
 }
 
-inline
-void CONVERT_OF(sail_int, sail_string)(sail_int *rop, sail_string str)
+void CONVERT_OF(sail_int, sail_string)(sail_int *rop, const_sail_string str)
 {
   mpz_set_str(*rop, str, 10);
 }
 
-inline
-void RECREATE_OF(sail_int, sail_string)(mpz_t *rop, sail_string str)
+void RECREATE_OF(sail_int, sail_string)(mpz_t *rop, const_sail_string str)
 {
   mpz_set_str(*rop, str, 10);
 }
 
-inline
 mach_int CONVERT_OF(mach_int, sail_int)(const sail_int op)
 {
   return mpz_get_si(op);
 }
 
-inline
 void CONVERT_OF(sail_int, mach_int)(sail_int *rop, const mach_int op)
 {
   mpz_set_si(*rop, op);
 }
 
-inline
 bool eq_int(const sail_int op1, const sail_int op2)
 {
   return !abs(mpz_cmp(op1, op2));
 }
 
-inline
 bool EQUAL(sail_int)(const sail_int op1, const sail_int op2)
 {
   return !abs(mpz_cmp(op1, op2));
 }
 
-inline
 bool lt(const sail_int op1, const sail_int op2)
 {
   return mpz_cmp(op1, op2) < 0;
 }
 
-inline
 bool gt(const mpz_t op1, const mpz_t op2)
 {
   return mpz_cmp(op1, op2) > 0;
 }
 
-inline
 bool lteq(const mpz_t op1, const mpz_t op2)
 {
   return mpz_cmp(op1, op2) <= 0;
 }
 
-inline
 bool gteq(const mpz_t op1, const mpz_t op2)
 {
   return mpz_cmp(op1, op2) >= 0;
@@ -396,7 +377,6 @@ mach_int shr_mach_int(const mach_int op1, const mach_int op2)
   return op1 >> op2;
 }
 
-inline
 void undefined_int(sail_int *rop, const int n)
 {
   mpz_set_ui(*rop, (uint64_t) n);
@@ -407,19 +387,16 @@ void undefined_nat(sail_int *rop, const unit u)
   mpz_set_ui(*rop, 0);
 }
 
-inline
 void undefined_range(sail_int *rop, const sail_int l, const sail_int u)
 {
   mpz_set(*rop, l);
 }
 
-inline
 void add_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_add(*rop, op1, op2);
 }
 
-inline
 void sub_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_sub(*rop, op1, op2);
@@ -433,14 +410,11 @@ void sub_nat(sail_int *rop, const sail_int op1, const sail_int op2)
   }
 }
 
-inline
 void mult_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_mul(*rop, op1, op2);
 }
 
-
-inline
 void ediv_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   /* GMP doesn't have Euclidean division but we can emulate it using 
@@ -452,7 +426,6 @@ void ediv_int(sail_int *rop, const sail_int op1, const sail_int op2)
   }
 }
 
-inline
 void emod_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   /* The documentation isn't that explicit but I think this is 
@@ -460,25 +433,21 @@ void emod_int(sail_int *rop, const sail_int op1, const sail_int op2)
   mpz_mod(*rop, op1, op2);
 }
 
-inline
 void tdiv_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_tdiv_q(*rop, op1, op2);
 }
 
-inline
 void tmod_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_tdiv_r(*rop, op1, op2);
 }
 
-inline
 void fdiv_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_fdiv_q(*rop, op1, op2);
 }
 
-inline
 void fmod_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   mpz_fdiv_r(*rop, op1, op2);
@@ -502,19 +471,16 @@ void min_int(sail_int *rop, const sail_int op1, const sail_int op2)
   }
 }
 
-inline
 void neg_int(sail_int *rop, const sail_int op)
 {
   mpz_neg(*rop, op);
 }
 
-inline
 void abs_int(sail_int *rop, const sail_int op)
 {
   mpz_abs(*rop, op);
 }
 
-inline
 void pow_int(sail_int *rop, const sail_int op1, const sail_int op2)
 {
   uint64_t n = mpz_get_ui(op2);
@@ -619,13 +585,11 @@ void RECREATE_OF(lbits, sbits)(lbits *rop, const sbits op, const bool direction)
 
 // Bitvector conversions
 
-inline
 fbits CONVERT_OF(fbits, lbits)(const lbits op, const bool direction)
 {
   return mpz_get_ui(*op.bits);
 }
 
-inline
 fbits CONVERT_OF(fbits, sbits)(const sbits op, const bool direction)
 {
   return op.bits;
@@ -644,7 +608,6 @@ void CONVERT_OF(lbits, sbits)(lbits *rop, const sbits op, const bool direction)
   mpz_set_ui(*rop->bits, op.bits & safe_rshift(UINT64_MAX, 64 - op.len));
 }
 
-inline
 sbits CONVERT_OF(sbits, fbits)(const fbits op, const uint64_t len, const bool direction)
 {
   sbits rop;
@@ -653,7 +616,6 @@ sbits CONVERT_OF(sbits, fbits)(const fbits op, const uint64_t len, const bool di
   return rop;
 }
 
-inline
 sbits CONVERT_OF(sbits, lbits)(const lbits op, const bool direction)
 {
   sbits rop;

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -214,17 +214,17 @@ void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str
   strcat(*stro, str2);
 }
 
-bool string_startswith(sail_string s, sail_string prefix)
+bool string_startswith(const_sail_string s, const_sail_string prefix)
 {
   return strstr(s, prefix) == s;
 }
 
-void string_length(sail_int *len, sail_string s)
+void string_length(sail_int *len, const_sail_string s)
 {
   mpz_set_ui(*len, strlen(s));
 }
 
-void string_drop(sail_string *dst, sail_string s, sail_int ns)
+void string_drop(sail_string *dst, const_sail_string s, sail_int ns)
 {
   size_t len = strlen(s);
   mach_int n = CREATE_OF(mach_int, sail_int)(ns);
@@ -238,7 +238,7 @@ void string_drop(sail_string *dst, sail_string s, sail_int ns)
   }
 }
 
-void string_take(sail_string *dst, sail_string s, sail_int ns)
+void string_take(sail_string *dst, const_sail_string s, sail_int ns)
 {
   size_t len = strlen(s);
   mach_int n = CREATE_OF(mach_int, sail_int)(ns);

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -161,7 +161,7 @@ void RECREATE(sail_string)(sail_string *str)
 void COPY(sail_string)(sail_string *str1, const sail_string str2)
 {
   size_t len = strlen(str2);
-  *str1 = realloc(*str1, len + 1);
+  *str1 = (sail_string)realloc(*str1, len + 1);
   *str1 = strcpy(*str1, str2);
 }
 
@@ -202,7 +202,7 @@ void undefined_string(sail_string *str, const unit u) {}
 
 void concat_str(sail_string *stro, const sail_string str1, const sail_string str2)
 {
-  *stro = realloc(*stro, strlen(str1) + strlen(str2) + 1);
+  *stro = (sail_string)realloc(*stro, strlen(str1) + strlen(str2) + 1);
   (*stro)[0] = '\0';
   strcat(*stro, str1);
   strcat(*stro, str2);
@@ -223,11 +223,11 @@ void string_drop(sail_string *dst, sail_string s, sail_int ns)
   size_t len = strlen(s);
   mach_int n = CREATE_OF(mach_int, sail_int)(ns);
   if (len >= n) {
-    *dst = realloc(*dst, (len - n) + 1);
+    *dst = (sail_string)realloc(*dst, (len - n) + 1);
     memcpy(*dst, s + n, len - n);
     (*dst)[len - n] = '\0';
   } else {
-    *dst = realloc(*dst, 1);
+    *dst = (sail_string)realloc(*dst, 1);
     **dst = '\0';
   }
 }
@@ -242,7 +242,7 @@ void string_take(sail_string *dst, sail_string s, sail_int ns)
   } else {
     to_copy = n;
   }
-  *dst = realloc(*dst, to_copy + 1);
+  *dst = (sail_string)realloc(*dst, to_copy + 1);
   memcpy(*dst, s, to_copy);
   (*dst)[to_copy] = '\0';
 }
@@ -541,7 +541,7 @@ bool EQUAL(ref_fbits)(const fbits *op1, const fbits *op2)
 
 void CREATE(lbits)(lbits *rop)
 {
-  rop->bits = sail_malloc(sizeof(mpz_t));
+  rop->bits = (mpz_t *)sail_malloc(sizeof(mpz_t));
   rop->len = 0;
   mpz_init(*rop->bits);
 }
@@ -566,7 +566,7 @@ void KILL(lbits)(lbits *rop)
 
 void CREATE_OF(lbits, fbits)(lbits *rop, const uint64_t op, const uint64_t len, const bool direction)
 {
-  rop->bits = sail_malloc(sizeof(mpz_t));
+  rop->bits = (mpz_t *)sail_malloc(sizeof(mpz_t));
   rop->len = len;
   mpz_init_set_ui(*rop->bits, op);
 }
@@ -600,7 +600,7 @@ void RECREATE_OF(lbits, fbits)(lbits *rop, const uint64_t op, const uint64_t len
 
 void CREATE_OF(lbits, sbits)(lbits *rop, const sbits op, const bool direction)
 {
-  rop->bits = sail_malloc(sizeof(mpz_t));
+  rop->bits = (mpz_t *)sail_malloc(sizeof(mpz_t));
   rop->len = op.len;
   mpz_init_set_ui(*rop->bits, op.bits);
 }
@@ -1653,7 +1653,7 @@ void fprint_bits(const sail_string pre,
     mpz_t buf;
     mpz_init_set(buf, *op.bits);
 
-    char *hex = sail_malloc((op.len / 4) * sizeof(char));
+    char *hex = (char *)sail_malloc((op.len / 4) * sizeof(char));
 
     for (int i = 0; i < op.len / 4; ++i) {
       char c = (char) ((0xF & mpz_get_ui(buf)) + 0x30);

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -133,10 +133,6 @@ bool eq_bit(const fbits a, const fbits b)
 
 /* ***** Sail booleans ***** */
 
-bool not(const bool b) {
-  return !b;
-}
-
 bool EQUAL(bool)(const bool a, const bool b) {
   return a == b;
 }

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -158,7 +158,7 @@ void RECREATE(sail_string)(sail_string *str)
   *str = istr;
 }
 
-void COPY(sail_string)(sail_string *str1, const sail_string str2)
+void COPY(sail_string)(sail_string *str1, const_sail_string str2)
 {
   size_t len = strlen(str2);
   *str1 = (sail_string)realloc(*str1, len + 1);
@@ -188,19 +188,19 @@ void hex_str_upper(sail_string *str, const mpz_t n)
   gmp_asprintf(str, "0x%ZX", n);
 }
 
-bool eq_string(const sail_string str1, const sail_string str2)
+bool eq_string(const_sail_string str1, const_sail_string str2)
 {
   return strcmp(str1, str2) == 0;
 }
 
-bool EQUAL(sail_string)(const sail_string str1, const sail_string str2)
+bool EQUAL(sail_string)(const_sail_string str1, const_sail_string str2)
 {
   return strcmp(str1, str2) == 0;
 }
 
 void undefined_string(sail_string *str, const unit u) {}
 
-void concat_str(sail_string *stro, const sail_string str1, const sail_string str2)
+void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2)
 {
   *stro = (sail_string)realloc(*stro, strlen(str1) + strlen(str2) + 1);
   (*stro)[0] = '\0';
@@ -1497,7 +1497,7 @@ void real_power(real *rop, const real base, const sail_int exp)
   mpq_clear(b);
 }
 
-void CREATE_OF(real, sail_string)(real *rop, const sail_string op)
+void CREATE_OF(real, sail_string)(real *rop, const_sail_string op)
 {
   int decimal;
   int total;
@@ -1515,7 +1515,7 @@ void CREATE_OF(real, sail_string)(real *rop, const sail_string op)
   mpq_add(*rop, *rop, sail_lib_tmp_real);
 }
 
-void CONVERT_OF(real, sail_string)(real *rop, const sail_string op)
+void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op)
 {
   int decimal;
   int total;
@@ -1532,13 +1532,13 @@ void CONVERT_OF(real, sail_string)(real *rop, const sail_string op)
   mpq_add(*rop, *rop, sail_lib_tmp_real);
 }
 
-unit print_real(const sail_string str, const real op)
+unit print_real(const_sail_string str, const real op)
 {
   gmp_printf("%s%Qd\n", str, op);
   return UNIT;
 }
 
-unit prerr_real(const sail_string str, const real op)
+unit prerr_real(const_sail_string str, const real op)
 {
   gmp_fprintf(stderr, "%s%Qd\n", str, op);
   return UNIT;
@@ -1604,7 +1604,7 @@ void decimal_string_of_lbits(sail_string *str, const lbits op)
   gmp_asprintf(str, "%Z", *op.bits);
 }
 
-void parse_hex_bits(lbits *res, const mpz_t n, const sail_string hex)
+void parse_hex_bits(lbits *res, const mpz_t n, const_sail_string hex)
 {
   if (strncmp(hex, "0x", 2) != 0) {
     goto failure;
@@ -1626,7 +1626,7 @@ failure:
   mpz_set_ui(*res->bits, 0);
 }
 
-bool valid_hex_bits(const mpz_t n, const sail_string hex) {
+bool valid_hex_bits(const mpz_t n, const_sail_string hex) {
   if (strncmp(hex, "0x", 2) != 0) {
     return false;
   }
@@ -1641,9 +1641,9 @@ bool valid_hex_bits(const mpz_t n, const sail_string hex) {
   return true;
 }
 
-void fprint_bits(const sail_string pre,
+void fprint_bits(const_sail_string pre,
 		 const lbits op,
-		 const sail_string post,
+		 const_sail_string post,
 		 FILE *stream)
 {
   fputs(pre, stream);
@@ -1677,43 +1677,43 @@ void fprint_bits(const sail_string pre,
   fputs(post, stream);
 }
 
-unit print_bits(const sail_string str, const lbits op)
+unit print_bits(const_sail_string str, const lbits op)
 {
   fprint_bits(str, op, "\n", stdout);
   return UNIT;
 }
 
-unit prerr_bits(const sail_string str, const lbits op)
+unit prerr_bits(const_sail_string str, const lbits op)
 {
   fprint_bits(str, op, "\n", stderr);
   return UNIT;
 }
 
-unit print(const sail_string str)
+unit print(const_sail_string str)
 {
   printf("%s", str);
   return UNIT;
 }
 
-unit print_endline(const sail_string str)
+unit print_endline(const_sail_string str)
 {
   printf("%s\n", str);
   return UNIT;
 }
 
-unit prerr(const sail_string str)
+unit prerr(const_sail_string str)
 {
   fprintf(stderr, "%s", str);
   return UNIT;
 }
 
-unit prerr_endline(const sail_string str)
+unit prerr_endline(const_sail_string str)
 {
   fprintf(stderr, "%s\n", str);
   return UNIT;
 }
 
-unit print_int(const sail_string str, const sail_int op)
+unit print_int(const_sail_string str, const sail_int op)
 {
   fputs(str, stdout);
   mpz_out_str(stdout, 10, op);
@@ -1721,7 +1721,7 @@ unit print_int(const sail_string str, const sail_int op)
   return UNIT;
 }
 
-unit prerr_int(const sail_string str, const sail_int op)
+unit prerr_int(const_sail_string str, const sail_int op)
 {
   fputs(str, stderr);
   mpz_out_str(stderr, 10, op);

--- a/lib/sail.c
+++ b/lib/sail.c
@@ -65,7 +65,9 @@
 /*  SUCH DAMAGE.                                                            */
 /****************************************************************************/
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include<assert.h>
 #include<inttypes.h>
 #include<stdbool.h>

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -111,12 +111,12 @@ void cleanup_library(void);
 #define UNDEFINED(type) undefined_ ## type
 #define EQUAL(type) eq_ ## type
 
-#define SAIL_BUILTIN_TYPE(type)\
+#define SAIL_BUILTIN_TYPE_IMPL(type, const_type)\
   void create_ ## type(type *);\
   void recreate_ ## type(type *);\
-  void copy_ ## type(type *, const type);\
+  void copy_ ## type(type *, const_type);\
   void kill_ ## type(type *);
-
+#define SAIL_BUILTIN_TYPE(type) SAIL_BUILTIN_TYPE_IMPL(type, const type)
 /* ***** Sail unit type ***** */
 
 typedef int unit;
@@ -151,7 +151,7 @@ bool UNDEFINED(bool)(const unit);
 typedef char *sail_string;
 typedef const char *const_sail_string;
 
-SAIL_BUILTIN_TYPE(sail_string)
+SAIL_BUILTIN_TYPE_IMPL(sail_string, const_sail_string)
 
 void dec_str(sail_string *str, const mpz_t n);
 void hex_str(sail_string *str, const mpz_t n);

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -76,6 +76,10 @@
 
 #include <time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void *sail_malloc(size_t size)
 {
   return malloc(size);
@@ -524,5 +528,9 @@ void get_time_ns(sail_int*, const unit);
 /* ***** ARM optimisations ***** */
 
 void arm_align(lbits *, const lbits, const sail_int);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -145,6 +145,7 @@ bool UNDEFINED(bool)(const unit);
  * Sail strings are just C strings.
  */
 typedef char *sail_string;
+typedef const char *const_sail_string;
 
 SAIL_BUILTIN_TYPE(sail_string)
 
@@ -154,10 +155,10 @@ void hex_str_upper(sail_string *str, const mpz_t n);
 
 void undefined_string(sail_string *str, const unit u);
 
-bool eq_string(const sail_string, const sail_string);
-bool EQUAL(sail_string)(const sail_string, const sail_string);
+bool eq_string(const_sail_string, const_sail_string);
+bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 
-void concat_str(sail_string *stro, const sail_string str1, const sail_string str2);
+void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
 bool string_startswith(sail_string s, sail_string prefix);
 
                        
@@ -180,10 +181,10 @@ void RECREATE_OF(sail_int, mach_int)(sail_int *, const mach_int);
 
 mach_int CREATE_OF(mach_int, sail_int)(const sail_int);
 
-void CREATE_OF(sail_int, sail_string)(sail_int *, const sail_string);
-void RECREATE_OF(sail_int, sail_string)(mpz_t *, const sail_string);
+void CREATE_OF(sail_int, sail_string)(sail_int *, const_sail_string);
+void RECREATE_OF(sail_int, sail_string)(mpz_t *, const_sail_string);
 
-void CONVERT_OF(sail_int, sail_string)(sail_int *, const sail_string);
+void CONVERT_OF(sail_int, sail_string)(sail_int *, const_sail_string);
 
 mach_int CONVERT_OF(mach_int, sail_int)(const sail_int);
 void CONVERT_OF(sail_int, mach_int)(sail_int *, const mach_int);
@@ -439,8 +440,8 @@ typedef mpq_t real;
 
 SAIL_BUILTIN_TYPE(real)
 
-void CREATE_OF(real, sail_string)(real *rop, const sail_string op);
-void CONVERT_OF(real, sail_string)(real *rop, const sail_string op);
+void CREATE_OF(real, sail_string)(real *rop, const_sail_string op);
+void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op);
 
 void UNDEFINED(real)(real *rop, unit u);
 
@@ -468,8 +469,8 @@ bool gteq_real(const real op1, const real op2);
 
 void real_power(real *rop, const real base, const sail_int exp);
 
-unit print_real(const sail_string, const real);
-unit prerr_real(const sail_string, const real);
+unit print_real(const_sail_string, const real);
+unit prerr_real(const_sail_string, const real);
 
 void random_real(real *rop, unit);
 
@@ -490,29 +491,29 @@ void decimal_string_of_fbits(sail_string *str, const fbits op);
 
 /* ***** Mapping support ***** */
 
-void parse_hex_bits(lbits *stro, const mpz_t n, const sail_string str);
+void parse_hex_bits(lbits *stro, const mpz_t n, const_sail_string str);
 
-bool valid_hex_bits(const mpz_t n, const sail_string str);
+bool valid_hex_bits(const mpz_t n, const_sail_string str);
 
 /*
  * Utility function not callable from Sail!
  */
-void fprint_bits(const sail_string pre,
+void fprint_bits(const_sail_string pre,
 		 const lbits op,
-		 const sail_string post,
+		 const_sail_string post,
 		 FILE *stream);
 
-unit print_bits(const sail_string str, const lbits op);
-unit prerr_bits(const sail_string str, const lbits op);
+unit print_bits(const_sail_string str, const lbits op);
+unit prerr_bits(const_sail_string str, const lbits op);
 
-unit print(const sail_string str);
-unit print_endline(const sail_string str);
+unit print(const_sail_string str);
+unit print_endline(const_sail_string str);
 
-unit prerr(const sail_string str);
-unit prerr_endline(const sail_string str);
+unit prerr(const_sail_string str);
+unit prerr_endline(const_sail_string str);
 
-unit print_int(const sail_string str, const sail_int op);
-unit prerr_int(const sail_string str, const sail_int op);
+unit print_int(const_sail_string str, const sail_int op);
+unit prerr_int(const_sail_string str, const sail_int op);
 
 unit sail_putchar(const sail_int op);
 

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -90,6 +90,9 @@ static inline void sail_free(void *ptr)
   free(ptr);
 }
 
+#define sail_new(type) (type *)(sail_malloc(sizeof(type)))
+#define sail_new_array(type, len) (type *)(sail_malloc((len) * sizeof(type)))
+
 /*
  * Called by the RTS to initialise and clear any library state.
  */

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -130,7 +130,12 @@ unit skip(const unit);
  * and_bool and or_bool are special-cased by the compiler to ensure
  * short-circuiting evaluation.
  */
-bool not(const bool);
+#ifndef __cplusplus
+static inline bool not(bool b)
+{
+     return !b;
+}
+#endif
 bool EQUAL(bool)(const bool, const bool);
 bool UNDEFINED(bool)(const unit);
 

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -166,7 +166,7 @@ bool eq_string(const_sail_string, const_sail_string);
 bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 
 void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
-bool string_startswith(sail_string s, sail_string prefix);
+bool string_startswith(const_sail_string s, const_sail_string prefix);
 
                        
 /* ***** Sail integers ***** */
@@ -483,9 +483,9 @@ void random_real(real *rop, unit);
 
 /* ***** String utilities ***** */
 
-void string_length(sail_int *len, sail_string s);
-void string_drop(sail_string *dst, sail_string s, sail_int len);
-void string_take(sail_string *dst, sail_string s, sail_int len);
+void string_length(sail_int *len, const_sail_string s);
+void string_drop(sail_string *dst, const_sail_string s, sail_int len);
+void string_take(sail_string *dst, const_sail_string s, sail_int len);
 
 
 /* ***** Printing ***** */

--- a/lib/sail_coverage.h
+++ b/lib/sail_coverage.h
@@ -68,6 +68,10 @@
 #ifndef SAIL_COVERAGE_H
 #define SAIL_COVERAGE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int sail_coverage_exit(void);
 
 void sail_set_coverage_file(const char *output_file);
@@ -77,5 +81,9 @@ void sail_function_entry(const char *function_name, const char *sail_file, int l
 void sail_branch_taken(int branch_id, const char *sail_file, int l1, int c1, int l2, int c2);
 
 void sail_branch_reached(int branch_id, const char *sail_file, int l1, int c1, int l2, int c2);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/sail_failure.c
+++ b/lib/sail_failure.c
@@ -71,13 +71,13 @@
 extern "C" {
 #endif
 
-void sail_match_failure(sail_string msg)
+void sail_match_failure(const_sail_string msg)
 {
   fprintf(stderr, "Pattern match failure in %s\n", msg);
   exit(EXIT_FAILURE);
 }
 
-unit sail_assert(bool b, sail_string msg)
+unit sail_assert(bool b, const_sail_string msg)
 {
   if (b) return UNIT;
   fprintf(stderr, "Assertion failed: %s\n", msg);

--- a/lib/sail_failure.c
+++ b/lib/sail_failure.c
@@ -67,6 +67,10 @@
 
 #include "sail_failure.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void sail_match_failure(sail_string msg)
 {
   fprintf(stderr, "Pattern match failure in %s\n", msg);
@@ -79,3 +83,7 @@ unit sail_assert(bool b, sail_string msg)
   fprintf(stderr, "Assertion failed: %s\n", msg);
   exit(EXIT_FAILURE);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/sail_failure.h
+++ b/lib/sail_failure.h
@@ -70,6 +70,10 @@
 
 #include "sail.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This function should be called whenever a pattern match failure
  * occurs. Pattern match failures are always fatal.
@@ -81,5 +85,9 @@ void sail_match_failure(sail_string msg);
  * assertion fails we immediately exit the model.
  */
 unit sail_assert(bool b, sail_string msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/sail_failure.h
+++ b/lib/sail_failure.h
@@ -78,13 +78,13 @@ extern "C" {
  * This function should be called whenever a pattern match failure
  * occurs. Pattern match failures are always fatal.
  */
-void sail_match_failure(sail_string msg);
+void sail_match_failure(const_sail_string msg);
 
 /*
  * sail_assert implements the assert construct in Sail. If any
  * assertion fails we immediately exit the model.
  */
-unit sail_assert(bool b, sail_string msg);
+unit sail_assert(bool b, const_sail_string msg);
 
 #ifdef __cplusplus
 }

--- a/lib/sail_state.h
+++ b/lib/sail_state.h
@@ -68,7 +68,15 @@
 #ifndef SAIL_STATE_H
 #define SAIL_STATE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct sail_state;
 typedef struct sail_state sail_state;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1997,9 +1997,9 @@ let compile_ast env effect_info output_chan c_includes ast =
       if not (Bindings.mem (mk_id "exception") ctx.variants) then ([], [])
       else
         ( [
-            "  current_exception = sail_malloc(sizeof(struct zexception));";
+            "  current_exception = (struct zexception *)sail_malloc(sizeof(struct zexception));";
             "  CREATE(zexception)(current_exception);";
-            "  throw_location = sail_malloc(sizeof(sail_string));";
+            "  throw_location = (sail_string *)sail_malloc(sizeof(sail_string));";
             "  CREATE(sail_string)(throw_location);";
           ],
           [

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1275,11 +1275,11 @@ let rec codegen_instr fid ctx (I_aux (instr, (_, l))) =
         | CT_enum (_, ctor :: _) -> (sgen_id ctor, [])
         | CT_tup ctyps when is_stack_ctyp ctyp ->
             let gs = ngensym () in
-            let fold (inits, prev) (n, ctyp) =
+            let fold (n, ctyp) (inits, prev) =
               let init, prev' = codegen_exn_return ctyp in
               (Printf.sprintf ".ztup%d = %s" n init :: inits, prev @ prev')
             in
-            let inits, prev = List.fold_left fold ([], []) (List.mapi (fun i x -> (i, x)) ctyps) in
+            let inits, prev = List.fold_right fold (List.mapi (fun i x -> (i, x)) ctyps) ([], []) in
             ( sgen_name gs,
               [
                 Printf.sprintf "struct %s %s = { " (sgen_ctyp_name ctyp) (sgen_name gs)

--- a/test/c/includes/xlen_val.h
+++ b/test/c/includes/xlen_val.h
@@ -1,7 +1,15 @@
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int64_t zxlen_val;
 
 int64_t test(int64_t x) {
   return zxlen_val;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -85,22 +85,42 @@ class Results:
     def __init__(self, name):
         self.passes = 0
         self.failures = 0
+        self.xfails = 0
+        self._xfail_reasons = {}
         self.xml = ""
         self.name = name
+
+    def expect_failure(self, test, reason):
+        self._xfail_reasons[test] = reason
+
+    def _add_status(self, test, result, msg):
+        self.xml += f'    <testcase name="{test}">\n      <{result} message="{msg}">{msg}</{result}>\n    </testcase>\n'
+
+    def _add_failure(self, test, msg):
+        self.failures += 1
+        self._add_status(test, "error", msg)
 
     def collect(self, tests):
         for test in tests:
             _, status = os.waitpid(tests[test], 0)
+            if test in self._xfail_reasons:
+                reason = self._xfail_reasons[test]
+                if status == 0:
+                    self._add_failure(test, "XPASS: " + reason)
+                else:
+                    self.xfails += 1
+                    self._add_status(test, "skipped", "XFAIL: " + reason)
+                continue
             if status != 0:
-                self.failures += 1
-                self.xml += '    <testcase name="{}">\n      <error message="fail">fail</error>\n    </testcase>\n'.format(test)
+                self._add_failure(test, "fail")
             else:
                 self.passes += 1
                 self.xml += '    <testcase name="{}"/>\n'.format(test)
         sys.stdout.flush()
 
     def finish(self):
-        print('{}{} passes and {} failures{}'.format(color.NOTICE, self.passes, self.failures, color.END))
+        xfail_msg = f' ({self.xfails} expected failures)' if self.xfails else ''
+        print('{}{} passes and {} failures{}{}'.format(color.NOTICE, self.passes, self.failures, xfail_msg, color.END))
 
         time = datetime.datetime.utcnow()
         suite = '  <testsuite name="{}" tests="{}" failures="{}" timestamp="{}">\n{}  </testsuite>\n'

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -70,9 +70,9 @@ def step(string, expected_status=0):
     if status != expected_status:
         print("{}Failed{}: {}".format(color.FAIL, color.END, string))
         print('{}stdout{}:'.format(color.NOTICE, color.END))
-        print(out)
+        print(out.decode('utf-8'))
         print('{}stderr{}:'.format(color.NOTICE, color.END))
-        print(err)
+        print(err.decode('utf-8'))
         sys.exit(1)
 
 def banner(string):


### PR DESCRIPTION
All tests except for one pass with these changes.
The final test fails with `tl_pat.c:66:31: error: ‘zX::<unnamed union>::<unnamed struct>::zX’ has the same name as the class in which it is declared` which apparently is legal in C but not C++.

Closes: https://github.com/rems-project/sail/issues/197