### PR TITLE
New options and SMT builtins

### DIFF
--- a/lib/sv/sail.sv
+++ b/lib/sv/sail.sv
@@ -7,6 +7,38 @@ typedef enum logic [0:0] {SAIL_UNIT=0} sail_unit;
 // The Sail zero-width bitvector.
 typedef enum logic [0:0] {SAIL_ZWBV=0} sail_zwbv;
 
+`ifdef SAIL_NOSTRINGS
+
+function automatic sail_unit sail_print_endline(sail_unit s);
+   return SAIL_UNIT;
+endfunction // sail_print_endline
+
+function automatic sail_unit sail_prerr_endline(sail_unit s);
+   return SAIL_UNIT;
+endfunction // sail_prerr_endline
+
+function automatic sail_unit sail_print(sail_unit s);
+   return SAIL_UNIT;
+endfunction // sail_print
+
+function automatic sail_unit sail_prerr(sail_unit s);
+   return SAIL_UNIT;
+endfunction // sail_prerr
+
+function automatic sail_unit sail_assert(bit b, sail_unit msg);
+   return SAIL_UNIT;
+endfunction // sail_assert
+
+function automatic bit sail_eq_string(sail_unit s1, sail_unit s2);
+   return 0;
+endfunction
+
+function automatic sail_unit sail_concat_str(sail_unit s1, sail_unit s2);
+   return SAIL_UNIT;
+endfunction
+
+`else
+
 function automatic sail_unit sail_print_endline(string s);
    $display(s);
    return SAIL_UNIT;
@@ -41,6 +73,8 @@ endfunction
 function automatic string sail_concat_str(string s1, string s2);
    return {s1, s2};
 endfunction
