### PR TITLE
Add support for including extra SMT files

### DIFF
--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -364,6 +364,13 @@ let same_content_files file1 file2 : bool =
        result
      end
 
+let read_whole_file filename =
+  (* open_in_bin works correctly on Unix and Windows *)
+  let ch = open_in_bin filename in
+  let s = really_input_string ch (in_channel_length ch) in
+  close_in ch;
+  s
+
 (*String formatting *)
 let rec string_of_list sep string_of = function
   | [] -> ""

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -178,7 +178,7 @@ val map_if : ('a -> bool) -> ('a -> 'a) -> 'a list -> 'a list
 val map_exists : ('b -> bool) -> ('a -> 'b) -> 'a list -> bool
 
 (** [list_to_front i l] resorts the list [l] by bringing the element at index [i]
-    to the front. 
+    to the front.
     @throws Failure if [i] is not smaller than the length of [l]*)
 val list_to_front : int -> 'a list -> 'a list
 
@@ -245,6 +245,9 @@ val input_byte_opt : in_channel -> int option
 If at least one of the files does not exist, [false] is returned. [same_content_files] throws an exception,
 if one of the files exists, but cannot be read. *)
 val same_content_files : string -> string -> bool
+
+(** [read_whole_file filename] reads the contents of the file and returns it as a string. *)
+val read_whole_file : string -> string
 
 (** {2 Strings} *)
 

--- a/src/sail_smt_backend/jib_smt.mli
+++ b/src/sail_smt_backend/jib_smt.mli
@@ -179,5 +179,6 @@ val generate_smt :
   (* Applied to each function name to generate the file name for the smtlib file *)
   Type_check.Env.t ->
   Effects.side_effect_info ->
+  string list ->
   Type_check.tannot ast ->
   unit

--- a/src/sail_smt_backend/sail_plugin_smt.ml
+++ b/src/sail_smt_backend/sail_plugin_smt.ml
@@ -67,9 +67,11 @@
 
 open Libsail
 
+let opt_includes_smt : string list ref = ref []
+
 let smt_options =
   [
-    ("-smt_auto", Arg.Tuple [Arg.Set Jib_smt.opt_auto], " generate SMT and automatically call the CVC4 solver");
+    ("-smt_auto", Arg.Tuple [Arg.Set Jib_smt.opt_auto], " generate SMT and automatically call the CVC5 solver");
     ("-smt_ignore_overflow", Arg.Set Jib_smt.opt_ignore_overflow, " ignore integer overflow in generated SMT");
     ("-smt_propagate_vars", Arg.Set Jib_smt.opt_propagate_vars, " propgate variables through generated SMT");
     ( "-smt_int_size",
@@ -83,6 +85,10 @@ let smt_options =
     ( "-smt_vector_size",
       Arg.String (fun n -> Jib_smt.opt_default_vector_index := int_of_string n),
       "<n> set a bound of 2 ^ n for generic vectors in generated SMT (default 5)"
+    );
+    ( "-smt_include",
+      Arg.String (fun i -> opt_includes_smt := i :: !opt_includes_smt),
+      "<filename> insert additional file in SMT output"
     );
   ]
 
@@ -132,6 +138,6 @@ let smt_target _ _ out_file ast effect_info env =
     match out_file with Some f -> fun str -> f ^ "_" ^ str ^ ".smt2" | None -> fun str -> str ^ ".smt2"
   in
   Reporting.opt_warnings := true;
-  Jib_smt.generate_smt props name_file env effect_info ast_smt
+  Jib_smt.generate_smt props name_file env effect_info !opt_includes_smt ast_smt
 
 let _ = Target.register ~name:"smt" ~options:smt_options ~rewrites:smt_rewrites smt_target


### PR DESCRIPTION
Add --smt-include which inserts additional smtlib2 files into the output. This is can be used to define external functions for the SMT backend.