### PR TITLE
Add new options to allow for a combinational output

### DIFF
--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -87,6 +87,9 @@ let opt_line_directives = ref false
 
 let opt_comb = ref false
 
+let opt_inregs = ref false
+let opt_outregs = ref false
+
 let verilog_options =
   [
     ( "-sv_verilate",
@@ -109,6 +112,14 @@ let verilog_options =
     ( "-sv_comb",
       Arg.Set opt_comb,
       " output an always_comb block instead of initial block"
+    );
+    ( "-sv_inregs",
+      Arg.Set opt_inregs,
+      " take register values from inputs"
+    );
+    ( "-sv_outregs",
+      Arg.Set opt_outregs,
+      " output register values"
     );
   ]
 
@@ -947,9 +958,10 @@ let jib_of_ast env ast effect_info =
   let ctx = initial_ctx env effect_info in
   Jibc.compile_ast ctx ast
 
-let wrap_module pre mod_name doc =
+let wrap_module pre mod_name ins_outs doc =
   pre ^^ hardline
-  ^^ string "module" ^^ space ^^ string mod_name ^^ semi
+  ^^ string "module" ^^ space ^^ string mod_name
+  ^^ parens (nest 4 (hardline ^^ separate (comma ^^ hardline) ins_outs) ^^ hardline) ^^ semi
   ^^ nest 4 (hardline ^^ doc)
   ^^ hardline ^^ string "endmodule" ^^ hardline
 
@@ -1014,7 +1026,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
         | CDLOC_In -> (doc_in ^^ cdef_doc, doc_out, fn_ctyps, setup_calls)
         | CDLOC_Out -> (doc_in, doc_out ^^ cdef_doc, fn_ctyps, setup_calls)
       )
-      (include_doc ^^ exception_vars, empty, Bindings.empty, [])
+      (exception_vars, include_doc, Bindings.empty, [])
       cdefs
   in
 
@@ -1025,25 +1037,55 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
     ^^ semi ^^ hardline ^^ string "endfunction" ^^ twice hardline
   in
 
+  let main_recv_inputs = if !opt_inregs then
+    separate empty (List.filter_map (function
+      | CDEF_register (id, ctyp, _) -> Some (sv_id id ^^ space ^^ equals ^^ space ^^ sv_id id ^^ string "_in" ^^ semi ^^ hardline)
+      | _ -> None
+    ) cdefs)
+  else empty in
+
+  let main_set_outputs = if !opt_inregs then
+    separate empty (List.filter_map (function
+      | CDEF_register (id, ctyp, _) -> Some (sv_id id ^^ string "_out" ^^ space ^^ equals ^^ space ^^ sv_id id ^^ semi ^^ hardline)
+      | _ -> None
+    ) cdefs)
+  else empty in
+
+  let main_body =
+      hardline ^^ string "sail_unit u;" ^^ hardline
+      ^^ string "$display(\"TEST START\");" ^^ hardline
+      ^^ string "sail_setup();" ^^ hardline
+      ^^ main_recv_inputs 
+      ^^ string "u = main(SAIL_UNIT);" ^^ hardline
+      ^^ main_set_outputs
+      ^^ string "$display(\"TEST END\");" in
+
   let invoke_main =
     if not !opt_comb then
       string "initial" ^^ space ^^ string "begin"
-      ^^ nest 4
-          (hardline ^^ string "sail_unit u;" ^^ hardline ^^ string "$display(\"TEST START\");" ^^ hardline
-          ^^ string "sail_setup();" ^^ hardline ^^ string "u = main(SAIL_UNIT);" ^^ hardline
-          ^^ string "$display(\"TEST END\");" ^^ hardline ^^ string "$finish;"
-          )
+      ^^ nest 4 main_body
       ^^ hardline ^^ string "end"
     else
       string "always_comb" ^^ space ^^ string "begin"
-      ^^ nest 4
-          (hardline ^^ string "sail_unit u;" ^^ hardline
-          ^^ string "sail_setup();" ^^ hardline ^^ string "u = main(SAIL_UNIT);"
-          )
+      ^^ nest 4 main_body
       ^^ hardline ^^ string "end"
   in
 
-  let sv_output = Pretty_print_sail.to_string (wrap_module out_doc ("sail_" ^ out) (in_doc ^^ setup_function ^^ invoke_main)) in
+  let inputs = if !opt_inregs then
+    List.filter_map (function
+      | CDEF_register (id, ctyp, _) -> Some (string "input" ^^ space ^^ sv_ctyp ctyp ^^ space ^^ sv_id id ^^ string "_in")
+      | _ -> None
+    ) cdefs
+  else [] in
+
+  let outputs = if !opt_inregs then
+    List.filter_map (function
+      | CDEF_register (id, ctyp, _) -> Some (string "output" ^^ space ^^ sv_ctyp ctyp ^^ space ^^ sv_id id ^^ string "_out")
+      | _ -> None
+    ) cdefs
+  else [] in
+
+  let sv_output = Pretty_print_sail.to_string (wrap_module out_doc ("sail_" ^ out) (List.append inputs outputs) (in_doc ^^ setup_function ^^ invoke_main)) in
   make_genlib_file (sprintf "sail_genlib_%s.sv" out);
 
   let ((out_chan, _, _, _) as file_info) = Util.open_output_with_check_unformatted None (out ^ ".sv") in

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -83,7 +83,7 @@ type verilate_mode = Verilator_none | Verilator_compile | Verilator_run
 
 let opt_verilate = ref Verilator_none
 
-let opt_line_directives = ref true
+let opt_line_directives = ref false
 
 let verilog_options =
   [
@@ -99,6 +99,10 @@ let verilog_options =
               )
         ),
       "<compile|run> Invoke verilator on generated output"
+    );
+    ( "-sv_lines",
+      Arg.Set opt_line_directives,
+      " output `line directives"
     );
   ]
 


### PR DESCRIPTION
1. Make line directives optional (disabled by default)
2. Allow outputting an always_comb block instead of an initial block
3. Emit types outside of the module so they are in global scope
4. Allow receiving register values from inputs and emitting them as outputs