### PR TITLE
More builtins and unit string stubs in generated primops

### DIFF
--- a/src/lib/smt_builtins.ml
+++ b/src/lib/smt_builtins.ml
@@ -725,6 +725,10 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
         return (Fn ("=", [smt1; smt2]))
     | _ -> builtin_type_error "eq_bits" [v1; v2] None
 
+  let builtin_neq_bits v1 v2 =
+    let* t = builtin_eq_bits v1 v2 in
+    return (Fn ("not", [t]))
+
   let builtin_append v1 v2 ret_ctyp =
     match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
     | CT_fbits (n, _), CT_fbits (m, _), CT_fbits (o, _) ->
@@ -1105,6 +1109,7 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
     | "append" -> binary_primop builtin_append
     | "get_slice_int" -> ternary_primop builtin_get_slice_int
     | "eq_bits" -> binary_primop_simple builtin_eq_bits
+    | "neq_bits" -> binary_primop_simple builtin_neq_bits
     | "not_bits" -> unary_primop builtin_not_bits
     | "sail_truncate" -> binary_primop builtin_sail_truncate
     | "sail_truncateLSB" -> binary_primop builtin_sail_truncateLSB

--- a/src/lib/smt_builtins.ml
+++ b/src/lib/smt_builtins.ml
@@ -562,10 +562,13 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
     | CT_fbits (n, _), _, CT_fbits (m, _) ->
         let* bv = smt_cval vbits in
         return (Fn ("concat", [bvzero (m - n); bv]))
+    | CT_fbits (n, _), CT_fint m, CT_lbits _ ->
+        let* bv = smt_cval vbits in
+        return (Fn ("concat", [bvzero (m - n); bv]))
+    | CT_lbits _, _, CT_fbits (m, _) ->
+        let* bv = smt_cval vbits in
+        return (Extract (m - 1, 0, Fn ("contents", [bv])))
         (*
-    | CT_lbits _, CT_fbits (m, _) ->
-      assert (lbits_size ctx >= m);
-      Extract (m - 1, 0, Fn ("contents", [smt_cval ctx vbits]))
     | CT_fbits (n, _), CT_lbits _ ->
       assert (lbits_size ctx >= n);
       let vbits =

--- a/src/sail_sv_backend/generate_primop.ml
+++ b/src/sail_sv_backend/generate_primop.ml
@@ -99,12 +99,26 @@ let print_lbits width =
   let footer = "endfunction" in
   header @ body @ [footer]
 
+let print_lbits_stub width =
+  [
+    nf "function automatic sail_unit sail_print_bits(sail_unit prefix, sail_bits bv);";
+    nf "    return SAIL_UNIT;";
+    nf "endfunction"
+  ]
+
 let dec_str width =
   [
     pf "function automatic string sail_dec_str(logic [%d:0] i);" (width - 1);
     nf "    string s;";
     nf "    s.itoa(i);";
     nf "    return s;";
+    nf "endfunction";
+  ]
+
+let dec_str_stub width =
+  [
+    pf "function automatic sail_unit sail_dec_str(logic [%d:0] i);" (width - 1);
+    nf "    return SAIL_UNIT;";
     nf "endfunction";
   ]
 
@@ -117,6 +131,13 @@ let hex_str width =
     nf "endfunction";
   ]
 
+let hex_str_stub width =
+  [
+    pf "function automatic sail_unit sail_hex_str(logic [%d:0] i);" (width - 1);
+    nf "    return SAIL_UNIT;";
+    nf "endfunction";
+  ]
+
 let hex_str_upper width =
   [
     pf "function automatic string sail_hex_str_upper(logic [%d:0] i);" (width - 1);
@@ -126,10 +147,24 @@ let hex_str_upper width =
     nf "endfunction";
   ]
 
+let hex_str_upper_stub width =
+  [
+    pf "function automatic sail_unit sail_hex_str_upper(logic [%d:0] i);" (width - 1);
+    nf "    return SAIL_UNIT;";
+    nf "endfunction";
+  ]
+
 let print_int width =
   [
     pf "function automatic sail_unit sail_print_int(string prefix, logic [%d:0] i);" (width - 1);
     nf "    $display(\"%s%0d\", prefix, signed'(i));";
+    nf "endfunction";
+  ]
+
+let print_int_stub width =
+  [
+    pf "function automatic sail_unit sail_print_int(sail_unit prefix, logic [%d:0] i);" (width - 1);
+    nf "    return SAIL_UNIT;";
     nf "endfunction";
   ]
 
@@ -152,6 +187,17 @@ let common_primops bv_width int_width =
   output_primop buf (hex_str_upper int_width);
   Buffer.contents buf
 
