### PR TITLE
Add a string_literal type, as a subtype of string

### DIFF
--- a/editors/sail-mode.el
+++ b/editors/sail-mode.el
@@ -40,7 +40,7 @@
     "exmem" "undef" "unspec" "nondet" "escape" "configuration"))
 
 (defconst sail-types
-  '("vector" "bitvector" "int" "nat" "atom" "range" "unit" "bit" "real" "list" "bool" "string" "bits" "option" "result"))
+  '("vector" "bitvector" "int" "nat" "atom" "range" "unit" "bit" "real" "list" "bool" "string" "string_literal" "bits" "option" "result"))
 
 (defconst sail-special
   '("_prove" "_not_prove" "create" "kill" "convert" "undefined"

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -168,6 +168,10 @@ let rec options =
         "<symbol> check if a feature symbol is set by default"
       );
       ("-no_color", Arg.Clear Util.opt_colors, " do not use terminal color codes in output");
+      ( "-string_literal_type",
+        Arg.Set Type_env.opt_string_literal_type,
+        " use a separate string_literal type for string literals"
+      );
       ( "-undefined_gen",
         Arg.Set Initial_check.opt_undefined_gen,
         " generate undefined_type functions for types in the specification"

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -481,6 +481,7 @@ let range_typ nexp1 nexp2 =
 let bool_typ = mk_id_typ (mk_id "bool")
 let atom_bool_typ nc = mk_typ (Typ_app (mk_id "atom_bool", [mk_typ_arg (A_bool nc)]))
 let string_typ = mk_id_typ (mk_id "string")
+let string_literal_typ = mk_id_typ (mk_id "string_literal")
 let list_typ typ = mk_typ (Typ_app (mk_id "list", [mk_typ_arg (A_typ typ)]))
 let tuple_typ typs = mk_typ (Typ_tuple typs)
 let function_typ arg_typs ret_typ = mk_typ (Typ_fn (arg_typs, ret_typ))

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -220,6 +220,7 @@ val app_typ : id -> typ_arg list -> typ
 val register_typ : typ -> typ
 val unit_typ : typ
 val string_typ : typ
+val string_literal_typ : typ
 val real_typ : typ
 val vector_typ : nexp -> typ -> typ
 val bitvector_typ : nexp -> typ

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1381,6 +1381,7 @@ let initial_ctx =
           ("unit", []);
           ("bit", []);
           ("string", []);
+          ("string_literal", []);
           ("real", []);
           ("list", [Some K_type]);
           ("register", [Some K_type]);

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -77,6 +77,8 @@ open Type_internal
    the SMT solver to use non-linear arithmetic. *)
 let opt_smt_linearize = ref false
 
+let opt_string_literal_type = ref false
+
 module IdPair = struct
   type t = id * id
   let compare (a, b) (c, d) =
@@ -278,6 +280,7 @@ let builtin_typs =
       ("real", []);
       ("list", [K_type]);
       ("string", []);
+      ("string_literal", []);
       ("itself", [K_int]);
       ("atom_bool", [K_bool]);
       ("float16", []);

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -72,6 +72,9 @@ open Ast_util
    the SMT solver to use non-linear arithmetic. *)
 val opt_smt_linearize : bool ref
 
+(** Val use a separate string literal type *)
+val opt_string_literal_type : bool ref
+
 type global_env
 
 type env

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -201,6 +201,7 @@ end) : CONFIG = struct
     | Typ_id id when string_of_id id = "nat" -> CT_lint
     | Typ_id id when string_of_id id = "unit" -> CT_unit
     | Typ_id id when string_of_id id = "string" -> CT_string
+    | Typ_id id when string_of_id id = "string_literal" -> CT_string
     | Typ_id id when string_of_id id = "real" -> CT_real
     | Typ_app (id, _) when string_of_id id = "atom_bool" -> CT_bool
     | Typ_app (id, args) when string_of_id id = "itself" -> convert_typ ctx (Typ_aux (Typ_app (mk_id "atom", args), l))

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -603,6 +603,7 @@ let rec doc_typ_fns ctx env =
     | _ -> atomic_typ atyp_needed ty
   and atomic_typ atyp_needed (Typ_aux (t, l) as ty) =
     match t with
+    | Typ_id (Id_aux (Id "string_literal", _)) -> string "string"
     | Typ_id (Id_aux (Id "bool", _)) -> string "bool"
     | Typ_id (Id_aux (Id "bit", _)) -> string "bitU"
     | Typ_id id ->

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -398,6 +398,7 @@ let doc_typ_lem, doc_typ_lem_brackets, doc_atomic_typ_lem =
     | _ -> atomic_typ params_to_print atyp_needed ty
   and atomic_typ params_to_print atyp_needed (Typ_aux (t, l) as ty) =
     match t with
