### PR TITLE
Fix formatting for set types

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -332,7 +332,7 @@ let run_sail_format (config : Yojson.Basic.t option) =
     (fun (f, (comments, parse_ast)) ->
       let source = file_to_string f in
       if is_format_file f && not (is_skipped_file f) then (
-        let formatted = Formatter.format_defs f source comments parse_ast in
+        let formatted = Formatter.format_defs ~debug:true f source comments parse_ast in
         begin
           match !opt_format_backup with
           | Some suffix ->

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -545,7 +545,6 @@ let chunk_infix_token comments chunk_primary (infix_token, _, _) =
       | Id_aux (Id "negate", _) -> Infix_prefix "-"
       | _ -> Infix_prefix (string_of_id id)
     )
-  | IT_in_set set -> Infix_op ("in {" ^ Util.string_of_list ", " Big_int.to_string set ^ "}")
   | IT_primary exp ->
       let chunks = Queue.create () in
       chunk_primary comments chunks exp;
@@ -563,10 +562,10 @@ let rec chunk_atyp comments chunks (ATyp_aux (aux, l)) =
   | ATyp_id id -> Queue.add (Atom (string_of_id id)) chunks
   | ATyp_var v -> Queue.add (Atom (string_of_var v)) chunks
   | ATyp_lit lit -> Queue.add (chunk_of_lit lit) chunks
-  | ATyp_nset (n, set) ->
-      let lhs_chunks = rec_chunk_atyp n in
-      let rhs_chunks = Queue.create () in
-      Queue.add (Atom ("{" ^ Util.string_of_list ", " Big_int.to_string set ^ "}")) rhs_chunks;
+  | ATyp_nset set -> Queue.add (Atom ("{" ^ Util.string_of_list ", " Big_int.to_string set ^ "}")) chunks
+  | ATyp_in (lhs, rhs) ->
+      let lhs_chunks = rec_chunk_atyp lhs in
+      let rhs_chunks = rec_chunk_atyp rhs in
       Queue.add (Binary (lhs_chunks, "in", rhs_chunks)) chunks
   | ATyp_infix [(IT_primary lhs, _, _); (IT_op (Id_aux (Id op, _)), _, _); (IT_primary rhs, _, _)] ->
       let lhs_chunks = rec_chunk_atyp lhs in

--- a/src/lib/infix_parser.mly
+++ b/src/lib/infix_parser.mly
@@ -63,9 +63,8 @@ let rec desugar_rchain chain s e =
 %token <Parse_ast.id> Op0l Op1l Op2l Op3l Op4l Op5l Op6l Op7l Op8l Op9l
 %token <Parse_ast.id> Op0r Op1r Op2r Op3r Op4r Op5r Op6r Op7r Op8r Op9r
 
-%token Lt Gt LtEq GtEq Minus Star Plus ColonColon At
+%token Lt Gt LtEq GtEq Minus Star Plus ColonColon At In
 %token TwoCaret
-%token <Nat_big_num.num list> InSet
 
 %start typ_eof
 %start exp_eof
@@ -219,8 +218,7 @@ typ8r:
   | typ9 { $1 }
 
 typ9:
-  | atomic_typ InSet
-    { mk_typ (ATyp_nset ($1, $2)) $startpos $endpos }
+  | atomic_typ In atomic_typ { mk_typ (ATyp_in ($1, $3)) $startpos $endpos }
   | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
   | typ9l Op9l atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
   | atomic_typ Op9r typ9r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -125,7 +125,7 @@ type kid = Kid_aux of kid_aux * l
 
 type id = Id_aux of id_aux * l
 
-type 'a infix_token = IT_primary of 'a | IT_op of id | IT_prefix of id | IT_in_set of Big_int.num list
+type 'a infix_token = IT_primary of 'a | IT_op of id | IT_prefix of id
 
 type lit_aux =
   | (* Literal constant *)
@@ -148,7 +148,8 @@ type atyp_aux =
   | ATyp_id of id (* identifier *)
   | ATyp_var of kid (* ticked variable *)
   | ATyp_lit of lit (* literal *)
-  | ATyp_nset of atyp * Big_int.num list (* set type *)
+  | ATyp_nset of Big_int.num list (* set type *)
+  | ATyp_in of atyp * atyp (* set type *)
   | ATyp_times of atyp * atyp (* product *)
   | ATyp_sum of atyp * atyp (* sum *)
   | ATyp_minus of atyp * atyp (* subtraction *)

--- a/test/format/default/set_syntax.expect
+++ b/test/format/default/set_syntax.expect
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+val main : unit -> unit
+
+function main () = {
+    let x : {1, 2, 3} = 3
+}

--- a/test/format/set_syntax.sail
+++ b/test/format/set_syntax.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+val main : unit -> unit
+
+function main() = {
+    let x: {|1, 2, 3|} = 3;
+}

--- a/test/typecheck/pass/existential_ast/v1.expect
+++ b/test/typecheck/pass/existential_ast/v1.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Deprecated [96mpass/existential_ast/v1.sail[0m:17.10-20:
+17[96m |[0m  let x : {|32, 64|} = if b == 0b0 then 32 else 64;
+  [91m |[0m          [91m^--------^[0m
+  [91m |[0m 
+Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
+
 [93mType error[0m:
 [96mpass/existential_ast/v1.sail[0m:46.7-21:
 46[96m |[0m  Some(Ctor2(y, x, c))

--- a/test/typecheck/pass/existential_ast/v2.expect
+++ b/test/typecheck/pass/existential_ast/v2.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Deprecated [96mpass/existential_ast/v2.sail[0m:17.10-20:
+17[96m |[0m  let x : {|32, 64|} = if b == 0b0 then 32 else 64;
+  [91m |[0m          [91m^--------^[0m
+  [91m |[0m 
+Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
+
 [93mType error[0m:
 [96mpass/existential_ast/v2.sail[0m:39.7-21:
 39[96m |[0m  Some(Ctor2(y, x, c))

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Deprecated [96mpass/existential_ast/v3.sail[0m:17.10-20:
+17[96m |[0m  let x : {|32, 64|} = if b == 0b0 then 32 else 64;
+  [91m |[0m          [91m^--------^[0m
+  [91m |[0m 
+Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
+
 [93mType error[0m:
 [96mpass/existential_ast/v3.sail[0m:26.7-21:
 26[96m |[0m  Some(Ctor1(a, x, c))

--- a/test/typecheck/pass/global_type_var/v1.expect
+++ b/test/typecheck/pass/global_type_var/v1.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Deprecated [96mpass/global_type_var/v1.sail[0m:3.22-32:
+3[96m |[0mlet (size as 'size) : {|32, 64|} = 32
+ [91m |[0m                      [91m^--------^[0m
+ [91m |[0m 
+Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
+
 [93mType error[0m:
 [96mpass/global_type_var/v1.sail[0m:21.13-15:
 21[96m |[0mlet _ = test(32)

--- a/test/typecheck/pass/global_type_var/v2.expect
+++ b/test/typecheck/pass/global_type_var/v2.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Deprecated [96mpass/global_type_var/v2.sail[0m:3.22-32:
+3[96m |[0mlet (size as 'size) : {|32, 64|} = 32
+ [91m |[0m                      [91m^--------^[0m
+ [91m |[0m 
+Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
+
 [93mType error[0m:
 [96mpass/global_type_var/v2.sail[0m:21.13-15:
 21[96m |[0mlet _ = test(64)

--- a/test/typecheck/pass/global_type_var/v3.expect
+++ b/test/typecheck/pass/global_type_var/v3.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Deprecated [96mpass/global_type_var/v3.sail[0m:3.22-32:
+3[96m |[0mlet (size as 'size) : {|32, 64|} = 32
+ [91m |[0m                      [91m^--------^[0m
+ [91m |[0m 
+Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
+
 [93mType error[0m:
 [96mpass/global_type_var/v3.sail[0m:13.23-27:
 13[96m |[0m    let y : atom(64) = size in


### PR DESCRIPTION
Also simplify the grammar so `in` is treated as a regular binary operator, and {|1, 2, 3|} and {1, 2, 3} are treated the same.