### PR TITLE
Suggest most similar function id when we can't find a function type

### DIFF
--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -442,6 +442,27 @@ let list_init len f =
   let rec list_init' len f acc = if acc >= len then [] else f acc :: list_init' len f (acc + 1) in
   list_init' len f 0
 
+let levenshtein_distance ?(osa = false) str1 str2 =
+  let dist = Array.make_matrix (String.length str1 + 1) (String.length str2 + 1) 0 in
+
+  for i = 1 to String.length str1 do
+    dist.(i).(0) <- i
+  done;
+  for j = 1 to String.length str2 do
+    dist.(0).(j) <- j
+  done;
+
+  for i = 1 to String.length str1 do
+    for j = 1 to String.length str2 do
+      let subst_cost = if str1.[i - 1] = str2.[j - 1] then 0 else 1 in
+      dist.(i).(j) <- min (min (dist.(i - 1).(j) + 1) (dist.(i).(j - 1) + 1)) (dist.(i - 1).(j - 1) + subst_cost);
+      if osa && i > 1 && j > 1 && str1.[i - 1] = str2.[j - 2] && str1.[i - 2] = str2.[j - 1] then
+        dist.(i).(j) <- min dist.(i).(j) (dist.(i - 2).(j - 2) + 1)
+    done
+  done;
+
+  dist.(String.length str1).(String.length str2)
+
 let termcode n = if !opt_colors then "\x1B[" ^ string_of_int n ^ "m" else ""
 
 let bold str = termcode 1 ^ str

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -219,6 +219,12 @@ val fold_left_index_last : (int -> bool -> 'a -> 'b -> 'a) -> 'a -> 'b list -> '
 
 val list_init : int -> (int -> 'a) -> 'a list
 
+(** Compute the levenshtein distance between two strings using the
+    Wagner–Fischer algorithm. If [~osa] is true computes the optimal
+    string alignment distance, which is similar but allows swaps as a
+    single action. *)
+val levenshtein_distance : ?osa:bool -> string -> string -> int
+
 (** {2 Files} *)
 
 (** [copy_file src dst] copies file [src] to file [dst]. Only files are supported,

--- a/test/typecheck/fail/no_function.expect
+++ b/test/typecheck/fail/no_function.expect
@@ -1,0 +1,7 @@
+[93mType error[0m:
+[96mfail/no_function.sail[0m:10.10-17:
+10[96m |[0m  let _ = foo_baz()
+  [91m |[0m          [91m^-----^[0m
+  [91m |[0m No function type found for foo_baz
+  [91m |[0m 
+  [91m |[0m Did you mean foo_bar?

--- a/test/typecheck/fail/no_function.sail
+++ b/test/typecheck/fail/no_function.sail
@@ -1,0 +1,11 @@
+default Order dec
+
+$include <prelude.sail>
+
+val foo_quux : unit -> unit
+
+val foo_bar : unit -> unit
+
+function test() -> unit = {
+  let _ = foo_baz()
+}

--- a/test/typecheck/fail/no_function2.expect
+++ b/test/typecheck/fail/no_function2.expect
@@ -1,0 +1,7 @@
+[93mType error[0m:
+[96mfail/no_function2.sail[0m:8.10-17:
+8[96m |[0m  let _ = foo_baz()
+ [91m |[0m          [91m^-----^[0m
+ [91m |[0m No function type found for foo_baz
+ [91m |[0m 
+ [91m |[0m Did you mean foo_quux?

--- a/test/typecheck/fail/no_function2.sail
+++ b/test/typecheck/fail/no_function2.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+val foo_quux : unit -> unit
+
+function test() -> unit = {
+  let _ = foo_baz()
+}

--- a/test/typecheck/fail/no_function3.expect
+++ b/test/typecheck/fail/no_function3.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mfail/no_function3.sail[0m:6.10-17:
+6[96m |[0m  let _ = foo_baz()
+ [91m |[0m          [91m^-----^[0m
+ [91m |[0m No function type found for foo_baz

--- a/test/typecheck/fail/no_function3.sail
+++ b/test/typecheck/fail/no_function3.sail
@@ -1,0 +1,7 @@
+default Order dec
+
+$include <prelude.sail>
+
+function test() -> unit = {
+  let _ = foo_baz()
+}


### PR DESCRIPTION
Find identifier with smallest optimal string alignment (OSA) distance (within reason) and suggest it. Only do this if the OSA distance is 4 or less, and the strings only differ in length be two or less to avoid suggesting unrelated identifiers. These numbers just felt ok with some basic testing, but maybe a better heuristic exists.