### PR TITLE
Remove Order type variables

### DIFF
--- a/doc/asciidoc/Makefile
+++ b/doc/asciidoc/Makefile
@@ -7,19 +7,27 @@ SAIL_DOCS += sail_doc/exn.json
 
 CUSTOM_SAIL_DOCS = custom_sail_doc/cannot_wildcard.json
 
+LIB_SAIL_DOCS = lib_sail_doc/concurrency_interface/read_write.json
+
 default: manual.pdf
 
 sail_doc/%.json: ../examples/%.sail
+	mkdir -p sail_doc
 	sail -doc $< -doc_file $< -doc_embed plain -doc_bundle $(notdir $@)
+
+lib_sail_doc/%.json: ../../lib/%.sail
+	mkdir -p lib_sail_doc
+	mkdir -p lib_sail_doc/concurrency_interface
+	sail -doc $< -doc_file $< -doc_embed plain -doc_bundle $(patsubst lib_sail_doc/%,%,$@) -o lib_sail_doc
 
 custom_sail_doc/cannot_wildcard.json: ../examples/cannot_wildcard.sail
 	mkdir -p custom_sail_doc
 	sail -no_color -doc $< -doc_file $< -doc_embed plain -doc_bundle $(notdir $@) -o custom_sail_doc 2> custom_sail_doc/cannot_wildcard_warning
 
-manual.pdf: *.adoc $(SAIL_DOCS) $(CUSTOM_SAIL_DOCS)
+manual.pdf: *.adoc $(SAIL_DOCS) $(LIB_SAIL_DOCS) $(CUSTOM_SAIL_DOCS)
 	asciidoctor-pdf manual.adoc -r $(SAIL_PLUGIN) -r asciidoctor-bibtex
 
-manual.html: *.adoc $(SAIL_DOCS) $(CUSTOM_SAIL_DOCS)
+manual.html: *.adoc $(SAIL_DOCS) $(LIB_SAIL_DOCS) $(CUSTOM_SAIL_DOCS)
 	asciidoctor manual.adoc -r $(SAIL_PLUGIN) -r asciidoctor-bibtex
 
 clean:

--- a/language/jib.ott
+++ b/language/jib.ott
@@ -137,9 +137,9 @@ ctyp :: 'CT_' ::=
 % lbits is a large (l) arbitrary precision bitvector
 % sbits is a small (s) bitvector, such that sbits(n, _) is guaranteed to have a length of at most n.
 % fbits is a fixed (f) bitvector, such that fbits(n, _) has a length of exactly n bits
-  | lbits ( bool )            :: :: lbits
-  | sbits ( nat , bool )      :: :: sbits
-  | fbits ( nat , bool )      :: :: fbits
+  | lbits                     :: :: lbits
+  | sbits ( nat )             :: :: sbits
+  | fbits ( nat )             :: :: fbits
 
 % Other Sail types
   | unit                      :: :: unit
@@ -166,8 +166,8 @@ ctyp :: 'CT_' ::=
   | variant id ( id0 * ctyp0 , ... , idn * ctypn ) :: :: variant
 
 % A vector type for non-bit vectors, and a (linked) list type.
-  | fvector ( nat , bool , ctyp )  :: :: fvector
-  | vector ( bool , ctyp )         :: :: vector
+  | fvector ( nat , ctyp )  :: :: fvector
+  | vector ( ctyp )         :: :: vector
   | list ( ctyp )                  :: :: list
 
   | ref ( ctyp )                   :: :: ref

--- a/language/sail.ott
+++ b/language/sail.ott
@@ -184,7 +184,7 @@ id :: '' ::=
   | ( operator x ) :: D :: operator {{ com remove infix status }}
 
 kid :: '' ::=
-  {{ com kinded IDs: Type, Int, and Order variables }}
+  {{ com kinded IDs: Type, Int, and Bool variables }}
   {{ aux _ l }}
   | ' x :: :: var
 
@@ -199,7 +199,6 @@ kind :: 'K_' ::=
   {{ aux _ l }}
   | Type  :: :: type  {{ com kind of types  }}
   | Int   :: :: int   {{ com kind of natural number size expressions  }}
-  | Order :: :: order {{ com kind of vector order specifications  }}
   | Bool  :: :: bool  {{ com kind of constraints }}
 
 nexp :: 'Nexp_' ::=
@@ -219,7 +218,6 @@ nexp :: 'Nexp_' ::=
 order :: 'Ord_' ::=
   {{ com vector order specifications, of kind Order }}
   {{ aux _ l }}
-  | kid                                 :: :: var {{ com variable }} 
   | inc                                 :: :: inc {{ com increasing }}
   | dec                                 :: :: dec {{ com decreasing }}
   | ( order )                           :: S :: paren {{ ichlo [[order]] }}
@@ -243,7 +241,6 @@ typ_arg :: 'A_' ::=
   {{ aux _ l }}
   | nexp         :: :: nexp
   | typ          :: :: typ
-  | order        :: :: order
   | n_constraint :: :: bool
 
 n_constraint :: 'NC_' ::=
@@ -686,7 +683,6 @@ val_spec_aux :: 'VS_' ::=
     {{ ocaml  (VS_val_spec [[typschm]] [[id]] [ ( "_" , [[string]] ) ]) }} {{ lem }} {{ isa }}
   | val id = { string1 = string'1 , ... , stringn = string'n } : typschm :: S :: extern_rename_some
     {{ ichlo }}
-
 
 default_spec :: 'DT_' ::=
   {{ com default kinding or typing assumption }}

--- a/lib/vector_dec.sail
+++ b/lib/vector_dec.sail
@@ -70,7 +70,7 @@ $define _VECTOR_DEC
 
 $include <flow.sail>
 
-type bits ('n : Int) = bitvector('n, dec)
+type bits('n : Int) = bitvector('n, dec)
 
 val eq_bits = pure {
   ocaml: "eq_list",

--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -432,10 +432,7 @@ let pp_lvar lvar doc =
 
 let pp_annot typ doc = string "[" ^^ string (string_of_typ typ |> Util.yellow |> Util.clear) ^^ string "]" ^^ doc
 
-let pp_order = function
-  | Ord_aux (Ord_inc, _) -> string "inc"
-  | Ord_aux (Ord_dec, _) -> string "dec"
-  | _ -> assert false (* Order types have been specialised, so no polymorphism in C backend. *)
+let pp_order = function Ord_aux (Ord_inc, _) -> string "inc" | Ord_aux (Ord_dec, _) -> string "dec"
 
 let pp_id id = string (string_of_id id)
 

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -132,13 +132,15 @@ val is_unbound : 'a lvar -> bool
 (** Note: Partial function -- fails for {!Unbound} lvars *)
 val lvar_typ : ?loc:l -> 'a lvar -> 'a
 
+val is_order_inc : order -> bool
+val is_order_dec : order -> bool
+
 (** {1 Functions for building and destructuring untyped AST elements} *)
 
 (** {2 Functions for building untyped AST elements} *)
 
 val mk_id : string -> id
 val mk_kid : string -> kid
-val mk_ord : order_aux -> order
 val mk_nc : n_constraint_aux -> n_constraint
 val mk_nexp : nexp_aux -> nexp
 val mk_exp : ?loc:l -> uannot exp_aux -> uannot exp
@@ -166,16 +168,11 @@ val mk_def : ?loc:l -> 'a def_aux -> 'a def
 (** Mapping patterns are a subset of patterns, so we can always convert one to the other *)
 val pat_of_mpat : 'a mpat -> 'a pat
 
-val inc_ord : order
-val dec_ord : order
-val order_compare : order -> order -> int
-
 (** {2 Unwrap aux constructors} *)
 
 val unaux_exp : 'a exp -> 'a exp_aux
 val unaux_pat : 'a pat -> 'a pat_aux
 val unaux_nexp : nexp -> nexp_aux
-val unaux_order : order -> order_aux
 val unaux_typ : typ -> typ_aux
 val unaux_kind : kind -> kind_aux
 val unaux_constraint : n_constraint -> n_constraint_aux
@@ -195,7 +192,6 @@ val kopt_kid : kinded_id -> kid
 val kopt_kind : kinded_id -> kind
 
 val is_int_kopt : kinded_id -> bool
-val is_order_kopt : kinded_id -> bool
 val is_typ_kopt : kinded_id -> bool
 val is_bool_kopt : kinded_id -> bool
 
@@ -207,7 +203,6 @@ val mk_id_typ : id -> typ
 
 val is_typ_arg_nexp : typ_arg -> bool
 val is_typ_arg_typ : typ_arg -> bool
-val is_typ_arg_order : typ_arg -> bool
 val is_typ_arg_bool : typ_arg -> bool
 
 (** {2 Sail built-in types} *)
@@ -226,8 +221,8 @@ val register_typ : typ -> typ
 val unit_typ : typ
 val string_typ : typ
 val real_typ : typ
-val vector_typ : nexp -> order -> typ -> typ
-val bitvector_typ : nexp -> order -> typ
+val vector_typ : nexp -> typ -> typ
+val bitvector_typ : nexp -> typ
 val list_typ : typ -> typ
 val exc_typ : typ
 val tuple_typ : typ list -> typ
@@ -300,7 +295,6 @@ val nc_var : kid -> n_constraint
 (** {2 Functions for building type arguments}*)
 
 val arg_nexp : ?loc:l -> nexp -> typ_arg
-val arg_order : ?loc:l -> order -> typ_arg
 val arg_typ : ?loc:l -> typ -> typ_arg
 val arg_bool : ?loc:l -> n_constraint -> typ_arg
 val arg_kopt : kinded_id -> typ_arg
@@ -437,7 +431,6 @@ val string_of_id : id -> string
 val string_of_kid : kid -> string
 val string_of_kind_aux : kind_aux -> string
 val string_of_kind : kind -> string
-val string_of_order : order -> string
 val string_of_nexp : nexp -> string
 val string_of_typ : typ -> string
 val string_of_typ_arg : typ_arg -> string
@@ -483,12 +476,8 @@ val int_of_nexp_opt : nexp -> Big_int.num option
 val lexp_to_exp : 'a lexp -> 'a exp
 
 val typ_app_args_of : typ -> string * typ_arg_aux list * Ast.l
-val vector_typ_args_of : typ -> nexp * order * typ
-val vector_start_index : typ -> nexp
+val vector_typ_args_of : typ -> nexp * typ
 
-val is_order_inc : order -> bool
-
-val kopts_of_order : order -> KOptSet.t
 val kopts_of_nexp : nexp -> KOptSet.t
 val kopts_of_typ : typ -> KOptSet.t
 val kopts_of_typ_arg : typ_arg -> KOptSet.t
@@ -583,7 +572,6 @@ val find_annot_ast : (Lexing.position * Lexing.position) option -> 'a ast -> (As
 
 val nexp_subst : kid -> typ_arg -> nexp -> nexp
 val constraint_subst : kid -> typ_arg -> n_constraint -> n_constraint
-val order_subst : kid -> typ_arg -> order -> order
 val typ_subst : kid -> typ_arg -> typ -> typ
 val typ_arg_subst : kid -> typ_arg -> typ_arg -> typ_arg
 

--- a/src/lib/bitfield.ml
+++ b/src/lib/bitfield.ml
@@ -72,7 +72,7 @@ open Ast
 open Ast_defs
 open Ast_util
 
-let bitvec_typ size order = bitvector_typ (nconstant size) order
+let constant_bitvector_typ size = bitvector_typ (nconstant size)
 let fun_typschm arg_typs ret_typ = mk_typschm (mk_typquant []) (function_typ arg_typs ret_typ)
 
 let index_of_nexp nexp =
@@ -93,8 +93,8 @@ let slice_width (i, j) = Big_int.succ (Big_int.abs (Big_int.sub i j))
 let range_width r = List.map slice_width (indices_of_range r) |> List.fold_left Big_int.add Big_int.zero
 
 (* Generate a constructor function for a bitfield type *)
-let constructor name order size =
-  let typschm = fun_typschm [bitvec_typ size order] (mk_id_typ name) in
+let constructor name size =
+  let typschm = fun_typschm [constant_bitvector_typ size] (mk_id_typ name) in
   let constructor_val = mk_val_spec (VS_val_spec (typschm, prepend_id "Mk_" name, None)) in
   let constructor_fun = Printf.sprintf "function Mk_%s v = struct { bits = v }" (string_of_id name) in
   constructor_val :: defs_of_string __POS__ constructor_fun
@@ -158,7 +158,7 @@ let field_accessor_ids type_name field =
 
 let field_getter typ_name field order range =
   let size = range_width range in
-  let typschm = fun_typschm [mk_id_typ typ_name] (bitvec_typ size order) in
+  let typschm = fun_typschm [mk_id_typ typ_name] (constant_bitvector_typ size) in
   let fun_id = (field_accessor_ids typ_name field).get in
   let spec = mk_val_spec (VS_val_spec (typschm, fun_id, None)) in
   let body = get_field_exp range (get_bits_field (mk_exp (E_id (mk_id "v")))) in
@@ -168,7 +168,7 @@ let field_getter typ_name field order range =
 let field_updater typ_name field order range =
   let size = range_width range in
   let typ = mk_id_typ typ_name in
-  let typschm = fun_typschm [typ; bitvec_typ size order] typ in
+  let typschm = fun_typschm [typ; constant_bitvector_typ size] typ in
   let fun_id = (field_accessor_ids typ_name field).update in
   let spec = mk_val_spec (VS_val_spec (typschm, fun_id, None)) in
   let orig_var = mk_id "v" in
@@ -187,7 +187,7 @@ let register_field_setter typ_name field order range =
   let fun_id = string_of_id (field_accessor_ids typ_name field).set in
   let update_fun_id = string_of_id (field_accessor_ids typ_name field).update in
   let typ_name = string_of_id typ_name in
-  let field_typ = string_of_typ (bitvec_typ size order) in
+  let field_typ = string_of_typ (constant_bitvector_typ size) in
   let rfs_val = Printf.sprintf "val %s : (register(%s), %s) -> unit" fun_id typ_name field_typ in
   (* Read-modify-write using an internal _reg_deref function without rreg effect *)
   let rfs_function =
@@ -221,4 +221,4 @@ let macro id size order ranges =
   let full_range = BF_aux (BF_range (nconstant (Big_int.pred size), nconstant Big_int.zero), Parse_ast.Unknown) in
   let ranges = (mk_id "bits", full_range) :: Bindings.bindings ranges in
   let accessors = List.map (fun (field, range) -> field_accessors id field order range) ranges in
-  List.concat ([constructor id order size] @ accessors)
+  List.concat ([constructor id size] @ accessors)

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -151,11 +151,7 @@ and typ_ids' (Typ_aux (aux, _)) =
   | Typ_exist (_, _, typ) -> typ_ids' typ
 
 and typ_arg_ids' (A_aux (aux, _)) =
-  match aux with
-  | A_typ typ -> typ_ids' typ
-  | A_nexp nexp -> nexp_ids' nexp
-  | A_bool nc -> constraint_ids' nc
-  | A_order _ -> IdSet.empty
+  match aux with A_typ typ -> typ_ids' typ | A_nexp nexp -> nexp_ids' nexp | A_bool nc -> constraint_ids' nc
 
 let constraint_ids nc = IdSet.diff (constraint_ids' nc) builtins
 

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -591,7 +591,6 @@ let rec step (E_aux (e_aux, annot) as orig_exp) =
                   )
             | _ -> assert false
           end
-        | Ord_aux (Ord_var _, _) -> fail "Polymorphic order in foreach"
       end
   | E_for (id, exp_from, exp_to, exp_step, ord, body) when is_value exp_to && is_value exp_step ->
       step exp_from >>= fun exp_from' -> wrap (E_for (id, exp_from', exp_to, exp_step, ord, body))
@@ -684,10 +683,10 @@ and pattern_match env (P_aux (p_aux, (l, _))) value =
       in
       begin
         match destruct_vector (env_of_pat pat) (typ_of_pat pat) with
-        | Some (Nexp_aux (Nexp_constant n, _), _, _) -> vector_concat_match n
+        | Some (Nexp_aux (Nexp_constant n, _), _) -> vector_concat_match n
         | None -> begin
             match destruct_bitvector (env_of_pat pat) (typ_of_pat pat) with
