### PR TITLE
Add access control mechanism to typing contexts

### DIFF
--- a/src/lib/preprocess.ml
+++ b/src/lib/preprocess.ml
@@ -240,7 +240,8 @@ let preprocess dir target opts =
        incorrect start/end annotations *)
     | (DEF_aux (DEF_pragma ("file_start", _), _) | DEF_aux (DEF_pragma ("file_end", _), _)) :: defs -> aux acc defs
     | DEF_aux (DEF_pragma (p, arg), l) :: defs ->
-        if not (StringSet.mem p all_pragmas) then Reporting.warn "" l ("Unrecognised directive: " ^ p);
+        if not (StringSet.mem p all_pragmas || String.contains p '#') then
+          Reporting.warn "" l ("Unrecognised directive: " ^ p);
         aux (DEF_aux (DEF_pragma (p, arg), l) :: acc) defs
     | DEF_aux (DEF_outcome (outcome_spec, inner_defs), l) :: defs ->
         aux (DEF_aux (DEF_outcome (outcome_spec, aux [] inner_defs), l) :: acc) defs

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -81,6 +81,12 @@ type env
 
 type t = env
 
+(** This implements the unscope# pragma, which removes an identifier
+    from scope by setting its module id to -1 (which is never a valid
+    module id). This is used only to test the typechecker, and should
+    not be used for any other reason! *)
+val unscope_pragma : string -> id -> t -> t
+
 val freshen_bind : t -> typquant * typ -> typquant * typ
 
 val get_default_order : t -> order

--- a/src/lib/type_error.ml
+++ b/src/lib/type_error.ml
@@ -352,6 +352,14 @@ let message_of_type_error =
           ([coercion; Line "Coercion failed because:"; msg trigger]
           @ if not (reasons = []) then Line "Possible reasons:" :: List.map msg reasons else []
           )
+    | Err_not_in_scope (explanation, Some l) ->
+        Seq
+          [
+            Line (Option.value ~default:"Not in scope" explanation);
+            Line "Try bringing the following definition into scope:";
+            Location ("", Some "definition here", l, Seq []);
+          ]
+    | Err_not_in_scope (explanation, None) -> Line (Option.value ~default:"Not in scope" explanation)
   in
   msg
 

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -94,6 +94,7 @@ type type_error =
   | Err_no_num_ident of id
   | Err_other of string
   | Err_inner of type_error * Parse_ast.l * string * string option * type_error
+  | Err_not_in_scope of string option * Parse_ast.l option
 
 exception Type_error of Parse_ast.l * type_error
 

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -109,6 +109,7 @@ type type_error =
   | Err_no_num_ident of id
   | Err_other of string
   | Err_inner of type_error * Parse_ast.l * string * string option * type_error
+  | Err_not_in_scope of string option * Parse_ast.l option
 
 let err_because (error1, l, error2) = Err_inner (error1, l, "Caused by", None, error2)
 