+
+`endif
 
 bit [7:0] sail_memory [63:0];
 

--- a/src/lib/smt_builtins.ml
+++ b/src/lib/smt_builtins.ml
@@ -1148,5 +1148,11 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
                 let* l = current_location in
                 Reporting.unreachable l __POS__ "reg_deref given non register reference"
         )
+    | "eq_anything" ->
+        binary_primop_simple (fun a b ->
+            let* a = smt_cval a in
+            let* b = smt_cval b in
+            return (Fn ("=", [a; b]))
+        )
     | _ -> None
 end

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -571,7 +571,7 @@ module Make (Config : CONFIG) = struct
   let rec sv_clexp = function
     | CL_id (id, _) -> sv_name id
     | CL_field (clexp, field) -> sv_clexp clexp ^^ dot ^^ sv_id field
-    | _ -> string "CLEXP"
+    | _ -> string "// CLEXP unknown"
 
   let clexp_conversion clexp cval =
     let ctyp_to = clexp_ctyp clexp in

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -82,6 +82,7 @@ module type CONFIG = sig
   val max_unknown_integer_width : int
   val max_unknown_bitvector_width : int
   val line_directives : bool
+  val nostrings : bool
 end
 
 module Make (Config : CONFIG) = struct
@@ -297,7 +298,7 @@ module Make (Config : CONFIG) = struct
     | CT_lbits _ -> string "sail_bits"
     | CT_fint width -> ksprintf string "logic [%d:0]" (width - 1)
     | CT_lint -> ksprintf string "logic [%d:0]" (Config.max_unknown_integer_width - 1)
-    | CT_string -> string "string"
+    | CT_string -> if Config.nostrings then string "sail_unit" else string "string"
     | CT_unit -> string "sail_unit"
     | CT_variant (id, _) | CT_struct (id, _) | CT_enum (id, _) -> sv_type_id id
     | CT_constant c ->
@@ -501,7 +502,7 @@ module Make (Config : CONFIG) = struct
         else ksprintf string "%d'b%s" len (Util.string_of_list "" string_of_bitU bits)
     | Bool_lit true -> string "1"
     | Bool_lit false -> string "0"
-    | String_lit s -> ksprintf string "\"%s\"" s
+    | String_lit s -> if Config.nostrings then string "SAIL_UNIT" else ksprintf string "\"%s\"" s
     | Enum "unit" -> string "SAIL_UNIT"
     | Fn ("reg_ref", [String_lit r]) -> ksprintf string "SAIL_REG_%s" (Util.zencode_upper_string r)
     | Fn ("Bits", [size; bv]) -> squote ^^ lbrace ^^ sv_smt size ^^ comma ^^ space ^^ sv_smt bv ^^ rbrace

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -83,13 +83,15 @@ module type CONFIG = sig
   val max_unknown_bitvector_width : int
   val line_directives : bool
   val nostrings : bool
+  val nopacked : bool
 end
 
 module Make (Config : CONFIG) = struct
   let lbits_index_width = required_width (Big_int.of_int (Config.max_unknown_bitvector_width - 1))
 
   let rec is_packed = function
-    | CT_fbits _ | CT_unit | CT_bit | CT_bool | CT_fint _ | CT_lbits _ | CT_lint | CT_enum _ | CT_constant _ -> true
+    | CT_fbits _ | CT_unit | CT_bit | CT_bool | CT_fint _ | CT_lbits _ | CT_lint | CT_enum _ | CT_constant _ ->
+        not Config.nopacked
     | CT_variant (_, ctors) -> List.for_all (fun (_, ctyp) -> is_packed ctyp) ctors
     | CT_struct (_, fields) -> List.for_all (fun (_, ctyp) -> is_packed ctyp) fields
     | _ -> false

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -97,6 +97,7 @@ let opt_max_unknown_integer_width = ref 128
 let opt_max_unknown_bitvector_width = ref 128
 
 let opt_nostrings = ref false
+let opt_nopacked = ref false
 
 let verilog_options =
   [
@@ -125,10 +126,8 @@ let verilog_options =
       Arg.Int (fun i -> opt_max_unknown_bitvector_width := i),
       "<n> set the maximum width for bitvectors with unknown width"
     );
-    ( "-sv_nostrings",
-      Arg.Set opt_nostrings,
-      " don't emit any strings, instead emit units"
-    );
+    ("-sv_nostrings", Arg.Set opt_nostrings, " don't emit any strings, instead emit units");
+    ("-sv_nopacked", Arg.Set opt_nopacked, " don't emit packed datastructures");
   ]
 
 let verilog_rewrites =
@@ -363,6 +362,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
     let max_unknown_bitvector_width = !opt_max_unknown_bitvector_width
     let line_directives = !opt_line_directives
     let nostrings = !opt_nostrings
+    let nopacked = !opt_nopacked
   end) in
   let open SV in
   let sail_dir = Reporting.get_sail_dir default_sail_dir in

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -96,6 +96,8 @@ let opt_outregs = ref false
 let opt_max_unknown_integer_width = ref 128
 let opt_max_unknown_bitvector_width = ref 128
 
+let opt_nostrings = ref false
+
 let verilog_options =
   [
     ( "-sv_verilate",
@@ -122,6 +124,10 @@ let verilog_options =
     ( "-sv_bits_size",
       Arg.Int (fun i -> opt_max_unknown_bitvector_width := i),
       "<n> set the maximum width for bitvectors with unknown width"
+    );
+    ( "-sv_nostrings",
+      Arg.Set opt_nostrings,
+      " don't emit any strings, instead emit units"
     );
   ]
 
@@ -356,6 +362,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
     let max_unknown_integer_width = !opt_max_unknown_integer_width
     let max_unknown_bitvector_width = !opt_max_unknown_bitvector_width
     let line_directives = !opt_line_directives
+    let nostrings = !opt_nostrings
   end) in
   let open SV in
   let sail_dir = Reporting.get_sail_dir default_sail_dir in

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -374,11 +374,16 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
   let registers = register_types cdefs in
 
   let include_doc =
-    string "`include \"sail.sv\"" ^^ hardline ^^ ksprintf string "`include \"sail_genlib_%s.sv\"" out ^^ twice hardline
+    (if !opt_nostrings then string "`define SAIL_NOSTRINGS" ^^ hardline else empty)
+    ^^ string "`include \"sail.sv\"" ^^ hardline
+    ^^ ksprintf string "`include \"sail_genlib_%s.sv\"" out
+    ^^ twice hardline
   in
 
   let exception_vars =
-    string "bit sail_have_exception;" ^^ hardline ^^ string "string sail_throw_location;" ^^ twice hardline
+    string "bit sail_have_exception;" ^^ hardline
+    ^^ (if !opt_nostrings then string "sail_unit" else string "string")
+    ^^ space ^^ string "sail_throw_location;" ^^ twice hardline
   in
 
   let in_doc, out_doc, reg_doc, fn_ctyps, setup_calls =


### PR DESCRIPTION
1. Add an option to emit unit in place of all strings
2. Add a couple of simple new SMT builtins
3. Add an option to never emit packed structures. This is just a temporary measure until we have padding.