-            | Some (Nexp_aux (Nexp_constant n, _), _) -> vector_concat_match n
+            | Some (Nexp_aux (Nexp_constant n, _)) -> vector_concat_match n
             | _ ->
                 failwith
                   ("Bad bitvector annotation for bitvector concatenation pattern "

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -189,9 +189,9 @@ let initial_ctx env effect_info =
 let rec mangle_string_of_ctyp ctx = function
   | CT_lint -> "i"
   | CT_fint n -> "I" ^ string_of_int n
-  | CT_lbits _ -> "b"
-  | CT_sbits (n, _) -> "S" ^ string_of_int n
-  | CT_fbits (n, _) -> "B" ^ string_of_int n
+  | CT_lbits -> "b"
+  | CT_sbits n -> "S" ^ string_of_int n
+  | CT_fbits n -> "B" ^ string_of_int n
   | CT_constant n -> "C" ^ Big_int.to_string n
   | CT_bit -> "t"
   | CT_unit -> "u"
@@ -226,8 +226,8 @@ let rec mangle_string_of_ctyp ctx = function
       ^ "<"
       ^ Util.string_of_list "," (mangle_string_of_ctyp ctx) unifiers
       ^ ">"
-  | CT_vector (_, ctyp) -> "V" ^ mangle_string_of_ctyp ctx ctyp
-  | CT_fvector (n, _, ctyp) -> "F" ^ string_of_int n ^ mangle_string_of_ctyp ctx ctyp
+  | CT_vector ctyp -> "V" ^ mangle_string_of_ctyp ctx ctyp
+  | CT_fvector (n, ctyp) -> "F" ^ string_of_int n ^ mangle_string_of_ctyp ctx ctyp
   | CT_list ctyp -> "L" ^ mangle_string_of_ctyp ctx ctyp
   | CT_poly kid -> "P" ^ string_of_kid kid
 
@@ -414,7 +414,7 @@ module Make (C : Config) = struct
         let vector_ctyp = ctyp_of_typ ctx typ in
         begin
           match ctyp_of_typ ctx typ with
-          | CT_fbits (0, ord) -> ([], V_lit (VL_bits ([], ord), vector_ctyp), [])
+          | CT_fbits 0 -> ([], V_lit (VL_bits [], vector_ctyp), [])
           | _ ->
               let gs = ngensym () in
               ( [
@@ -433,43 +433,40 @@ module Make (C : Config) = struct
         let bitstring = List.map value_of_aval_bit avals in
         let len = List.length avals in
         match (destruct_bitvector ctx.tc_env typ, Env.get_default_order ctx.tc_env) with
-        | Some _, Ord_aux (Ord_inc, _) -> ([], V_lit (VL_bits (bitstring, false), CT_fbits (len, false)), [])
-        | Some _, Ord_aux (Ord_dec, _) -> ([], V_lit (VL_bits (bitstring, true), CT_fbits (len, true)), [])
+        | Some _, Ord_aux (Ord_inc, _) -> ([], V_lit (VL_bits (List.rev bitstring), CT_fbits len), [])
+        | Some _, Ord_aux (Ord_dec, _) -> ([], V_lit (VL_bits bitstring, CT_fbits len), [])
         | None, _ -> raise (Reporting.err_general l "Encountered vector literal without vector type")
       end
     (* Convert a bitvector literal that is larger than 64-bits to a
        variable size bitvector, converting it in 64-bit chunks. *)
     | AV_vector (avals, typ) when is_bitvector avals ->
         let len = List.length avals in
-        let bitstring avals = VL_bits (List.map value_of_aval_bit avals, true) in
+        let bitstring avals = VL_bits (List.map value_of_aval_bit avals) in
         let first_chunk = bitstring (Util.take (len mod 64) avals) in
         let chunks = Util.drop (len mod 64) avals |> chunkify 64 |> List.map bitstring in
         let gs = ngensym () in
-        ( [iinit l (CT_lbits true) gs (V_lit (first_chunk, CT_fbits (len mod 64, true)))]
+        ( [iinit l CT_lbits gs (V_lit (first_chunk, CT_fbits (len mod 64)))]
           @ List.map
               (fun chunk ->
                 ifuncall l
-                  (CL_id (gs, CT_lbits true))
+                  (CL_id (gs, CT_lbits))
                   (mk_id "append_64", [])
-                  [V_id (gs, CT_lbits true); V_lit (chunk, CT_fbits (64, true))]
+                  [V_id (gs, CT_lbits); V_lit (chunk, CT_fbits 64)]
               )
               chunks,
-          V_id (gs, CT_lbits true),
-          [iclear (CT_lbits true) gs]
+          V_id (gs, CT_lbits),
+          [iclear CT_lbits gs]
         )
     (* If we have a bitvector value, that isn't a literal then we need to set bits individually. *)
     | AV_vector (avals, Typ_aux (Typ_app (id, _), _)) when string_of_id id = "bitvector" && List.length avals <= 64 ->
-        let ord = Env.get_default_order ctx.tc_env in
         let len = List.length avals in
-        let direction = match ord with Ord_aux (Ord_inc, _) -> false | Ord_aux (Ord_dec, _) -> true in
         let gs = ngensym () in
-        let ctyp = CT_fbits (len, direction) in
+        let ctyp = CT_fbits len in
         let mask i =
           VL_bits
-            ( Util.list_init (63 - i) (fun _ -> Sail2_values.B0)
-              @ [Sail2_values.B1]
-              @ Util.list_init i (fun _ -> Sail2_values.B0),
-              direction
+            (Util.list_init (63 - i) (fun _ -> Sail2_values.B0)
+            @ [Sail2_values.B1]
+            @ Util.list_init i (fun _ -> Sail2_values.B0)
             )
         in
         let aval_mask i aval =
@@ -490,7 +487,7 @@ module Make (C : Config) = struct
         in
         ( [
             idecl l ctyp gs;
-            icopy l (CL_id (gs, ctyp)) (V_lit (VL_bits (Util.list_init len (fun _ -> Sail2_values.B0), direction), ctyp));
+            icopy l (CL_id (gs, ctyp)) (V_lit (VL_bits (Util.list_init len (fun _ -> Sail2_values.B0)), ctyp));
           ]
           @ List.concat (List.mapi aval_mask (List.rev avals)),
           V_id (gs, ctyp),
@@ -502,7 +499,7 @@ module Make (C : Config) = struct
         let len = List.length avals in
         let direction = match ord with Ord_aux (Ord_inc, _) -> false | Ord_aux (Ord_dec, _) -> true in
         let elem_ctyp = ctyp_of_typ ctx typ in
-        let vector_ctyp = CT_vector (direction, elem_ctyp) in
+        let vector_ctyp = CT_vector elem_ctyp in
         let gs = ngensym () in
         let aval_set i aval =
           let setup, cval, cleanup = compile_aval l ctx aval in
@@ -1731,13 +1728,13 @@ let optimize_call l ctx clexp id args arg_ctyps ret_ctyp =
     else specialize_functions ~specialized_calls ctx cdefs
 
   let map_structs_and_variants f = function
-    | ( CT_lint | CT_fint _ | CT_constant _ | CT_lbits _ | CT_fbits _ | CT_sbits _ | CT_bit | CT_unit | CT_bool
-      | CT_real | CT_string | CT_poly _ | CT_enum _ | CT_float _ | CT_rounding_mode ) as ctyp ->
+    | ( CT_lint | CT_fint _ | CT_constant _ | CT_lbits | CT_fbits _ | CT_sbits _ | CT_bit | CT_unit | CT_bool | CT_real
+      | CT_string | CT_poly _ | CT_enum _ | CT_float _ | CT_rounding_mode ) as ctyp ->
         ctyp
     | CT_tup ctyps -> CT_tup (List.map (map_ctyp f) ctyps)
     | CT_ref ctyp -> CT_ref (map_ctyp f ctyp)
-    | CT_vector (direction, ctyp) -> CT_vector (direction, map_ctyp f ctyp)
-    | CT_fvector (n, direction, ctyp) -> CT_fvector (n, direction, map_ctyp f ctyp)
+    | CT_vector ctyp -> CT_vector (map_ctyp f ctyp)
+    | CT_fvector (n, ctyp) -> CT_fvector (n, map_ctyp f ctyp)
     | CT_list ctyp -> CT_list (map_ctyp f ctyp)
     | CT_struct (id, fields) -> begin
         match f (CT_struct (id, fields)) with

--- a/src/lib/jib_optimize.ml
+++ b/src/lib/jib_optimize.ml
@@ -382,8 +382,8 @@ let remove_tuples cdefs ctx =
     | CT_tup ctyps as ctyp -> CTSet.add ctyp (List.fold_left CTSet.union CTSet.empty (List.map all_tuples ctyps))
     | CT_struct (_, id_ctyps) | CT_variant (_, id_ctyps) ->
         List.fold_left (fun cts (_, ctyp) -> CTSet.union (all_tuples ctyp) cts) CTSet.empty id_ctyps
-    | CT_list ctyp | CT_vector (_, ctyp) | CT_fvector (_, _, ctyp) | CT_ref ctyp -> all_tuples ctyp
-    | CT_lint | CT_fint _ | CT_lbits _ | CT_sbits _ | CT_fbits _ | CT_constant _ | CT_float _ | CT_unit | CT_bool
+    | CT_list ctyp | CT_vector ctyp | CT_fvector (_, ctyp) | CT_ref ctyp -> all_tuples ctyp
+    | CT_lint | CT_fint _ | CT_lbits | CT_sbits _ | CT_fbits _ | CT_constant _ | CT_float _ | CT_unit | CT_bool
     | CT_real | CT_bit | CT_poly _ | CT_string | CT_enum _ | CT_rounding_mode ->
         CTSet.empty
   in
@@ -391,8 +391,8 @@ let remove_tuples cdefs ctx =
     | CT_tup ctyps -> 1 + List.fold_left (fun d ctyp -> max d (tuple_depth ctyp)) 0 ctyps
     | CT_struct (_, id_ctyps) | CT_variant (_, id_ctyps) ->
         List.fold_left (fun d (_, ctyp) -> max (tuple_depth ctyp) d) 0 id_ctyps
-    | CT_list ctyp | CT_vector (_, ctyp) | CT_fvector (_, _, ctyp) | CT_ref ctyp -> tuple_depth ctyp
-    | CT_lint | CT_fint _ | CT_lbits _ | CT_sbits _ | CT_fbits _ | CT_constant _ | CT_unit | CT_bool | CT_real | CT_bit
+    | CT_list ctyp | CT_vector ctyp | CT_fvector (_, ctyp) | CT_ref ctyp -> tuple_depth ctyp
+    | CT_lint | CT_fint _ | CT_lbits | CT_sbits _ | CT_fbits _ | CT_constant _ | CT_unit | CT_bool | CT_real | CT_bit
     | CT_poly _ | CT_string | CT_enum _ | CT_float _ | CT_rounding_mode ->
         0
   in
@@ -404,10 +404,10 @@ let remove_tuples cdefs ctx =
     | CT_struct (id, id_ctyps) -> CT_struct (id, List.map (fun (id, ctyp) -> (id, fix_tuples ctyp)) id_ctyps)
     | CT_variant (id, id_ctyps) -> CT_variant (id, List.map (fun (id, ctyp) -> (id, fix_tuples ctyp)) id_ctyps)
     | CT_list ctyp -> CT_list (fix_tuples ctyp)
-    | CT_vector (d, ctyp) -> CT_vector (d, fix_tuples ctyp)
-    | CT_fvector (n, d, ctyp) -> CT_fvector (n, d, fix_tuples ctyp)
+    | CT_vector ctyp -> CT_vector (fix_tuples ctyp)
+    | CT_fvector (n, ctyp) -> CT_fvector (n, fix_tuples ctyp)
     | CT_ref ctyp -> CT_ref (fix_tuples ctyp)
-    | ( CT_lint | CT_fint _ | CT_lbits _ | CT_sbits _ | CT_fbits _ | CT_constant _ | CT_float _ | CT_unit | CT_bool
+    | ( CT_lint | CT_fint _ | CT_lbits | CT_sbits _ | CT_fbits _ | CT_constant _ | CT_float _ | CT_unit | CT_bool
       | CT_real | CT_bit | CT_poly _ | CT_string | CT_enum _ | CT_rounding_mode ) as ctyp ->
         ctyp
   and fix_cval = function

--- a/src/lib/mappings.ml
+++ b/src/lib/mappings.ml
@@ -346,7 +346,7 @@ let rewrite_ast ast =
         let typ = typ_of_annot annot in
         begin
           match typ with
-          | Typ_aux (Typ_app (f, [A_aux (A_nexp (Nexp_aux (Nexp_constant n, _)), _); _]), _)
+          | Typ_aux (Typ_app (f, [A_aux (A_nexp (Nexp_aux (Nexp_constant n, _)), _)]), _)
             when string_of_id f = "bitvector" ->
               P_aux (P_typ (typ, P_aux (P_app (mapping, pats), annot)), annot)
           | _ -> P_aux (P_app (mapping, pats), annot)

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -94,11 +94,10 @@ let rec lem_nexps_of_typ (Typ_aux (t, l)) =
   | Typ_var kid -> NexpSet.singleton (orig_nexp (nvar kid))
   | Typ_fn (t1, t2) -> List.fold_left NexpSet.union (trec t2) (List.map trec t1)
   | Typ_tuple ts -> List.fold_left (fun s t -> NexpSet.union s (trec t)) NexpSet.empty ts
-  | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _); A_aux (A_order ord, _)]) ->
+  | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]) ->
       let m = nexp_simp m in
       if !opt_mwords && not (is_nexp_constant m) then NexpSet.singleton (orig_nexp m) else trec bit_typ
-  | Typ_app (Id_aux (Id "vector", _), [A_aux (A_nexp m, _); A_aux (A_order ord, _); A_aux (A_typ elem_typ, _)]) ->
-      trec elem_typ
+  | Typ_app (Id_aux (Id "vector", _), [A_aux (A_nexp m, _); A_aux (A_typ elem_typ, _)]) -> trec elem_typ
   | Typ_app (Id_aux (Id "register", _), [A_aux (A_typ etyp, _)]) -> trec etyp
   | Typ_app (Id_aux (Id "range", _), _) | Typ_app (Id_aux (Id "implicit", _), _) | Typ_app (Id_aux (Id "atom", _), _) ->
       NexpSet.empty
@@ -113,7 +112,6 @@ and lem_nexps_of_typ_arg (A_aux (ta, _)) =
       let nexp = nexp_simp (orig_nexp nexp) in
       if is_nexp_constant nexp then NexpSet.empty else NexpSet.singleton nexp
   | A_typ typ -> lem_nexps_of_typ typ
-  | A_order _ -> NexpSet.empty
   | A_bool _ -> NexpSet.empty
 
 let rec typeclass_nexps (Typ_aux (t, l)) =
@@ -122,7 +120,7 @@ let rec typeclass_nexps (Typ_aux (t, l)) =
     | Typ_id _ | Typ_var _ -> NexpSet.empty
     | Typ_fn (ts, t) -> List.fold_left NexpSet.union (typeclass_nexps t) (List.map typeclass_nexps ts)
     | Typ_tuple ts -> List.fold_left NexpSet.union NexpSet.empty (List.map typeclass_nexps ts)
-    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp size_nexp, _); _])
+    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp size_nexp, _)])
     | Typ_app (Id_aux (Id "itself", _), [A_aux (A_nexp size_nexp, _)]) ->
         let size_nexp = nexp_simp size_nexp in
         if is_nexp_constant size_nexp then NexpSet.empty else NexpSet.singleton (orig_nexp size_nexp)
@@ -173,12 +171,6 @@ let tabulate f n =
   if Big_int.equal n Big_int.zero then [] else aux [] (Big_int.sub n (Big_int.of_int 1))
 
 let make_vectors sz = tabulate (make_vector_lit sz) (Big_int.shift_left (Big_int.of_int 1) sz)
-
-let is_inc_vec typ =
-  try
-    let _, ord, _ = vector_typ_args_of typ in
-    is_order_inc ord
-  with _ -> false
 
 let rec cross' = function
   | [] -> [[]]
@@ -277,7 +269,7 @@ let rec contains_exist (Typ_aux (ty, l)) =
   | Typ_internal_unknown -> Reporting.unreachable l __POS__ "escaped Typ_internal_unknown"
 
 and contains_exist_arg (A_aux (arg, _)) =
-  match arg with A_nexp _ | A_order _ | A_bool _ -> false | A_typ typ -> contains_exist typ
+  match arg with A_nexp _ | A_bool _ -> false | A_typ typ -> contains_exist typ
 
 let is_number typ = match destruct_numeric typ with Some _ -> true | None -> false
 
@@ -322,8 +314,7 @@ let split_src_type all_errors env id ty (TypQ_aux (q, ql)) =
             (cross' tys)
         in
         (kidset_bigunion vars, insttys)
-    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp sz, _); _]) ->
-        (KidSet.of_list (size_nvars_nexp sz), [([], typ)])
+    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp sz, _)]) -> (KidSet.of_list (size_nvars_nexp sz), [([], typ)])
     | Typ_app (_, tas) ->
         (KidSet.empty, [([], typ)])
         (* We only support sizes for bitvectors mentioned explicitly, not any buried
@@ -770,7 +761,7 @@ let split_defs target all_errors (splits : split_req list) env ast =
           | _ -> cannot ("don't know about type " ^ string_of_id id)
         )
       )
-    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp len, _); _]) -> (
+    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp len, _)]) -> (
         match len with
         | Nexp_aux (Nexp_constant sz, _) when Big_int.greater_equal sz Big_int.zero ->
             let sz = Big_int.to_int sz in
@@ -1457,7 +1448,7 @@ module AtomToItself = struct
           match destruct_tannot tannot with
           | Some (env, typ) -> begin
               match Env.base_typ_of env typ with
-              | Typ_aux (Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp size, _); _]), _)
+              | Typ_aux (Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp size, _)]), _)
                 when not (is_nexp_constant size) ->
                   parameters_for_nexp env size
               | _ -> IntSet.empty
@@ -2022,14 +2013,13 @@ module Analysis = struct
     | A_nexp (Nexp_aux (Nexp_var kid, _)) when List.exists (fun k -> Kid.compare kid k == 0) env.top_kids ->
         parents_call_dep (CallerKidSet.singleton (fn_id, kid))
     | A_nexp nexp -> in_fun_call_dep (deps_of_nexp l env.kid_deps arg_deps nexp)
-    | A_order _ -> in_fun_call_dep dempty
     | A_typ typ -> in_fun_call_dep (deps_of_typ l env.kid_deps arg_deps typ)
     | A_bool nc -> in_fun_call_dep (deps_of_nc env.kid_deps nc)
 
   let mk_subrange_pattern vannot vstart vend =
-    let len, ord, typ = vector_typ_args_of (Env.base_typ_of (env_of_annot vannot) (typ_of_annot vannot)) in
+    let ord = Env.get_default_order (env_of_annot vannot) in
+    let len, typ = vector_typ_args_of (Env.base_typ_of (env_of_annot vannot) (typ_of_annot vannot)) in
     match ord with
