### PR TITLE
Perform a well-formedness check on types from function definitions

### DIFF
--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5352,6 +5352,7 @@ let infer_funtyp l env tannotopt funcls =
             match typ_from_pat pat with Typ_aux (Typ_tuple arg_typs, _) -> arg_typs | arg_typ -> [arg_typ]
           in
           let fn_typ = mk_typ (Typ_fn (arg_typs, ret_typ)) in
+          wf_binding l env (quant, fn_typ);
           (quant, fn_typ)
       | _ -> typ_error env l "Cannot infer function type for function with multiple clauses"
     end

--- a/test/typecheck/fail/unbound_tyvar.expect
+++ b/test/typecheck/fail/unbound_tyvar.expect
@@ -1,0 +1,7 @@
+[93mType error[0m:
+Well-formedness check failed for type
+
+[93mCaused by [0m[96mfail/unbound_tyvar.sail[0m:5.23-44:
+5[96m |[0mfunction foo() -> bits(definitelydoesntexist) = {
+ [91m |[0m                       [91m^-------------------^[0m
+ [91m |[0m Undefined type synonym definitelydoesntexist

--- a/test/typecheck/fail/unbound_tyvar.sail
+++ b/test/typecheck/fail/unbound_tyvar.sail
@@ -1,0 +1,7 @@
+default Order dec
+
+$include <vector_dec.sail>
+
+function foo() -> bits(definitelydoesntexist) = {
+  0b0
+}

--- a/test/typecheck/fail/unbound_tyvar2.expect
+++ b/test/typecheck/fail/unbound_tyvar2.expect
@@ -1,0 +1,10 @@
+[93mType error[0m:
+[96mfail/unbound_tyvar2.sail[0m:5.10-45:
+5[96m |[0mval foo : unit -> bits(definitelydoesntexist)
+ [91m |[0m          [91m^---------------------------------^[0m
+ [91m |[0m Well-formedness check failed for type
+ [91m |[0m 
+ [91m |[0m [93mCaused by [0m[96mfail/unbound_tyvar2.sail[0m:5.23-44:
+ [91m |[0m 5[96m |[0mval foo : unit -> bits(definitelydoesntexist)
+ [91m |[0m  [91m |[0m                       [91m^-------------------^[0m
+ [91m |[0m  [91m |[0m Undefined type synonym definitelydoesntexist

--- a/test/typecheck/fail/unbound_tyvar2.sail
+++ b/test/typecheck/fail/unbound_tyvar2.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <vector_dec.sail>
+
+val foo : unit -> bits(definitelydoesntexist)
+
+function foo() = {
+  0b0
+}

--- a/test/typecheck/pass/constraint_ctor/v4.expect
+++ b/test/typecheck/pass/constraint_ctor/v4.expect
@@ -1,10 +1,7 @@
 [93mType error[0m:
-[96mpass/constraint_ctor/v4.sail[0m:17.33-40:
+Well-formedness check failed for type
+
+[93mCaused by [0m[96mpass/constraint_ctor/v4.sail[0m:17.33-36:
 17[96m |[0mfunction bar(Bar(x as int('x)) : Bar(23)) -> unit = {
-  [91m |[0m                                 [91m^-----^[0m
-  [91m |[0m Well-formedness check failed for type
-  [91m |[0m 
-  [91m |[0m [93mCaused by [0m[96mpass/constraint_ctor/v4.sail[0m:17.33-36:
-  [91m |[0m 17[96m |[0mfunction bar(Bar(x as int('x)) : Bar(23)) -> unit = {
-  [91m |[0m   [91m |[0m                                 [91m^-^[0m
-  [91m |[0m   [91m |[0m Could not prove 23 <= 22 for type constructor Bar
+  [91m |[0m                                 [91m^-^[0m
+  [91m |[0m Could not prove 23 <= 22 for type constructor Bar


### PR DESCRIPTION
This brings them into line with predeclared functions, where well-formedness is checked at the declaration.
Fixes #307