### PR TITLE
Add warning for Old bitfield syntax

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -232,6 +232,7 @@ let rec options =
         "<symbol> define a symbol for the preprocessor, as $define does in the source code"
       );
       ("-no_warn", Arg.Clear Reporting.opt_warnings, " do not print warnings");
+      ("-all_warnings", Arg.Set Reporting.opt_all_warnings, " print all warning messages");
       ("-strict_var", Arg.Set Type_check.opt_strict_var, " require var expressions for variable declarations");
       ("-plugin", Arg.String (fun plugin -> load_plugin options plugin), "<file> load a Sail plugin");
       ("-just_check", Arg.Set opt_just_check, " terminate immediately after typechecking");
@@ -435,9 +436,11 @@ let run_sail (config : Yojson.Basic.t option) tgt =
   let ast, env = Frontend.initial_rewrite effect_info env ast in
   let ast, env = List.fold_right (fun file (ast, _) -> Splice.splice ast file) !opt_splice (ast, env) in
   let effect_info = Effects.infer_side_effects (Target.asserts_termination tgt) ast in
-  Reporting.opt_warnings := false;
 
   (* Don't show warnings during re-writing for now *)
+  Reporting.suppressed_warning_info ();
+  Reporting.opt_warnings := false;
+
   Target.run_pre_rewrites_hook tgt ast effect_info env;
   let ast, effect_info, env = Rewrites.rewrite effect_info env (Target.rewrites tgt) ast in
 

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -80,6 +80,9 @@
 (** If this is false, Sail will never generate any warnings *)
 val opt_warnings : bool ref
 
+(** If this is true, we will print all warnings, even if generated with [~once_from]. *)
+val opt_all_warnings : bool ref
+
 (** How many backtrace entries to show for unreachable code errors *)
 val opt_backtrace_length : int ref
 
@@ -155,6 +158,9 @@ val forbid_errors : string * int * int * int -> ('a -> 'b) -> 'a -> 'b
 val warn : ?once_from:string * int * int * int -> string -> Parse_ast.l -> string -> unit
 
 val format_warn : ?once_from:string * int * int * int -> string -> Parse_ast.l -> Error_format.message -> unit
+
+(** Print information about suppressed warnings *)
+val suppressed_warning_info : unit -> unit
 
 (** Print a simple one-line warning without a location. *)
 val simple_warn : string -> unit


### PR DESCRIPTION
Print the number of suppressed warnings, and add an --all-warnings flag that can print all warnings even when ~once_from is used.