### PR TITLE
Use cvc5 for SMT solving and enable floating point logic

### DIFF
--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -2258,7 +2258,7 @@ let smt_cdef props lets name_file ctx all_cdefs = function
           let header = smt_header ctx all_cdefs in
 
           if !(ctx.use_string) || !(ctx.use_real) then output_string out_chan "(set-logic ALL)\n"
-          else output_string out_chan "(set-logic QF_AUFBVDT)\n";
+          else output_string out_chan "(set-logic QF_AUFBVFPDT)\n";
 
           List.iter
             (fun def ->

--- a/src/sail_smt_backend/sail_plugin_smt.ml
+++ b/src/sail_smt_backend/sail_plugin_smt.ml
@@ -69,7 +69,7 @@ open Libsail
 
 let smt_options =
   [
-    ("-smt_auto", Arg.Tuple [Arg.Set Jib_smt.opt_auto], " generate SMT and automatically call the CVC4 solver");
+    ("-smt_auto", Arg.Tuple [Arg.Set Jib_smt.opt_auto], " generate SMT and automatically call the CVC5 solver");
     ("-smt_ignore_overflow", Arg.Set Jib_smt.opt_ignore_overflow, " ignore integer overflow in generated SMT");
     ("-smt_propagate_vars", Arg.Set Jib_smt.opt_propagate_vars, " propgate variables through generated SMT");
     ( "-smt_int_size",

--- a/src/sail_smt_backend/smtlib.ml
+++ b/src/sail_smt_backend/smtlib.ml
@@ -655,7 +655,7 @@ let rec run frame =
 let check_counterexample ast env fname function_id args arg_ctyps arg_smt_names =
   let open Printf in
   prerr_endline ("Checking counterexample: " ^ fname);
-  let in_chan = ksprintf Unix.open_process_in "cvc4 --lang=smt2.6 %s" fname in
+  let in_chan = ksprintf Unix.open_process_in "cvc5 --lang=smt2.6 %s" fname in
   let lines = ref [] in
   begin
     try
@@ -667,7 +667,7 @@ let check_counterexample ast env fname function_id args arg_ctyps arg_smt_names 
   let solver_output = List.rev !lines |> String.concat "\n" |> parse_sexps in
   begin
     match solver_output with
-    | Atom "sat" :: List (Atom "model" :: model) :: _ ->
+    | Atom "sat" :: List model :: _ ->
         let open Value in
         let open Interpreter in
         prerr_endline (sprintf "Solver found counterexample: %s" Util.("ok" |> green |> clear));


### PR DESCRIPTION
Update the SMT backend's auto-solver to be cvc5 instead of cvc4, and add `FP` (floating point) to the logic.