### PR TITLE
Improve branch coverage output

### DIFF
--- a/lib/sail_coverage.h
+++ b/lib/sail_coverage.h
@@ -76,11 +76,11 @@ int sail_coverage_exit(void);
 
 void sail_set_coverage_file(const char *output_file);
 
-void sail_function_entry(const char *function_name, const char *sail_file, int l1, int c1, int l2, int c2);
-
-void sail_branch_taken(int branch_id, const char *sail_file, int l1, int c1, int l2, int c2);
+void sail_function_entry(int function_id, const char *function_name, const char *sail_file, int l1, int c1, int l2, int c2);
 
 void sail_branch_reached(int branch_id, const char *sail_file, int l1, int c1, int l2, int c2);
+
+void sail_branch_target_taken(int branch_id, int branch_target_id, const char *sail_file, int l1, int c1, int l2, int c2);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. Distinguish between branches (e.g. and entire `match`) and branch targets (each arm of the `match`). This leads to slightly less naming. `sail_branch_taken` was renamed to `sail_branch_target_taken`.

2. Add integer function IDs and branch target IDs. This speeds up coverage collection since you can just look them up in an array rather than hashing the filenames etc (though I haven't changed the existing Rust library to do that). It also allows logging of the control flow (I have a plan to make a post-execution debugger so you can sort of step through the Sail code).

3. Always call `sail_branch_reached()` even if the source code location could not be determined (e.g. because for mapping it could be spread over multiple files).

Ideally the source code location would be known for `scattered` definitions, but I don't know enough about the compiler to do that.

Fixes #337 