### PR TITLE
Fix dune warnings and clean up some dead code

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -87,13 +87,6 @@ let opt_format_backup : string option ref = ref None
 let opt_format_only : string list ref = ref []
 let opt_format_skip : string list ref = ref []
 
-let non_canonical_spec ~flag ~canonical_flag spec =
-  if !opt_new_cli then (
-    let explanation = Printf.sprintf "Old style flag %s, use %s instead" flag canonical_flag in
-    Arg.Tuple [Arg.Unit (fun () -> Reporting.warn "Old style flag" Parse_ast.Unknown explanation); spec]
-  )
-  else spec
-
 (* Allow calling all options as either -foo_bar, -foo-bar, or
    --foo-bar (for long options). The standard long-opt version
    --foo-bar is treated as the canonical choice. If !opt_new_cli is

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -1695,7 +1695,7 @@ module Make (C : CONFIG) = struct
     object
       inherit empty_jib_visitor
 
-      method vctyp =
+      method! vctyp =
         function
         | CT_variant (id, ctors) when Id.compare var_id id = 0 ->
             let generic_ctors = Bindings.find id ctx.variants |> snd |> Bindings.bindings in
@@ -1723,10 +1723,10 @@ module Make (C : CONFIG) = struct
     object
       inherit empty_jib_visitor
 
-      method vctyp _ = SkipChildren
-      method vclexp _ = SkipChildren
+      method! vctyp _ = SkipChildren
+      method! vclexp _ = SkipChildren
 
-      method vcval =
+      method! vcval =
         function
         | V_ctor_kind (cval, (id, unifiers), pat_ctyp) when Id.compare id ctor_id = 0 ->
             change_do_children (V_ctor_kind (cval, (mangle_mono_id id ctx unifiers, []), pat_ctyp))
@@ -1734,7 +1734,7 @@ module Make (C : CONFIG) = struct
             change_do_children (V_ctor_unwrap (cval, (mangle_mono_id id ctx unifiers, []), ctor_ctyp))
         | _ -> DoChildren
 
-      method vinstr =
+      method! vinstr =
         function
         | I_aux (I_funcall (clexp, extern, (id, ctyp_args), args), aux) when Id.compare id ctor_id = 0 ->
             instantiations := CTListSet.add ctyp_args !instantiations;
@@ -1746,11 +1746,11 @@ module Make (C : CONFIG) = struct
     object
       inherit empty_jib_visitor
 
-      method vctyp _ = SkipChildren
-      method vclexp _ = SkipChildren
-      method vcval _ = SkipChildren
+      method! vctyp _ = SkipChildren
+      method! vclexp _ = SkipChildren
+      method! vcval _ = SkipChildren
 
-      method vinstr =
+      method! vinstr =
         function
         | I_aux (I_decl (CT_struct (struct_id', fields), _), (_, l)) when Id.compare struct_id struct_id' = 0 ->
             let generic_fields = Bindings.find struct_id ctx.records |> snd |> Bindings.bindings in
@@ -1767,7 +1767,7 @@ module Make (C : CONFIG) = struct
     object
       inherit empty_jib_visitor
 
-      method vctyp =
+      method! vctyp =
         function
         | CT_variant (var_id', ctors) when Id.compare var_id var_id' = 0 ->
             let generic_ctors = Bindings.find var_id ctx.variants |> snd |> Bindings.bindings in

--- a/src/lib/jib_util.ml
+++ b/src/lib/jib_util.ml
@@ -168,9 +168,9 @@ class rename_visitor from_name to_name : jib_visitor =
   object
     inherit empty_jib_visitor
 
-    method vctyp _ = SkipChildren
+    method! vctyp _ = SkipChildren
 
-    method vname name = if Name.compare name from_name = 0 then Some to_name else None
+    method! vname name = if Name.compare name from_name = 0 then Some to_name else None
   end
 
 let cval_rename from_name to_name = visit_cval (new rename_visitor from_name to_name)
@@ -179,10 +179,10 @@ class map_cval_visitor f : jib_visitor =
   object
     inherit empty_jib_visitor
 
-    method vctyp _ = SkipChildren
-    method vclexp _ = SkipChildren
+    method! vctyp _ = SkipChildren
+    method! vclexp _ = SkipChildren
 
-    method vcval cval = ChangeDoChildrenPost (cval, f)
+    method! vcval cval = ChangeDoChildrenPost (cval, f)
   end
 
 let map_cval f = visit_cval (new map_cval_visitor f)
@@ -751,11 +751,11 @@ class instr_visitor f : jib_visitor =
   object
     inherit empty_jib_visitor
 
-    method vcval _ = SkipChildren
-    method vctyp _ = SkipChildren
-    method vclexp _ = SkipChildren
+    method! vcval _ = SkipChildren
+    method! vctyp _ = SkipChildren
+    method! vclexp _ = SkipChildren
 
-    method vinstr instr = ChangeDoChildrenPost (instr, f)
+    method! vinstr instr = ChangeDoChildrenPost (instr, f)
   end
 
 let map_instr f = visit_instr (new instr_visitor f)
@@ -1049,7 +1049,7 @@ let cdef_ctyps = function
       |> CTSet.union (instrs_ctyps instrs)
   | CDEF_pragma (_, _) -> CTSet.empty
 
-let rec cdef_ctyps_exist pred = function
+let cdef_ctyps_exist pred = function
   | CDEF_register (_, ctyp, instrs) -> pred ctyp || instrs_ctyps_exist pred instrs
   | CDEF_val (_, _, ctyps, ctyp) -> List.exists pred ctyps || pred ctyp
   | CDEF_fundef (_, _, _, instrs) | CDEF_startup (_, instrs) | CDEF_finish (_, instrs) -> instrs_ctyps_exist pred instrs

--- a/src/lib/jib_visitor.ml
+++ b/src/lib/jib_visitor.ml
@@ -236,7 +236,7 @@ and visit_instrs vis outer_instrs =
   in
   do_visit vis (vis#vinstrs outer_instrs) aux outer_instrs
 
-let rec visit_cdef vis outer_cdef =
+let visit_cdef vis outer_cdef =
   let aux vis no_change =
     match no_change with
     | CDEF_register (id, ctyp, instrs) ->

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -97,8 +97,6 @@ let prepend_id str1 = function
 let mk_id i n m = Id_aux (i, loc n m)
 let mk_kid str n m = Kid_aux (Var str, loc n m)
 
-let mk_kopt k n m = KOpt_aux (k, loc n m)
-
 let id_of_kid = function
   | Kid_aux (Var v, l) -> Id_aux (Id (String.sub v 1 (String.length v - 1)), l)
 
@@ -172,42 +170,6 @@ let mk_tannot typq typ n m = Typ_annot_opt_aux (Typ_annot_opt_some (typq, typ), 
 let mk_eannotn = Effect_opt_aux (Effect_opt_none,Unknown)
 
 let mk_typq kopts nc n m = TypQ_aux (TypQ_tq (List.map qi_id_of_kopt kopts @ nc), loc n m)
-
-type lchain =
-  LC_lt
-| LC_lteq
-| LC_nexp of atyp
-
-let tyop op t1 t2 s e = mk_typ (ATyp_app (Id_aux (Operator op, loc s e), [t1; t2])) s e
-
-let rec desugar_lchain chain s e =
-  match chain with
-  | [LC_nexp n1; LC_lteq; LC_nexp n2] -> tyop "<=" n1 n2 s e
-  | [LC_nexp n1; LC_lt; LC_nexp n2] -> tyop "<" n1 n2 s e
-  | (LC_nexp n1 :: LC_lteq :: LC_nexp n2 :: chain) ->
-     let nc1 = tyop "<=" n1 n2 s e in
-     tyop "&" nc1 (desugar_lchain (LC_nexp n2 :: chain) s e) s e
-  | (LC_nexp n1 :: LC_lt :: LC_nexp n2 :: chain) ->
-     let nc1 = tyop "<" n1 n2 s e in
-     tyop "&" nc1 (desugar_lchain (LC_nexp n2 :: chain) s e) s e
-  | _ -> assert false
-
-type rchain =
-  RC_gt
-| RC_gteq
-| RC_nexp of atyp
-
-let rec desugar_rchain chain s e =
-  match chain with
-  | [RC_nexp n1; RC_gteq; RC_nexp n2] -> tyop ">=" n1 n2 s e
-  | [RC_nexp n1; RC_gt; RC_nexp n2] -> tyop ">" n1 n2 s e
-  | (RC_nexp n1 :: RC_gteq :: RC_nexp n2 :: chain) ->
-     let nc1 = tyop ">=" n1 n2 s e in
-     tyop "&" nc1 (desugar_rchain (RC_nexp n2 :: chain) s e) s e
-  | (RC_nexp n1 :: RC_gt :: RC_nexp n2 :: chain) ->
-     let nc1 = tyop ">" n1 n2 s e in
-     tyop "&" nc1 (desugar_rchain (RC_nexp n2 :: chain) s e) s e
-  | _ -> assert false
 
 type vector_update =
   VU_single of exp * exp

--- a/src/lib/project.ml
+++ b/src/lib/project.ml
@@ -181,7 +181,7 @@ let rec visit_exp vis outer_exp =
   in
   do_visit vis (vis#vexp outer_exp) aux outer_exp
 
-let rec visit_dependency vis l outer_dependency =
+let visit_dependency vis l outer_dependency =
   let aux vis no_change =
     match no_change with
     | D_requires (e, es) ->
@@ -321,7 +321,7 @@ class eval_visitor (vars : value StringMap.t ref) =
 
     val mutable declared : StringSet.t = StringSet.empty
 
-    method vdef def =
+    method! vdef def =
       let aux no_change =
         match no_change with
         | Def_var ((name, l), (E_value v, _)), _ ->
@@ -335,7 +335,7 @@ class eval_visitor (vars : value StringMap.t ref) =
       in
       ChangeDoChildrenPost (def, aux)
 
-    method vexp outer_exp =
+    method! vexp outer_exp =
       let aux no_change =
         match no_change with
         | (E_string s | E_file s | E_id s), l -> (E_value (V_string s), l)
@@ -372,7 +372,7 @@ class eval_visitor (vars : value StringMap.t ref) =
       in
       ChangeDoChildrenPost (outer_exp, aux)
 
-    method short_circuit_if = true
+    method! short_circuit_if = true
   end
 
 (**************************************************************************)
@@ -398,9 +398,9 @@ class order_visitor (xs : string spanned list ref) =
   object
     inherit empty_project_visitor
 
-    method vexp _ = SkipChildren
+    method! vexp _ = SkipChildren
 
-    method vmodule m =
+    method! vmodule m =
       xs := m.name :: !xs;
       DoChildren
   end
@@ -450,10 +450,10 @@ class structure_visitor (proj : project_structure) =
 
     val mutable last_root : string option = None
 
-    method vexp _ = SkipChildren
-    method vdependency _ _ = SkipChildren
+    method! vexp _ = SkipChildren
+    method! vdependency _ _ = SkipChildren
 
-    method vmodule m =
+    method! vmodule m =
       let name = fst m.name in
       let id = StringMap.find name proj.ids in
       let files = collect_files m.defs in
@@ -467,7 +467,7 @@ class structure_visitor (proj : project_structure) =
             m
         )
 
-    method on_root_change new_root = last_root <- Some new_root
+    method! on_root_change new_root = last_root <- Some new_root
   end
 
 (**************************************************************************)
@@ -522,9 +522,9 @@ class dependency_visitor (proj : project_structure) =
 
     val mutable stack : stack = []
 
-    method vexp _ = SkipChildren
+    method! vexp _ = SkipChildren
 
-    method vdependency _ dep =
+    method! vdependency _ dep =
       begin
         match dep with
         | D_requires (e, es) ->
@@ -538,7 +538,7 @@ class dependency_visitor (proj : project_structure) =
       end;
       SkipChildren
 
-    method vmodule m =
+    method! vmodule m =
       let name = fst m.name in
       let l = snd m.name in
       let id = StringMap.find name proj.ids in

--- a/src/lib/smt_gen.ml
+++ b/src/lib/smt_gen.ml
@@ -70,21 +70,10 @@ open Jib
 open Jib_util
 open Smt_exp
 
-let zencode_upper_id id = Util.zencode_upper_string (string_of_id id)
-let zencode_id id = Util.zencode_string (string_of_id id)
-
 let zencode_uid (id, ctyps) =
   match ctyps with
   | [] -> Util.zencode_string (string_of_id id)
   | _ -> Util.zencode_string (string_of_id id ^ "#" ^ Util.string_of_list "_" string_of_ctyp ctyps)
-
-(* [required_width n] is the required number of bits to losslessly
-   represent an integer n *)
-let required_width n =
-  let rec required_width' n =
-    if Big_int.equal n Big_int.zero then 1 else 1 + required_width' (Big_int.shift_right n 1)
-  in
-  required_width' (Big_int.abs n)
 
 (* Generate SMT definitions in a writer monad that keeps tracks of any
    overflow checks needed. *)

--- a/src/lib/smt_gen.mli
+++ b/src/lib/smt_gen.mli
@@ -163,6 +163,8 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) : sig
 
   val int_size : ctyp -> int
 
+  val bv_size : ctyp -> int
+
   (** Create an SMT expression that converts an expression of the jib
       type [from] into an SMT expression for the jib type [into]. Note
       that this function assumes that the input is of the correct

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -325,19 +325,6 @@ let vector_start_index env typ =
   | Ord_aux (Ord_inc, _) -> nint 0
   | Ord_aux (Ord_dec, _) -> nexp_simp (nminus len (nint 1))
 
-let rec is_typ_monomorphic (Typ_aux (typ, l)) =
-  match typ with
-  | Typ_id _ -> true
-  | Typ_tuple typs -> List.for_all is_typ_monomorphic typs
-  | Typ_app (_, args) -> List.for_all is_typ_arg_monomorphic args
-  | Typ_fn (arg_typs, ret_typ) -> List.for_all is_typ_monomorphic arg_typs && is_typ_monomorphic ret_typ
-  | Typ_bidir (typ1, typ2) -> is_typ_monomorphic typ1 && is_typ_monomorphic typ2
-  | Typ_exist _ | Typ_var _ -> false
-  | Typ_internal_unknown -> Reporting.unreachable l __POS__ "escaped Typ_internal_unknown"
-
-and is_typ_arg_monomorphic (A_aux (arg, _)) =
-  match arg with A_nexp _ -> true | A_typ typ -> is_typ_monomorphic typ | A_bool _ -> true
-
 (**************************************************************************)
 (* 2. Subtyping and constraint solving                                    *)
 (**************************************************************************)

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -442,6 +442,8 @@ val destruct_numeric : ?name:string option -> typ -> (kid list * n_constraint * 
 val destruct_vector : Env.t -> typ -> (nexp * typ) option
 val destruct_bitvector : Env.t -> typ -> nexp option
 
+val destruct_boolean : ?name:string option -> typ -> (kid * n_constraint) option
+
 val vector_start_index : Env.t -> typ -> nexp
 
 (** Construct an existential type with a guaranteed fresh

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1167,7 +1167,7 @@ let add_enum_clause id member env =
             { global with enums = Bindings.add id { item with item = (true, IdSet.add member members) } global.enums }
           )
           env
-  | Some { item = false, _; loc = l } ->
+  | Some { item = false, _; loc = l; _ } ->
       typ_error
         (Parse_ast.Hint ("Declared as regular enumeration here", l, id_loc id))
         ("Enumeration " ^ string_of_id id ^ " is not scattered - cannot add a new member with 'enum clause'")
@@ -1390,7 +1390,9 @@ let lookup_id id env =
           | Some typ -> Register typ
           | None -> (
               match
-                List.find_opt (fun (_, { item = _, ctors }) -> IdSet.mem id ctors) (Bindings.bindings env.global.enums)
+                List.find_opt
+                  (fun (_, { item = _, ctors; _ }) -> IdSet.mem id ctors)
+                  (Bindings.bindings env.global.enums)
               with
               | Some (enum_id, item) ->
                   if item_in_scope env item then Enum (mk_typ (Typ_id enum_id))

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -781,7 +781,7 @@ module Combine_variables = struct
     object
       inherit empty_jib_visitor
 
-      method vinstrs =
+      method! vinstrs =
         function
         | (I_aux (I_decl (ctyp, id), _) as instr) :: instrs -> begin
             match pattern ctyp id instrs with
@@ -797,7 +797,7 @@ module Combine_variables = struct
           end
         | _ -> DoChildren
 
-      method vcdef = function CDEF_fundef _ -> DoChildren | _ -> SkipChildren
+      method! vcdef = function CDEF_fundef _ -> DoChildren | _ -> SkipChildren
     end
 end
 

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -319,12 +319,6 @@ module Verilog_config (C : JIB_CONFIG) : Jib_compile.CONFIG = struct
   let use_real = false
 end
 
-type function_footprint = { register_reads : IdSet.t; register_writes : IdSet.t }
-
-let rec instr_footprint (I_aux (aux, _)) = ()
-
-and instrs_footprint instrs = ()
-
 let register_types cdefs =
   List.fold_left
     (fun acc cdef -> match cdef with CDEF_register (id, ctyp, _) -> Bindings.add id ctyp acc | _ -> acc)


### PR DESCRIPTION
Dune has warning 7 enabled (which would usually be disabled by default) that wants us to change `method` to `method!` when overriding. This wasn't even a feature of OCaml I was aware of, but `method!` does seem slightly safer as it protects against a typo creating a new method rather than overriding