--- a/test/typecheck/fail/unscope_enum.expect
+++ b/test/typecheck/fail/unscope_enum.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/unscope_enum.sail[0m:14.10-11:
+14[96m |[0m  let _ = A;
+  [91m |[0m          [91m^[0m
+  [91m |[0m Enumeration E containing A is not in scope
+  [91m |[0m Try bringing the following definition into scope:
+  [91m |[0m [96mfail/unscope_enum.sail[0m:7.5-6:
+  [91m |[0m 7[96m |[0menum E = A | B | C
+  [91m |[0m  [91m |[0m     [91m^[0m [91mdefinition here[0m

--- a/test/typecheck/fail/unscope_enum.sail
+++ b/test/typecheck/fail/unscope_enum.sail
@@ -1,0 +1,16 @@
+$option -dmagic_hash
+
+default Order dec
+
+$include <prelude.sail>
+
+enum E = A | B | C
+
+$unscope# enum E
+
+val bar : unit -> unit
+
+function bar() = {
+  let _ = A;
+  ()
+}

--- a/test/typecheck/fail/unscope_let.expect
+++ b/test/typecheck/fail/unscope_let.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/unscope_let.sail[0m:14.10-13:
+14[96m |[0m  let _ = foo;
+  [91m |[0m          [91m^-^[0m
+  [91m |[0m Not in scope
+  [91m |[0m Try bringing the following definition into scope:
+  [91m |[0m [96mfail/unscope_let.sail[0m:7.4-7:
+  [91m |[0m 7[96m |[0mlet foo : bits(32) = 0xFFFF_FFFF
+  [91m |[0m  [91m |[0m    [91m^-^[0m [91mdefinition here[0m

--- a/test/typecheck/fail/unscope_let.sail
+++ b/test/typecheck/fail/unscope_let.sail
@@ -1,0 +1,16 @@
+$option -dmagic_hash
+
+default Order dec
+
+$include <prelude.sail>
+
+let foo : bits(32) = 0xFFFF_FFFF
+
+$unscope# let foo
+
+val bar : unit -> unit
+
+function bar() = {
+  let _ = foo;
+  ()
+}

--- a/test/typecheck/fail/unscope_register.expect
+++ b/test/typecheck/fail/unscope_register.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/unscope_register.sail[0m:14.10-13:
+14[96m |[0m  let _ = foo;
+  [91m |[0m          [91m^-^[0m
+  [91m |[0m Not in scope
+  [91m |[0m Try bringing the following definition into scope:
+  [91m |[0m [96mfail/unscope_register.sail[0m:7.9-12:
+  [91m |[0m 7[96m |[0mregister foo : bits(32)
+  [91m |[0m  [91m |[0m         [91m^-^[0m [91mdefinition here[0m

--- a/test/typecheck/fail/unscope_register.sail
+++ b/test/typecheck/fail/unscope_register.sail
@@ -1,0 +1,16 @@
+$option -dmagic_hash
+
+default Order dec
+
+$include <prelude.sail>
+
+register foo : bits(32)
+
+$unscope# register foo
+
+val bar : unit -> unit
+
+function bar() = {
+  let _ = foo;
+  ()
+}

--- a/test/typecheck/fail/unscope_type.expect
+++ b/test/typecheck/fail/unscope_type.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/unscope_type.sail[0m:14.10-13:
+14[96m |[0m  let _ : foo = 0xFFFF_FFFF;
+  [91m |[0m          [91m^-^[0m
+  [91m |[0m Not in scope
+  [91m |[0m Try bringing the following definition into scope:
+  [91m |[0m [96mfail/unscope_type.sail[0m:7.5-8:
+  [91m |[0m 7[96m |[0mtype foo = bits(32)
+  [91m |[0m  [91m |[0m     [91m^-^[0m [91mdefinition here[0m

--- a/test/typecheck/fail/unscope_type.sail
+++ b/test/typecheck/fail/unscope_type.sail
@@ -1,0 +1,16 @@
+$option -dmagic_hash
+
+default Order dec
+
+$include <prelude.sail>
+
+type foo = bits(32)
+
+$unscope# type foo
+
+val bar : unit -> unit
+
+function bar() = {
+  let _ : foo = 0xFFFF_FFFF;
+  ()
+}

--- a/test/typecheck/fail/unscope_val.expect
+++ b/test/typecheck/fail/unscope_val.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/unscope_val.sail[0m:11.9-12:
+11[96m |[0mfunction foo() = ()
+  [91m |[0m         [91m^-^[0m
+  [91m |[0m Cannot infer type of function as it has a defined type already. However, this type is not in scope.
+  [91m |[0m Try bringing the following definition into scope:
+  [91m |[0m [96mfail/unscope_val.sail[0m:7.4-7:
+  [91m |[0m 7[96m |[0mval foo : unit -> unit
+  [91m |[0m  [91m |[0m    [91m^-^[0m [91mdefinition here[0m

--- a/test/typecheck/fail/unscope_val.sail
+++ b/test/typecheck/fail/unscope_val.sail
@@ -1,0 +1,11 @@
+$option -dmagic_hash
+
+default Order dec
+
+$include <prelude.sail>
+
+val foo : unit -> unit
+
+$unscope# val foo
+
+function foo() = ()


### PR DESCRIPTION
This commit adds a feature that allows for typechecking using only a subset of objects (functions/types/registers etc) in the global typing context. Each `env_item` is extended with an identifier, and the local typing context contains a set of 'in scope' such identifiers. All functions accessing objects in the typing context will either raise Err_not_in_scope (if accessing a single object) or return a filtered set of objects based on the set of in-scope identifiers.

Note that this commit is effectively a no-op. While it adds the mechanism, it does not add any way to use it other than a magic directive `unscope#` which kicks an object out of the current scope (this is guarded by the -dmagic_hash flag), which is used to test that simple cases have reasonable error messages.