### PR TITLE
Don't emit translations for -sv_fun2wires

### DIFF
--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -387,6 +387,7 @@ let verilog_target _ default_sail_dir out_opt ast effect_info env =
     let nopacked = !opt_nopacked
     let unreachable = !opt_unreachable
     let comb = !opt_comb
+    let ignore = !opt_fun2wires
   end) in
   let open SV in
   let sail_dir = Reporting.get_sail_dir default_sail_dir in


### PR DESCRIPTION
This means we can replace Sail functions with equivalents in handwritten SV.