-    | Ord_aux (Ord_var _, _) -> None
     | Ord_aux (ord', _) -> (
         let vstart, vend = if ord' = Ord_inc then (vstart, vend) else (vend, vstart) in
         let dummyl = Generated Unknown in
@@ -2046,7 +2036,7 @@ module Analysis = struct
                     [
                       pat;
                       P_aux
-                        ( P_typ (bitvector_typ (nconstant end_len) ord, P_aux (P_wild, (dummyl, empty_tannot))),
+                        ( P_typ (bitvector_typ (nconstant end_len), P_aux (P_wild, (dummyl, empty_tannot))),
                           (dummyl, empty_tannot)
                         );
                     ]
@@ -2055,7 +2045,7 @@ module Analysis = struct
                 let pats =
                   if Big_int.greater vstart Big_int.zero then
                     P_aux
-                      ( P_typ (bitvector_typ (nconstant vstart) ord, P_aux (P_wild, (dummyl, empty_tannot))),
+                      ( P_typ (bitvector_typ (nconstant vstart), P_aux (P_wild, (dummyl, empty_tannot))),
                         (dummyl, empty_tannot)
                       )
                     :: pats
@@ -2468,7 +2458,7 @@ module Analysis = struct
           in
           let rec check_typ typ =
             if is_bitvector_typ typ then (
-              let size, _, _ = vector_typ_args_of typ in
+              let size, _ = vector_typ_args_of typ in
               let (Nexp_aux (size, _) as size_nexp) = simplify_size_nexp env tenv size in
               let is_tyvar_parameter v = List.exists (fun k -> Kid.compare k v == 0) env.top_kids in
               match size with
@@ -2959,7 +2949,7 @@ module MonoRewrites = struct
   let get_constant_vec_len ?(solve = false) env typ =
     let typ = Env.base_typ_of env typ in
     match destruct_bitvector env typ with
-    | Some (size, _) -> begin
+    | Some size -> begin
         match nexp_simp size with
         | Nexp_aux (Nexp_constant i, _) -> Some i
         | nexp when solve -> solve_unique env nexp
@@ -3013,12 +3003,12 @@ module MonoRewrites = struct
         )
     in
     let try_cast_to_typ (E_aux (e, (l, _)) as exp) =
-      let size, order, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
+      let size, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
       (* vector_typ_args_of might simplify size, so rebuild the type even if it's constant *)
       match size with
-      | Nexp_aux (Nexp_constant c, _) -> E_typ (bitvector_typ (nconstant c) order, exp)
+      | Nexp_aux (Nexp_constant c, _) -> E_typ (bitvector_typ (nconstant c), exp)
       | _ -> (
-          match solve_unique env size with Some c -> E_typ (bitvector_typ (nconstant c) order, exp) | None -> e
+          match solve_unique env size with Some c -> E_typ (bitvector_typ (nconstant c), exp) | None -> e
         )
     in
     let rewrap e = E_aux (e, (Unknown, empty_tannot)) in
@@ -3034,13 +3024,13 @@ module MonoRewrites = struct
              && is_bitvector_typ (typ_of vector1)
              && is_bitvector_typ (typ_of vector2)
              && not (is_constant_vec_typ env (typ_of sub1) || is_constant_vec_typ env (typ_of sub2)) ->
-          let size, order, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
-          let size1, _, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
+          let size, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
+          let size1, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
           let midsize = nminus size size1 in
           begin
             match solve_unique env midsize with
             | Some c ->
-                let midtyp = bitvector_typ (nconstant c) order in
+                let midtyp = bitvector_typ (nconstant c) in
                 E_app
                   ( append,
                     [
@@ -3079,13 +3069,13 @@ module MonoRewrites = struct
              && is_bitvector_typ (typ_of vector1)
              && is_bitvector_typ (typ_of vector2)
              && not (is_constant length1 || is_constant length2) ->
-          let size, order, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
-          let size1, _, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
+          let size, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
+          let size1, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
           let midsize = nminus size size1 in
           begin
             match solve_unique env midsize with
             | Some c ->
-                let midtyp = bitvector_typ (nconstant c) order in
+                let midtyp = bitvector_typ (nconstant c) in
                 E_app
                   ( append,
                     [
@@ -3207,13 +3197,13 @@ module MonoRewrites = struct
              && is_bitvector_typ (typ_of vector1)
              && not (is_constant_vec_typ env (typ_of slice1) || is_constant length2) ->
           let op' = mk_id (if is_subrange op then "subrange_zeros_concat" else "slice_zeros_concat") in
-          let size, order, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
-          let size1, _, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
+          let size, bittyp = vector_typ_args_of (Env.base_typ_of env typ) in
+          let size1, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
           let midsize = nminus size size1 in
           begin
             match solve_unique env midsize with
             | Some c ->
-                let midtyp = bitvector_typ (nconstant c) order in
+                let midtyp = bitvector_typ (nconstant c) in
                 try_cast_to_typ
                   (E_aux
                      ( E_app
@@ -3249,10 +3239,10 @@ module MonoRewrites = struct
              && is_constant_vec_typ env (typ_of e1)
              && is_constant_vec_typ env (typ_of e2)
              && not (is_constant_vec_typ env (typ_of e3)) ->
-          let size1, order, bittyp = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
-          let size2, _, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e2)) in
+          let size1, bittyp = vector_typ_args_of (Env.base_typ_of env (typ_of e1)) in
+          let size2, _ = vector_typ_args_of (Env.base_typ_of env (typ_of e2)) in
           let size12 = nexp_simp (nsum size1 size2) in
-          let tannot12 = mk_tannot env (bitvector_typ size12 order) in
+          let tannot12 = mk_tannot env (bitvector_typ size12) in
           E_app (id, [E_aux (E_app (append1, [e1; e2]), (Unknown, tannot12)); e3])
       | _ -> E_app (id, args)
     )
@@ -3381,7 +3371,7 @@ module MonoRewrites = struct
                 match vector1 with
                 | E_aux (E_app (slice1, [vector1; start1; length1]), _) -> (vector1, start1, length1)
                 | _ ->
-                    let length1, _, _ = vector_typ_args_of (Env.base_typ_of env (typ_of vector1)) in
+                    let length1, _ = vector_typ_args_of (Env.base_typ_of env (typ_of vector1)) in
                     (vector1, mk_exp (E_lit (mk_lit (L_num Big_int.zero))), mk_exp (E_sizeof length1))
               in
               try_cast_to_typ (rewrap (E_app (mk_id "place_slice", length_arg @ [vector1; start1; length1; zlen])))
@@ -3530,10 +3520,10 @@ module MonoRewrites = struct
       match (get_constant_vec_len ~solve:true env typ, args) with
       | Some i, [vector1; start1; end1]
         when is_bitvector_typ (typ_of vector1) && not (is_constant start1 && is_constant end1) ->
-          let inc = is_inc_vec (typ_of vector1) in
+          let inc = is_order_inc (Env.get_default_order (env_of vector1)) in
           let low = if inc then start1 else end1 in
           let exp' = rewrap (E_app (mk_id "slice", [vector1; low; mk_exp (E_lit (mk_lit (L_num i)))])) in
-          E_typ (bitvector_typ (nconstant i) (if inc then inc_ord else dec_ord), exp')
+          E_typ (bitvector_typ (nconstant i), exp')
       | _, _ ->
           E_app (id, args)
           (* Rewrite (v[x .. y] + i) to (v + (i << y))[x .. y], which is more amenable to further rewriting *)
@@ -3542,7 +3532,7 @@ module MonoRewrites = struct
       match args with
       | [(E_aux (E_app (subrange1, [vec1; start1; end1]), a) as exp1); exp2]
         when is_subrange subrange1 && is_bitvector_typ (typ_of vec1) && not (is_constant_vec_typ env (typ_of exp1)) ->
-          let low = if is_inc_vec (typ_of vec1) then start1 else end1 in
+          let low = if is_order_inc (Env.get_default_order (env_of vec1)) then start1 else end1 in
           let exp2' = mk_exp (E_app (mk_id "shl_int", [exp2; low])) in
           let vec1' = E_aux (E_app (id, [vec1; exp2']), a) in
           E_app (subrange1, [vec1'; start1; end1])
@@ -3723,12 +3713,12 @@ module BitvectorSizeCasts = struct
           ( P_aux (P_typ (src_typ, P_aux (P_tuple ps, (Generated src_l, src_ann))), (Generated src_l, src_ann)),
             E_aux (E_tuple es, (Generated tar_l, tar_ann))
           )
-      | ( Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp size, _); _]),
-          Typ_app ((Id_aux (Id "bitvector", _) as t_id), [A_aux (A_nexp size', l_size'); t_ord]) ) -> begin
+      | ( Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp size, _)]),
+          Typ_app ((Id_aux (Id "bitvector", _) as t_id), [A_aux (A_nexp size', l_size')]) ) -> begin
           match (simplify_size_nexp env quant_kids size, simplify_size_nexp top_env quant_kids size') with
           | Some size, Some size' when Nexp.compare size size' <> 0 ->
               let var = fresh () in
-              let tar_typ' = Typ_aux (Typ_app (t_id, [A_aux (A_nexp size', l_size'); t_ord]), tar_l) in
+              let tar_typ' = Typ_aux (Typ_app (t_id, [A_aux (A_nexp size', l_size')]), tar_l) in
               let () = at_least_one := Some tar_typ' in
               ( P_aux (P_id var, (Generated src_l, src_ann)),
                 E_aux
@@ -3952,7 +3942,7 @@ module BitvectorSizeCasts = struct
       KidSet.fold
         (fun kid subst ->
           match Env.get_typ_var kid env with
-          | K_type | K_order | K_bool -> subst
+          | K_type | K_bool -> subst
           | K_int -> (
               match solve_unique env (nvar kid) with None -> subst | Some n -> KBindings.add kid (nconstant n) subst
             )
@@ -4224,9 +4214,8 @@ module BitvectorSizeCasts = struct
     let defs = List.mapi rewrite_def defs in
     let _ = Util.progress "Adding casts " "done" (List.length defs) (List.length defs) in
     let cast_specs, _ =
-      (* TODO: use default/relevant order *)
       let kid = mk_kid "n" in
-      let bitsn = bitvector_typ (nvar kid) dec_ord in
+      let bitsn = bitvector_typ (nvar kid) in
       let ts = mk_typschm (mk_typquant [mk_qi_id K_int kid]) (function_typ [bitsn] bitsn) in
       let mkfn name = mk_val_spec (VS_val_spec (ts, name, Some { pure = true; bindings = [("_", "zeroExtend")] })) in
       let defs = List.map mkfn (IdSet.elements !specs_required) in
@@ -4267,7 +4256,7 @@ module ToplevelNexpRewrites = struct
       | A_typ typ ->
           let f, typ = aux typ in
           (f, A_aux (A_typ typ, l))
-      | A_order _ | A_bool _ -> (false, typ_arg)
+      | A_bool _ -> (false, typ_arg)
     in
     aux typ
 
@@ -4332,7 +4321,7 @@ module ToplevelNexpRewrites = struct
                     in
                     let new_nexp = nvar kid in
                     (nexp_map, A_aux (A_nexp new_nexp, l))
-                | A_bool _ | A_order _ -> (nexp_map, arg_full)
+                | A_bool _ -> (nexp_map, arg_full)
               in
               let nexp_map, args =
                 List.fold_right
@@ -4380,10 +4369,9 @@ module ToplevelNexpRewrites = struct
             Typ_aux (Typ_exist (kids, (* TODO? *) nc, aux typ'), l)
         | Typ_app (id, targs) -> Typ_aux (Typ_app (id, List.map aux_targ targs), l)
         | _ -> typ_full
-      and aux_targ (A_aux (ta, l) as ta_full) =
+      and aux_targ (A_aux (ta, l)) =
         match ta with
         | A_typ typ -> A_aux (A_typ (aux typ), l)
-        | A_order _ -> ta_full
         | A_nexp nexp -> A_aux (A_nexp (aux_nexp nexp), l)
         | A_bool nc -> A_aux (A_bool (aux_nconstraint nc), l)
       and aux_nexp nexp = match find_nexp env nexp_map nexp with kid, _ -> nvar kid | exception Not_found -> nexp

--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -387,7 +387,7 @@ module Make (C : Config) = struct
               match acc with
               | None -> None
               | Some lengths -> (
-                  let nexp, _, _ = vector_typ_args_of typ in
+                  let nexp, _ = vector_typ_args_of typ in
                   match int_of_nexp_opt nexp with Some n -> Some (Big_int.to_int n :: lengths) | None -> None
                 )
             )

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -87,7 +87,6 @@ let doc_attr attr arg =
 let doc_kopt_no_parens = function
   | kopt when is_int_kopt kopt -> doc_kid (kopt_kid kopt)
   | kopt when is_typ_kopt kopt -> separate space [doc_kid (kopt_kid kopt); colon; string "Type"]
-  | kopt when is_order_kopt kopt -> separate space [doc_kid (kopt_kid kopt); colon; string "Order"]
   | kopt -> separate space [doc_kid (kopt_kid kopt); colon; string "Bool"]
 
 let doc_kopt = function
@@ -96,7 +95,7 @@ let doc_kopt = function
 
 let doc_int n = string (Big_int.to_string n)
 
-let doc_ord (Ord_aux (o, _)) = match o with Ord_var v -> doc_kid v | Ord_inc -> string "inc" | Ord_dec -> string "dec"
+let doc_ord (Ord_aux (o, _)) = match o with Ord_inc -> string "inc" | Ord_dec -> string "dec"
 
 let rec doc_typ_pat (TP_aux (tpat_aux, _)) =
   match tpat_aux with
@@ -204,11 +203,7 @@ and doc_typ ?(simple = false) (Typ_aux (typ_aux, l)) =
   | Typ_internal_unknown -> raise (Reporting.err_unreachable l __POS__ "escaped Typ_internal_unknown")
 
 and doc_typ_arg (A_aux (ta_aux, _)) =
-  match ta_aux with
-  | A_typ typ -> doc_typ typ
-  | A_nexp nexp -> doc_nexp nexp
-  | A_order o -> doc_ord o
-  | A_bool nc -> doc_nc nc
+  match ta_aux with A_typ typ -> doc_typ typ | A_nexp nexp -> doc_nexp nexp | A_bool nc -> doc_nc nc
 
 and doc_arg_typs = function [typ] -> doc_typ typ | typs -> parens (separate_map (comma ^^ space) doc_typ typs)
 
@@ -217,8 +212,7 @@ let doc_subst (IS_aux (subst_aux, _)) =
   | IS_typ (kid, typ) -> doc_kid kid ^^ space ^^ equals ^^ space ^^ doc_typ typ
   | IS_id (id1, id2) -> doc_id id1 ^^ space ^^ equals ^^ space ^^ doc_id id2
 
-let doc_kind (K_aux (k, _)) =
-  string (match k with K_int -> "Int" | K_type -> "Type" | K_bool -> "Bool" | K_order -> "Order")
+let doc_kind (K_aux (k, _)) = string (match k with K_int -> "Int" | K_type -> "Type" | K_bool -> "Bool")
 
 let doc_kopts = separate_map space doc_kopt
 
@@ -241,8 +235,7 @@ let doc_param_quants quants =
     match qi_aux with
     | QI_id kopt when is_int_kopt kopt -> [doc_kid (kopt_kid kopt) ^^ colon ^^ space ^^ string "Int"]
     | QI_id kopt when is_typ_kopt kopt -> [doc_kid (kopt_kid kopt) ^^ colon ^^ space ^^ string "Type"]
-    | QI_id kopt when is_bool_kopt kopt -> [doc_kid (kopt_kid kopt) ^^ colon ^^ space ^^ string "Bool"]
-    | QI_id kopt -> [doc_kid (kopt_kid kopt) ^^ colon ^^ space ^^ string "Order"]
+    | QI_id kopt -> [doc_kid (kopt_kid kopt) ^^ colon ^^ space ^^ string "Bool"]
     | QI_constraint _ -> []
   in
   let qi_nc (QI_aux (qi_aux, _)) = match qi_aux with QI_constraint nc -> [nc] | _ -> [] in
@@ -667,7 +660,6 @@ let doc_typ_arg_kind sep (A_aux (aux, _)) =
   match aux with
   | A_nexp _ -> space ^^ string sep ^^ space ^^ string "Int"
   | A_bool _ -> space ^^ string sep ^^ space ^^ string "Bool"
-  | A_order _ -> space ^^ string sep ^^ space ^^ string "Order"
   | A_typ _ -> empty
 
 let doc_typdef (TD_aux (td, _)) =

--- a/src/lib/specialize.mli
+++ b/src/lib/specialize.mli
@@ -76,8 +76,8 @@ val opt_ddump_spec_ast : (string * int) option ref
 
 type specialization
 
-(** Only specialize Type- and Ord- kinded polymorphism. *)
-val typ_ord_specialization : specialization
+(** Only specialize Type- kinded polymorphism. *)
+val typ_specialization : specialization
 
 (** (experimental) specialise Int-kinded definitions *)
 val int_specialization : specialization

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -153,6 +153,8 @@ module Env : sig
 
   val add_local : id -> mut * typ -> t -> t
 
+  val get_default_order : t -> order
+
   val get_default_order_option : t -> order option
 
   val add_scattered_variant : id -> typquant -> t -> t
@@ -471,8 +473,10 @@ val destruct_range : Env.t -> typ -> (kid list * n_constraint * nexp * nexp) opt
 
 val destruct_numeric : ?name:string option -> typ -> (kid list * n_constraint * nexp) option
 
-val destruct_vector : Env.t -> typ -> (nexp * order * typ) option
-val destruct_bitvector : Env.t -> typ -> (nexp * order) option
+val destruct_vector : Env.t -> typ -> (nexp * typ) option
+val destruct_bitvector : Env.t -> typ -> nexp option
+
+val vector_start_index : Env.t -> typ -> nexp
 
 (** Construct an existential type with a guaranteed fresh
    identifier. *)

--- a/src/lib/value2.lem
+++ b/src/lib/value2.lem
@@ -70,7 +70,7 @@ open import Pervasives
 open import Sail2_values
 
 type vl =
-  | VL_bits of list bitU * bool
+  | VL_bits of list bitU
   | VL_bit of bitU
   | VL_bool of bool
   | VL_unit

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -132,8 +132,8 @@ let rec is_stack_ctyp ctyp =
   | CT_fint n -> n <= 64
   | CT_lint when !optimize_fixed_int -> true
   | CT_lint -> false
-  | CT_lbits _ when !optimize_fixed_bits -> true
-  | CT_lbits _ -> false
+  | CT_lbits when !optimize_fixed_bits -> true
+  | CT_lbits -> false
   | CT_real | CT_string | CT_list _ | CT_vector _ | CT_fvector _ -> false
   | CT_struct (_, fields) -> List.for_all (fun (_, ctyp) -> is_stack_ctyp ctyp) fields
   | CT_variant (_, _) ->
@@ -147,7 +147,7 @@ let rec is_stack_ctyp ctyp =
   | CT_rounding_mode -> true
   | CT_constant n -> Big_int.less_equal (min_int 64) n && Big_int.greater_equal n (max_int 64)
 
-let v_mask_lower i = V_lit (VL_bits (Util.list_init i (fun _ -> Sail2_values.B1), true), CT_fbits (i, true))
+let v_mask_lower i = V_lit (VL_bits (Util.list_init i (fun _ -> Sail2_values.B1)), CT_fbits i)
 
 let hex_char =
   let open Sail2_values in
@@ -178,7 +178,7 @@ let literal_to_fragment (L_aux (l_aux, _)) =
       let padding = 16 - String.length str in
       let padding = Util.list_init padding (fun _ -> Sail2_values.B0) in
       let content = Util.string_to_list str |> List.map hex_char |> List.concat in
-      Some (V_lit (VL_bits (padding @ content, true), CT_fbits (String.length str * 4, true)))
+      Some (V_lit (VL_bits (padding @ content), CT_fbits (String.length str * 4)))
   | L_unit -> Some (V_lit (VL_unit, CT_unit))
   | L_true -> Some (V_lit (VL_bool true, CT_bool))
   | L_false -> Some (V_lit (VL_bool false, CT_bool))
@@ -231,18 +231,14 @@ end) : Config = struct
        - If the length is obviously static and smaller than 64, use the fixed bits type (aka uint64_t), fbits.
        - If the length is less than 64, then use a small bits type, sbits.
        - If the length may be larger than 64, use a large bits type lbits. *)
-    | Typ_app (id, [A_aux (A_nexp n, _)]) when string_of_id id = "bitvector" ->
-        let direction = true in
-        begin
-          match nexp_simp n with
-          | Nexp_aux (Nexp_constant n, _) when Big_int.less_equal n (Big_int.of_int 64) ->
-              CT_fbits (Big_int.to_int n, direction)
-          | n when prove __POS__ ctx.local_env (nc_lteq n (nint 64)) -> CT_sbits (64, direction)
-          | _ -> CT_lbits direction
-        end
+    | Typ_app (id, [A_aux (A_nexp n, _)]) when string_of_id id = "bitvector" -> begin
+        match nexp_simp n with
+        | Nexp_aux (Nexp_constant n, _) when Big_int.less_equal n (Big_int.of_int 64) -> CT_fbits (Big_int.to_int n)
+        | n when prove __POS__ ctx.local_env (nc_lteq n (nint 64)) -> CT_sbits 64
+        | _ -> CT_lbits
+      end
     | Typ_app (id, [A_aux (A_nexp _, _); A_aux (A_typ typ, _)]) when string_of_id id = "vector" ->
-        let direction = true in
-        CT_vector (direction, convert_typ ctx typ)
+        CT_vector (convert_typ ctx typ)
     | Typ_app (id, [A_aux (A_typ typ, _)]) when string_of_id id = "register" -> CT_ref (convert_typ ctx typ)
     | Typ_id id when Bindings.mem id ctx.records ->
         CT_struct (id, Bindings.find id ctx.records |> snd |> Bindings.bindings)
@@ -318,7 +314,7 @@ end) : Config = struct
   (** Used to make sure the -Ofixed_int and -Ofixed_bits don't
      interfere with assumptions made about optimizations in the common
      case. *)
-  let never_optimize = function CT_lbits _ | CT_lint -> true | _ -> false
+  let never_optimize = function CT_lbits | CT_lint -> true | _ -> false
 
   let rec c_aval ctx = function
     | AV_lit (lit, typ) as v -> begin
@@ -351,8 +347,8 @@ end) : Config = struct
         | _ -> v
       end
     | AV_vector (v, typ) when is_bitvector v && List.length v <= 64 ->
-        let bitstring = VL_bits (List.map value_of_aval_bit v, true) in
-        AV_cval (V_lit (bitstring, CT_fbits (List.length v, true)), typ)
+        let bitstring = VL_bits (List.map value_of_aval_bit v) in
+        AV_cval (V_lit (bitstring, CT_fbits (List.length v)), typ)
     | AV_tuple avals -> AV_tuple (List.map (c_aval ctx) avals)
     | aval -> aval
 
@@ -432,8 +428,7 @@ end) : Config = struct
         | Some (Nexp_aux (Nexp_constant n, _), Typ_aux (Typ_id id, _))
           when string_of_id id = "bit" && Big_int.less_equal n (Big_int.of_int 64) ->
             let n = Big_int.to_int n in
-            AE_val
-              (AV_cval (V_lit (VL_bits (Util.list_init n (fun _ -> Sail2_values.B0), true), CT_fbits (n, true)), typ))
+            AE_val (AV_cval (V_lit (VL_bits (Util.list_init n (fun _ -> Sail2_values.B0)), CT_fbits n), typ))
         | _ -> no_change
       end
     | "zero_extend", [AV_cval (v, _); _] -> begin
@@ -472,13 +467,13 @@ end) : Config = struct
         AE_val (AV_cval (V_call (Bvxor, [v1; v2]), typ))
     | "vector_subrange", [AV_cval (vec, _); AV_cval (_, _); AV_cval (t, _)] -> begin
         match convert_typ ctx typ with
