### PR TITLE
Extend split to also update invocations

### DIFF
--- a/src/sail_sv_backend/generate_primop.ml
+++ b/src/sail_sv_backend/generate_primop.ml
@@ -342,7 +342,7 @@ let rec count_leading_zeros width =
         [
           pf "function automatic logic [%d:0] %s(logic [%d:0] bv);" (width - 1) name (width - 1);
           pf "    if (%s == 0) begin" upper;
-          pf "        return %d + %d'(%s(%s));" upper_width width clz_lower lower;
+          pf "        return %d'd%d + %d'(%s(%s));" width upper_width width clz_lower lower;
           nf "    end else begin";
           pf "        return %d'(%s(%s));" width clz_upper upper;
           nf "    end;";

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -387,6 +387,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
     let nostrings = !opt_nostrings
     let nopacked = !opt_nopacked
     let unreachable = !opt_unreachable
+    let comb = !opt_comb
   end) in
   let open SV in
   let sail_dir = Reporting.get_sail_dir default_sail_dir in


### PR DESCRIPTION
Find all locations where the split function is called with a constructor directly, and replace it with the specialized call.