### PR TITLE
Make sure realize_mappings handles mappings in overloads

### DIFF
--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4134,6 +4134,26 @@ let rewrite_ast_realize_mappings effect_info env ast =
     match def with
     | DEF_aux (DEF_val spec, def_annot) -> realize_val_spec def_annot spec
     | DEF_aux (DEF_mapdef mdef, def_annot) -> realize_mapdef def_annot mdef
+    | DEF_aux (DEF_overload (id, overloads), def_annot) ->
+        [
+          DEF_aux
+            ( DEF_overload
+                ( id,
+                  List.map
+                    (fun overload ->
+                      if Env.is_mapping overload env then (
+                        let forwards_id = mk_id (string_of_id overload ^ "_forwards") in
+                        let backwards_id = mk_id (string_of_id overload ^ "_backwards") in
+                        [forwards_id; backwards_id]
+                      )
+                      else [overload]
+                    )
+                    overloads
+                  |> List.concat
+                ),
+              def_annot
+            );
+        ]
     | d -> [d]
   in
   let ast = { ast with defs = List.map rewrite_def ast.defs |> List.flatten } in

--- a/test/c/overload_mapping.expect
+++ b/test/c/overload_mapping.expect
@@ -1,0 +1,3 @@
+foo(A) = 0
+bar(A) = 0
+got A

--- a/test/c/overload_mapping.sail
+++ b/test/c/overload_mapping.sail
@@ -1,0 +1,24 @@
+default Order dec
+
+$include <prelude.sail>
+
+enum E = {A, B, C}
+
+mapping foo : E <-> int = {
+    A <-> 0,
+    B <-> 1,
+    C <-> 2
+}
+
+overload bar = {foo}
+
+val main : unit -> unit
+
+function main() = {
+    print_int("foo(A) = ", foo(A));
+    print_int("bar(A) = ", bar(A));
+    match bar(0) {
+        A => print_endline("got A"),
+        _ => (),
+    }
+}


### PR DESCRIPTION
Probably we shouldn't allow this, but the RISC-V spec does this, so we can't fail