-        | CT_fbits (n, true) -> AE_val (AV_cval (V_call (Slice n, [vec; t]), typ))
+        | CT_fbits n -> AE_val (AV_cval (V_call (Slice n, [vec; t]), typ))
         | _ -> no_change
       end
     | "slice", [AV_cval (vec, _); AV_cval (start, _); AV_cval (len, _)] -> begin
         match convert_typ ctx typ with
-        | CT_fbits (n, _) -> AE_val (AV_cval (V_call (Slice n, [vec; start]), typ))
-        | CT_sbits (64, _) -> AE_val (AV_cval (V_call (Sslice 64, [vec; start; len]), typ))
+        | CT_fbits n -> AE_val (AV_cval (V_call (Slice n, [vec; start]), typ))
+        | CT_sbits 64 -> AE_val (AV_cval (V_call (Sslice 64, [vec; start; len]), typ))
         | _ -> no_change
       end
     | "vector_access", [AV_cval (vec, _); AV_cval (n, _)] -> AE_val (AV_cval (V_call (Bvaccess, [vec; n]), typ))
@@ -625,7 +620,7 @@ let add_local_labels instrs =
 (* 5. Optimizations                                                       *)
 (**************************************************************************)
 
-let hoist_ctyp = function CT_lint | CT_lbits _ | CT_struct _ -> true | _ -> false
+let hoist_ctyp = function CT_lint | CT_lbits | CT_struct _ -> true | _ -> false
 
 let hoist_counter = ref 0
 let hoist_id () =
@@ -841,14 +836,14 @@ let rec sgen_ctyp = function
   | CT_fint _ -> "int64_t"
   | CT_constant _ -> "int64_t"
   | CT_lint -> "sail_int"
-  | CT_lbits _ -> "lbits"
+  | CT_lbits -> "lbits"
   | CT_tup _ as tup -> "struct " ^ Util.zencode_string ("tuple_" ^ string_of_ctyp tup)
   | CT_struct (id, _) -> "struct " ^ sgen_id id
   | CT_enum (id, _) -> "enum " ^ sgen_id id
   | CT_variant (id, _) -> "struct " ^ sgen_id id
   | CT_list _ as l -> Util.zencode_string (string_of_ctyp l)
   | CT_vector _ as v -> Util.zencode_string (string_of_ctyp v)
-  | CT_fvector (_, ord, typ) -> sgen_ctyp (CT_vector (ord, typ))
+  | CT_fvector (_, typ) -> sgen_ctyp (CT_vector typ)
   | CT_string -> "sail_string"
   | CT_real -> "real"
   | CT_ref ctyp -> sgen_ctyp ctyp ^ "*"
@@ -867,14 +862,14 @@ let rec sgen_ctyp_name = function
   | CT_fint _ -> "mach_int"
   | CT_constant _ -> "mach_int"
   | CT_lint -> "sail_int"
-  | CT_lbits _ -> "lbits"
+  | CT_lbits -> "lbits"
   | CT_tup _ as tup -> Util.zencode_string ("tuple_" ^ string_of_ctyp tup)
   | CT_struct (id, _) -> sgen_id id
   | CT_enum (id, _) -> sgen_id id
   | CT_variant (id, _) -> sgen_id id
   | CT_list _ as l -> Util.zencode_string (string_of_ctyp l)
   | CT_vector _ as v -> Util.zencode_string (string_of_ctyp v)
-  | CT_fvector (_, ord, typ) -> sgen_ctyp_name (CT_vector (ord, typ))
+  | CT_fvector (_, typ) -> sgen_ctyp_name (CT_vector typ)
   | CT_string -> "sail_string"
   | CT_real -> "real"
   | CT_ref ctyp -> "ref_" ^ sgen_ctyp_name ctyp
@@ -892,9 +887,8 @@ let sgen_mask n =
   else failwith "Tried to create a mask literal for a vector greater than 64 bits."
 
 let sgen_value = function
-  | VL_bits ([], _) -> "UINT64_C(0)"
-  | VL_bits (bs, true) -> "UINT64_C(" ^ Sail2_values.show_bitlist bs ^ ")"
-  | VL_bits (bs, false) -> "UINT64_C(" ^ Sail2_values.show_bitlist (List.rev bs) ^ ")"
+  | VL_bits [] -> "UINT64_C(0)"
+  | VL_bits bs -> "UINT64_C(" ^ Sail2_values.show_bitlist bs ^ ")"
   | VL_int i -> if Big_int.equal i (min_int 64) then "INT64_MIN" else "INT64_C(" ^ Big_int.to_string i ^ ")"
   | VL_bool true -> "true"
   | VL_bool false -> "false"
@@ -948,7 +942,7 @@ and sgen_call op cvals =
   | Isub, [v1; v2] -> sprintf "(%s - %s)" (sgen_cval v1) (sgen_cval v2)
   | Unsigned 64, [vec] -> sprintf "((mach_int) %s)" (sgen_cval vec)
   | Signed 64, [vec] -> begin
-      match cval_ctyp vec with CT_fbits (n, _) -> sprintf "fast_signed(%s, %d)" (sgen_cval vec) n | _ -> assert false
+      match cval_ctyp vec with CT_fbits n -> sprintf "fast_signed(%s, %d)" (sgen_cval vec) n | _ -> assert false
     end
   | Bvand, [v1; v2] -> begin
       match cval_ctyp v1 with
@@ -958,7 +952,7 @@ and sgen_call op cvals =
     end
   | Bvnot, [v] -> begin
       match cval_ctyp v with
-      | CT_fbits (n, _) -> sprintf "(~(%s) & %s)" (sgen_cval v) (sgen_cval (v_mask_lower n))
+      | CT_fbits n -> sprintf "(~(%s) & %s)" (sgen_cval v) (sgen_cval (v_mask_lower n))
       | CT_sbits _ -> sprintf "not_sbits(%s)" (sgen_cval v)
       | _ -> assert false
     end
@@ -976,13 +970,13 @@ and sgen_call op cvals =
     end
   | Bvadd, [v1; v2] -> begin
       match cval_ctyp v1 with
-      | CT_fbits (n, _) -> sprintf "((%s + %s) & %s)" (sgen_cval v1) (sgen_cval v2) (sgen_cval (v_mask_lower n))
+      | CT_fbits n -> sprintf "((%s + %s) & %s)" (sgen_cval v1) (sgen_cval v2) (sgen_cval (v_mask_lower n))
       | CT_sbits _ -> sprintf "add_sbits(%s, %s)" (sgen_cval v1) (sgen_cval v2)
       | _ -> assert false
     end
   | Bvsub, [v1; v2] -> begin
       match cval_ctyp v1 with
-      | CT_fbits (n, _) -> sprintf "((%s - %s) & %s)" (sgen_cval v1) (sgen_cval v2) (sgen_cval (v_mask_lower n))
+      | CT_fbits n -> sprintf "((%s - %s) & %s)" (sgen_cval v1) (sgen_cval v2) (sgen_cval (v_mask_lower n))
       | CT_sbits _ -> sprintf "sub_sbits(%s, %s)" (sgen_cval v1) (sgen_cval v2)
       | _ -> assert false
     end
@@ -1007,7 +1001,7 @@ and sgen_call op cvals =
     end
   | Set_slice, [vec; start; slice] -> begin
       match (cval_ctyp vec, cval_ctyp slice) with
-      | CT_fbits (_, _), CT_fbits (m, _) ->
+      | CT_fbits _, CT_fbits m ->
           sprintf "((%s & ~(%s << %s)) | (%s << %s))" (sgen_cval vec) (sgen_mask m) (sgen_cval start) (sgen_cval slice)
             (sgen_cval start)
       | _ -> assert false
@@ -1020,33 +1014,33 @@ and sgen_call op cvals =
     end
   | Sign_extend n, [v] -> begin
       match cval_ctyp v with
-      | CT_fbits (m, _) -> sprintf "fast_sign_extend(%s, %d, %d)" (sgen_cval v) m n
+      | CT_fbits m -> sprintf "fast_sign_extend(%s, %d, %d)" (sgen_cval v) m n
       | CT_sbits _ -> sprintf "fast_sign_extend2(%s, %d)" (sgen_cval v) n
       | _ -> assert false
     end
   | Replicate n, [v] -> begin
       match cval_ctyp v with
-      | CT_fbits (m, _) -> sprintf "fast_replicate_bits(UINT64_C(%d), %s, %d)" m (sgen_cval v) n
+      | CT_fbits m -> sprintf "fast_replicate_bits(UINT64_C(%d), %s, %d)" m (sgen_cval v) n
       | _ -> assert false
     end
   | Concat, [v1; v2] -> begin
       (* Optimized routines for all combinations of fixed and small bits
          appends, where the result is guaranteed to be smaller than 64. *)
       match (cval_ctyp v1, cval_ctyp v2) with
-      | CT_fbits (0, _), CT_fbits (_, _) -> sgen_cval v2
-      | CT_fbits (_, _), CT_fbits (n2, _) -> sprintf "(%s << %d) | %s" (sgen_cval v1) n2 (sgen_cval v2)
-      | CT_sbits (64, _), CT_fbits (n2, _) -> sprintf "append_sf(%s, %s, %d)" (sgen_cval v1) (sgen_cval v2) n2
-      | CT_fbits (n1, _), CT_sbits (64, _) -> sprintf "append_fs(%s, %d, %s)" (sgen_cval v1) n1 (sgen_cval v2)
-      | CT_sbits (64, _), CT_sbits (64, _) -> sprintf "append_ss(%s, %s)" (sgen_cval v1) (sgen_cval v2)
+      | CT_fbits 0, CT_fbits _ -> sgen_cval v2
+      | CT_fbits _, CT_fbits n2 -> sprintf "(%s << %d) | %s" (sgen_cval v1) n2 (sgen_cval v2)
+      | CT_sbits 64, CT_fbits n2 -> sprintf "append_sf(%s, %s, %d)" (sgen_cval v1) (sgen_cval v2) n2
+      | CT_fbits n1, CT_sbits 64 -> sprintf "append_fs(%s, %d, %s)" (sgen_cval v1) n1 (sgen_cval v2)
+      | CT_sbits 64, CT_sbits 64 -> sprintf "append_ss(%s, %s)" (sgen_cval v1) (sgen_cval v2)
       | _ -> assert false
     end
   | _, _ -> failwith "Could not generate cval primop"
 
 let sgen_cval_param cval =
   match cval_ctyp cval with
-  | CT_lbits direction -> sgen_cval cval ^ ", " ^ string_of_bool direction
-  | CT_sbits (_, direction) -> sgen_cval cval ^ ", " ^ string_of_bool direction
-  | CT_fbits (len, direction) -> sgen_cval cval ^ ", UINT64_C(" ^ string_of_int len ^ ") , " ^ string_of_bool direction
+  | CT_lbits -> sgen_cval cval ^ ", " ^ string_of_bool true
+  | CT_sbits _ -> sgen_cval cval ^ ", " ^ string_of_bool true
+  | CT_fbits len -> sgen_cval cval ^ ", UINT64_C(" ^ string_of_int len ^ ") , " ^ string_of_bool true
   | _ -> sgen_cval cval
 
 let rec sgen_clexp l = function