+let common_primops_stubs bv_width int_width =
+  let buf = Buffer.create 4096 in
+  output_primop buf (sail_bits bv_width);
+  output_primop buf (print_lbits_stub bv_width);
+  output_primop buf (print_int_stub int_width);
+  output_primop buf (dec_str_stub int_width);
+  output_primop buf (hex_str_stub int_width);
+  output_primop buf (hex_str_upper_stub int_width);
+  Buffer.contents buf
+  
+
 let print_fbits width =
   let name = pf "sail_print_fixed_bits_%d" width in
   register_primop name (fun () ->
@@ -173,6 +219,16 @@ let print_fbits width =
       @ ["    return SAIL_UNIT;"; "endfunction"]
   )
 
+let print_fbits_stub width =
+  let name = pf "sail_print_fixed_bits_%d" width in
+  register_primop name (fun () ->
+    [
+      pf "function automatic sail_unit %s(sail_unit prefix, logic [%d:0] i);" name (width - 1);
+      nf "    return SAIL_UNIT;";
+      nf "endfunction";
+    ]
+  )
+
 let dec_str_fint width =
   let name = pf "sail_dec_str_%d" width in
   register_primop name (fun () ->
@@ -181,6 +237,16 @@ let dec_str_fint width =
         nf "    string s;";
         nf "    s.itoa(i);";
         nf "    return s;";
+        nf "endfunction";
+      ]
+  )
+
+let dec_str_fint_stub width =
+  let name = pf "sail_dec_str_%d" width in
+  register_primop name (fun () ->
+      [
+        pf "function automatic sail_unit %s(logic [%d:0] i);" name (width - 1);
+        nf "    return SAIL_UNIT;";
         nf "endfunction";
       ]
   )
@@ -197,6 +263,16 @@ let hex_str_fint width =
       ]
   )
 
+let hex_str_fint_stub width =
+  let name = pf "sail_hex_str_%d" width in
+  register_primop name (fun () ->
+      [
+        pf "function automatic sail_unit %s(logic [%d:0] i);" name (width - 1);
+        nf "    return SAIL_UNIT;";
+        nf "endfunction";
+      ]
+  )
+
 let hex_str_upper_fint width =
   let name = pf "sail_hex_str_upper_%d" width in
   register_primop name (fun () ->
@@ -205,6 +281,16 @@ let hex_str_upper_fint width =
         nf "    string s;";
         nf "    s.hextoa(i);";
         nf "    return {\"0x\", s.toupper()};";
+        nf "endfunction";
+      ]
+  )
+
+let hex_str_upper_fint_stub width =
+  let name = pf "sail_hex_str_upper_%d" width in
+  register_primop name (fun () ->
+      [
+        pf "function automatic sail_unit %s(logic [%d:0] i);" name (width - 1);
+        nf "    return SAIL_UNIT;";
         nf "endfunction";
       ]
   )

--- a/src/sail_sv_backend/generate_primop.ml
+++ b/src/sail_sv_backend/generate_primop.ml
@@ -103,7 +103,7 @@ let print_lbits_stub width =
   [
     nf "function automatic sail_unit sail_print_bits(sail_unit prefix, sail_bits bv);";
     nf "    return SAIL_UNIT;";
-    nf "endfunction"
+    nf "endfunction";
   ]
 
 let dec_str width =
@@ -196,7 +196,6 @@ let common_primops_stubs bv_width int_width =
   output_primop buf (hex_str_stub int_width);
   output_primop buf (hex_str_upper_stub int_width);
   Buffer.contents buf
-  
 
 let print_fbits width =
   let name = pf "sail_print_fixed_bits_%d" width in
