### PR TITLE
Parse doc comments on mapping clauses

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -87,7 +87,7 @@ let get_attributes annot = annot.attrs
 let find_attribute_opt attr1 attrs =
   List.find_opt (fun (_, attr2, _) -> attr1 = attr2) attrs |> Option.map (fun (_, _, arg) -> arg)
 
-let mk_def_annot l = { doc_comment = None; attrs = []; loc = l }
+let mk_def_annot ?doc ?(attrs = []) l = { doc_comment = doc; attrs; loc = l }
 
 let map_clause_annot f (def_annot, annot) =
   let l, annot' = f (def_annot.loc, annot) in

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -97,7 +97,7 @@ val get_attributes : uannot -> (l * string * string) list
 
 val find_attribute_opt : string -> (l * string * string) list -> string option
 
-val mk_def_annot : l -> def_annot
+val mk_def_annot : ?doc:string -> ?attrs:(l * string * string) list -> l -> def_annot
 
 val add_def_attribute : l -> string -> string -> def_annot -> def_annot
 

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -372,13 +372,15 @@ type mpexp_aux = MPat_pat of mpat | MPat_when of mpat * exp
 
 type mpexp = MPat_aux of mpexp_aux * l
 
-type mapcl_aux =
+type mapcl = MCL_aux of mapcl_aux * l
+
+and mapcl_aux =
   (* mapping clause (bidirectional pattern-match) *)
+  | MCL_attribute of string * string * mapcl
+  | MCL_doc of string * mapcl
   | MCL_bidir of mpexp * mpexp
   | MCL_forwards of mpexp * exp
   | MCL_backwards of mpexp * exp
-
-type mapcl = MCL_aux of mapcl_aux * l
 
 type mapdef_aux =
   (* mapping definition (bidirectional pattern-match function) *)

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -1166,6 +1166,10 @@ fmpat:
     { mk_mpexp (MPat_when ($1, $3)) $startpos $endpos }
 
 mapcl:
+  | attr = Attribute; mcl = mapcl
+    { MCL_aux (MCL_attribute (fst attr, snd attr, mcl), loc $startpos(attr) $endpos(attr)) }
+  | doc = Doc; mcl = mapcl
+    { MCL_aux (MCL_doc (doc, mcl), loc $startpos(doc) $endpos(doc)) }
   | mpexp Bidir mpexp
     { mk_bidir_mapcl $1 $3 $startpos $endpos }
   | mpexp EqGt exp

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -84,8 +84,6 @@ let doc_kid kid = string (Ast_util.string_of_kid kid)
 let doc_attr attr arg =
   if arg = "" then Printf.ksprintf string "$[%s]" attr ^^ space else Printf.ksprintf string "$[%s %s]" attr arg ^^ space
 
-let get_column l = match Reporting.simp_loc l with Some (l1, _) -> Some (l1.pos_cnum - l1.pos_bol) | None -> None
-
 let doc_def_annot def_annot =
   (match def_annot.doc_comment with Some str -> string "/*!" ^^ string str ^^ string "*/" ^^ hardline | _ -> empty)
   ^^
@@ -202,7 +200,7 @@ and doc_typ ?(simple = false) (Typ_aux (typ_aux, l)) =
         Typ_aux (Typ_app (id, [A_aux (A_nexp (Nexp_aux (Nexp_var kid2, _)), _)]), _)
       )
     when Kid.compare (kopt_kid kopt) kid1 == 0 && Kid.compare kid1 kid2 == 0 && Id.compare (mk_id "atom") id == 0 ->
-      enclose (string "{|") (string "|}") (separate_map (string ", ") doc_int ints)
+      enclose (char '{') (char '}') (separate_map (string ", ") doc_int ints)
   | Typ_exist (kopts, nc, typ) ->
       braces (separate_map space doc_kopt kopts ^^ comma ^^ space ^^ doc_nc nc ^^ dot ^^ space ^^ doc_typ typ)
   | Typ_fn ([Typ_aux (Typ_tuple typs, _)], typ) ->
@@ -626,7 +624,9 @@ let doc_mpexp (MPat_aux (mpexp, _)) =
   | MPat_pat mpat -> doc_mpat mpat
   | MPat_when (mpat, guard) -> doc_mpat mpat ^^ space ^^ string "if" ^^ space ^^ doc_exp guard
 
-let doc_mapcl (MCL_aux (cl, _)) =
+let doc_mapcl (MCL_aux (cl, (def_annot, _))) =
+  doc_def_annot def_annot
+  ^^
   match cl with
   | MCL_bidir (mpexp1, mpexp2) ->
       let left = doc_mpexp mpexp1 in

--- a/test/lexing/doc_comment_eof.expect
+++ b/test/lexing/doc_comment_eof.expect
@@ -2,4 +2,4 @@
 [96mdoc_comment_eof.sail[0m:3.0-0:
 3[96m |[0m/*! doc
  [91m |[0m[91m^[0m
- [91m |[0m Unbalanced comment
+ [91m |[0m Unbalanced documentation comment

--- a/test/typecheck/pass/scattered_mapping_doc.sail
+++ b/test/typecheck/pass/scattered_mapping_doc.sail
@@ -1,0 +1,25 @@
+default Order dec
+
+$include <prelude.sail>
+
+enum E = A | B | C
+
+/*! Documentation
+ * comment
+ * with
+ * asterisks
+ */
+val foo : E <-> int
+
+scattered mapping foo
+
+/*! Mapping clause doc comment /* nested */ */
+mapping clause foo = A <-> 3
+
+/*! Mapping clause
+ * box style
+ * comment */
+mapping clause foo = B <-> 2
+
+$[some_attribute]
+mapping clause foo = C <-> 1


### PR DESCRIPTION
Allows round-tripping mapping doc comments through the pretty-printer

Previously, some doc comments would be silently stripped by descattering as there is nowhere for them to go. While this patch and previous ones address some of these issues there are still a few places where this is unavoidable, so warn when that occurs.

Adjust the syntax of doc comments slightly to address formatting issues:

* Nested comments are now preserved in the documentation string

* We allow doc comments to be written with leading asterisks, i.e.

  ```
  /*!
   * Some doc comment
   * with leading asterisks
   */
  ```

  These asterisks (and a space on each side)  will be stripped out, so the above is equivalent to:

  ```
  /*!
  Some doc comment
  with leading asterisks
  */
  ```

  In order for an asterisk to be recognized, it must now be preceded
  by a newline, then 1 or more whitespace characters, and followed by exactly 1
  whitespace character, before the comment continues. This sequence will
  be replaced by a newline followed by the whitespace with the final
  " * " sequence removed.

  Previously it was 0 or more whitespace characters before the asterisk,
  and the whitespace after was optional.