### PR TITLE
Fix and update sailcov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: System dependencies
       run: |
-        sudo apt install build-essential libgmp-dev z3 cvc4 opam
+        sudo apt install build-essential libgmp-dev z3 cvc4 opam cargo
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -53,6 +53,17 @@ jobs:
         eval $(opam env)
         dune build --release --instrument-with bisect_ppx
         dune install
+
+    - name: Build sailcov
+      working-directory: sailcov
+      run: |
+        eval $(opam env)
+        make
+
+    - name: Build sailcov library
+      working-directory: lib/coverage
+      run: |
+        make
 
     - name: Test Sail
       run: |

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -90,6 +90,7 @@ let opt_prefix = ref "z"
 let opt_extra_params = ref None
 let opt_extra_arguments = ref None
 let opt_branch_coverage = ref None
+let opt_branch_coverage_output = ref "sail_coverage"
 
 let extra_params () = match !opt_extra_params with Some str -> str ^ ", " | _ -> ""
 
@@ -2047,6 +2048,10 @@ let compile_ast env effect_info output_chan c_includes ast =
       separate hardline
         (List.map string
            ([Printf.sprintf "%svoid model_init(void)" (static ()); "{"; "  setup_rts();"]
+           @ ( if Option.is_some !opt_branch_coverage then
+                 [Printf.sprintf "  sail_set_coverage_file(\"%s\");" !opt_branch_coverage_output]
+               else []
+             )
            @ fst exn_boilerplate @ startup cdefs @ letbind_initializers
            @ List.concat (List.map (fun r -> fst (register_init_clear r)) regs)
            @ (if regs = [] then [] else [Printf.sprintf "  %s(UNIT);" (sgen_function_id (mk_id "initialize_registers"))])

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -111,6 +111,8 @@ val opt_extra_arguments : string option ref
 
 val opt_branch_coverage : out_channel option ref
 
+val opt_branch_coverage_output : string ref
+
 (** Optimization flags *)
 
 val optimize_primops : bool ref

--- a/src/sail_c_backend/sail_plugin_c.ml
+++ b/src/sail_c_backend/sail_plugin_c.ml
@@ -104,6 +104,10 @@ let c_options =
       Arg.String (fun str -> C_backend.opt_branch_coverage := Some (open_out str)),
       "<file> Turn on coverage tracking and output information about all branches and functions to a file"
     );
+    ( "-c_coverage_output",
+      Arg.String (fun str -> C_backend.opt_branch_coverage_output := str),
+      "<file> The generated C will output coverage at runtime to the filename provided (default sail_coverage)"
+    );
     ( "-O",
       Arg.Tuple
         [

--- a/test/run_coverage_tests.sh
+++ b/test/run_coverage_tests.sh
@@ -50,6 +50,12 @@ printf "==========================================\n"
 ./smt/run_tests.py || returncode=1
 
 printf "\n==========================================\n"
+printf "sailcov tests\n"
+printf "==========================================\n"
+
+./sailcov/run_tests.py || returncode=1
+
+printf "\n==========================================\n"
 printf "Formatting tests\n"
 printf "==========================================\n"
 

--- a/test/sailcov/run_tests.py
+++ b/test/sailcov/run_tests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import hashlib
+
+mydir = os.path.dirname(__file__)
+os.chdir(mydir)
+sys.path.insert(0, os.path.realpath('..'))
+
+from sailtest import *
+
+sail_dir = get_sail_dir()
+sail = get_sail()
+
+print("Sail is {}".format(sail))
+print("Sail dir is {}".format(sail_dir))
+
+sailcov = '{}/sailcov/sailcov'.format(sail_dir)
+
+def have_sailcov():
+    try:
+        subprocess.call([sailcov, '--help'], stdout=subprocess.DEVNULL)
+        return True
+    except FileNotFoundError:
+        return False
+
+def test_sailcov():
+    banner('Testing sailcov')
+    results = Results('sailcov')
+    if not have_sailcov():
+        print('Skipping because no sailcov executable found')
+        return results.finish()
+    for filenames in chunks(os.listdir('.'), parallel()):
+        tests = {}
+        for filename in filenames:
+            basename = os.path.splitext(os.path.basename(filename))[0]
+            tests[filename] = os.fork()
+            if tests[filename] == 0:
+                step('{} -no_warn -no_memo_z3 -c -c_include sail_coverage.h -c_coverage {}.branches -c_coverage_output {}.taken {} -o {}'.format(sail, basename, basename, filename, basename))
+                step('cc {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lz -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
+                step('./{}.bin'.format(basename))
+                step('{} --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
+                step('diff {}.html {}.expect'.format(basename, basename))
+                print_ok(filename)
+                sys.exit()
+        results.collect(tests)
+    return results.finish()
+
+xml = '<testsuites>\n'
+
+xml += test_sailcov()
+
+xml += '</testsuites>\n'
+
+output = open('tests.xml', 'w')
+output.write(xml)
+output.close()

--- a/test/sailcov/simple_if.expect
+++ b/test/sailcov/simple_if.expect
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>simple_if</title></head>
+<body>
+<h1>simple_if.sail (3/4) 75%</h1>
+<code style="display: block">
+default&nbsp;Order&nbsp;dec<br>
+<br>
+$include&nbsp;&lt;prelude.sail&gt;<br>
+<br>
+register&nbsp;R&nbsp;:&nbsp;bool&nbsp;=&nbsp;true<br>
+<br>
+val&nbsp;main&nbsp;:&nbsp;unit&nbsp;-&gt;&nbsp;unit<br>
+<br>
+function&nbsp;main()&nbsp;=&nbsp;<span style="background-color: hsl(120, 85%, 80%)">{<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<span style="background-color: hsl(120, 85%, 75%)">if&nbsp;R&nbsp;then&nbsp;<span style="background-color: hsl(120, 85%, 70%)">{<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;print_endline(&quot;taken&quot;)<br>
+&nbsp;&nbsp;&nbsp;&nbsp;}</span>&nbsp;else&nbsp;<span style="background-color: hsl(0, 85%, 80%)">{<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;print_endline(&quot;not&nbsp;taken&quot;)<br>
+&nbsp;&nbsp;&nbsp;&nbsp;}</span></span><br>
+}</span><br>
+</code>
+</body>
+</html>

--- a/test/sailcov/simple_if.sail
+++ b/test/sailcov/simple_if.sail
@@ -1,0 +1,15 @@
+default Order dec
+
+$include <prelude.sail>
+
+register R : bool = true
+
+val main : unit -> unit
+
+function main() = {
+    if R then {
+        print_endline("taken")
+    } else {
+        print_endline("not taken")
+    }
+}


### PR DESCRIPTION
The output of the runtime library contains slightly less information that what is produced by the compiler when it generates information about all coverage points. Update sailcov to handle this correctly. The runtime library is updated to output span information for reached branches, and sailcov just treats them like regular spans.

This does mean the coverage information will report higher for the same files, as there is now and extra span for each branch consisting of the entire branch.

Update the CI to run a simple test case