@@ -222,11 +221,11 @@ let print_fbits width =
 let print_fbits_stub width =
   let name = pf "sail_print_fixed_bits_%d" width in
   register_primop name (fun () ->
-    [
-      pf "function automatic sail_unit %s(sail_unit prefix, logic [%d:0] i);" name (width - 1);
-      nf "    return SAIL_UNIT;";
-      nf "endfunction";
-    ]
+      [
+        pf "function automatic sail_unit %s(sail_unit prefix, logic [%d:0] i);" name (width - 1);
+        nf "    return SAIL_UNIT;";
+        nf "endfunction";
+      ]
   )
 
 let dec_str_fint width =

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -296,21 +296,25 @@ module Make (Config : CONFIG) = struct
       (struct
         let print_bits l = function
           | CT_lbits _ -> "sail_print_bits"
+          | CT_fbits (sz, _) when Config.nostrings -> Generate_primop.print_fbits_stub sz
           | CT_fbits (sz, _) -> Generate_primop.print_fbits sz
           | _ -> Reporting.unreachable l __POS__ "print_bits"
 
         let dec_str l = function
           | CT_lint -> "sail_dec_str"
+          | CT_fint sz when Config.nostrings -> Generate_primop.dec_str_fint_stub sz
           | CT_fint sz -> Generate_primop.dec_str_fint sz
           | _ -> Reporting.unreachable l __POS__ "dec_str"
 
         let hex_str l = function
           | CT_lint -> "sail_hex_str"
+          | CT_fint sz when Config.nostrings -> Generate_primop.hex_str_fint_stub sz
           | CT_fint sz -> Generate_primop.hex_str_fint sz
           | _ -> Reporting.unreachable l __POS__ "hex_str"
 
         let hex_str_upper l = function
           | CT_lint -> "sail_hex_str_upper"
+          | CT_fint sz when Config.nostrings -> Generate_primop.hex_str_upper_fint_stub sz
           | CT_fint sz -> Generate_primop.hex_str_upper_fint sz
           | _ -> Reporting.unreachable l __POS__ "hex_str_upper"
 

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -336,9 +336,11 @@ let verilator_cpp_wrapper name =
   ]
 
 let make_genlib_file filename =
-  let common_primops = if !opt_nostrings
-    then Generate_primop.common_primops_stubs !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width
-    else Generate_primop.common_primops !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width in
+  let common_primops =
+    if !opt_nostrings then
+      Generate_primop.common_primops_stubs !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width
+    else Generate_primop.common_primops !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width
+  in
   let defs = Generate_primop.get_generated_primops () in
   let ((out_chan, _, _, _) as file_info) = Util.open_output_with_check_unformatted None filename in
   output_string out_chan "`ifndef SAIL_LIBRARY_GENERATED\n";

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -336,7 +336,9 @@ let verilator_cpp_wrapper name =
   ]
 
 let make_genlib_file filename =
-  let common_primops = Generate_primop.common_primops !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width in
+  let common_primops = if !opt_nostrings
+    then Generate_primop.common_primops_stubs !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width
+    else Generate_primop.common_primops !opt_max_unknown_bitvector_width !opt_max_unknown_integer_width in
   let defs = Generate_primop.get_generated_primops () in
   let ((out_chan, _, _, _) as file_info) = Util.open_output_with_check_unformatted None filename in
   output_string out_chan "`ifndef SAIL_LIBRARY_GENERATED\n";

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -99,6 +99,8 @@ let opt_max_unknown_bitvector_width = ref 128
 let opt_nostrings = ref false
 let opt_nopacked = ref false
 
+let opt_unreachable = ref []
+
 let verilog_options =
   [
     ( "-sv_verilate",
@@ -128,6 +130,10 @@ let verilog_options =
     );
     ("-sv_nostrings", Arg.Set opt_nostrings, " don't emit any strings, instead emit units");
     ("-sv_nopacked", Arg.Set opt_nopacked, " don't emit packed datastructures");
+    ( "-sv_unreachable",
+      Arg.String (fun fn -> opt_unreachable := fn :: !opt_unreachable),
+      "<functionname> Mark function as unreachable."
+    );
   ]
 
 let verilog_rewrites =
@@ -367,6 +373,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
     let line_directives = !opt_line_directives
     let nostrings = !opt_nostrings
     let nopacked = !opt_nopacked
+    let unreachable = !opt_unreachable
   end) in
   let open SV in
   let sail_dir = Reporting.get_sail_dir default_sail_dir in
@@ -385,7 +392,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
   in
 
   let exception_vars =
-    string "bit sail_have_exception;" ^^ hardline
+    string "bit sail_reached_unreachable;" ^^ hardline ^^ string "bit sail_have_exception;" ^^ hardline
     ^^ (if !opt_nostrings then string "sail_unit" else string "string")
     ^^ space ^^ string "sail_throw_location;" ^^ twice hardline
   in

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -419,7 +419,10 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
   let setup_function =
     string "function automatic void sail_setup();"
     ^^ nest 4
-         (hardline ^^ separate_map (semi ^^ hardline) (fun call -> string call ^^ string "()") (List.rev setup_calls))
+         (hardline ^^ string "sail_reached_unreachable = 0;" ^^ hardline ^^ string "sail_have_exception = 0;"
+        ^^ hardline
+         ^^ separate_map (semi ^^ hardline) (fun call -> string call ^^ string "()") (List.rev setup_calls)
+         )
     ^^ semi ^^ hardline ^^ string "endfunction" ^^ twice hardline
   in
 


### PR DESCRIPTION
- Add implementations of zero_extend and neq_bits SMT builtins
- When building with -sv_nostrings, emit stub primops
- Add -sv_unreachable, which emits `sail_reached_unreachable = 1;` and no return statement for functions marked as unreachable.