@@ -1089,7 +1083,7 @@ let rec codegen_conversion l clexp cval =
       if is_stack_ctyp ctyp_to then ksprintf string "  %s = %s;" (sgen_clexp_pure l clexp) (sgen_cval cval)
       else ksprintf string "  COPY(%s)(%s, %s);" (sgen_ctyp_name ctyp_to) (sgen_clexp l clexp) (sgen_cval cval)
   | CT_ref _, _ -> codegen_conversion l (CL_addr clexp) cval
-  | CT_vector (_, ctyp_elem_to), CT_vector (_, ctyp_elem_from) ->
+  | CT_vector ctyp_elem_to, CT_vector ctyp_elem_from ->
       let i = ngensym () in
       let from = ngensym () in
       let into = ngensym () in
@@ -1220,24 +1214,24 @@ let rec codegen_instr fid ctx (I_aux (instr, (_, l))) =
         | "vector_update_subrange", _ -> Printf.sprintf "vector_update_subrange_%s" (sgen_ctyp_name ctyp)
         | "vector_subrange", _ -> Printf.sprintf "vector_subrange_%s" (sgen_ctyp_name ctyp)
         | "vector_update", CT_fbits _ -> "update_fbits"
-        | "vector_update", CT_lbits _ -> "update_lbits"
+        | "vector_update", CT_lbits -> "update_lbits"
         | "vector_update", _ -> Printf.sprintf "vector_update_%s" (sgen_ctyp_name ctyp)
         | "string_of_bits", _ -> begin
             match cval_ctyp (List.nth args 0) with
             | CT_fbits _ -> "string_of_fbits"
-            | CT_lbits _ -> "string_of_lbits"
+            | CT_lbits -> "string_of_lbits"
             | _ -> assert false
           end
         | "decimal_string_of_bits", _ -> begin
             match cval_ctyp (List.nth args 0) with
             | CT_fbits _ -> "decimal_string_of_fbits"
-            | CT_lbits _ -> "decimal_string_of_lbits"
+            | CT_lbits -> "decimal_string_of_lbits"
             | _ -> assert false
           end
         | "internal_vector_update", _ -> Printf.sprintf "internal_vector_update_%s" (sgen_ctyp_name ctyp)
         | "internal_vector_init", _ -> Printf.sprintf "internal_vector_init_%s" (sgen_ctyp_name ctyp)
         | "undefined_bitvector", CT_fbits _ -> "UNDEFINED(fbits)"
-        | "undefined_bitvector", CT_lbits _ -> "UNDEFINED(lbits)"
+        | "undefined_bitvector", CT_lbits -> "UNDEFINED(lbits)"
         | "undefined_bit", _ -> "UNDEFINED(fbits)"
         | "undefined_vector", _ -> Printf.sprintf "UNDEFINED(vector_%s)" (sgen_ctyp_name ctyp)
         | "undefined_list", _ -> Printf.sprintf "UNDEFINED(%s)" (sgen_ctyp_name ctyp)
@@ -1268,7 +1262,7 @@ let rec codegen_instr fid ctx (I_aux (instr, (_, l))) =
         | CT_lint when !optimize_fixed_int -> ("((sail_int) 0xdeadc0de)", [])
         | CT_fbits _ -> ("UINT64_C(0xdeadc0de)", [])
         | CT_sbits _ -> ("undefined_sbits()", [])
-        | CT_lbits _ when !optimize_fixed_bits -> ("undefined_lbits(false)", [])
+        | CT_lbits when !optimize_fixed_bits -> ("undefined_lbits(false)", [])
         | CT_bool -> ("false", [])
         | CT_enum (_, ctor :: _) -> (sgen_id ctor, [])
         | CT_tup ctyps when is_stack_ctyp ctyp ->
@@ -1653,8 +1647,8 @@ let codegen_list ctyp =
   end
 
 (* Generate functions for working with non-bit vectors of some specific type. *)
-let codegen_vector (direction, ctyp) =
-  let id = mk_id (string_of_ctyp (CT_vector (direction, ctyp))) in
+let codegen_vector ctyp =
+  let id = mk_id (string_of_ctyp (CT_vector ctyp)) in
   if IdSet.mem id !generated then empty
   else (
     let vector_typedef =
@@ -1908,22 +1902,21 @@ let codegen_def' ctx = function
    repeated in ctyp_dependencies so it's up to the code-generator not
    to repeat definitions pointlessly (using the !generated variable)
    *)
-type c_gen_typ = CTG_tup of ctyp list | CTG_list of ctyp | CTG_vector of bool * ctyp
+type c_gen_typ = CTG_tup of ctyp list | CTG_list of ctyp | CTG_vector of ctyp
 
 let rec ctyp_dependencies = function
   | CT_tup ctyps -> List.concat (List.map ctyp_dependencies ctyps) @ [CTG_tup ctyps]
   | CT_list ctyp -> ctyp_dependencies ctyp @ [CTG_list ctyp]
-  | CT_vector (direction, ctyp) | CT_fvector (_, direction, ctyp) ->
-      ctyp_dependencies ctyp @ [CTG_vector (direction, ctyp)]
+  | CT_vector ctyp | CT_fvector (_, ctyp) -> ctyp_dependencies ctyp @ [CTG_vector ctyp]
   | CT_ref ctyp -> ctyp_dependencies ctyp
   | CT_struct (_, ctors) -> List.concat (List.map (fun (_, ctyp) -> ctyp_dependencies ctyp) ctors)
   | CT_variant (_, ctors) -> List.concat (List.map (fun (_, ctyp) -> ctyp_dependencies ctyp) ctors)
-  | CT_lint | CT_fint _ | CT_lbits _ | CT_fbits _ | CT_sbits _ | CT_unit | CT_bool | CT_real | CT_bit | CT_string
+  | CT_lint | CT_fint _ | CT_lbits | CT_fbits _ | CT_sbits _ | CT_unit | CT_bool | CT_real | CT_bit | CT_string
   | CT_enum _ | CT_poly _ | CT_constant _ | CT_float _ | CT_rounding_mode ->
       []
 
 let codegen_ctg = function
-  | CTG_vector (direction, ctyp) -> codegen_vector (direction, ctyp)
+  | CTG_vector ctyp -> codegen_vector ctyp
   | CTG_tup ctyps -> codegen_tup ctyps
   | CTG_list ctyp -> codegen_list ctyp
 

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -324,7 +324,7 @@ and orig_typ_arg (A_aux (arg, l)) =
   match arg with
   | A_nexp nexp -> rewrap (A_nexp (orig_nexp nexp))
   | A_bool nc -> rewrap (A_bool (orig_nc nc))
-  | A_order _ | A_typ _ -> raise (Reporting.err_unreachable l __POS__ "Tried to pass Type or Order kind to SMT function")
+  | A_typ _ -> raise (Reporting.err_unreachable l __POS__ "Tried to pass Type or Order kind to SMT function")
 
 (* Returns the set of type variables that will appear in the Coq output,
    which may be smaller than those in the Sail type.  May need to be
@@ -351,7 +351,6 @@ and coq_nvars_of_typ_arg (A_aux (ta, _)) =
   match ta with
   | A_nexp nexp -> tyvars_of_nexp (orig_nexp nexp)
   | A_typ typ -> coq_nvars_of_typ typ
-  | A_order _ -> KidSet.empty
   | A_bool nc -> tyvars_of_constraint (orig_nc nc)
 
 let maybe_expand_range_type (Typ_aux (typ, l) as full_typ) =
@@ -408,10 +407,7 @@ let rec count_nexp_vars (Nexp_aux (nexp, _)) =
 
 let rec count_nc_vars (NC_aux (nc, _)) =
   let count_arg (A_aux (arg, _)) =
-    match arg with
-    | A_bool nc -> count_nc_vars nc
-    | A_nexp nexp -> count_nexp_vars nexp
-    | A_typ _ | A_order _ -> KBindings.empty
+    match arg with A_bool nc -> count_nc_vars nc | A_nexp nexp -> count_nexp_vars nexp | A_typ _ -> KBindings.empty
   in
   match nc with
   | NC_or (nc1, nc2) | NC_and (nc1, nc2) -> merge_kid_count (count_nc_vars nc1) (count_nc_vars nc2)
@@ -574,11 +570,11 @@ let rec doc_typ_fns ctx env =
     | _ -> app_typ atyp_needed ty
   and app_typ atyp_needed (Typ_aux (t, l) as ty) =
     match t with
-    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _); A_aux (A_order ord, _)]) ->
+    | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]) ->
         (* TODO: remove duplication with exists, below *)
         let tpp = string "mword " ^^ doc_nexp ctx m in
         if atyp_needed then parens tpp else tpp
-    | Typ_app (Id_aux (Id "vector", _), [A_aux (A_nexp m, _); A_aux (A_order ord, _); A_aux (A_typ elem_typ, _)]) ->
+    | Typ_app (Id_aux (Id "vector", _), [A_aux (A_nexp m, _); A_aux (A_typ elem_typ, _)]) ->
         (* TODO: remove duplication with exists, below *)
         let tpp = string "vec" ^^ space ^^ typ elem_typ ^^ space ^^ doc_nexp ctx m in
         if atyp_needed then parens tpp else tpp
@@ -743,11 +739,7 @@ let rec doc_typ_fns ctx env =
     | Typ_bidir _ -> unreachable l __POS__ "Coq doesn't support bidir types"
     | Typ_internal_unknown -> unreachable l __POS__ "escaped Typ_internal_unknown"
   and doc_typ_arg ?(prop_vars = false) (A_aux (t, _)) =
-    match t with
-    | A_typ t -> app_typ true t
-    | A_nexp n -> doc_nexp ctx n
-    | A_order o -> empty
-    | A_bool nc -> parens (doc_nc_exp ctx env nc)
+    match t with A_typ t -> app_typ true t | A_nexp n -> doc_nexp ctx n | A_bool nc -> parens (doc_nc_exp ctx env nc)
   in
   (typ', atomic_typ, doc_typ_arg)
 
@@ -836,8 +828,7 @@ and doc_nc_exp ctx env nc =
     match arg with
     | A_nexp nexp -> doc_nexp ctx nexp
     | A_bool nc -> newnc l0 nc
-    | A_order _ | A_typ _ ->
-        raise (Reporting.err_unreachable l __POS__ "Tried to pass Type or Order kind to SMT function")
+    | A_typ _ -> raise (Reporting.err_unreachable l __POS__ "Tried to pass Type kind to SMT function")
   in
   newnc l70 nc
 
@@ -930,7 +921,6 @@ let doc_quant_item_id ?(prop_vars = false) ctx delimit (QI_aux (qi, _)) =
                 Some (parens (separate space [doc_var ctx kid; colon; string "Z :="; string (Big_int.to_string value)]))
             | None -> Some (delimit (separate space [doc_var ctx kid; colon; string "Z"]))
           end
-        | K_order -> None
         | K_bool ->
             Some (delimit (separate space [doc_var ctx kid; colon; string (if prop_vars then "Prop" else "bool")]))
       )
@@ -945,7 +935,6 @@ let quant_item_id_name ctx (QI_aux (qi, _)) =
         match kind with
         | K_type -> Some (doc_var ctx kid)
         | K_int -> Some (doc_var ctx kid)
-        | K_order -> None
         | K_bool -> Some (doc_var ctx kid)
       )
     end
@@ -2005,8 +1994,9 @@ let doc_exp, doc_let =
           enclose_record_update (doc_op (string "with") (expY e) (separate_map semi_sp (doc_fexp ctxt recordtyp) fexps))
     | E_vector exps ->
         let t = Env.base_typ_of (env_of full_exp) (typ_of full_exp) in
-        let start, (len, order, etyp) =
-          if is_vector_typ t || is_bitvector_typ t then (vector_start_index t, vector_typ_args_of t)
+        let order = Env.get_default_order (env_of full_exp) in
+        let start, (len, etyp) =
+          if is_vector_typ t || is_bitvector_typ t then (vector_start_index (env_of full_exp) t, vector_typ_args_of t)
           else raise (Reporting.err_unreachable l __POS__ "E_vector of non-vector type")
         in
         let dir, dir_out = if is_order_inc order then (true, "true") else (false, "false") in
