### PR TITLE
overload error for non-existent identifier

### DIFF
--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -408,6 +408,11 @@ let filter_ast_extra cuts g ast keep_std =
     | DEF_aux (DEF_register rdec, def_annot) :: defs when NM.mem (Register (id_of_reg_dec rdec)) g ->
         DEF_aux (DEF_register rdec, def_annot) :: filter_ast' g defs
     | DEF_aux (DEF_register _, _) :: defs -> filter_ast' g defs
+    | DEF_aux (DEF_overload (id, overloads), def_annot) :: defs ->
+        let cut_overload overload =
+          NS.mem (Function overload) cuts || NS.mem (Constructor overload) cuts || NS.mem (Overload overload) cuts
+        in
+        DEF_aux (DEF_overload (id, List.filter cut_overload overloads), def_annot) :: filter_ast' g defs
     | DEF_aux (DEF_val vs, def_annot) :: defs when NM.mem (Function (id_of_val_spec vs)) g ->
         DEF_aux (DEF_val vs, def_annot) :: filter_ast' g defs
     | DEF_aux (DEF_val _, _) :: defs -> filter_ast' g defs

--- a/test/typecheck/pass/add_vec_lit.sail
+++ b/test/typecheck/pass/add_vec_lit.sail
@@ -7,7 +7,7 @@ val add_vec = pure {ocaml: "add_vec", lem: "add_vec"}: forall ('n : Int).
 val unsigned : forall ('n : Int).
   bitvector('n, inc) -> range(0, 2 ^ 'n - 1)
 
-overload operator + = {add_vec, add_range}
+overload operator + = {add_vec}
 
 let x : range(0, 30) = unsigned(0xF + 0x2)
 let y : range(0, 30) = unsigned(0xF) + unsigned(0x2)

--- a/test/typecheck/pass/global_type_var.sail
+++ b/test/typecheck/pass/global_type_var.sail
@@ -1,7 +1,5 @@
 $include <flow.sail>
 
-overload operator == = {eq_atom}
-
 let (size as 'size) : {|32, 64|} = 32
 
 val zeros : forall 'n. atom('n) -> vector ('n, dec, bit)

--- a/test/typecheck/pass/global_type_var/v1.expect
+++ b/test/typecheck/pass/global_type_var/v1.expect
@@ -1,6 +1,6 @@
 [93mType error[0m:
-[96mpass/global_type_var/v1.sail[0m:23.13-15:
-23[96m |[0mlet _ = test(32)
+[96mpass/global_type_var/v1.sail[0m:21.13-15:
+21[96m |[0mlet _ = test(32)
   [91m |[0m             [91m^^[0m
   [91m |[0m int(32) is not a subtype of int('size)
   [91m |[0m as 32 == 'size could not be proven

--- a/test/typecheck/pass/global_type_var/v1.sail
+++ b/test/typecheck/pass/global_type_var/v1.sail
@@ -1,7 +1,5 @@
 $include <flow.sail>
 
-overload operator == = {eq_atom}
-
 let (size as 'size) : {|32, 64|} = 32
 
 val zeros : forall 'n. atom('n) -> vector ('n, dec, bit)

--- a/test/typecheck/pass/global_type_var/v2.expect
+++ b/test/typecheck/pass/global_type_var/v2.expect
@@ -1,6 +1,6 @@
 [93mType error[0m:
-[96mpass/global_type_var/v2.sail[0m:23.13-15:
-23[96m |[0mlet _ = test(64)
+[96mpass/global_type_var/v2.sail[0m:21.13-15:
+21[96m |[0mlet _ = test(64)
   [91m |[0m             [91m^^[0m
   [91m |[0m int(64) is not a subtype of int('size)
   [91m |[0m as 64 == 'size could not be proven

--- a/test/typecheck/pass/global_type_var/v2.sail
+++ b/test/typecheck/pass/global_type_var/v2.sail
@@ -1,7 +1,5 @@
 $include <flow.sail>
 
-overload operator == = {eq_atom}
-
 let (size as 'size) : {|32, 64|} = 32
 
 val zeros : forall 'n. atom('n) -> vector ('n, dec, bit)

--- a/test/typecheck/pass/global_type_var/v3.expect
+++ b/test/typecheck/pass/global_type_var/v3.expect
@@ -1,6 +1,6 @@
 [93mType error[0m:
-[96mpass/global_type_var/v3.sail[0m:15.23-27:
-15[96m |[0m    let y : atom(64) = size in
+[96mpass/global_type_var/v3.sail[0m:13.23-27:
+13[96m |[0m    let y : atom(64) = size in
   [91m |[0m                       [91m^--^[0m
   [91m |[0m int('size) is not a subtype of int(64)
   [91m |[0m as 'size == 64 could not be proven

--- a/test/typecheck/pass/global_type_var/v3.sail
+++ b/test/typecheck/pass/global_type_var/v3.sail
@@ -1,7 +1,5 @@
 $include <flow.sail>
 
-overload operator == = {eq_atom}
-
 let (size as 'size) : {|32, 64|} = 32
 
 val zeros : forall 'n. atom('n) -> vector ('n, dec, bit)

--- a/test/typecheck/pass/while_MM.sail
+++ b/test/typecheck/pass/while_MM.sail
@@ -5,7 +5,7 @@ val add_int = {ocaml: "add", lem: "add"}: (int, int) -> int
 val add_vec_int : forall ('n : Int) ('ord : Order).
   (bitvector('n, 'ord), int) -> bitvector('n, 'ord)
 
-overload operator + = {add_vec_int, add_range, add_int}
+overload operator + = {add_vec_int, add_int}
 
 val bool_not = pure {ocaml: "not", lem: "not"}: bool -> bool
 

--- a/test/typecheck/pass/while_MP.sail
+++ b/test/typecheck/pass/while_MP.sail
@@ -2,7 +2,7 @@ default Order dec
 
 val add_int = pure {ocaml: "add", lem: "integerAdd"}: (int, int) -> int
 
-overload operator + = {add_vec_int, add_range, add_int}
+overload operator + = {add_int}
 
 val bool_not = pure {ocaml: "not", lem: "not"}: bool -> bool
 


### PR DESCRIPTION
Slightly more complex than it first appears because we can't remove unreachable functions without also adjusting any overloads.