### PR TITLE
Preserve doc comments and attributes on union clauses

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -309,7 +309,7 @@ type_def_aux  :: 'TD_' ::=
 
 type_union :: 'Tu_' ::=
   {{ com type union constructors }}
-  {{ aux _ l }}
+  {{ aux _ def_annot }}
   | typ id                                              :: :: ty_id
 
 index_range :: 'BF_' ::= {{ com index specification, for bitfields in register types}} 

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -1162,8 +1162,9 @@ let record_ids defs =
   IdSet.of_list (rec_ids defs)
 
 let rec get_scattered_union_clauses id = function
-  | DEF_aux (DEF_scattered (SD_aux (SD_unioncl (uid, tu), _)), _) :: defs when Id.compare id uid = 0 ->
-      tu :: get_scattered_union_clauses id defs
+  | DEF_aux (DEF_scattered (SD_aux (SD_unioncl (uid, Tu_aux (tu, _)), _)), def_annot) :: defs when Id.compare id uid = 0
+    ->
+      Tu_aux (tu, def_annot) :: get_scattered_union_clauses id defs
   | _ :: defs -> get_scattered_union_clauses id defs
   | [] -> []
 

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -657,12 +657,16 @@ let split_defs target all_errors (splits : split_req list) env ast =
   let no_errors_happened = ref true in
   let error_opt = if all_errors then Some no_errors_happened else None in
   let split_constructors defs =
-    let sc_type_union q (Tu_aux (Tu_ty_id (ty, id), l)) =
-      let env = Env.add_typquant l q env in
+    let sc_type_union q (Tu_aux (Tu_ty_id (ty, id), def_annot)) =
+      let env = Env.add_typquant def_annot.loc q env in
       match split_src_type error_opt env id ty q with
-      | None -> ([], [Tu_aux (Tu_ty_id (ty, id), l)])
+      | None -> ([], [Tu_aux (Tu_ty_id (ty, id), def_annot)])
       | Some variants ->
-          ([(id, variants)], List.map (fun (insts, id', ty) -> Tu_aux (Tu_ty_id (ty, id'), Generated l)) variants)
+          ( [(id, variants)],
+            List.map
+              (fun (insts, id', ty) -> Tu_aux (Tu_ty_id (ty, id'), def_annot_map_loc (fun l -> Generated l) def_annot))
+              variants
+          )
     in
     let sc_type_def (TD_aux (tda, annot) as td) =
       match tda with

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -311,8 +311,14 @@ type rec_opt_aux =
 type funcl_aux = (* Function clause *)
   | FCL_funcl of id * pexp
 
-type type_union_aux = (* Type union constructors *)
-  | Tu_ty_id of atyp * id | Tu_ty_anon_rec of (atyp * id) list * id
+type type_union = Tu_aux of type_union_aux * l
+
+and type_union_aux =
+  (* Type union constructors *)
+  | Tu_attribute of string * string * type_union
+  | Tu_doc of string * type_union
+  | Tu_ty_id of atyp * id
+  | Tu_ty_anon_rec of (atyp * id) list * id
 
 type tannot_opt = Typ_annot_opt_aux of tannot_opt_aux * l
 
@@ -321,8 +327,6 @@ type effect_opt = Effect_opt_aux of effect_opt_aux * l
 type rec_opt = Rec_aux of rec_opt_aux * l
 
 type funcl = FCL_aux of funcl_aux * l
-
-type type_union = Tu_aux of type_union_aux * l
 
 type subst_aux =
   (* instantiation substitution *)

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -1046,6 +1046,10 @@ struct_fields:
     { $1 :: $3 }
 
 type_union:
+  | attr = Attribute; tu = type_union
+    { Tu_aux (Tu_attribute (fst attr, snd attr, tu), loc $startpos $endpos) }
+  | doc = Doc; tu = type_union
+    { Tu_aux (Tu_doc (doc, tu), loc $startpos(doc) $endpos(doc)) }
   | id Colon typ
     { Tu_aux (Tu_ty_id ($3, $1), loc $startpos $endpos) }
   | id Colon typ MinusGt typ

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4145,11 +4145,11 @@ let forbid_recursive_types type_l f =
     let msg = "Types are not well-formed within this type definition. Note that recursive types are forbidden." in
     raise (Type_error (type_l, err_because (Err_other msg, l, err)))
 
-let check_type_union u_l non_rec_env env variant typq (Tu_aux (Tu_ty_id (arg_typ, v), l)) =
+let check_type_union u_l non_rec_env env variant typq (Tu_aux (Tu_ty_id (arg_typ, v), def_annot)) =
   let ret_typ = app_typ variant (List.fold_left fold_union_quant [] (quant_items typq)) in
   let typ = mk_typ (Typ_fn ([arg_typ], ret_typ)) in
-  forbid_recursive_types u_l (fun () -> wf_binding l non_rec_env (typq, arg_typ));
-  wf_binding l env (typq, typ);
+  forbid_recursive_types u_l (fun () -> wf_binding def_annot.loc non_rec_env (typq, arg_typ));
+  wf_binding def_annot.loc env (typq, typ);
   env |> Env.add_union_id v (typq, typ) |> Env.add_val_spec v (typq, typ)
 
 let check_record l env def_annot id typq fields =

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1127,7 +1127,9 @@ let is_variant id env = Bindings.mem id env.global.unions
 let add_variant id (typq, constructors) env =
   let constructors =
     List.map
-      (fun (Tu_aux (Tu_ty_id (typ, id), l)) -> Tu_aux (Tu_ty_id (expand_synonyms (add_typquant l typq env) typ, id), l))
+      (fun (Tu_aux (Tu_ty_id (typ, id), def_annot)) ->
+        Tu_aux (Tu_ty_id (expand_synonyms (add_typquant def_annot.loc typq env) typ, id), def_annot)
+      )
       constructors
   in
   if bound_typ_id env id then already_bound "union" id env

--- a/test/typecheck/pass/scattered_union_doc.sail
+++ b/test/typecheck/pass/scattered_union_doc.sail
@@ -1,0 +1,14 @@
+default Order dec
+
+/*!
+Doc comment on scattered def
+*/
+$[foo]
+scattered union U
+
+$[custom_attr]
+/*!
+Some doc comment
+*/
+$[custom_attr2 arg]
+union clause U = A : unit


### PR DESCRIPTION
This means we now allow documentation comments and attributes on regular type union arms, as this is where those top-level doc comments end up, and we want to be able to round trip