@@ -2361,7 +2351,6 @@ let doc_typdef types_mod avoid_target_names generic_eq_types (TD_aux (td, (l, an
       ^^ dot ^^ hardline
       ^^ separate space [string "#[export] Hint Unfold"; idpp; colon; string "sail."]
       ^^ twice hardline
-  | TD_abbrev _ -> empty (* TODO? *)
   | TD_bitfield _ -> empty (* TODO? *)
   | TD_record (id, typq, fs, _) ->
       let fname fid =
@@ -3124,10 +3113,7 @@ let doc_regtype_fields avoid_target_names (tname, (n1, n2, fields)) =
             )
     in
     let fsize = Big_int.succ (Big_int.abs (Big_int.sub i j)) in
-    (* TODO Assumes normalised, decreasing bitvector slices; however, since
-       start indices or indexing order do not appear in Lem type annotations,
-       this does not matter. *)
-    let ftyp = vector_typ (nconstant fsize) dec_ord bit_typ in
+    let ftyp = vector_typ (nconstant fsize) bit_typ in
     let reftyp =
       mk_typ
         (Typ_app

--- a/src/sail_doc_backend/wavedrom.ml
+++ b/src/sail_doc_backend/wavedrom.ml
@@ -120,7 +120,7 @@ let wavedrom_elem (label, (P_aux (_, (_, tannot)) as pat)) =
   | None -> raise Invalid_wavedrom
   | Some (env, typ) -> (
       match Type_check.destruct_bitvector env typ with
-      | Some (Nexp_aux (Nexp_constant size, _), _) ->
+      | Some (Nexp_aux (Nexp_constant size, _)) ->
           let size = Big_int.to_int size in
           wavedrom_elem_string size label pat
       | _ -> raise Invalid_wavedrom

--- a/src/sail_ocaml_backend/toFromInterp_backend.ml
+++ b/src/sail_ocaml_backend/toFromInterp_backend.ml
@@ -120,7 +120,6 @@ let frominterp_typedef (TD_aux (td_aux, (l, _))) =
     match a_aux with
     | A_typ typ -> parens (string "fun v -> " ^^ parens (fromValueTyp typ "v"))
     | A_nexp nexp -> fromValueNexp nexp
-    | A_order order -> string ("Order_" ^ string_of_order order)
     | A_bool _ -> parens (string "boolFromInterpValue")
   and fromValueTyp (Typ_aux (typ_aux, l) as typ) arg_name =
     match typ_aux with
@@ -129,11 +128,7 @@ let frominterp_typedef (TD_aux (td_aux, (l, _))) =
     (* special case bit vectors for lem *)
     | Typ_app
         ( Id_aux (Id "vector", _),
-          [
-            A_aux (A_nexp len_nexp, _);
-            A_aux (A_order (Ord_aux (Ord_dec, _)), _);
-            A_aux (A_typ (Typ_aux (Typ_id (Id_aux (Id "bit", _)), _)), _);
-          ]
+          [A_aux (A_nexp len_nexp, _); A_aux (A_typ (Typ_aux (Typ_id (Id_aux (Id "bit", _)), _)), _)]
         )
       when !lem_mode ->
         parens (separate space [string (maybe_zencode "bitsFromInterpValue"); string arg_name])
@@ -371,7 +366,6 @@ let tointerp_typedef (TD_aux (td_aux, (l, _))) =
     match a_aux with
     | A_typ typ -> parens (string "fun v -> " ^^ parens (toValueTyp typ "v"))
     | A_nexp nexp -> toValueNexp nexp
-    | A_order order -> string ("Order_" ^ string_of_order order)
     | A_bool _ -> parens (string "boolToInterpValue")
   and toValueTyp (Typ_aux (typ_aux, l) as typ) arg_name =
     match typ_aux with
@@ -380,11 +374,7 @@ let tointerp_typedef (TD_aux (td_aux, (l, _))) =
     (* special case bit vectors for lem *)
     | Typ_app
         ( Id_aux (Id "vector", _),
-          [
-            A_aux (A_nexp len_nexp, _);
-            A_aux (A_order (Ord_aux (Ord_dec, _)), _);
-            A_aux (A_typ (Typ_aux (Typ_id (Id_aux (Id "bit", _)), _)), _);
-          ]
+          [A_aux (A_nexp len_nexp, _); A_aux (A_typ (Typ_aux (Typ_id (Id_aux (Id "bit", _)), _)), _)]
         )
       when !lem_mode ->
         parens (separate space [string (maybe_zencode "bitsToInterpValue"); string arg_name])

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -1419,21 +1419,16 @@ end) : Jib_compile.Config = struct
       end
     | Typ_app (id, [A_aux (A_typ typ, _)]) when string_of_id id = "list" -> CT_list (convert_typ ctx typ)
     (* Note that we have to use lbits for zero-length bitvectors because they are not allowed by SMTLIB *)
-    | Typ_app (id, [A_aux (A_nexp n, _); A_aux (A_order ord, _)]) when string_of_id id = "bitvector" ->
-        let direction =
-          match ord with Ord_aux (Ord_dec, _) -> true | Ord_aux (Ord_inc, _) -> false | _ -> assert false
-        in
+    | Typ_app (id, [A_aux (A_nexp n, _)]) when string_of_id id = "bitvector" ->
+        let direction = true in
         begin
           match nexp_simp n with
           | Nexp_aux (Nexp_constant n, _) when Big_int.equal n Big_int.zero -> CT_lbits direction
           | Nexp_aux (Nexp_constant n, _) -> CT_fbits (Big_int.to_int n, direction)
           | _ -> CT_lbits direction
         end
-    | Typ_app (id, [A_aux (A_nexp n, _); A_aux (A_order ord, _); A_aux (A_typ typ, _)]) when string_of_id id = "vector"
-      ->
-        let direction =
-          match ord with Ord_aux (Ord_dec, _) -> true | Ord_aux (Ord_inc, _) -> false | _ -> assert false
-        in
+    | Typ_app (id, [A_aux (A_nexp n, _); A_aux (A_typ typ, _)]) when string_of_id id = "vector" ->
+        let direction = true in
         CT_vector (direction, convert_typ ctx typ)
     | Typ_app (id, [A_aux (A_typ typ, _)]) when string_of_id id = "register" -> CT_ref (convert_typ ctx typ)
     | Typ_id id when Bindings.mem id ctx.records ->

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -197,9 +197,9 @@ let rec smt_ctyp ctx = function
   | CT_lint -> Bitvec ctx.lint_size
   | CT_unit -> smt_unit
   | CT_bit -> Bitvec 1
-  | CT_fbits (n, _) -> Bitvec n
-  | CT_sbits (n, _) -> smt_lbits ctx
-  | CT_lbits _ -> smt_lbits ctx
+  | CT_fbits n -> Bitvec n
+  | CT_sbits n -> smt_lbits ctx
+  | CT_lbits -> smt_lbits ctx
   | CT_bool -> Bool
   | CT_enum (id, elems) -> mk_enum (zencode_upper_id id) (List.map zencode_id elems)
   | CT_struct (id, fields) ->
@@ -209,7 +209,7 @@ let rec smt_ctyp ctx = function
   | CT_tup ctyps ->
       ctx.tuple_sizes := IntSet.add (List.length ctyps) !(ctx.tuple_sizes);
       Tuple (List.map (smt_ctyp ctx) ctyps)
-  | CT_vector (_, ctyp) -> Array (Bitvec !vector_index, smt_ctyp ctx ctyp)
+  | CT_vector ctyp -> Array (Bitvec !vector_index, smt_ctyp ctx ctyp)
   | CT_string ->
       ctx.use_string := true;
       String
@@ -302,14 +302,14 @@ let smt_conversion ctx from_ctyp to_ctyp x =
   | CT_constant c, CT_lint -> bvint ctx.lint_size c
   | CT_fint sz, CT_lint -> force_size ctx ctx.lint_size sz x
   | CT_lint, CT_fint sz -> force_size ctx sz ctx.lint_size x
-  | CT_lint, CT_fbits (n, _) -> force_size ctx n ctx.lint_size x
-  | CT_lint, CT_lbits _ ->
+  | CT_lint, CT_fbits n -> force_size ctx n ctx.lint_size x
+  | CT_lint, CT_lbits ->
       Fn
         ("Bits", [bvint ctx.lbits_index (Big_int.of_int ctx.lint_size); force_size ctx (lbits_size ctx) ctx.lint_size x])
-  | CT_fint n, CT_lbits _ -> Fn ("Bits", [bvint ctx.lbits_index (Big_int.of_int n); force_size ctx (lbits_size ctx) n x])
-  | CT_lbits _, CT_fbits (n, _) -> unsigned_size ctx n (lbits_size ctx) (Fn ("contents", [x]))
-  | CT_fbits (n, _), CT_fbits (m, _) -> unsigned_size ctx m n x
-  | CT_fbits (n, _), CT_lbits _ ->
+  | CT_fint n, CT_lbits -> Fn ("Bits", [bvint ctx.lbits_index (Big_int.of_int n); force_size ctx (lbits_size ctx) n x])
+  | CT_lbits, CT_fbits n -> unsigned_size ctx n (lbits_size ctx) (Fn ("contents", [x]))
+  | CT_fbits n, CT_fbits m -> unsigned_size ctx m n x
+  | CT_fbits n, CT_lbits ->
       Fn ("Bits", [bvint ctx.lbits_index (Big_int.of_int n); unsigned_size ctx (lbits_size ctx) n x])
   | _, _ ->
       failwith
@@ -319,8 +319,8 @@ let smt_conversion ctx from_ctyp to_ctyp x =
 let smt_value ctx vl ctyp =
   let open Value2 in
   match (vl, ctyp) with
-  | VL_bits (bv, true), CT_fbits (n, _) -> unsigned_size ctx n (List.length bv) (Bitvec_lit bv)
-  | VL_bits (bv, true), CT_lbits _ ->
+  | VL_bits bv, CT_fbits n -> unsigned_size ctx n (List.length bv) (Bitvec_lit bv)
+  | VL_bits bv, CT_lbits ->
       let sz = List.length bv in
       Fn ("Bits", [bvint ctx.lbits_index (Big_int.of_int sz); unsigned_size ctx (lbits_size ctx) sz (Bitvec_lit bv)])
   | VL_bool b, _ -> Bool_lit b
@@ -569,12 +569,12 @@ let fbits_mask ctx n len = bvnot (bvshl (bvones n) len)
 
 let builtin_eq_bits ctx v1 v2 =
   match (cval_ctyp v1, cval_ctyp v2) with
-  | CT_fbits (n, _), CT_fbits (m, _) ->
+  | CT_fbits n, CT_fbits m ->
       let o = max n m in
       let smt1 = unsigned_size ctx o n (smt_cval ctx v1) in
       let smt2 = unsigned_size ctx o n (smt_cval ctx v2) in
       Fn ("=", [smt1; smt2])
-  | CT_lbits _, CT_lbits _ ->
+  | CT_lbits, CT_lbits ->
       let len1 = Fn ("len", [smt_cval ctx v1]) in
       let contents1 = Fn ("contents", [smt_cval ctx v1]) in
       let len2 = Fn ("len", [smt_cval ctx v1]) in
@@ -586,25 +586,25 @@ let builtin_eq_bits ctx v1 v2 =
             Fn ("=", [Fn ("bvand", [bvmask ctx len1; contents1]); Fn ("bvand", [bvmask ctx len2; contents2])]);
           ]
         )
-  | CT_lbits _, CT_fbits (n, _) ->
+  | CT_lbits, CT_fbits n ->
       let smt1 = unsigned_size ctx n (lbits_size ctx) (Fn ("contents", [smt_cval ctx v1])) in
       Fn ("=", [smt1; smt_cval ctx v2])
-  | CT_fbits (n, _), CT_lbits _ ->
+  | CT_fbits n, CT_lbits ->
       let smt2 = unsigned_size ctx n (lbits_size ctx) (Fn ("contents", [smt_cval ctx v2])) in
       Fn ("=", [smt_cval ctx v1; smt2])
   | _ -> builtin_type_error ctx "eq_bits" [v1; v2] None
 
 let builtin_zeros ctx v ret_ctyp =
   match (cval_ctyp v, ret_ctyp) with
-  | _, CT_fbits (n, _) -> bvzero n
-  | CT_constant c, CT_lbits _ -> Fn ("Bits", [bvint ctx.lbits_index c; bvzero (lbits_size ctx)])
-  | ctyp, CT_lbits _ when int_size ctx ctyp >= ctx.lbits_index ->
+  | _, CT_fbits n -> bvzero n
+  | CT_constant c, CT_lbits -> Fn ("Bits", [bvint ctx.lbits_index c; bvzero (lbits_size ctx)])
+  | ctyp, CT_lbits when int_size ctx ctyp >= ctx.lbits_index ->
       Fn ("Bits", [extract (ctx.lbits_index - 1) 0 (smt_cval ctx v); bvzero (lbits_size ctx)])
   | _ -> builtin_type_error ctx "zeros" [v] (Some ret_ctyp)
 
 let builtin_ones ctx cval = function
-  | CT_fbits (n, _) -> bvones n
-  | CT_lbits _ ->
+  | CT_fbits n -> bvones n
+  | CT_lbits ->
       let len = extract (ctx.lbits_index - 1) 0 (smt_cval ctx cval) in
       Fn ("Bits", [len; Fn ("bvand", [bvmask ctx len; bvones (lbits_size ctx)])])
   | ret_ctyp -> builtin_type_error ctx "ones" [cval] (Some ret_ctyp)
@@ -623,14 +623,14 @@ let bvzeint ctx esz cval =
 
 let builtin_zero_extend ctx vbits vlen ret_ctyp =
   match (cval_ctyp vbits, ret_ctyp) with
-  | CT_fbits (n, _), CT_fbits (m, _) when n = m -> smt_cval ctx vbits
-  | CT_fbits (n, _), CT_fbits (m, _) ->
+  | CT_fbits n, CT_fbits m when n = m -> smt_cval ctx vbits
+  | CT_fbits n, CT_fbits m ->
       let bv = smt_cval ctx vbits in
       Fn ("concat", [bvzero (m - n); bv])
-  | CT_lbits _, CT_fbits (m, _) ->
+  | CT_lbits, CT_fbits m ->
       assert (lbits_size ctx >= m);
       Extract (m - 1, 0, Fn ("contents", [smt_cval ctx vbits]))
-  | CT_fbits (n, _), CT_lbits _ ->
+  | CT_fbits n, CT_lbits ->
       assert (lbits_size ctx >= n);
       let vbits =
         if lbits_size ctx = n then smt_cval ctx vbits
@@ -642,8 +642,8 @@ let builtin_zero_extend ctx vbits vlen ret_ctyp =
 
 let builtin_sign_extend ctx vbits vlen ret_ctyp =
   match (cval_ctyp vbits, ret_ctyp) with
-  | CT_fbits (n, _), CT_fbits (m, _) when n = m -> smt_cval ctx vbits
-  | CT_fbits (n, _), CT_fbits (m, _) ->
+  | CT_fbits n, CT_fbits m when n = m -> smt_cval ctx vbits
+  | CT_fbits n, CT_fbits m ->
       let bv = smt_cval ctx vbits in
       let top_bit_one = Fn ("=", [Extract (n - 1, n - 1, bv); Bitvec_lit [Sail2_values.B1]]) in
       Ite (top_bit_one, Fn ("concat", [bvones (m - n); bv]), Fn ("concat", [bvzero (m - n); bv]))
@@ -651,11 +651,11 @@ let builtin_sign_extend ctx vbits vlen ret_ctyp =
 
 let builtin_shift shiftop ctx vbits vshift ret_ctyp =
   match cval_ctyp vbits with
-  | CT_fbits (n, _) ->
+  | CT_fbits n ->
       let bv = smt_cval ctx vbits in
       let len = bvzeint ctx n vshift in
       Fn (shiftop, [bv; len])
-  | CT_lbits _ ->
+  | CT_lbits ->
       let bv = smt_cval ctx vbits in
       let shift = bvzeint ctx (lbits_size ctx) vshift in
       Fn ("Bits", [Fn ("len", [bv]); Fn (shiftop, [Fn ("contents", [bv]); shift])])
@@ -663,22 +663,22 @@ let builtin_shift shiftop ctx vbits vshift ret_ctyp =
 
 let builtin_not_bits ctx v ret_ctyp =
   match (cval_ctyp v, ret_ctyp) with
-  | CT_lbits _, CT_fbits (n, _) -> bvnot (Extract (n - 1, 0, Fn ("contents", [smt_cval ctx v])))
-  | CT_lbits _, CT_lbits _ ->
+  | CT_lbits, CT_fbits n -> bvnot (Extract (n - 1, 0, Fn ("contents", [smt_cval ctx v])))
+  | CT_lbits, CT_lbits ->
       let bv = smt_cval ctx v in
       let len = Fn ("len", [bv]) in
       Fn ("Bits", [len; Fn ("bvand", [bvmask ctx len; bvnot (Fn ("contents", [bv]))])])
-  | CT_fbits (n, _), CT_fbits (m, _) when n = m -> bvnot (smt_cval ctx v)
+  | CT_fbits n, CT_fbits m when n = m -> bvnot (smt_cval ctx v)
   | _, _ -> builtin_type_error ctx "not_bits" [v] (Some ret_ctyp)
 
 let builtin_bitwise fn ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_fbits (m, _), CT_fbits (o, _) ->
+  | CT_fbits n, CT_fbits m, CT_fbits o ->
       assert (n = m && m = o);
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Fn (fn, [smt1; smt2])
-  | CT_lbits _, CT_lbits _, CT_lbits _ ->
+  | CT_lbits, CT_lbits, CT_lbits ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Fn ("Bits", [Fn ("len", [smt1]); Fn (fn, [Fn ("contents", [smt1]); Fn ("contents", [smt2])])])
@@ -690,12 +690,12 @@ let builtin_xor_bits = builtin_bitwise "bvxor"
 
 let builtin_append ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_fbits (m, _), CT_fbits (o, _) ->
+  | CT_fbits n, CT_fbits m, CT_fbits o ->
       assert (n + m = o);
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Fn ("concat", [smt1; smt2])
-  | CT_fbits (n, _), CT_lbits _, CT_lbits _ ->
+  | CT_fbits n, CT_lbits, CT_lbits ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       let x = Fn ("concat", [bvzero (lbits_size ctx - n); smt1]) in
@@ -707,11 +707,11 @@ let builtin_append ctx v1 v2 ret_ctyp =
             bvor (bvshl x shift) (Fn ("contents", [smt2]));
           ]
         )
-  | CT_lbits _, CT_fbits (n, _), CT_fbits (m, _) ->
+  | CT_lbits, CT_fbits n, CT_fbits m ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Extract (m - 1, 0, Fn ("concat", [Fn ("contents", [smt1]); smt2]))
-  | CT_lbits _, CT_fbits (n, _), CT_lbits _ ->
+  | CT_lbits, CT_fbits n, CT_lbits ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Fn
@@ -721,7 +721,7 @@ let builtin_append ctx v1 v2 ret_ctyp =
             Extract (lbits_size ctx - 1, 0, Fn ("concat", [Fn ("contents", [smt1]); smt2]));
           ]
         )
-  | CT_fbits (n, _), CT_fbits (m, _), CT_lbits _ ->
+  | CT_fbits n, CT_fbits m, CT_lbits ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Fn
@@ -731,13 +731,13 @@ let builtin_append ctx v1 v2 ret_ctyp =
             unsigned_size ctx (lbits_size ctx) (n + m) (Fn ("concat", [smt1; smt2]));
           ]
         )
-  | CT_lbits _, CT_lbits _, CT_lbits _ ->
+  | CT_lbits, CT_lbits, CT_lbits ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       let x = Fn ("contents", [smt1]) in
       let shift = Fn ("concat", [bvzero (lbits_size ctx - ctx.lbits_index); Fn ("len", [smt2])]) in
       Fn ("Bits", [bvadd (Fn ("len", [smt1])) (Fn ("len", [smt2])); bvor (bvshl x shift) (Fn ("contents", [smt2]))])
-  | CT_lbits _, CT_lbits _, CT_fbits (n, _) ->
+  | CT_lbits, CT_lbits, CT_fbits n ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       let x = Fn ("contents", [smt1]) in
@@ -747,8 +747,8 @@ let builtin_append ctx v1 v2 ret_ctyp =
 
 let builtin_length ctx v ret_ctyp =
   match (cval_ctyp v, ret_ctyp) with
-  | CT_fbits (n, _), (CT_constant _ | CT_fint _ | CT_lint) -> bvint (int_size ctx ret_ctyp) (Big_int.of_int n)
-  | CT_lbits _, (CT_constant _ | CT_fint _ | CT_lint) ->
+  | CT_fbits n, (CT_constant _ | CT_fint _ | CT_lint) -> bvint (int_size ctx ret_ctyp) (Big_int.of_int n)
+  | CT_lbits, (CT_constant _ | CT_fint _ | CT_lint) ->
       let sz = ctx.lbits_index in
       let m = int_size ctx ret_ctyp in
       let len = Fn ("len", [smt_cval ctx v]) in
@@ -757,28 +757,27 @@ let builtin_length ctx v ret_ctyp =
 
 let builtin_vector_subrange ctx vec i j ret_ctyp =
   match (cval_ctyp vec, cval_ctyp i, cval_ctyp j, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant i, CT_constant j, CT_fbits _ ->
+  | CT_fbits n, CT_constant i, CT_constant j, CT_fbits _ ->
       Extract (Big_int.to_int i, Big_int.to_int j, smt_cval ctx vec)
-  | CT_lbits _, CT_constant i, CT_constant j, CT_fbits _ ->
+  | CT_lbits, CT_constant i, CT_constant j, CT_fbits _ ->
       Extract (Big_int.to_int i, Big_int.to_int j, Fn ("contents", [smt_cval ctx vec]))
-  | CT_fbits (n, _), i_ctyp, CT_constant j, CT_lbits _ when Big_int.equal j Big_int.zero ->
+  | CT_fbits n, i_ctyp, CT_constant j, CT_lbits when Big_int.equal j Big_int.zero ->
       let i' = force_size ~checked:false ctx ctx.lbits_index (int_size ctx i_ctyp) (smt_cval ctx i) in
       let len = bvadd i' (bvint ctx.lbits_index (Big_int.of_int 1)) in
       Fn ("Bits", [len; Fn ("bvand", [bvmask ctx len; unsigned_size ctx (lbits_size ctx) n (smt_cval ctx vec)])])
-  | CT_fbits (n, b), i_ctyp, j_ctyp, ret_ctyp ->
+  | CT_fbits n, i_ctyp, j_ctyp, ret_ctyp ->
       let i' = force_size ctx n (int_size ctx i_ctyp) (smt_cval ctx i) in
       let j' = force_size ctx n (int_size ctx j_ctyp) (smt_cval ctx j) in
       let len = bvadd (bvadd i' (bvneg j')) (bvint n (Big_int.of_int 1)) in
       let vec' = bvand (bvlshr (smt_cval ctx vec) j') (fbits_mask ctx n len) in
