### PR TITLE
Fix issues with missing well-formedness checks

### DIFF
--- a/test/lem/run_tests.py
+++ b/test/lem/run_tests.py
@@ -43,6 +43,7 @@ skip_tests_mwords = {
     # The Lem backend needs sail_mem_read to be instantiated at a minimum
     'concurrency_interface_dec',
     'concurrency_interface_inc',
+    'wf_register_type',
 }
 
 print('Sail is {}'.format(sail))

--- a/test/typecheck/fail/wf_assign_type.expect
+++ b/test/typecheck/fail/wf_assign_type.expect
@@ -1,0 +1,10 @@
+[93mType error[0m:
+[96mfail/wf_assign_type.sail[0m:9.10-17:
+9[96m |[0m  var Y : bits(X) = 0b00;
+ [91m |[0m          [91m^-----^[0m
+ [91m |[0m Well-formedness check failed for type
+ [91m |[0m 
+ [91m |[0m [93mCaused by [0m[96mfail/wf_assign_type.sail[0m:9.15-16:
+ [91m |[0m 9[96m |[0m  var Y : bits(X) = 0b00;
+ [91m |[0m  [91m |[0m               [91m^[0m
+ [91m |[0m  [91m |[0m Undefined type synonym X

--- a/test/typecheck/fail/wf_assign_type.sail
+++ b/test/typecheck/fail/wf_assign_type.sail
@@ -1,0 +1,11 @@
+default Order dec
+
+$include <prelude.sail>
+
+type bar : Int = 10
+
+function foo() -> bits(bar) = {
+  let X = sizeof(bar);
+  var Y : bits(X) = 0b00;
+  Y
+}

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -9,4 +9,4 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 26[96m |[0m  Some(Ctor1(a, x, c))
   [91m |[0m       [91m^------------^[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
-  [91m |[0m [94m*[0m 'ex340# in {32, 64}
+  [91m |[0m [94m*[0m 'ex343# in {32, 64}

--- a/test/typecheck/pass/wf_register_type.sail
+++ b/test/typecheck/pass/wf_register_type.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+type x : Int = 8
+
+type operator /('n : Int, 'm : Int) -> Int = div('n, 'm)
+
+register r : bits(x / 2) = 0x0

--- a/test/typecheck/pass/wf_register_type/v1.expect
+++ b/test/typecheck/pass/wf_register_type/v1.expect
@@ -1,0 +1,10 @@
+[93mType error[0m:
+[96mpass/wf_register_type/v1.sail[0m:7.13-24:
+7[96m |[0mregister r : bits(x / 2) = 0x0
+ [91m |[0m             [91m^---------^[0m
+ [91m |[0m Well-formedness check failed for type
+ [91m |[0m 
+ [91m |[0m [93mCaused by [0m[96mpass/wf_register_type/v1.sail[0m:7.18-23:
+ [91m |[0m 7[96m |[0mregister r : bits(x / 2) = 0x0
+ [91m |[0m  [91m |[0m                  [91m^---^[0m
+ [91m |[0m  [91m |[0m Unknown type level operator or function (operator /)

--- a/test/typecheck/pass/wf_register_type/v1.sail
+++ b/test/typecheck/pass/wf_register_type/v1.sail
@@ -1,0 +1,7 @@
+default Order dec
+
+$include <prelude.sail>
+
+type x : Int = 8
+
+register r : bits(x / 2) = 0x0


### PR DESCRIPTION
Make sure numeric type synonyms with arguments are expanded correctly