### PR TITLE
Only specialize Jib definitions containing relevant types

### DIFF
--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -1691,6 +1691,10 @@ module Make (C : CONFIG) = struct
     if IdSet.is_empty (IdSet.diff polymorphic_functions unreachable_polymorphic_functions) then (cdefs, ctx)
     else specialize_functions ~specialized_calls ctx cdefs
 
+  let is_struct id = function CT_struct (id', _) -> Id.compare id id' = 0 | _ -> false
+
+  let is_variant id = function CT_variant (id', _) -> Id.compare id id' = 0 | _ -> false
+
   let map_structs_and_variants f = function
     | ( CT_lint | CT_fint _ | CT_constant _ | CT_lbits | CT_fbits _ | CT_sbits _ | CT_bit | CT_unit | CT_bool | CT_real
       | CT_string | CT_poly _ | CT_enum _ | CT_float _ | CT_rounding_mode ) as ctyp ->
@@ -1845,8 +1849,8 @@ module Make (C : CONFIG) = struct
           |> List.concat
         in
 
-        let prior = List.map (cdef_map_ctyp (fix_variants ctx var_id)) prior in
-        let cdefs = List.map (cdef_map_ctyp (fix_variants ctx var_id)) cdefs in
+        let prior = Util.map_if (cdef_ctyps_has (is_variant var_id)) (cdef_map_ctyp (fix_variants ctx var_id)) prior in
+        let cdefs = Util.map_if (cdef_ctyps_has (is_variant var_id)) (cdef_map_ctyp (fix_variants ctx var_id)) cdefs in
 
         let ctx =
           {
@@ -1900,8 +1904,12 @@ module Make (C : CONFIG) = struct
           |> List.concat
         in
 
-        let prior = List.map (cdef_map_ctyp (fix_variants ctx struct_id)) prior in
-        let cdefs = List.map (cdef_map_ctyp (fix_variants ctx struct_id)) cdefs in
+        let prior =
+          Util.map_if (cdef_ctyps_has (is_struct struct_id)) (cdef_map_ctyp (fix_variants ctx struct_id)) prior
+        in
+        let cdefs =
+          Util.map_if (cdef_ctyps_has (is_struct struct_id)) (cdef_map_ctyp (fix_variants ctx struct_id)) cdefs
+        in
         let ctx =
           {
             ctx with

--- a/src/lib/jib_util.mli
+++ b/src/lib/jib_util.mli
@@ -186,6 +186,8 @@ val cval_ctyp : cval -> ctyp
 val clexp_ctyp : clexp -> ctyp
 val cdef_ctyps : cdef -> CTSet.t
 
+val cdef_ctyps_has : (ctyp -> bool) -> cdef -> bool
+
 (** {1 Functions for mapping over and extracting information from instructions, values, and definitions} *)
 
 val instr_ids : instr -> NameSet.t

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -421,6 +421,15 @@ let fold_left_index_last f init xs =
   let rec go n acc = function [] -> acc | [x] -> f n true acc x | x :: xs -> go (n + 1) (f n false acc x) xs in
   go 0 init xs
 
+let map_if pred f xs =
+  let rec go acc = function
+    | x :: xs -> begin match pred x with true -> go (f x :: acc) xs | false -> go (x :: acc) xs end
+    | [] -> List.rev acc
+  in
+  go [] xs
+
+let rec map_exists pred f = function x :: xs -> if pred (f x) then true else map_exists pred f xs | [] -> false
+
 let rec take n xs = match (n, xs) with 0, _ -> [] | _, [] -> [] | n, x :: xs -> x :: take (n - 1) xs
 
 let rec drop n xs = match (n, xs) with 0, xs -> xs | _, [] -> [] | n, _ :: xs -> drop (n - 1) xs

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -168,6 +168,10 @@ val map_split : ('a -> ('b, 'c) result) -> 'a list -> 'b list * 'c list
     the [Some] function is removed from the list. *)
 val map_all : ('a -> 'b option) -> 'a list -> 'b list option
 
+val map_if : ('a -> bool) -> ('a -> 'a) -> 'a list -> 'a list
+
+val map_exists : ('b -> bool) -> ('a -> 'b) -> 'a list -> bool
+
 (** [list_to_front i l] resorts the list [l] by bringing the element at index [i]
     to the front. 
     @throws Failure if [i] is not smaller than the length of [l]*)


### PR DESCRIPTION
When specializing a polymorphic type, previously we would specialize all functions even if they didn't contain references to this type. While this would not change the definition it essentially caused it to be copied which caused the GC to have to do a bunch of extra work.

This reduces the RISC-V model into C compilation memory use by about half on my machine