-      smt_conversion ctx (CT_fbits (n, b)) ret_ctyp vec'
+      smt_conversion ctx (CT_fbits n) ret_ctyp vec'
   | _ -> builtin_type_error ctx "vector_subrange" [vec; i; j] (Some ret_ctyp)
 
 let builtin_vector_access ctx vec i ret_ctyp =
   match (cval_ctyp vec, cval_ctyp i, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant i, CT_bit -> Extract (Big_int.to_int i, Big_int.to_int i, smt_cval ctx vec)
-  | CT_lbits _, CT_constant i, CT_bit ->
-      Extract (Big_int.to_int i, Big_int.to_int i, Fn ("contents", [smt_cval ctx vec]))
-  | CT_lbits _, i_ctyp, CT_bit ->
+  | CT_fbits n, CT_constant i, CT_bit -> Extract (Big_int.to_int i, Big_int.to_int i, smt_cval ctx vec)
+  | CT_lbits, CT_constant i, CT_bit -> Extract (Big_int.to_int i, Big_int.to_int i, Fn ("contents", [smt_cval ctx vec]))
+  | CT_lbits, i_ctyp, CT_bit ->
       let shift = force_size ~checked:false ctx (lbits_size ctx) (int_size ctx i_ctyp) (smt_cval ctx i) in
       Extract (0, 0, Fn ("bvlshr", [Fn ("contents", [smt_cval ctx vec]); shift]))
   | CT_vector _, CT_constant i, _ -> Fn ("select", [smt_cval ctx vec; bvint !vector_index i])
@@ -788,18 +787,18 @@ let builtin_vector_access ctx vec i ret_ctyp =
 
 let builtin_vector_update ctx vec i x ret_ctyp =
   match (cval_ctyp vec, cval_ctyp i, cval_ctyp x, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant i, CT_bit, CT_fbits (m, _) when n - 1 > Big_int.to_int i && Big_int.to_int i > 0 ->
+  | CT_fbits n, CT_constant i, CT_bit, CT_fbits m when n - 1 > Big_int.to_int i && Big_int.to_int i > 0 ->
       assert (n = m);
       let top = Extract (n - 1, Big_int.to_int i + 1, smt_cval ctx vec) in
       let bot = Extract (Big_int.to_int i - 1, 0, smt_cval ctx vec) in
       Fn ("concat", [top; Fn ("concat", [smt_cval ctx x; bot])])
-  | CT_fbits (n, _), CT_constant i, CT_bit, CT_fbits (m, _) when n - 1 = Big_int.to_int i && Big_int.to_int i > 0 ->
+  | CT_fbits n, CT_constant i, CT_bit, CT_fbits m when n - 1 = Big_int.to_int i && Big_int.to_int i > 0 ->
       let bot = Extract (Big_int.to_int i - 1, 0, smt_cval ctx vec) in
       Fn ("concat", [smt_cval ctx x; bot])
-  | CT_fbits (n, _), CT_constant i, CT_bit, CT_fbits (m, _) when n - 1 > Big_int.to_int i && Big_int.to_int i = 0 ->
+  | CT_fbits n, CT_constant i, CT_bit, CT_fbits m when n - 1 > Big_int.to_int i && Big_int.to_int i = 0 ->
       let top = Extract (n - 1, 1, smt_cval ctx vec) in
       Fn ("concat", [top; smt_cval ctx x])
-  | CT_fbits (n, _), CT_constant i, CT_bit, CT_fbits (m, _) when n - 1 = 0 && Big_int.to_int i = 0 -> smt_cval ctx x
+  | CT_fbits n, CT_constant i, CT_bit, CT_fbits m when n - 1 = 0 && Big_int.to_int i = 0 -> smt_cval ctx x
   | CT_vector _, CT_constant i, ctyp, CT_vector _ ->
       Fn ("store", [smt_cval ctx vec; bvint !vector_index i; smt_cval ctx x])
   | CT_vector _, index_ctyp, _, CT_vector _ ->
@@ -811,30 +810,30 @@ let builtin_vector_update ctx vec i x ret_ctyp =
 
 let builtin_vector_update_subrange ctx vec i j x ret_ctyp =
   match (cval_ctyp vec, cval_ctyp i, cval_ctyp j, cval_ctyp x, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant i, CT_constant j, CT_fbits (sz, _), CT_fbits (m, _)
+  | CT_fbits n, CT_constant i, CT_constant j, CT_fbits sz, CT_fbits m
     when n - 1 > Big_int.to_int i && Big_int.to_int j > 0 ->
       assert (n = m);
       let top = Extract (n - 1, Big_int.to_int i + 1, smt_cval ctx vec) in
       let bot = Extract (Big_int.to_int j - 1, 0, smt_cval ctx vec) in
       Fn ("concat", [top; Fn ("concat", [smt_cval ctx x; bot])])
-  | CT_fbits (n, _), CT_constant i, CT_constant j, CT_fbits (sz, _), CT_fbits (m, _)
+  | CT_fbits n, CT_constant i, CT_constant j, CT_fbits sz, CT_fbits m
     when n - 1 = Big_int.to_int i && Big_int.to_int j > 0 ->
       assert (n = m);
       let bot = Extract (Big_int.to_int j - 1, 0, smt_cval ctx vec) in
       Fn ("concat", [smt_cval ctx x; bot])
-  | CT_fbits (n, _), CT_constant i, CT_constant j, CT_fbits (sz, _), CT_fbits (m, _)
+  | CT_fbits n, CT_constant i, CT_constant j, CT_fbits sz, CT_fbits m
     when n - 1 > Big_int.to_int i && Big_int.to_int j = 0 ->
       assert (n = m);
       let top = Extract (n - 1, Big_int.to_int i + 1, smt_cval ctx vec) in
       Fn ("concat", [top; smt_cval ctx x])
-  | CT_fbits (n, _), CT_constant i, CT_constant j, CT_fbits (sz, _), CT_fbits (m, _)
+  | CT_fbits n, CT_constant i, CT_constant j, CT_fbits sz, CT_fbits m
     when n - 1 = Big_int.to_int i && Big_int.to_int j = 0 ->
       smt_cval ctx x
-  | CT_fbits (n, b), ctyp_i, ctyp_j, ctyp_x, CT_fbits (m, _) ->
+  | CT_fbits n, ctyp_i, ctyp_j, ctyp_x, CT_fbits m ->
       assert (n = m);
       let i' = force_size ctx n (int_size ctx ctyp_i) (smt_cval ctx i) in
       let j' = force_size ctx n (int_size ctx ctyp_j) (smt_cval ctx j) in
-      let x' = smt_conversion ctx ctyp_x (CT_fbits (n, b)) (smt_cval ctx x) in
+      let x' = smt_conversion ctx ctyp_x (CT_fbits n) (smt_cval ctx x) in
       let len = bvadd (bvadd i' (bvneg j')) (bvint n (Big_int.of_int 1)) in
       let mask = bvshl (fbits_mask ctx n len) j' in
       bvor (bvand (smt_cval ctx vec) (bvnot mask)) (bvand (bvshl x' j') mask)
@@ -842,34 +841,34 @@ let builtin_vector_update_subrange ctx vec i j x ret_ctyp =
 
 let builtin_unsigned ctx v ret_ctyp =
   match (cval_ctyp v, ret_ctyp) with
-  | CT_fbits (n, _), CT_fint m when m > n ->
+  | CT_fbits n, CT_fint m when m > n ->
       let smt = smt_cval ctx v in
       Fn ("concat", [bvzero (m - n); smt])
-  | CT_fbits (n, _), CT_lint ->
+  | CT_fbits n, CT_lint ->
       if n >= ctx.lint_size then failwith "Overflow detected"
       else (
         let smt = smt_cval ctx v in
         Fn ("concat", [bvzero (ctx.lint_size - n); smt])
       )
-  | CT_lbits _, CT_lint -> Extract (ctx.lint_size - 1, 0, Fn ("contents", [smt_cval ctx v]))
-  | CT_lbits _, CT_fint m ->
+  | CT_lbits, CT_lint -> Extract (ctx.lint_size - 1, 0, Fn ("contents", [smt_cval ctx v]))
+  | CT_lbits, CT_fint m ->
       let smt = Fn ("contents", [smt_cval ctx v]) in
       force_size ctx m (lbits_size ctx) smt
   | ctyp, _ -> builtin_type_error ctx "unsigned" [v] (Some ret_ctyp)
 
 let builtin_signed ctx v ret_ctyp =
   match (cval_ctyp v, ret_ctyp) with
-  | CT_fbits (n, _), CT_fint m when m >= n -> SignExtend (m - n, smt_cval ctx v)
-  | CT_fbits (n, _), CT_lint -> SignExtend (ctx.lint_size - n, smt_cval ctx v)
-  | CT_lbits _, CT_lint -> Extract (ctx.lint_size - 1, 0, Fn ("contents", [smt_cval ctx v]))
+  | CT_fbits n, CT_fint m when m >= n -> SignExtend (m - n, smt_cval ctx v)
+  | CT_fbits n, CT_lint -> SignExtend (ctx.lint_size - n, smt_cval ctx v)
+  | CT_lbits, CT_lint -> Extract (ctx.lint_size - 1, 0, Fn ("contents", [smt_cval ctx v]))
   | ctyp, _ -> builtin_type_error ctx "signed" [v] (Some ret_ctyp)
 
 let builtin_add_bits ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_fbits (m, _), CT_fbits (o, _) ->
+  | CT_fbits n, CT_fbits m, CT_fbits o ->
       assert (n = m && m = o);
       Fn ("bvadd", [smt_cval ctx v1; smt_cval ctx v2])
-  | CT_lbits _, CT_lbits _, CT_lbits _ ->
+  | CT_lbits, CT_lbits, CT_lbits ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = smt_cval ctx v2 in
       Fn ("Bits", [Fn ("len", [smt1]); Fn ("bvadd", [Fn ("contents", [smt1]); Fn ("contents", [smt2])])])
@@ -877,19 +876,18 @@ let builtin_add_bits ctx v1 v2 ret_ctyp =
 
 let builtin_sub_bits ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_fbits (m, _), CT_fbits (o, _) ->
+  | CT_fbits n, CT_fbits m, CT_fbits o ->
       assert (n = m && m = o);
       Fn ("bvadd", [smt_cval ctx v1; Fn ("bvneg", [smt_cval ctx v2])])
   | _ -> failwith "Cannot compile sub_bits"
 
 let builtin_add_bits_int ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant c, CT_fbits (o, _) when n = o -> Fn ("bvadd", [smt_cval ctx v1; bvint o c])
-  | CT_fbits (n, _), CT_fint m, CT_fbits (o, _) when n = o ->
-      Fn ("bvadd", [smt_cval ctx v1; force_size ctx o m (smt_cval ctx v2)])
-  | CT_fbits (n, _), CT_lint, CT_fbits (o, _) when n = o ->
+  | CT_fbits n, CT_constant c, CT_fbits o when n = o -> Fn ("bvadd", [smt_cval ctx v1; bvint o c])
+  | CT_fbits n, CT_fint m, CT_fbits o when n = o -> Fn ("bvadd", [smt_cval ctx v1; force_size ctx o m (smt_cval ctx v2)])
+  | CT_fbits n, CT_lint, CT_fbits o when n = o ->
       Fn ("bvadd", [smt_cval ctx v1; force_size ctx o ctx.lint_size (smt_cval ctx v2)])
-  | CT_lbits _, CT_fint n, CT_lbits _ when n < lbits_size ctx ->
+  | CT_lbits, CT_fint n, CT_lbits when n < lbits_size ctx ->
       let smt1 = smt_cval ctx v1 in
       let smt2 = force_size ctx (lbits_size ctx) n (smt_cval ctx v2) in
       Fn ("Bits", [Fn ("len", [smt1]); Fn ("bvadd", [Fn ("contents", [smt1]); smt2])])
@@ -897,25 +895,23 @@ let builtin_add_bits_int ctx v1 v2 ret_ctyp =
 
 let builtin_sub_bits_int ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant c, CT_fbits (o, _) when n = o ->
-      Fn ("bvadd", [smt_cval ctx v1; bvint o (Big_int.negate c)])
-  | CT_fbits (n, _), CT_fint m, CT_fbits (o, _) when n = o ->
-      Fn ("bvsub", [smt_cval ctx v1; force_size ctx o m (smt_cval ctx v2)])
-  | CT_fbits (n, _), CT_lint, CT_fbits (o, _) when n = o ->
+  | CT_fbits n, CT_constant c, CT_fbits o when n = o -> Fn ("bvadd", [smt_cval ctx v1; bvint o (Big_int.negate c)])
+  | CT_fbits n, CT_fint m, CT_fbits o when n = o -> Fn ("bvsub", [smt_cval ctx v1; force_size ctx o m (smt_cval ctx v2)])
+  | CT_fbits n, CT_lint, CT_fbits o when n = o ->
       Fn ("bvsub", [smt_cval ctx v1; force_size ctx o ctx.lint_size (smt_cval ctx v2)])
   | _ -> builtin_type_error ctx "sub_bits_int" [v1; v2] (Some ret_ctyp)
 
 let builtin_replicate_bits ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant c, CT_fbits (m, _) ->
+  | CT_fbits n, CT_constant c, CT_fbits m ->
       assert (n * Big_int.to_int c = m);
       let smt = smt_cval ctx v1 in
       Fn ("concat", List.init (Big_int.to_int c) (fun _ -> smt))
-  | CT_fbits (n, _), _, CT_fbits (m, _) ->
+  | CT_fbits n, _, CT_fbits m ->
       let smt = smt_cval ctx v1 in
       let c = m / n in
       Fn ("concat", List.init c (fun _ -> smt))
-  | CT_fbits (n, _), v2_ctyp, CT_lbits _ ->
+  | CT_fbits n, v2_ctyp, CT_lbits ->
       let times = (lbits_size ctx / n) + 1 in
       let len = force_size ~checked:false ctx ctx.lbits_index (int_size ctx v2_ctyp) (smt_cval ctx v2) in
       let smt1 = smt_cval ctx v1 in
@@ -925,13 +921,13 @@ let builtin_replicate_bits ctx v1 v2 ret_ctyp =
 
 let builtin_sail_truncate ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant c, CT_fbits (m, _) ->
+  | CT_fbits n, CT_constant c, CT_fbits m ->
       assert (Big_int.to_int c = m);
       Extract (Big_int.to_int c - 1, 0, smt_cval ctx v1)
-  | CT_lbits _, CT_constant c, CT_fbits (m, _) ->
+  | CT_lbits, CT_constant c, CT_fbits m ->
       assert (Big_int.to_int c = m && m < lbits_size ctx);
       Extract (Big_int.to_int c - 1, 0, Fn ("contents", [smt_cval ctx v1]))
-  | CT_fbits (n, _), _, CT_lbits _ ->
+  | CT_fbits n, _, CT_lbits ->
       let smt1 = unsigned_size ctx (lbits_size ctx) n (smt_cval ctx v1) in
       let smt2 = bvzeint ctx ctx.lbits_index v2 in
       Fn ("Bits", [smt2; Fn ("bvand", [bvmask ctx smt2; smt1])])
@@ -939,22 +935,22 @@ let builtin_sail_truncate ctx v1 v2 ret_ctyp =
 
 let builtin_sail_truncateLSB ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, ret_ctyp) with
-  | CT_fbits (n, _), CT_constant c, CT_fbits (m, _) ->
+  | CT_fbits n, CT_constant c, CT_fbits m ->
       assert (Big_int.to_int c = m);
       Extract (n - 1, n - Big_int.to_int c, smt_cval ctx v1)
   | _ -> builtin_type_error ctx "sail_truncateLSB" [v1; v2] (Some ret_ctyp)
 
 let builtin_slice ctx v1 v2 v3 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, cval_ctyp v3, ret_ctyp) with
-  | CT_lbits _, CT_constant start, CT_constant len, CT_fbits (_, _) ->
+  | CT_lbits, CT_constant start, CT_constant len, CT_fbits _ ->
       let top = Big_int.pred (Big_int.add start len) in
       Extract (Big_int.to_int top, Big_int.to_int start, Fn ("contents", [smt_cval ctx v1]))
-  | CT_fbits (_, _), CT_constant start, CT_constant len, CT_fbits (_, _) ->
+  | CT_fbits _, CT_constant start, CT_constant len, CT_fbits _ ->
       let top = Big_int.pred (Big_int.add start len) in
       Extract (Big_int.to_int top, Big_int.to_int start, smt_cval ctx v1)
-  | CT_fbits (_, ord), CT_fint _, CT_constant len, CT_fbits (_, _) ->
+  | CT_fbits _, CT_fint _, CT_constant len, CT_fbits _ ->
       Extract (Big_int.to_int (Big_int.pred len), 0, builtin_shift "bvlshr" ctx v1 v2 (cval_ctyp v1))
-  | CT_fbits (n, ord), ctyp2, _, CT_lbits _ ->
+  | CT_fbits n, ctyp2, _, CT_lbits ->
       let smt1 = force_size ctx (lbits_size ctx) n (smt_cval ctx v1) in
       let smt2 = force_size ctx (lbits_size ctx) (int_size ctx ctyp2) (smt_cval ctx v2) in
       let smt3 = bvzeint ctx ctx.lbits_index v3 in
@@ -963,13 +959,13 @@ let builtin_slice ctx v1 v2 v3 ret_ctyp =
 
 let builtin_get_slice_int ctx v1 v2 v3 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, cval_ctyp v3, ret_ctyp) with
-  | CT_constant len, ctyp, CT_constant start, CT_fbits (ret_sz, _) ->
+  | CT_constant len, ctyp, CT_constant start, CT_fbits ret_sz ->
       let len = Big_int.to_int len in
       let start = Big_int.to_int start in
       let in_sz = int_size ctx ctyp in
       let smt = if in_sz < len + start then force_size ctx (len + start) in_sz (smt_cval ctx v2) else smt_cval ctx v2 in
       Extract (start + len - 1, start, smt)
