### PR TITLE
Improve interpreter value printing

### DIFF
--- a/src/lib/constant_fold.ml
+++ b/src/lib/constant_fold.ml
@@ -90,7 +90,7 @@ and exp_of_value =
   | V_bool true -> mk_lit_exp L_true
   | V_bool false -> mk_lit_exp L_false
   | V_string str -> mk_lit_exp (L_string str)
-  | V_record ctors -> mk_exp (E_struct (List.map fexp_of_ctor (StringMap.bindings ctors)))
+  | V_record fields -> mk_exp (E_struct (List.map fexp_of_ctor (StringMap.bindings fields)))
   | V_vector vs -> mk_exp (E_vector (List.map exp_of_value vs))
   | V_tuple vs -> mk_exp (E_tuple (List.map exp_of_value vs))
   | V_unit -> mk_lit_exp L_unit
@@ -103,7 +103,7 @@ and exp_of_value =
 let rec is_too_large =
   let open Value in
   function
-  | V_int _ | V_bit _ | V_bool _ | V_string _ | V_unit | V_attempted_read _ | V_real _ | V_ref _ -> false
+  | V_int _ | V_bit _ | V_bool _ | V_string _ | V_unit | V_attempted_read _ | V_real _ | V_ref _ | V_member _ -> false
   | V_vector vs | V_tuple vs | V_list vs -> List.compare_length_with vs 256 > 0
   | V_record fields -> StringMap.exists (fun _ v -> is_too_large v) fields
   | V_ctor (_, vs) -> List.exists is_too_large vs

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -468,7 +468,7 @@ let rec step (E_aux (e_aux, annot) as orig_exp) =
           get_global_letbinds () >>= fun lbs ->
           let chain = build_letchain id lbs orig_exp in
           return chain
-      | Enum _ -> return (exp_of_value (V_ctor (string_of_id id, [])))
+      | Enum _ -> return (exp_of_value (V_member (string_of_id id)))
       | _ -> fail ("Couldn't find id " ^ string_of_id id)
     end
   | E_struct fexps ->
@@ -651,7 +651,7 @@ and pattern_match env (P_aux (p_aux, (l, _))) value =
       begin
         match Env.lookup_id id env with
         | Enum _ ->
-            if is_ctor value && string_of_id id = fst (coerce_ctor value) then (true, Bindings.empty)
+            if is_member value && string_of_id id = coerce_member value then (true, Bindings.empty)
             else (false, Bindings.empty)
         | _ -> (true, Bindings.singleton id (Complete_binding value))
       end

--- a/src/sail_smt_backend/smtlib.ml
+++ b/src/sail_smt_backend/smtlib.ml
@@ -655,7 +655,7 @@ let rec value_of_sexpr sexpr =
       match sexpr with
       | Atom name -> begin
           match List.find_opt (fun member -> Util.zencode_string (string_of_id member) = name) members with
-          | Some member -> V_ctor (string_of_id member, [])
+          | Some member -> V_member (string_of_id member)
           | None ->
               failwith
                 ("Could not find enum member for " ^ name ^ " in " ^ Util.string_of_list ", " string_of_id members)


### PR DESCRIPTION
Some interpreter values printed in a slightly odd way, particularly enums which were treated like constructors and therefore got printed as `X()` for an enumeration member `X` which is not valid syntax.

This means that SMT counterexamples should be pasteable into the interpreter more easily now