### PR TITLE
Improve performance

### DIFF
--- a/THIRD_PARTY_FILES.md
+++ b/THIRD_PARTY_FILES.md
@@ -1,0 +1,80 @@
+The following files are adapted from ASL interpreter,
+https://github.com/alastairreid/asl-interpreter, and originally from
+CIL https://github.com/cil-project/cil
+
+| License      | Files                  | Source   |
+| ------------ | ---------------------- | -------- |
+| BSD 3-Clause | src/lib/visitor.ml     | ASLi/CIL |
+| BSD 3-Clause | src/lib/jib_visitor.ml | ASLi     |
+
+CIL
+===
+
+```
+Copyright (c) 2001-2003,
+ George C. Necula    <necula@cs.berkeley.edu>
+ Scott McPeak        <smcpeak@cs.berkeley.edu>
+ Wes Weimer          <weimer@cs.berkeley.edu>
+ Ben Liblit          <liblit@cs.berkeley.edu>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. The names of the contributors may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+ASL interpreter
+===============
+
+```
+Copyright 2017-2019 Arm Limited
+SPDX-Licence-Identifier: BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/src/lib/jib_visitor.ml
+++ b/src/lib/jib_visitor.ml
@@ -1,0 +1,277 @@
+open Jib
+include Visitor
+
+class type jib_visitor = object
+  method vid : Ast.id -> Ast.id option
+  method vname : name -> name option
+  method vctyp : ctyp -> ctyp visit_action
+  method vcval : cval -> cval visit_action
+  method vclexp : clexp -> clexp visit_action
+  method vinstr : instr -> instr visit_action
+  method vcdef : cdef -> cdef visit_action
+end
+
+let visit_id vis id = Option.value ~default:id (vis#vid id)
+
+let visit_name vis name = Option.value ~default:name (vis#vname name)
+
+let rec visit_ctyp vis outer_ctyp =
+  let aux vis no_change =
+    match no_change with
+    | CT_lint | CT_fint _ | CT_constant _ | CT_lbits | CT_sbits _ | CT_fbits _ | CT_unit | CT_bool | CT_bit | CT_string
+    | CT_real | CT_float _ | CT_rounding_mode | CT_poly _ ->
+        no_change
+    | CT_tup ctyps ->
+        let ctyps' = visit_ctyps vis ctyps in
+        if ctyps == ctyps' then no_change else CT_tup ctyps'
+    | CT_enum (id, members) ->
+        let id' = visit_id vis id in
+        let members' = map_no_copy (visit_id vis) members in
+        if id == id' && members == members' then no_change else CT_enum (id', members')
+    | CT_struct (id, fields) ->
+        let id' = visit_id vis id in
+        let fields' = map_no_copy (visit_binding vis) fields in
+        if id == id' && fields == fields' then no_change else CT_struct (id', fields')
+    | CT_variant (id, ctors) ->
+        let id' = visit_id vis id in
+        let ctors' = map_no_copy (visit_binding vis) ctors in
+        if id == id' && ctors == ctors' then no_change else CT_variant (id', ctors')
+    | CT_fvector (n, ctyp) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else CT_fvector (n, ctyp')
+    | CT_vector ctyp ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else CT_vector ctyp'
+    | CT_list ctyp ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else CT_list ctyp'
+    | CT_ref ctyp ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else CT_ref ctyp'
+  in
+  do_visit vis (vis#vctyp outer_ctyp) aux outer_ctyp
+
+and visit_ctyps vis ctyps = map_no_copy (visit_ctyp vis) ctyps
+
+and visit_binding vis ((id, ctyp) as binding) =
+  let id' = visit_id vis id in
+  let ctyp' = visit_ctyp vis ctyp in
+  if id == id' && ctyp == ctyp' then binding else (id', ctyp')
+
+let visit_ctype_def vis no_change =
+  match no_change with
+  | CTD_enum (id, members) ->
+      let id' = visit_id vis id in
+      let members' = map_no_copy (visit_id vis) members in
+      if id == id' && members == members' then no_change else CTD_enum (id', members')
+  | CTD_struct (id, fields) ->
+      let id' = visit_id vis id in
+      let fields' = map_no_copy (visit_binding vis) fields in
+      if id == id' && fields == fields' then no_change else CTD_struct (id', fields')
+  | CTD_variant (id, ctors) ->
+      let id' = visit_id vis id in
+      let ctors' = map_no_copy (visit_binding vis) ctors in
+      if id == id' && ctors == ctors' then no_change else CTD_variant (id', ctors')
+
+let rec visit_clexp vis outer_clexp =
+  let aux vis no_change =
+    match no_change with
+    | CL_id (name, ctyp) ->
+        let name' = visit_name vis name in
+        let ctyp' = visit_ctyp vis ctyp in
+        if name == name' && ctyp == ctyp' then no_change else CL_id (name', ctyp')
+    | CL_rmw (name1, name2, ctyp) ->
+        let name1' = visit_name vis name1 in
+        let name2' = visit_name vis name2 in
+        let ctyp' = visit_ctyp vis ctyp in
+        if name1 == name1' && name2 == name2' && ctyp == ctyp' then no_change else CL_rmw (name1', name2', ctyp')
+    | CL_field (clexp, id) ->
+        let clexp' = visit_clexp vis clexp in
+        let id' = visit_id vis id in
+        if clexp == clexp' && id == id' then no_change else CL_field (clexp', id')
+    | CL_addr clexp ->
+        let clexp' = visit_clexp vis clexp in
+        if clexp == clexp' then no_change else CL_addr clexp'
+    | CL_tuple (clexp, n) ->
+        let clexp' = visit_clexp vis clexp in
+        if clexp == clexp' then no_change else CL_tuple (clexp', n)
+    | CL_void -> no_change
+  in
+  do_visit vis (vis#vclexp outer_clexp) aux outer_clexp
+
+let rec visit_cval vis outer_cval =
+  let aux vis no_change =
+    match no_change with
+    | V_id (name, ctyp) ->
+        let name' = visit_name vis name in
+        let ctyp' = visit_ctyp vis ctyp in
+        if name == name' && ctyp == ctyp' then no_change else V_id (name', ctyp')
+    | V_lit (value, ctyp) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else V_lit (value, ctyp')
+    | V_tuple (cvals, ctyp) ->
+        let cvals' = visit_cvals vis cvals in
+        let ctyp' = visit_ctyp vis ctyp in
+        if cvals == cvals' && ctyp == ctyp' then no_change else V_tuple (cvals', ctyp')
+    | V_struct (fields, ctyp) ->
+        let fields' = map_no_copy (visit_field vis) fields in
+        let ctyp' = visit_ctyp vis ctyp in
+        if fields == fields' && ctyp == ctyp' then no_change else V_struct (fields', ctyp')
+    | V_ctor_kind (cval, (id, ctyps), ctyp) ->
+        let cval' = visit_cval vis cval in
+        let id' = visit_id vis id in
+        let ctyps' = visit_ctyps vis ctyps in
+        let ctyp' = visit_ctyp vis ctyp in
+        if cval == cval' && id == id' && ctyps == ctyps' && ctyp == ctyp' then no_change
+        else V_ctor_kind (cval', (id', ctyps'), ctyp')
+    | V_ctor_unwrap (cval, (id, ctyps), ctyp) ->
+        let cval' = visit_cval vis cval in
+        let id' = visit_id vis id in
+        let ctyps' = visit_ctyps vis ctyps in
+        let ctyp' = visit_ctyp vis ctyp in
+        if cval == cval' && id == id' && ctyps == ctyps' && ctyp == ctyp' then no_change
+        else V_ctor_unwrap (cval', (id', ctyps'), ctyp')
+    | V_tuple_member (cval, n, m) ->
+        let cval' = visit_cval vis cval in
+        if cval == cval' then no_change else V_tuple_member (cval', n, m)
+    | V_call (op, cvals) ->
+        let cvals' = visit_cvals vis cvals in
+        if cvals == cvals' then no_change else V_call (op, cvals')
+    | V_field (cval, id) ->
+        let cval' = visit_cval vis cval in
+        let id' = visit_id vis id in
+        if cval == cval' && id == id' then no_change else V_field (cval', id')
+  in
+  do_visit vis (vis#vcval outer_cval) aux outer_cval
+
+and visit_field vis ((id, cval) as field) =
+  let id' = visit_id vis id in
+  let cval' = visit_cval vis cval in
+  if id == id' && cval == cval' then field else (id', cval')
+
+and visit_cvals vis cvals = map_no_copy (visit_cval vis) cvals
+
+let rec visit_instr vis outer_instr =
+  let aux vis no_change =
+    match no_change with
+    | I_aux (I_decl (ctyp, name), aux) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        let name' = visit_name vis name in
+        if ctyp == ctyp' && name == name' then no_change else I_aux (I_decl (ctyp', name'), aux)
+    | I_aux (I_init (ctyp, name, cval), aux) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        let name' = visit_name vis name in
+        let cval' = visit_cval vis cval in
+        if ctyp == ctyp' && name == name' && cval == cval' then no_change else I_aux (I_init (ctyp', name', cval'), aux)
+    | I_aux (I_jump (cval, label), aux) ->
+        let cval' = visit_cval vis cval in
+        if cval == cval' then no_change else I_aux (I_jump (cval', label), aux)
+    | I_aux (I_goto _, aux) -> no_change
+    | I_aux (I_label _, aux) -> no_change
+    | I_aux (I_funcall (clexp, extern, (id, ctyps), cvals), aux) ->
+        let clexp' = visit_clexp vis clexp in
+        let id' = visit_id vis id in
+        let ctyps' = visit_ctyps vis ctyps in
+        let cvals' = visit_cvals vis cvals in
+        if clexp == clexp' && id == id' && ctyps == ctyps' && cvals == cvals' then no_change
+        else I_aux (I_funcall (clexp', extern, (id', ctyps'), cvals'), aux)
+    | I_aux (I_copy (clexp, cval), aux) ->
+        let clexp' = visit_clexp vis clexp in
+        let cval' = visit_cval vis cval in
+        if clexp == clexp' && cval == cval' then no_change else I_aux (I_copy (clexp', cval'), aux)
+    | I_aux (I_clear (ctyp, name), aux) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        let name' = visit_name vis name in
+        if ctyp == ctyp' && name == name' then no_change else I_aux (I_clear (ctyp', name'), aux)
+    | I_aux (I_undefined ctyp, aux) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else I_aux (I_undefined ctyp', aux)
+    | I_aux (I_exit _, aux) -> no_change
+    | I_aux (I_end name, aux) ->
+        let name' = visit_name vis name in
+        if name == name' then no_change else I_aux (I_end name', aux)
+    | I_aux (I_comment _, aux) -> no_change
+    | I_aux (I_raw _, aux) -> no_change
+    | I_aux (I_return cval, aux) -> no_change
+    | I_aux (I_if (cval, then_instrs, else_instrs, ctyp), aux) ->
+        let cval' = visit_cval vis cval in
+        let then_instrs' = visit_instrs vis then_instrs in
+        let else_instrs' = visit_instrs vis else_instrs in
+        let ctyp' = visit_ctyp vis ctyp in
+        if cval == cval' && then_instrs == then_instrs' && else_instrs == else_instrs' && ctyp == ctyp' then no_change
+        else I_aux (I_if (cval', then_instrs', else_instrs', ctyp'), aux)
+    | I_aux (I_block instrs, aux) ->
+        let instrs' = visit_instrs vis instrs in
+        if instrs == instrs' then no_change else I_aux (I_block instrs', aux)
+    | I_aux (I_try_block instrs, aux) ->
+        let instrs' = visit_instrs vis instrs in
+        if instrs == instrs' then no_change else I_aux (I_try_block instrs', aux)
+    | I_aux (I_throw cval, aux) ->
+        let cval' = visit_cval vis cval in
+        if cval == cval' then no_change else I_aux (I_throw cval', aux)
+    | I_aux (I_reset (ctyp, name), aux) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        let name' = visit_name vis name in
+        if ctyp == ctyp' && name == name' then no_change else I_aux (I_reset (ctyp', name'), aux)
+    | I_aux (I_reinit (ctyp, name, cval), aux) ->
+        let ctyp' = visit_ctyp vis ctyp in
+        let name' = visit_name vis name in
+        let cval' = visit_cval vis cval in
+        if ctyp == ctyp' && name == name' && cval == cval' then no_change
+        else I_aux (I_reinit (ctyp', name', cval'), aux)
+  in
+  do_visit vis (vis#vinstr outer_instr) aux outer_instr
+
+and visit_instrs vis instrs = map_no_copy (visit_instr vis) instrs
+
+let rec visit_cdef vis outer_cdef =
+  let aux vis no_change =
+    match no_change with
+    | CDEF_register (id, ctyp, instrs) ->
+        let id' = visit_id vis id in
+        let ctyp' = visit_ctyp vis ctyp in
+        let instrs' = visit_instrs vis instrs in
+        if id == id' && ctyp == ctyp' && instrs == instrs' then no_change else CDEF_register (id', ctyp', instrs')
+    | CDEF_type ctd ->
+        let ctd' = visit_ctype_def vis ctd in
+        if ctd == ctd' then no_change else CDEF_type ctd'
+    | CDEF_let (n, bindings, instrs) ->
+        let bindings' = map_no_copy (visit_binding vis) bindings in
+        let instrs' = visit_instrs vis instrs in
+        if bindings == bindings' && instrs == instrs' then no_change else CDEF_let (n, bindings', instrs')
+    | CDEF_val (id, extern, ctyps, ctyp) ->
+        let id' = visit_id vis id in
+        let ctyps' = visit_ctyps vis ctyps in
+        let ctyp' = visit_ctyp vis ctyp in
+        if id == id' && ctyps == ctyps' && ctyp == ctyp' then no_change else CDEF_val (id', extern, ctyps', ctyp')
+    | CDEF_fundef (id, ret_id, params, instrs) ->
+        let id' = visit_id vis id in
+        let ret_id' = map_no_copy_opt (visit_id vis) ret_id in
+        let params' = map_no_copy (visit_id vis) params in
+        let instrs' = visit_instrs vis instrs in
+        if id == id' && ret_id == ret_id' && params == params' && instrs == instrs' then no_change
+        else CDEF_fundef (id', ret_id', params', instrs')
+    | CDEF_startup (id, instrs) ->
+        let id' = visit_id vis id in
+        let instrs' = visit_instrs vis instrs in
+        if id == id' && instrs == instrs' then no_change else CDEF_startup (id', instrs')
+    | CDEF_finish (id, instrs) ->
+        let id' = visit_id vis id in
+        let instrs' = visit_instrs vis instrs in
+        if id == id' && instrs == instrs' then no_change else CDEF_finish (id', instrs')
+    | CDEF_pragma (_, _) -> no_change
+  in
+  do_visit vis (vis#vcdef outer_cdef) aux outer_cdef
+
+let visit_cdefs vis cdefs = map_no_copy (visit_cdef vis) cdefs
+
+class empty_jib_visitor : jib_visitor =
+  object
+    method vid _ = None
+    method vname _ = None
+    method vctyp _ = DoChildren
+    method vcval _ = DoChildren
+    method vclexp _ = DoChildren
+    method vinstr _ = DoChildren
+    method vcdef _ = DoChildren
+  end

--- a/src/lib/jib_visitor.ml
+++ b/src/lib/jib_visitor.ml
@@ -7,6 +7,7 @@ class type jib_visitor = object
   method vctyp : ctyp -> ctyp visit_action
   method vcval : cval -> cval visit_action
   method vclexp : clexp -> clexp visit_action
+  method vinstrs : instr list -> instr list visit_action
   method vinstr : instr -> instr visit_action
   method vcdef : cdef -> cdef visit_action
 end
@@ -222,7 +223,16 @@ let rec visit_instr vis outer_instr =
   in
   do_visit vis (vis#vinstr outer_instr) aux outer_instr
 
-and visit_instrs vis instrs = map_no_copy (visit_instr vis) instrs
+and visit_instrs vis outer_instrs =
+  let aux vis no_change =
+    match no_change with
+    | instr :: instrs ->
+        let instr' = visit_instr vis instr in
+        let instrs' = visit_instrs vis instrs in
+        if instr == instr' && instrs == instrs' then no_change else instr' :: instrs'
+    | [] -> []
+  in
+  do_visit vis (vis#vinstrs outer_instrs) aux outer_instrs
 
 let rec visit_cdef vis outer_cdef =
   let aux vis no_change =
@@ -272,6 +282,7 @@ class empty_jib_visitor : jib_visitor =
     method vctyp _ = DoChildren
     method vcval _ = DoChildren
     method vclexp _ = DoChildren
+    method vinstrs _ = DoChildren
     method vinstr _ = DoChildren
     method vcdef _ = DoChildren
   end

--- a/src/lib/jib_visitor.mli
+++ b/src/lib/jib_visitor.mli
@@ -1,0 +1,39 @@
+open Jib
+
+type 'a visit_action =
+  | SkipChildren  (** Do not visit the children. Return the node as it is. *)
+  | DoChildren
+      (** Continue with the children of this node. Rebuild the node on
+     return if any of the children changes (use == test) *)
+  | ChangeTo of 'a  (** Replace the expression with the given one *)
+  | ChangeDoChildrenPost of 'a * ('a -> 'a)
+      (** First consider that the entire exp is replaced by the first
+     parameter. Then continue with the children. On return rebuild the
+     node if any of the children has changed and then apply the
+     function on the node *)
+
+class type jib_visitor = object
+  method vid : Ast.id -> Ast.id option
+  method vname : name -> name option
+  method vctyp : ctyp -> ctyp visit_action
+  method vcval : cval -> cval visit_action
+  method vclexp : clexp -> clexp visit_action
+  method vinstr : instr -> instr visit_action
+  method vcdef : cdef -> cdef visit_action
+end
+
+class empty_jib_visitor : jib_visitor
+
+val visit_ctyp : jib_visitor -> ctyp -> ctyp
+
+val visit_cval : jib_visitor -> cval -> cval
+
+val visit_clexp : jib_visitor -> clexp -> clexp
+
+val visit_instr : jib_visitor -> instr -> instr
+
+val visit_instrs : jib_visitor -> instr list -> instr list
+
+val visit_cdef : jib_visitor -> cdef -> cdef
+
+val visit_cdefs : jib_visitor -> cdef list -> cdef list

--- a/src/lib/jib_visitor.mli
+++ b/src/lib/jib_visitor.mli
@@ -12,12 +12,17 @@ type 'a visit_action =
      node if any of the children has changed and then apply the
      function on the node *)
 
+val change_do_children : 'a -> 'a visit_action
+
+val map_no_copy : ('a -> 'a) -> 'a list -> 'a list
+
 class type jib_visitor = object
   method vid : Ast.id -> Ast.id option
   method vname : name -> name option
   method vctyp : ctyp -> ctyp visit_action
   method vcval : cval -> cval visit_action
   method vclexp : clexp -> clexp visit_action
+  method vinstrs : instr list -> instr list visit_action
   method vinstr : instr -> instr visit_action
   method vcdef : cdef -> cdef visit_action
 end

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -976,10 +976,7 @@ let union_constructor_info id env =
     type_unions
 
 let is_union_constructor id env =
-  let type_unions =
-    List.concat (List.map (fun (_, { item = _, tus; _ }) -> tus) (Bindings.bindings env.global.unions))
-  in
-  List.exists (is_ctor id) type_unions
+  Bindings.exists (fun _ { item = _, tus; _ } -> List.exists (is_ctor id) tus) env.global.unions
 
 let is_singleton_union_constructor id env =
   let type_unions = List.map (fun (_, { item = _, tus; _ }) -> tus) (Bindings.bindings env.global.unions) in

--- a/src/lib/visitor.ml
+++ b/src/lib/visitor.ml
@@ -1,0 +1,155 @@
+(* Copyright 2017-2019 Arm Limited
+ * SPDX-Licence-Identifier: BSD-3-Clause
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *)
+(*
+ *
+ * Copyright (c) 2001-2003,
+ *  George C. Necula    <necula@cs.berkeley.edu>
+ *  Scott McPeak        <smcpeak@cs.berkeley.edu>
+ *  Wes Weimer          <weimer@cs.berkeley.edu>
+ *  Ben Liblit          <liblit@cs.berkeley.edu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. The names of the contributors may not be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *)
+
+(****************************************************************
+ * Visitor support code
+ *
+ * The code in this file is copied from George Necula's excellent
+ * CIL project (https://people.eecs.berkeley.edu/~necula/cil/)
+ * with minor change to allow it to be used with an arbitrary AST,
+ * taken from ASLi.
+ ****************************************************************)
+
+(****************************************************************
+ * Visit action
+ *
+ * Visitor methods can request one of four actions on the AST.
+ ****************************************************************)
+
+(** Different visiting actions. 'a will be instantiated with various AST types. *)
+type 'a visit_action =
+  | SkipChildren  (** Do not visit the children. Return the node as it is. *)
+  | DoChildren
+      (** Continue with the children of this node. Rebuild the node on
+     return if any of the children changes (use == test) *)
+  | ChangeTo of 'a  (** Replace the expression with the given one *)
+  | ChangeDoChildrenPost of 'a * ('a -> 'a)
+      (** First consider that the entire exp is replaced by the first
+     parameter. Then continue with the children. On return rebuild the
+     node if any of the children has changed and then apply the
+     function on the node *)
+
+(****************************************************************
+ * Visitor engine
+ *
+ * These functions implement the various actions a visitor can
+ * request and provide helper functions for writing visitors.
+ *
+ * Note that the visitor functions implement a space-saving optimisation:
+ * if the result would be identical to the input value, they return the
+ * input value to avoid allocating another copy of the object.
+ * This optimisation is supported by the mapNoCopy, mapNoCopyList
+ * and doVisitList functions.
+ *
+ * This code is changed from the CIL original by replacing the
+ * "cilVisitor" type by "'v" so that the code is independent of
+ * the particular AST it is used with.
+ ****************************************************************)
+
+(*** Define the visiting engine ****)
+(* visit all the nodes in an tree *)
+let do_visit (vis : 'v) (action : 'a visit_action) (children : 'v -> 'a -> 'a) (node : 'a) : 'a =
+  match action with
+  | SkipChildren -> node
+  | ChangeTo node' -> node'
+  | DoChildren -> children vis node
+  | ChangeDoChildrenPost (node', f) -> f (children vis node')
+
+(* map_no_copy is like map but avoid copying the list if the function does not
+ * change the elements. *)
+let rec map_no_copy (f : 'a -> 'a) = function
+  | [] -> []
+  | i :: resti as li ->
+      let i' = f i in
+      let resti' = map_no_copy f resti in
+      if i' != i || resti' != resti then i' :: resti' else li
+
+let rec map_no_copy_list (f : 'a -> 'a list) = function
+  | [] -> []
+  | i :: resti as li -> (
+      let il' = f i in
+      let resti' = map_no_copy_list f resti in
+      match il' with [i'] when i' == i && resti' == resti -> li | _ -> il' @ resti'
+    )
+
+(* not part of original cil framework *)
+let map_no_copy_opt (f : 'a -> 'a) : 'a option -> 'a option = function
+  | None -> None
+  | Some x as ox ->
+      let x' = f x in
+      if x' == x then ox else Some x'
+
+(* A visitor for lists *)
+let do_visit_list (vis : 'v) (action : 'a list visit_action) (children : 'v -> 'a -> 'a) (node : 'a) : 'a list =
+  match action with
+  | SkipChildren -> [node]
+  | ChangeTo nodes' -> nodes'
+  | DoChildren -> [children vis node]
+  | ChangeDoChildrenPost (nodes', f) -> f (map_no_copy (fun n -> children vis n) nodes')
+
+(****************************************************************
+ * End
+ ****************************************************************)

--- a/src/lib/visitor.ml
+++ b/src/lib/visitor.ml
@@ -118,6 +118,8 @@ let do_visit (vis : 'v) (action : 'a visit_action) (children : 'v -> 'a -> 'a) (
   | DoChildren -> children vis node
   | ChangeDoChildrenPost (node', f) -> f (children vis node')
 
+let change_do_children node' = ChangeDoChildrenPost (node', fun n -> n)
+
 (* map_no_copy is like map but avoid copying the list if the function does not
  * change the elements. *)
 let rec map_no_copy (f : 'a -> 'a) = function

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -712,9 +712,11 @@ let remove_alias =
     | instr -> instr
   in
   let rec opt = function
-    | (I_aux (I_decl (ctyp, id), _) as instr) :: instrs -> begin
+    | (I_aux (I_decl (ctyp, id), _) as instr) :: instrs as original_instrs -> begin
         match pattern ctyp id instrs with
-        | None -> instr :: opt instrs
+        | None ->
+            let instrs' = opt instrs in
+            if instrs == instrs' then original_instrs else instr :: instrs'
         | Some alias ->
             let instrs = List.map (map_instr (remove_alias id alias)) instrs in
             filter_instrs is_not_removed (List.map (instr_rename id alias) instrs)
@@ -774,9 +776,11 @@ let combine_variables =
     | _ -> true
   in
   let rec opt = function
-    | (I_aux (I_decl (ctyp, id), _) as instr) :: instrs -> begin
+    | (I_aux (I_decl (ctyp, id), _) as instr) :: instrs as original_instrs -> begin
         match pattern ctyp id instrs with
-        | None -> instr :: opt instrs
+        | None ->
+            let instrs' = opt instrs in
+            if instrs == instrs' then original_instrs else instr :: instrs'
         | Some combine ->
             let instrs = List.map (map_instr (remove_variable combine)) instrs in
             let instrs =


### PR DESCRIPTION
Introduce a vistor pattern rewrite system for Jib IR, as suggested by Alastair Reid and based on the one in ASL interpreter

This massively reduces memory usage for the IR -> IR rewrites, with a corresponding increase in performance.