-  | CT_lint, CT_lint, CT_constant start, CT_lbits _ when Big_int.equal start Big_int.zero ->
+  | CT_lint, CT_lint, CT_constant start, CT_lbits when Big_int.equal start Big_int.zero ->
       let len = Extract (ctx.lbits_index - 1, 0, smt_cval ctx v1) in
       let contents = unsigned_size ~checked:false ctx (lbits_size ctx) ctx.lint_size (smt_cval ctx v2) in
       Fn ("Bits", [len; Fn ("bvand", [bvmask ctx len; contents])])
@@ -1009,15 +1005,15 @@ let builtin_count_leading_zeros ctx v ret_ctyp =
     !m
   in
   match cval_ctyp v with
-  | CT_fbits (sz, _) when sz land (sz - 1) = 0 -> lzcnt sz (smt_cval ctx v)
-  | CT_fbits (sz, _) ->
+  | CT_fbits sz when sz land (sz - 1) = 0 -> lzcnt sz (smt_cval ctx v)
+  | CT_fbits sz ->
       let padded_sz = smallest_greater_power_of_two sz in
       let padding = bvzero (padded_sz - sz) in
       Fn
         ( "bvsub",
           [lzcnt padded_sz (Fn ("concat", [padding; smt_cval ctx v])); bvint ret_sz (Big_int.of_int (padded_sz - sz))]
         )
-  | CT_lbits _ ->
+  | CT_lbits ->
       let smt = smt_cval ctx v in
       Fn
         ( "bvsub",
@@ -1036,7 +1032,7 @@ let builtin_count_leading_zeros ctx v ret_ctyp =
 
 let builtin_set_slice_bits ctx v1 v2 v3 v4 v5 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2, cval_ctyp v3, cval_ctyp v4, cval_ctyp v5, ret_ctyp) with
-  | CT_constant n', CT_constant m', CT_fbits (n, _), CT_constant pos, CT_fbits (m, _), CT_fbits (n'', _)
+  | CT_constant n', CT_constant m', CT_fbits n, CT_constant pos, CT_fbits m, CT_fbits n''
     when Big_int.to_int m' = m && Big_int.to_int n' = n && n'' = n && Big_int.less_equal (Big_int.add pos m') n' ->
       let pos = Big_int.to_int pos in
       if pos = 0 then (
@@ -1057,7 +1053,7 @@ let builtin_set_slice_bits ctx v1 v2 v3 v4 v5 ret_ctyp =
   (* set_slice_bits(len, slen, x, pos, y) =
        let mask = slice_mask(len, pos, slen) in
        (x AND NOT(mask)) OR ((unsigned_size(len, y) << pos) AND mask) *)
-  | CT_constant n', _, CT_fbits (n, _), _, CT_lbits _, CT_fbits (n'', _) when Big_int.to_int n' = n && n'' = n ->
+  | CT_constant n', _, CT_fbits n, _, CT_lbits, CT_fbits n'' when Big_int.to_int n' = n && n'' = n ->
       let pos = bvzeint ctx (lbits_size ctx) v4 in
       let slen = bvzeint ctx ctx.lbits_index v2 in
       let mask = Fn ("bvshl", [bvmask ctx slen; pos]) in
@@ -1070,7 +1066,7 @@ let builtin_set_slice_bits ctx v1 v2 v3 v4 v5 ret_ctyp =
 
 let builtin_compare_bits fn ctx v1 v2 ret_ctyp =
   match (cval_ctyp v1, cval_ctyp v2) with
-  | CT_fbits (n, _), CT_fbits (m, _) when n = m -> Fn (fn, [smt_cval ctx v1; smt_cval ctx v2])
+  | CT_fbits n, CT_fbits m when n = m -> Fn (fn, [smt_cval ctx v1; smt_cval ctx v2])
   | _ -> builtin_type_error ctx fn [v1; v2] (Some ret_ctyp)
 
 (* ***** String operations: lib/real.sail ***** *)
@@ -1078,7 +1074,7 @@ let builtin_compare_bits fn ctx v1 v2 ret_ctyp =
 let builtin_decimal_string_of_bits ctx v =
   begin
     match cval_ctyp v with
-    | CT_fbits (n, _) -> Fn ("int.to.str", [Fn ("bv2nat", [smt_cval ctx v])])
+    | CT_fbits n -> Fn ("int.to.str", [Fn ("bv2nat", [smt_cval ctx v])])
     | _ -> builtin_type_error ctx "decimal_string_of_bits" [v] None
   end
 
@@ -1419,17 +1415,14 @@ end) : Jib_compile.Config = struct
       end
     | Typ_app (id, [A_aux (A_typ typ, _)]) when string_of_id id = "list" -> CT_list (convert_typ ctx typ)
     (* Note that we have to use lbits for zero-length bitvectors because they are not allowed by SMTLIB *)
-    | Typ_app (id, [A_aux (A_nexp n, _)]) when string_of_id id = "bitvector" ->
-        let direction = true in
-        begin
-          match nexp_simp n with
-          | Nexp_aux (Nexp_constant n, _) when Big_int.equal n Big_int.zero -> CT_lbits direction
-          | Nexp_aux (Nexp_constant n, _) -> CT_fbits (Big_int.to_int n, direction)
-          | _ -> CT_lbits direction
-        end
+    | Typ_app (id, [A_aux (A_nexp n, _)]) when string_of_id id = "bitvector" -> begin
+        match nexp_simp n with
+        | Nexp_aux (Nexp_constant n, _) when Big_int.equal n Big_int.zero -> CT_lbits
+        | Nexp_aux (Nexp_constant n, _) -> CT_fbits (Big_int.to_int n)
+        | _ -> CT_lbits
+      end
     | Typ_app (id, [A_aux (A_nexp n, _); A_aux (A_typ typ, _)]) when string_of_id id = "vector" ->
-        let direction = true in
-        CT_vector (direction, convert_typ ctx typ)
+        CT_vector (convert_typ ctx typ)
     | Typ_app (id, [A_aux (A_typ typ, _)]) when string_of_id id = "register" -> CT_ref (convert_typ ctx typ)
     | Typ_id id when Bindings.mem id ctx.records ->
         CT_struct (id, Bindings.find id ctx.records |> snd |> Bindings.bindings)
@@ -1503,7 +1496,7 @@ end) : Jib_compile.Config = struct
     | L_num n -> Some (V_lit (VL_int n, CT_constant n))
     | L_hex str when String.length str <= 16 ->
         let content = Util.string_to_list str |> List.map hex_char |> List.concat in
-        Some (V_lit (VL_bits (content, true), CT_fbits (String.length str * 4, true)))
+        Some (V_lit (VL_bits content, CT_fbits (String.length str * 4)))
     | L_unit -> Some (V_lit (VL_unit, CT_unit))
     | L_true -> Some (V_lit (VL_bool true, CT_bool))
     | L_false -> Some (V_lit (VL_bool false, CT_bool))

--- a/src/sail_smt_backend/sail_plugin_smt.ml
+++ b/src/sail_smt_backend/sail_plugin_smt.ml
@@ -124,7 +124,7 @@ let smt_target _ _ out_file ast effect_info env =
   let prop_ids = Bindings.bindings props |> List.map fst |> IdSet.of_list in
   let ast = Callgraph.filter_ast_ids prop_ids IdSet.empty ast in
   Specialize.add_initial_calls prop_ids;
-  let ast_smt, env, effect_info = Specialize.(specialize typ_ord_specialization env ast effect_info) in
+  let ast_smt, env, effect_info = Specialize.(specialize typ_specialization env ast effect_info) in
   let ast_smt, env, effect_info =
     Specialize.(specialize_passes 2 int_specialization_with_externs env ast_smt effect_info)
   in

--- a/src/sail_smt_backend/smtlib.ml
+++ b/src/sail_smt_backend/smtlib.ml
@@ -619,7 +619,7 @@ let value_of_sexpr sexpr =
   let open Jib in
   let open Value in
   function
-  | CT_fbits (n, _) -> begin
+  | CT_fbits n -> begin
       match sexpr with
       | List [Atom "_"; Atom v; Atom m] when int_of_string m = n && String.length v > 2 && String.sub v 0 2 = "bv" ->
           let v = String.sub v 2 (String.length v - 2) in

--- a/test/typecheck/fail/add_vec_lit_old.expect
+++ b/test/typecheck/fail/add_vec_lit_old.expect
@@ -10,6 +10,6 @@ Cast annotations are deprecated. They will be removed in a future version of the
   [91m |[0m                       [91m^-------^[0m
   [91m |[0m No overloading for (operator +), tried:
   [91m |[0m [94m*[0m add_vec
-  [91m |[0m    Could not unify int('ex5#) and bitvector(4, inc)
+  [91m |[0m    Could not unify int('ex5#) and bitvector(4)
   [91m |[0m [94m*[0m add_range
-  [91m |[0m    Could not unify int('ex1#) and bitvector(4, inc)
+  [91m |[0m    Could not unify int('ex1#) and bitvector(4)

--- a/test/typecheck/fail/issue277.expect
+++ b/test/typecheck/fail/issue277.expect
@@ -1,0 +1,6 @@
+[93mType error[0m:
+[96mfail/issue277.sail[0m:12.8-20:
+12[96m |[0m    foo(sizeof(xlen))
+  [91m |[0m        [91m^----------^[0m
+  [91m |[0m int(64) is not a subtype of int(32)
+  [91m |[0m as 64 == 32 could not be proven

--- a/test/typecheck/fail/issue277.sail
+++ b/test/typecheck/fail/issue277.sail
@@ -1,0 +1,13 @@
+default Order dec
+
+$include <prelude.sail>
+
+type xlen : Int = 64
+
+val foo : int(32) -> unit
+
+val main : unit -> unit
+
+function main() = {
+    foo(sizeof(xlen))
+}

--- a/test/typecheck/pass/bind_typ_var/v1.expect
+++ b/test/typecheck/pass/bind_typ_var/v1.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/bind_typ_var/v1.sail[0m:9.11-29:
+9[96m |[0m  let v as vector('len, _, _) = mk_vector ();
+ [91m |[0m           [91m^----------------^[0m
+ [91m |[0m Couldn't bind type vector('_v, bit) with vector('len, _, _)

--- a/test/typecheck/pass/bind_typ_var/v1.sail
+++ b/test/typecheck/pass/bind_typ_var/v1.sail
@@ -6,7 +6,7 @@ val mk_square : unit -> {'n 'm, 'n == 'm. vector('n, dec, vector('m, dec, bit))}
 val test : unit -> unit
 
 function test () = {
-  let v as vector('len, _) = mk_vector ();
+  let v as vector('len, _, _) = mk_vector ();
   // could still be
   let v2 as 'len2 = mk_vector ();
   let matrix as vector('width, 'height) = mk_square ();

--- a/test/typecheck/pass/if_infer/v1.expect
+++ b/test/typecheck/pass/if_infer/v1.expect
@@ -7,7 +7,7 @@
   [91m |[0m    Could not resolve quantifiers for bitvector_access
   [91m |[0m    [94m*[0m (0 <= 'ex233# & 'ex233# < 3)
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(3, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(3)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v1.sail[0m:10.10-37:
   [91m |[0m 10[96m |[0m  let _ = 0b100[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v2.expect
+++ b/test/typecheck/pass/if_infer/v2.expect
@@ -7,7 +7,7 @@
   [91m |[0m    Could not resolve quantifiers for bitvector_access
   [91m |[0m    [94m*[0m (0 <= 'ex233# & 'ex233# < 4)
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(4, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(4)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v2.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v3.expect
+++ b/test/typecheck/pass/if_infer/v3.expect
@@ -6,7 +6,7 @@
   [91m |[0m [94m*[0m bitvector_access
   [91m |[0m    Numeric type is non-simple
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(4, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(4)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v3.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/negative_bits_list/v1.expect
+++ b/test/typecheck/pass/negative_bits_list/v1.expect
@@ -2,4 +2,4 @@
 [96mpass/negative_bits_list/v1.sail[0m:10.30-39:
 10[96m |[0m    let z: list(bits(-1)) = [|undefined|];
   [91m |[0m                              [91m^-------^[0m
-  [91m |[0m Type bitvector(-1, dec) is empty
+  [91m |[0m Type bitvector(-1) is empty

--- a/test/typecheck/pass/outcome_impl/v3.expect
+++ b/test/typecheck/pass/outcome_impl/v3.expect
@@ -2,9 +2,9 @@
 [96mpass/outcome_impl/v3.sail[0m:30.2-29:
 30[96m |[0m  to_bits = instance_to_bits2
   [91m |[0m  [91m^-------------------------^[0m
-  [91m |[0m bitvector(32, dec) is not a subtype of string
+  [91m |[0m bitvector(32) is not a subtype of string
   [91m |[0m 
   [91m |[0m [93mAlso tried [0m[96mpass/outcome_impl/v3.sail[0m:30.2-29:
   [91m |[0m 30[96m |[0m  to_bits = instance_to_bits2
   [91m |[0m   [91m |[0m  [91m^-------------------------^[0m
-  [91m |[0m   [91m |[0m bitvector(32, dec) is not a subtype of string
+  [91m |[0m   [91m |[0m bitvector(32) is not a subtype of string

--- a/test/typecheck/pass/poly_vector/v1.expect
+++ b/test/typecheck/pass/poly_vector/v1.expect
@@ -4,16 +4,16 @@
   [91m |[0m     [91m^-----------------^[0m
   [91m |[0m No overloading for (operator ==), tried:
   [91m |[0m [94m*[0m eq_int
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
   [91m |[0m [94m*[0m eq_bit
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
   [91m |[0m [94m*[0m eq_bool
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
   [91m |[0m [94m*[0m eq_unit
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
   [91m |[0m [94m*[0m eq_bit
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
   [91m |[0m [94m*[0m eq_bits
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
   [91m |[0m [94m*[0m eq_string
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(32, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)

--- a/test/typecheck/pass/poly_vector/v2.expect
+++ b/test/typecheck/pass/poly_vector/v2.expect
@@ -1,5 +1,5 @@
 [93mType error[0m:
-[96mpass/poly_vector/v2.sail[0m:5.5-14:
-5[96m |[0mtype bitvector('n, 'ord: Order) = vector('n, 'ord, bit)
- [91m |[0m     [91m^-------^[0m
- [91m |[0m Cannot define type synonym bitvector, as a type or synonym with that name already exists
+[96mpass/poly_vector/v2.sail[0m:7.30-48:
+7[96m |[0mval "to_generic" : forall 'n. bitvector('n, dec) -> vector('n, dec, bit)
+ [91m |[0m                              [91m^----------------^[0m
+ [91m |[0m bitvector : Int -> Type expected 1 arguments, given 2

--- a/test/typecheck/pass/reg_32_64/v1.expect
+++ b/test/typecheck/pass/reg_32_64/v1.expect
@@ -13,4 +13,4 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m    Could not resolve quantifiers for set_R
   [91m |[0m    [94m*[0m (regno(0) & (56 == 32 | 56 == 64))
   [91m |[0m [94m*[0m get_R
-  [91m |[0m    Could not unify int('r) and bitvector(56, dec)
+  [91m |[0m    Could not unify int('r) and bitvector(56)

--- a/test/typecheck/pass/vec_length/v1.expect
+++ b/test/typecheck/pass/vec_length/v1.expect
@@ -7,7 +7,7 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_access
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_access
- [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(8, dec)
+ [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v1.sail[0m:6.10-15:
  [91m |[0m 6[96m |[0m  let y = x[10];

--- a/test/typecheck/pass/vec_length/v1_inc.expect
+++ b/test/typecheck/pass/vec_length/v1_inc.expect
@@ -7,7 +7,7 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_access
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_access
- [91m |[0m    Could not unify vector('n, inc, 'a) and bitvector(8, inc)
+ [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v1_inc.sail[0m:6.10-15:
  [91m |[0m 6[96m |[0m  let y = x[10];

--- a/test/typecheck/pass/vec_length/v2.expect
+++ b/test/typecheck/pass/vec_length/v2.expect
@@ -7,7 +7,7 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_update
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_update
- [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(8, dec)
+ [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v2.sail[0m:7.10-25:
  [91m |[0m 7[96m |[0m  let z = [x with 10 = y];

--- a/test/typecheck/pass/vec_length/v2_inc.expect
+++ b/test/typecheck/pass/vec_length/v2_inc.expect
@@ -7,7 +7,7 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_update
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_update
- [91m |[0m    Could not unify vector('n, inc, 'a) and bitvector(8, inc)
+ [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v2_inc.sail[0m:7.10-25:
  [91m |[0m 7[96m |[0m  let z = [x with 10 = y];

--- a/test/typecheck/pass/vec_length/v3.expect
+++ b/test/typecheck/pass/vec_length/v3.expect
@@ -9,7 +9,7 @@
   [91m |[0m    Could not resolve quantifiers for bitvector_access
   [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, dec, 'a) and bitvector(8, dec)
+  [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/vec_length/v3.sail[0m:6.10-12.3:
   [91m |[0m 6 [96m |[0m  let y = x[


### PR DESCRIPTION
Currently we will still understand the extra parameters on vector and
bitvector, and they are treated as optional. User-defined types with Order
parameters will raise an error however (in practice they have never been
used).

Any code that tried to care about bitvector order in a meaningful way
now just uses the default Order (which in practice should be equivalent
as no spec ever mixes bitvector ordering). This translation was very
mechanical, but I think much of the code that we have that tries to
handle this is confused in general and probably only works in the `dec`
case anyway.