### PR TITLE
Update mono tests

### DIFF
--- a/test/mono/assert.sail
+++ b/test/mono/assert.sail
@@ -4,7 +4,7 @@ $include <smt.sail>
 
 /* Tests set constraints in different constraints */
 
-val f : forall 'n 'm. (atom('n), atom('m)) -> unit effect {escape}
+val f : forall 'n 'm. (int('n), int('m)) -> unit
 
 function f(n,m) = {
     assert(constraint('n in {8,16} & 'm < 'n), "nconstraint");
@@ -13,7 +13,7 @@ function f(n,m) = {
     ()
 }
 
-val f' : forall 'n 'm. (atom('n), atom('m)) -> unit effect {escape}
+val f' : forall 'n 'm. (int('n), int('m)) -> unit
 
 function f'(n,m) = {
     assert(constraint(('n == 8 | 'n == 16) & 'm < 'n), "nconstraint");
@@ -22,7 +22,7 @@ function f'(n,m) = {
     ()
 }
 
-val g : forall 'n 'm. (atom('n), atom('m)) -> unit effect {escape}
+val g : forall 'n 'm. (int('n), int('m)) -> unit
 
 function g(n,m) = {
     assert(constraint('n in {8,16}) & 'm < 'n, "set and exp");
@@ -30,7 +30,7 @@ function g(n,m) = {
     let x : bits('p) = replicate_bits(0b0,'p) in
     ()
 }
-val h : forall 'n 'm. (atom('n), atom('m)) -> unit effect {escape}
+val h : forall 'n 'm. (int('n), int('m)) -> unit
 
 function h(n,m) = {
     assert(('n == 8 | 'n == 16) & 'm < 'n, "all exp");
@@ -39,7 +39,7 @@ function h(n,m) = {
     ()
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
     f(8,3);

--- a/test/mono/assert2.sail
+++ b/test/mono/assert2.sail
@@ -3,7 +3,7 @@ $include <prelude.sail>
 
 /* Should find a set constraint below the let */
 
-val f : forall 'n. atom('n) -> unit effect {escape}
+val f : forall 'n. int('n) -> unit
 
 function f(n) = {
     let 'm = 2 * n in {
@@ -14,7 +14,7 @@ function f(n) = {
 }
 
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
     f(8);

--- a/test/mono/assign_range.sail
+++ b/test/mono/assign_range.sail
@@ -22,7 +22,7 @@ function test2(n) = {
   use(size)
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(test1(2) == 18);

--- a/test/mono/atomsplit.sail
+++ b/test/mono/atomsplit.sail
@@ -3,7 +3,7 @@ $include <prelude.sail>
 
 /* Test splitting required because there's a size calculation in the function */
 
-val foo : forall 'n. atom('n) -> unit effect {escape}
+val foo : forall 'n. int('n) -> unit
 
 function foo(n) = {
   assert(constraint('n in {2,4}));
@@ -13,7 +13,7 @@ function foo(n) = {
   ()
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
     foo(2);

--- a/test/mono/builtins.sail
+++ b/test/mono/builtins.sail
@@ -19,23 +19,23 @@ val UInt = {
    TODO: need some way to check that everything has propagated. */
 
 /* A function that constant propagation won't touch */
-val launder : forall 'n. bits('n) -> bits('n) effect {escape}
+val launder : forall 'n. bits('n) -> bits('n)
 function launder(x) = {
   assert(true);
   x
 }
 
 /* A function that constant propagation won't touch */
-val launder_int : int -> int effect {escape}
+val launder_int : int -> int
 function launder_int(x) = {
   assert(true);
   x
 }
 
-val test : bool -> unit effect {escape}
+val test : bool -> unit
 
 function test(b) = {
-    let 'n : {'n, 'n in {8,16}. atom('n)} = if b then 8 else 16;
+    let 'n : {'n, 'n in {8,16}. int('n)} = if b then 8 else 16;
     let x : bits('n) = match 'n { 8 => 0x12, 16 => 0x1234 };
     let x' : bits('n) = launder(x);
     let y : bits('n) = match 'n { 8 => 0x35, 16 => 0x5637 };
@@ -48,7 +48,7 @@ function test(b) = {
     assert(shl_int(5,2) == shl_int(launder_int(5),2), "shl_int");
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run() = {
     test(true);

--- a/test/mono/castreq.sail
+++ b/test/mono/castreq.sail
@@ -1,14 +1,9 @@
 default Order dec
 $include <prelude.sail>
 $include <smt.sail>
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extzv : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extzv(m, v) = extz_vec(m,v)
-val bitvector_cast_in = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val bitvector_cast_out = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val bitvector_length = "length" : forall 'n. bits('n) -> atom('n)
-overload length = {bitvector_length}
-overload __size = {length}
+
+val extzv : forall 'n 'm, 'm >= 0 & 'n >= 0. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
+function extzv(m, v) = sail_mask(m, v)
 
 
 /* Test generation of casts across case splits (e.g., going from bits('m) to bits(32)) */
@@ -49,7 +44,7 @@ function bar_if(x) =
   then use(x@x)
   else /* 16 */ use(x)
 
-val ret : forall 'm 'n, 'm in {8,16} & 'n in {32,64}. (implicit('n), bits('m)) -> bits('n) effect {undef}
+val ret : forall 'm 'n, 'm in {8,16} & 'n in {32,64}. (implicit('n), bits('m)) -> bits('n)
 
 function ret(n, x) =
   let y : bits(16) = extzv(x) in
@@ -58,7 +53,7 @@ function ret(n, x) =
     64 => let z = y@y@y@y in { dfsf = 4; return z; undefined }
   }
 
-val assign : forall 'm 'n, 'm in {8,16} & 'n in {32,64}. (implicit('n), bits('m)) -> bits('n) effect {undef}
+val assign : forall 'm 'n, 'm in {8,16} & 'n in {32,64}. (implicit('n), bits('m)) -> bits('n)
 
 function assign(n, x) = {
   let y : bits(16) = extzv(x);
@@ -151,7 +146,7 @@ function refine_mutable_exp2(n, x) = {
 
 /* Adding casts for top-level pattern matches */
 
-val foo2 : forall 'm 'n, 'm in {8,16} & 'n in {32,64}. (atom('n), bits('m)) -> bits('n) effect pure
+val foo2 : forall 'm 'n, 'm in {8,16} & 'n in {32,64}. (int('n), bits('m)) -> bits('n) effect pure
 
 function foo2(32,x) =
   let y : bits(16) = extzv(x) in
@@ -160,7 +155,7 @@ and foo2(64,x) =
   let y : bits(16) = extzv(x) in
   let z = y@y@y@y in let dfsf = 4 in z
 
-val foo3 : forall 'm 'n, 'n in {4,8}. (atom('n), bits('m)) -> bits(8 * 'n) effect pure
+val foo3 : forall 'm 'n, 'm >= 0 & 'n in {4,8}. (int('n), bits('m)) -> bits(8 * 'n) effect pure
 
 function foo3(4,x) =
   let y : bits(16) = extzv(x) in
@@ -170,7 +165,7 @@ and foo3(8,x) =
   let z = y@y@y@y in let dfsf = 4 in z
 
 /* Casting an argument isn't supported yet 
-val bar2 : forall 'n, 'n in {8,16}. (atom('n),bits('n)) -> unit effect pure
+val bar2 : forall 'n, 'n in {8,16}. (int('n),bits('n)) -> unit effect pure
 
 function bar2(8,x) =
   use(x@x)
@@ -179,7 +174,7 @@ and bar2(16,x) =
 */
 
 
-val run : unit -> unit effect {escape,undef}
+val run : unit -> unit
 
 function run () = {
     bar(0x12);

--- a/test/mono/castrequnion.sail
+++ b/test/mono/castrequnion.sail
@@ -43,7 +43,7 @@ and cmp (Some(x),Some(y)) = x == y
 
 overload operator == = {cmp}
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run() = {
   assert((foo(0x12) : option(bits(16))) == None());

--- a/test/mono/control_deps.sail
+++ b/test/mono/control_deps.sail
@@ -1,23 +1,8 @@
-$include <smt.sail>
-$include <flow.sail>
 default Order dec
-type bits ('n : Int) = bitvector('n, dec)
-val operator & = "and_bool" : (bool, bool) -> bool
-val eq_vec = {ocaml: "eq_list", lem: "eq_vec"} : forall 'n. (bits('n), bits('n)) -> bool
-overload operator == = {eq_int, eq_vec}
-val mult_int = {ocaml: "mult", lem: "integerMult"} : (int, int) -> int
-overload operator * = {mult_range, mult_int, mult_real}
-val replicate_bits = "replicate_bits" : forall 'n 'm. (bits('n), atom('m)) -> bits('n * 'm)
-overload operator < = {lt_atom, lt_int}
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extz : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extz(m, v) = extz_vec(m,v)
-val bitvector_concat = {ocaml: "append", lem: "concat_vec", c: "append"} : forall ('n : Int) ('m : Int).
-  (bits('n), bits('m)) -> bits('n + 'm)
-overload append = {bitvector_concat}
-val bitvector_cast = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val bitvector_length = "length" : forall 'n. bits('n) -> atom('n)
-overload length = {bitvector_length}
+$include <prelude.sail>
+
+val extz : forall 'm 'n, 'm >= 0 & 'n >= 0. (implicit('n), bits('m)) -> bits('n)
+function extz(n, v) = sail_mask(n, v)
 
 /* Test monomorphisation control dependencies */
 
@@ -25,7 +10,7 @@ val f : (bool,bool) -> unit
 
 function f(nosplit,split) = {
   if nosplit then {
-    let 'x : {'x, true. atom('x)} = if split then 16 else 32 in
+    let 'x : {'x, 'x >= 0. int('x)} = if split then 16 else 32 in
     let v : bits('x) = extz(0b0) in
     ()
   } else ()
@@ -34,8 +19,8 @@ function f(nosplit,split) = {
 val g : (bool,bool) -> unit
 
 function g(split,nosplit) = {
-  x : {'x, true. atom('x)} = 16;
-  y : {'y, true. atom('y)} = 16;
+  x : {'x, 'x >= 0. int('x)} = 16;
+  y : {'y, 'y >= 0. int('y)} = 16;
   if split then
     x = 32
   else
@@ -44,19 +29,19 @@ function g(split,nosplit) = {
     y = 32
   else
     ();
-  let 'z : {'z, true. atom('z)} = x in
+  let 'z : {'z, 'z >= 0. int('z)} = x in
   let v : bits('z)= extz(0b0) in
   ()
 }
 
 type exception = unit
 
-val h : bool -> unit effect {escape}
+val h : bool -> unit
 
 /* Note: we don't really need to split on b, but it's awkward to avoid.
    The important bit is not to overreact to the exception. */
 function h(b) = {
-  let 'x : {'x, true. atom('x)} =
+  let 'x : {'x, 'x >= 0. int('x)} =
     if b then 16 else throw () in
   let v : bits('x) = extz(0b0) in
   ()
@@ -65,10 +50,10 @@ function h(b) = {
 // A common pattern in current Arm decode functions (where undefined is
 // actually implementation defined)
 
-val i : bool -> unit effect {escape, undef}
+val i : bool -> unit
 
 function i(b) = {
-  x : {|16,32|} = 16;
+  x : {16,32} = 16;
   if b then {
     x = 32;
   } else {
@@ -83,7 +68,7 @@ function i(b) = {
   ()
 }
 
-val run : unit -> unit effect {escape, undef}
+val run : unit -> unit
 
 function run () = {
   assert(true);

--- a/test/mono/exint.sail
+++ b/test/mono/exint.sail
@@ -1,37 +1,20 @@
-$include <smt.sail>
-$include <flow.sail>
 default Order dec
-type bits ('n : Int) = bitvector('n, dec)
-val operator & = "and_bool" : (bool, bool) -> bool
-val eq_vec = {ocaml: "eq_list", lem: "eq_vec"} : forall 'n. (bits('n), bits('n)) -> bool
-overload operator == = {eq_int, eq_vec}
-val mult_int = {ocaml: "mult", lem: "integerMult"} : (int, int) -> int
-overload operator * = {mult_range, mult_int, mult_real}
-val replicate_bits = "replicate_bits" : forall 'n 'm. (bits('n), atom('m)) -> bits('n * 'm)
-overload operator < = {lt_atom, lt_int}
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extzv : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extzv(m, v) = extz_vec(m,v)
-val bitvector_concat = {ocaml: "append", lem: "concat_vec", c: "append"} : forall ('n : Int) ('m : Int).
-  (bits('n), bits('m)) -> bits('n + 'm)
-overload append = {bitvector_concat}
-val bitvector_cast = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val bitvector_length = "length" : forall 'n. bits('n) -> atom('n)
-overload length = {bitvector_length}
-val cast ex_int : int -> {'n, true. atom('n)}
+$include <prelude.sail>
+
+val cast ex_int : int -> {'n, true. int('n)}
 function ex_int 'n = n
 
 
 /* Decode -> int -> existential test */
 
-val needssize : forall 'n, 'n >= 0. atom('n) -> unit effect pure
+val needssize : forall 'n, 'n >= 0. int('n) -> unit
 
 function needssize(n) = {
   let x : bits('n) = replicate_bits(0b0,n) in
   ()
 }
 
-val test : bits(2) -> unit effect {undef,escape}
+val test : bits(2) -> unit
 
 function test(x) = {
   n : int = undefined;
@@ -47,7 +30,7 @@ function test(x) = {
   }
 }
 
-val run : unit -> unit effect {undef,escape}
+val run : unit -> unit
 
 function run () = {
   test(0b00);

--- a/test/mono/feature.sail
+++ b/test/mono/feature.sail
@@ -11,7 +11,7 @@ val HaveSomeFeature : unit -> bool
 
 function HaveSomeFeature () = return(true)
 
-val foo : bits(1) -> unit effect {escape, undef}
+val foo : bits(1) -> unit
 
 function foo(x) = {
   let i : int =
@@ -27,7 +27,7 @@ function foo(x) = {
   }
 }
 
-val run : unit -> unit effect {escape, undef}
+val run : unit -> unit
 
 function run () = {
     foo(0b0);

--- a/test/mono/flow_extend.sail
+++ b/test/mono/flow_extend.sail
@@ -1,14 +1,11 @@
 default Order dec
 $include <prelude.sail>
 
-val bitvector_cast_in = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val bitvector_cast_out = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-
 val byte_extend : forall 'n, 'n >= 8. (bits(8), int('n)) -> bits('n)
 
 function byte_extend (v, n) = if (n == 8) then v else sail_zero_extend(v, n)
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run() = {
   assert(byte_extend(0x12,8) == 0x12);

--- a/test/mono/fnreduce.sail
+++ b/test/mono/fnreduce.sail
@@ -1,9 +1,5 @@
-val add_int = {ocaml: "add_int", lem: "integerAdd"} : (int, int) -> int
-overload operator + = {add_int}
-val eq_int = {ocaml: "eq_int", lem: "eq"} : (int, int) -> bool
-val eq_anything = {ocaml: "(fun (x, y) -> x = y)", lem: "eq"} : forall ('a : Type). ('a, 'a) -> bool
-overload operator == = {eq_int, eq_anything}
-
+$include <prelude.sail>
+$include <generic_equality.sail>
 
 /* Test constant propagation part of monomorphisation involving
    functions.  We should reduce a function application when the
@@ -38,7 +34,7 @@ function cannotReduce (x) = {
 
 register whatever : int
 
-val impure : AnEnum -> AnEnum effect {rreg}
+val impure : AnEnum -> AnEnum
 
 function impure (x) = {
   match (x) {
@@ -66,7 +62,7 @@ function canReduceUnion2 (x) = {
 }
 
 
-val test : AnEnum -> (AnEnum,int,AnEnum,EnumlikeUnion,ProperUnion) effect {rreg}
+val test : AnEnum -> (AnEnum,int,AnEnum,EnumlikeUnion,ProperUnion)
 
 function test (x) = {
   let a = canReduce(x) in
@@ -77,7 +73,7 @@ function test (x) = {
   (a,b,c,d,e)
 }
 
-val run : unit -> unit effect {rreg,escape}
+val run : unit -> unit
 
 function run () = {
   assert(test(One) == (Two,3,Two,First,Nonsense(First)));

--- a/test/mono/itself_rewriting.sail
+++ b/test/mono/itself_rewriting.sail
@@ -1,35 +1,11 @@
-$include <smt.sail>
-$include <flow.sail>
-$include <arith.sail>
 default Order dec
-type bits ('n : Int) = bitvector('n, dec)
-val operator & = "and_bool" : (bool, bool) -> bool
-val eq_vec = {ocaml: "eq_list", lem: "eq_vec"} : forall 'n. (bits('n), bits('n)) -> bool
-overload operator == = {eq_int, eq_vec}
-val neq_vec = {lem: "neq"} : forall 'n. (bits('n), bits('n)) -> bool
-function neq_vec (x, y) = not_bool(eq_vec(x, y))
-overload operator != = {neq_atom, neq_vec}
-val vector_subrange = {ocaml: "subrange", lem: "subrange_vec_dec"} : forall ('n : Int) ('m : Int) ('o : Int), 'o <= 'm <= 'n.
-  (bits('n), atom('m), atom('o)) -> bits('m - ('o - 1))
-val mult_int = {ocaml: "mult", lem: "integerMult"} : (int, int) -> int
-overload operator * = {mult_range, mult_int, mult_real}
-val UInt = {
-  ocaml: "uint",
-  lem: "uint",
-  interpreter: "uint",
-  c: "sail_uint"
-} : forall 'n. bits('n) -> range(0, 2 ^ 'n - 1)
-val bitvector_cast = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val slice = "slice" : forall ('n : Int) ('m : Int), 'm >= 0 & 'n >= 0.
-  (bits('m), int, atom('n)) -> bits('n)
-val replicate_bits = "replicate_bits" : forall 'n 'm. (bits('n), atom('m)) -> bits('n * 'm)
-overload operator > = {gt_int}
+$include <prelude.sail>
 
 /* This was written to manually inspect that "let n = size_itself_int n in" gets
    added in the right places, but it's also worth running in case that gets
    broken. */
 
-val needs_size_in_guard : forall 'n. atom('n) -> unit
+val needs_size_in_guard : forall 'n. int('n) -> unit
 
 function needs_size_in_guard(n if n > 8) = {
   let x : bits('n) = replicate_bits(0b0,n);
@@ -40,7 +16,7 @@ and needs_size_in_guard(n) = {
   ()
 }
 
-val no_size_in_guard : forall 'n. (atom('n), int) -> unit
+val no_size_in_guard : forall 'n. (int('n), int) -> unit
 
 function no_size_in_guard((n,m) if m > 8) = {
   let x : bits('n) = replicate_bits(0b0,n);
@@ -51,7 +27,7 @@ and no_size_in_guard(n,m) = {
   ()
 }
 
-val shadowed : forall 'n. atom('n) -> unit
+val shadowed : forall 'n. int('n) -> unit
 
 function shadowed(n) = {
   let n = 8;
@@ -97,7 +73,7 @@ function transitive_split(x) = {
   transitive_itself(n);
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(true); /* To force us into the monad */

--- a/test/mono/mapping.sail
+++ b/test/mono/mapping.sail
@@ -9,7 +9,7 @@ mapping map_foo : foo <-> bool = {
   B <-> false
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run() = {
   assert(map_foo(A))

--- a/test/mono/mutrecmono.sail
+++ b/test/mono/mutrecmono.sail
@@ -1,12 +1,8 @@
-$include <smt.sail>
-$include <flow.sail>
 default Order dec
-type bits ('n : Int) = bitvector('n, dec)
-val eq_vec = {ocaml: "eq_list", lem: "eq_vec"} : forall 'n. (bits('n), bits('n)) -> bool
-overload operator == = {eq_int, eq_vec}
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extz : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extz(m,v) = extz_vec(m,v)
+$include <prelude.sail>
+
+val extz : forall 'n 'm, 'n >= 0 & 'm >= 0. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
+function extz(m,v) = sail_mask(m,v)
 val UInt = {
   ocaml: "uint",
   lem: "uint",
@@ -15,13 +11,13 @@ val UInt = {
 } : forall 'n. bits('n) -> range(0, 2 ^ 'n - 1)
 
 
-val a : {|8,16,32|} -> int
-val b : {|8,16,32|} -> int
+val a : {8,16,32} -> int
+val b : {8,16,32} -> int
 
 function a 'n = if n == 8 then b(n) else let x : bits('n) = extz(0x12) in UInt(x)
 function b 'n = if n == 32 then a(n) else let x : bits('n) = extz(0x34) in UInt(x)
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(a(8) == 52);

--- a/test/mono/nonlinearpat.sail
+++ b/test/mono/nonlinearpat.sail
@@ -1,7 +1,7 @@
 default Order dec
 $include <prelude.sail>
 
-val test : forall 'n, 'n in {8,16}. (int('n),int('n),bits(1)) -> bits(64) effect pure
+val test : forall 'n, 'n in {8,16}. (int('n),int('n),bits(1)) -> bits(64)
 
 function test(x,y,b) = {
   let 'z = x + y in
@@ -9,7 +9,7 @@ function test(x,y,b) = {
   sail_zero_extend(v,64)
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(test(8,8,0b0) == 0x0000000000000000);

--- a/test/mono/parameterchoice.sail
+++ b/test/mono/parameterchoice.sail
@@ -10,7 +10,7 @@ function f(m,n,b) = {
   sail_zero_extend(x, 32)
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(f(8,16,false) == 0x000000fa);

--- a/test/mono/repeatedint.sail
+++ b/test/mono/repeatedint.sail
@@ -14,7 +14,7 @@ function test(SomeInstr(s as int('size),r)) = {
   sail_sign_extend(x,32)
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(test(SomeInstr(8,8)) == 0xffffff80);

--- a/test/mono/rewrites.sail
+++ b/test/mono/rewrites.sail
@@ -17,7 +17,7 @@ function zero_subrange(n, x) = x[n..2] == sail_zeros(n - 2 + 1)
 val ones_subrange : forall 'n, 2 < 'n & 'n < 8. (int('n), bits(8)) -> bool
 function ones_subrange(n, x) = x[n..2] == sail_ones(n - 2 + 1)
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run() = {
     let x : bits(12) = 0x123;

--- a/test/mono/set.sail
+++ b/test/mono/set.sail
@@ -1,16 +1,16 @@
 default Order dec
 $include <prelude.sail>
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extz : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extz(m,v) = extz_vec(m,v)
-val "exts_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val exts : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function exts(m,v) = exts_vec(m,v)
+
+val extz : forall 'n 'm, 'n >= 0 & 'm >= 'n. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
+function extz(m,v) = sail_zero_extend(v, m)
+
+val exts : forall 'n 'm, 'n >= 0 & 'm >= 'n. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
+function exts(m,v) = sail_sign_extend(v, m)
 
 /* A function which is merely parametrised by a size does not need to be
    monomorphised */
 
-val parametric : forall 'n, 'n in {32,64}. atom('n) -> bits(64)
+val parametric : forall 'n, 'n in {32,64}. int('n) -> bits(64)
 
 function parametric(n) = {
   let x : bits('n) = exts(0x80000000) in
@@ -19,7 +19,7 @@ function parametric(n) = {
 
 /* But if we do a calculation on the size then we'll need to case split */
 
-val depends : forall 'n, 'n in {16,32}. atom('n) -> bits(64)
+val depends : forall 'n, 'n in {16,32}. int('n) -> bits(64)
 
 function depends(n) = {
   let 'm = 2 * n in
@@ -27,7 +27,7 @@ function depends(n) = {
   extz(x)
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(parametric(32) == 0x0000000080000000);

--- a/test/mono/set2.sail
+++ b/test/mono/set2.sail
@@ -3,7 +3,7 @@ default Order dec
 (* A function which is merely parametrised by a size does not need to be
    monomorphised *)
 
-val forall 'n, 'n in {32,64}. ([:'n:], bit[32]) -> bit[64] effect pure parametric
+val forall 'n, 'n in {32,64}. ([:'n:], bit[32]) -> bit[64] parametric
 
 function parametric(n,v) = {
   let (bit['n]) x = exts(v) in
@@ -12,7 +12,7 @@ function parametric(n,v) = {
 
 (* But if we do a calculation on the size then we'll need to case split *)
 
-val forall 'n, 'n in {16,32}. ([:'n:], bit[32]) -> bit[64] effect pure depends
+val forall 'n, 'n in {16,32}. ([:'n:], bit[32]) -> bit[64] depends
 
 function depends(n,v) = {
   let 'm = 2 * n in

--- a/test/mono/times8.sail
+++ b/test/mono/times8.sail
@@ -1,40 +1,20 @@
-$include <smt.sail>
-$include <flow.sail>
 default Order dec
-type bits ('n : Int) = bitvector('n, dec)
-val operator & = "and_bool" : (bool, bool) -> bool
-val eq_vec = {ocaml: "eq_list", lem: "eq_vec"} : forall 'n. (bits('n), bits('n)) -> bool
-overload operator == = {eq_int, eq_vec}
-val mult_int = {ocaml: "mult", lem: "integerMult"} : (int, int) -> int
-overload operator * = {mult_range, mult_int, mult_real}
-val replicate_bits = "replicate_bits" : forall 'n 'm. (bits('n), atom('m)) -> bits('n * 'm)
-overload operator < = {lt_atom, lt_int}
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extzv : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extzv(m,v) = extz_vec(m,v)
-val bitvector_concat = {ocaml: "append", lem: "concat_vec", c: "append"} : forall ('n : Int) ('m : Int).
-  (bits('n), bits('m)) -> bits('n + 'm)
-overload append = {bitvector_concat}
-val bitvector_cast = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val bitvector_length = "length" : forall 'n. bits('n) -> atom('n)
-overload length = {bitvector_length}
-val cast ex_int : int -> {'n, true. atom('n)}
-function ex_int 'n = n
+$include <prelude.sail>
 
 /* Another byte/bit size conversion */
 
-val bar : forall 'n. atom('n) -> bits(8 * 'n) effect pure
+val bar : forall 'n. int('n) -> bits(8 * 'n)
 
 function bar (n) = replicate_bits(0x12,n)
 
-val foo : forall 'size, 8 * 'size >= 0. atom('size) -> bits(8 * 'size) effect {escape}
+val foo : forall 'size, 8 * 'size >= 0. int('size) -> bits(8 * 'size)
 
 function foo(size) = {
   assert('size == 1 | 'size == 2, "size");
   return bar('size)
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(foo(1) == 0x12);

--- a/test/mono/times8div8.sail
+++ b/test/mono/times8div8.sail
@@ -1,27 +1,27 @@
 default Order dec
 $include <prelude.sail>
 $include <smt.sail>
-val "extz_vec" : forall 'n 'm. (atom('m),bitvector('n, dec)) -> bitvector('m, dec) effect pure
-val extzv : forall 'n 'm. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec) effect pure
-function extzv(m,v) = extz_vec(m,v)
-val bitvector_cast = "zeroExtend" : forall 'n. bits('n) -> bits('n) effect pure
-val cast ex_int : int -> {'n, true. atom('n)}
+
+val extzv : forall 'n 'm, 'n >= 0 & 'm >= 'n. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec)
+function extzv(m,v) = sail_zero_extend(v, m)
+
+val cast ex_int : int -> {'n, true. int('n)}
 function ex_int 'n = n
 val quotient = {ocaml: "quotient", lem: "integerDiv", c: "div_int"} : (int, int) -> int
 overload operator / = {quotient}
 
 /* Byte/bits size conversions are a pain */
 
-val accept : forall 'n. (atom('n), bits(8 * 'n)) -> unit
+val accept : forall 'n. (int('n), bits(8 * 'n)) -> unit
 
 function accept (_,_) = ()
 
-val f : forall 'n. atom('n) -> unit effect {escape,undef}
+val f : forall 'n. int('n) -> unit
 
 function f(n) = {
     assert(constraint('n in {8,16}));
     x : bits('n) = undefined;
-    let 'm : {'o, true. atom('o)} = ex_int(n / 8) in {
+    let 'm : {'o, true. int('o)} = ex_int(n / 8) in {
         assert(constraint(8 * 'm == 'n));
         x = replicate_bits(0b00000000,'m);
         accept(m,x);
@@ -33,17 +33,17 @@ val accept2 : forall 'n. bits('n) -> unit
 
 function accept2 (_) = ()
 
-val g : forall 'm 'n. (atom('m), atom('n), bits('n)) -> unit effect {escape}
+val g : forall 'm 'n. (int('m), int('n), bits('n)) -> unit
 
 function g(m,n,v) = {
   assert(constraint('m >= 0 & 'n >= 0));
-  let 'o : {'p, true. atom('p)} = ex_int(m / n) in {
+  let 'o : {'p, true. int('p)} = ex_int(m / n) in {
     assert(constraint('o * 'n == 'm));
     accept2(replicate_bits(v,o))
   }
 }
 
-val run : unit -> unit effect {escape, undef}
+val run : unit -> unit
 
 function run () = {
     f(8);

--- a/test/mono/union-exist.sail
+++ b/test/mono/union-exist.sail
@@ -19,7 +19,7 @@ val use : myunion -> bits(32)
 
 function use(MyConstr(n,v)) = sail_zero_extend(v,32)
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(use(make(0b00)) == 0x00000012);

--- a/test/mono/union-exist2.sail
+++ b/test/mono/union-exist2.sail
@@ -21,7 +21,7 @@ val use : myunion -> bits(32)
 
 function use(MyConstr(n,v,_,_,_)) = sail_zero_extend(v,32)
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(use(make(0b00)) == 0x00000012);

--- a/test/mono/varmatch.sail
+++ b/test/mono/varmatch.sail
@@ -18,7 +18,7 @@ function foo(x) = {
   }
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(foo(One) == Two);

--- a/test/mono/varpatterns.sail
+++ b/test/mono/varpatterns.sail
@@ -3,7 +3,7 @@ $include <prelude.sail>
 
 /* Test constant propagation on some variable patterns in let expressions */
 
-val test : bool -> unit effect {escape}
+val test : bool -> unit
 
 function test(b) = {
     let 'n : {|8,16|} = if b then 8 else 16;
@@ -11,7 +11,7 @@ function test(b) = {
     assert(unsigned(x) == (match n { 8 => 18, 16 => 4660 }) : int, "unsigned");
 }
 
-val test2 : bool -> unit effect {escape}
+val test2 : bool -> unit
 
 function test2(b) = {
     let 'n = (if b then 8 else 16) : {|8,16|};
@@ -19,7 +19,7 @@ function test2(b) = {
     assert(unsigned(x) == (match n { 8 => 18, 16 => 4660 }) : int, "unsigned");
 }
 
-val test_mult : {|4,8|} -> unit effect {escape}
+val test_mult : {|4,8|} -> unit
 
 function test_mult('m) = {
     let 'n = 2 * 'm;
@@ -27,7 +27,7 @@ function test_mult('m) = {
     assert(unsigned(x) == (match n { 8 => 18, 16 => 4660 }) : int, "unsigned");
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run() = {
     test(true);

--- a/test/mono/vector.sail
+++ b/test/mono/vector.sail
@@ -1,11 +1,5 @@
 default Order dec
-type bits ('n : Int) = bitvector('n, dec)
-val eq_vec = {ocaml: "eq_list", lem: "eq_vec"} : forall 'n. (bits('n), bits('n)) -> bool
-val eq_int = {ocaml: "eq_int", lem: "eq"} : (int, int) -> bool
-overload operator == = {eq_int, eq_vec}
-val vector_subrange = {ocaml: "subrange", lem: "subrange_vec_dec"} : forall ('n : Int) ('m : Int) ('o : Int), 'o <= 'm <= 'n.
-  (bits('n), atom('m), atom('o)) -> bits('m - ('o - 1))
-
+$include <prelude.sail>
 
 /* Check case splitting on a vector */
 
@@ -19,7 +13,7 @@ function test((sel : bits(2)) @ (_ : bits(30))) = {
   }
 }
 
-val run : unit -> unit effect {escape}
+val run : unit -> unit
 
 function run () = {
   assert(test(0x0f353533) == 5);


### PR DESCRIPTION
- necessary for overloading improvement
- use prelude in preference to per-test declarations
- replace old atom types with int
- remove old effect declarations