+    | Typ_id (Id_aux (Id "string_literal", _)) -> string "string"
     | Typ_id (Id_aux (Id "bool", _)) -> string "bool"
     | Typ_id (Id_aux (Id "bit", _)) -> string "bitU"
     | Typ_id id ->

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -145,6 +145,7 @@ let rec ocaml_string_typ (Typ_aux (typ_aux, l)) arg =
 
 let ocaml_typ_id ctx = function
   | id when Id.compare id (mk_id "string") = 0 -> string "string"
+  | id when Id.compare id (mk_id "string_literal") = 0 -> string "string"
   | id when Id.compare id (mk_id "list") = 0 -> string "list"
   | id when Id.compare id (mk_id "bit") = 0 -> string "bit"
   | id when Id.compare id (mk_id "int") = 0 -> string "Big_int.num"

--- a/test/c/string_literal_type.expect
+++ b/test/c/string_literal_type.expect
@@ -1,0 +1,7 @@
+foo
+foo
+baz
+baz
+ok
+ok
+ok

--- a/test/c/string_literal_type.sail
+++ b/test/c/string_literal_type.sail
@@ -1,0 +1,33 @@
+$include <prelude.sail>
+
+$option -string_literal_type
+
+val test : string_literal -> unit
+
+function test(s) = print_endline(s)
+
+val main : unit -> unit
+
+function main() = {
+  let x : string_literal = "foo";
+  var y : string_literal = "bar";
+  let z = "baz";
+  y = x;
+  print_endline(y);
+  test(y);
+  y = z;
+  print_endline(y);
+  test(y);
+  match x {
+    "foo" => print_endline("ok"),
+    _ => print_endline("fail"),
+  };
+  match y {
+    "baz" => print_endline("ok"),
+    _ => print_endline("fail"),
+  };
+  match concat_str(x, z) {
+    "foobaz" => print_endline("ok"),
+    _ => print_endline("fail"),
+  }
+}

--- a/test/typecheck/pass/string_literal_type.sail
+++ b/test/typecheck/pass/string_literal_type.sail
@@ -1,0 +1,34 @@
+$include <prelude.sail>
+
+$option -string_literal_type
+
+val test : string_literal -> unit
+
+function test(s) = print_endline(s)
+
+val main : unit -> unit
+
+function main() = {
+  let x : string_literal = "foo";
+  var y : string_literal = "bar";
+  let z = "baz";
+  test(z);
+  y = x;
+  print_endline(y);
+  test(y);
+  y = z;
+  print_endline(y);
+  test(y);
+  match x {
+    "foo" => print_endline("ok"),
+    _ => print_endline("fail"),
+  };
+  match y {
+    "baz" => print_endline("ok"),
+    _ => print_endline("fail"),
+  };
+  match concat_str(x, z) {
+    "foobaz" => print_endline("ok"),
+    _ => print_endline("fail"),
+  }
+}

--- a/test/typecheck/pass/string_literal_type/v1.expect
+++ b/test/typecheck/pass/string_literal_type/v1.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/string_literal_type/v1.sail[0m:14.7-23:
+14[96m |[0m  test(concat_str(x, z))
+  [91m |[0m       [91m^--------------^[0m
+  [91m |[0m string is not a subtype of string_literal

--- a/test/typecheck/pass/string_literal_type/v1.sail
+++ b/test/typecheck/pass/string_literal_type/v1.sail
@@ -1,0 +1,15 @@
+$include <prelude.sail>
+
+$option -string_literal_type
+
+val test : string_literal -> unit
+
+function test(s) = print_endline(s)
+
+val main : unit -> unit
+
+function main() = {
+  let x : string_literal = "foo";
+  let z = "baz";
+  test(concat_str(x, z))
+}


### PR DESCRIPTION
The main motivation for this is for the Sail->SystemVerilog backend, where we can easily represent string literals as elements of an enumeration-like type, but cannot deal at all with run-time created strings. There is an option -sv_nostrings that removes all strings, but with this option we can at least keep literal strings.

Eventually the plan would be to use the effect system to track runtime created strings in such a way we can guarantee that they never affect the behaviour of the model, so can be safely removed.

This commit adds a -string_literal_type option that causes string literals to be inferred as the `string_literal` type which is a subtype of the `string` type. We already have subtyping for refinement types so mostly this just works with a few minor adjustments for mappings and string literal patterns.