### PR TITLE
Allow parsing doc comments and attributes on function clauses

### DIFF
--- a/scattered_function_doc.sail
+++ b/scattered_function_doc.sail
@@ -1,0 +1,11 @@
+default Order dec
+
+val foo : int -> unit
+
+scattered function foo
+
+/*! First clause doc comment */
+function clause foo(0) = ()
+
+/*! Second clause doc comment */
+function clause foo(_) = ()

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -95,7 +95,7 @@ and chunk =
       rec_opt : chunks option;
       typq_opt : chunks option;
       return_typ_opt : chunks option;
-      funcls : pexp_chunks list;
+      funcls : (chunks * pexp_chunks) list;
     }
   | Val of { id : Parse_ast.id; extern_opt : Parse_ast.extern option; typq_opt : chunks option; typ : chunks }
   | Enum of { id : Parse_ast.id; enum_functions : chunks list option; members : chunks list }

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -670,12 +670,14 @@ module Make (Config : CONFIG) = struct
     let guarded_pat, body = doc_pexp_chunks_pair opts pexp in
     separate space [guarded_pat; string "=>"; body]
 
-  and doc_funcl return_typ_opt opts pexp =
+  and doc_funcl return_typ_opt opts (header, pexp) =
     let return_typ =
       match return_typ_opt with
       | Some chunks -> space ^^ prefix_parens indent (string "->") (doc_chunks opts chunks) ^^ space
       | None -> space
     in
+    doc_chunks opts header
+    ^^
     match pexp.guard with
     | None ->
         (if pexp.funcl_space then space else empty)

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -308,7 +308,12 @@ type rec_opt_aux =
     Rec_none (* no termination measure *)
   | Rec_measure of pat * exp (* recursive with termination measure *)
 
-type funcl_aux = (* Function clause *)
+type funcl = FCL_aux of funcl_aux * l
+
+and funcl_aux =
+  (* Function clause *)
+  | FCL_attribute of string * string * funcl
+  | FCL_doc of string * funcl
   | FCL_funcl of id * pexp
 
 type type_union = Tu_aux of type_union_aux * l
@@ -325,8 +330,6 @@ type tannot_opt = Typ_annot_opt_aux of tannot_opt_aux * l
 type effect_opt = Effect_opt_aux of effect_opt_aux * l
 
 type rec_opt = Rec_aux of rec_opt_aux * l
-
-type funcl = FCL_aux of funcl_aux * l
 
 type subst_aux =
   (* instantiation substitution *)

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -583,7 +583,9 @@ and doc_vector_update = function
   | VU_range (high, low, value) ->
       separate space [doc_atomic_exp high; string ".."; doc_atomic_exp low; equals; doc_exp value]
 
-let doc_funcl (FCL_aux (FCL_funcl (id, Pat_aux (pexp, _)), _)) =
+let doc_funcl (FCL_aux (FCL_funcl (id, Pat_aux (pexp, _)), (def_annot, _))) =
+  doc_def_annot def_annot
+  ^^
   match pexp with
   | Pat_exp (pat, exp) -> group (separate space [doc_id id; doc_pat pat; equals; doc_exp_as_block exp])
   | Pat_when (pat, wh, exp) ->

--- a/test/typecheck/scattered_function_doc.sail
+++ b/test/typecheck/scattered_function_doc.sail
@@ -1,0 +1,11 @@
+default Order dec
+
+val foo : int -> unit
+
+scattered function foo
+
+/*! First clause doc comment */
+function clause foo(0) = ()
+
+/*! Second clause doc comment */
+function clause foo(_) = ()


### PR DESCRIPTION
After de-scattering, top-level doc comments on function clauses will end up attached to the function clause AST nodes themselves, so we now print and parse such comments (and attributes) appropriately