### PR TITLE
Add type-level if-then-else

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -218,16 +218,17 @@ kind :: 'K_' ::=
 nexp :: 'Nexp_' ::=
   {{ com numeric expression, of kind Int }}
   {{ aux _ l }}
-  | id                         :: :: id       {{ com abbreviation identifier }}
-  | kid                        :: :: var      {{ com variable }}
-  | num                        :: :: constant {{ com constant }}
-  | id ( nexp1 , ... , nexpn ) :: :: app      {{ com app }}
-  | nexp1 * nexp2              :: :: times    {{ com product }}
-  | nexp1 + nexp2              :: :: sum      {{ com sum }}
-  | nexp1 - nexp2              :: :: minus    {{ com subtraction }}
-  | 2 ^ nexp                   :: :: exp      {{ com exponential }}
-  | - nexp                     :: :: neg      {{ com unary negation}}
-  | ( nexp )                   :: S :: paren  {{ ichlo [[nexp]] }}
+  | id                                    :: :: id       {{ com abbreviation identifier }}
+  | kid                                   :: :: var      {{ com variable }}
+  | num                                   :: :: constant {{ com constant }}
+  | id ( nexp1 , ... , nexpn )            :: :: app      {{ com app }}
+  | if n_constraint then nexp1 else nexp2 :: :: if       {{ com if-then-else }}
+  | nexp1 * nexp2                         :: :: times    {{ com product }}
+  | nexp1 + nexp2                         :: :: sum      {{ com sum }}
+  | nexp1 - nexp2                         :: :: minus    {{ com subtraction }}
+  | 2 ^ nexp                              :: :: exp      {{ com exponential }}
+  | - nexp                                :: :: neg      {{ com unary negation}}
+  | ( nexp )                              :: S :: paren  {{ ichlo [[nexp]] }}
 
 order :: 'Ord_' ::=
   {{ com vector order specifications, of kind Order }}

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -488,7 +488,6 @@ val prepend_kid : string -> kid -> kid
 
 (** {1 Misc functions} *)
 
-val nexp_frees : nexp -> KidSet.t
 val nexp_identical : nexp -> nexp -> bool
 val is_nexp_constant : nexp -> bool
 val int_of_nexp_opt : nexp -> Big_int.num option

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -140,6 +140,7 @@ and nexp_ids' (Nexp_aux (aux, _)) =
   | Nexp_var _ | Nexp_constant _ -> IdSet.empty
   | Nexp_exp n | Nexp_neg n -> nexp_ids' n
   | Nexp_times (n1, n2) | Nexp_sum (n1, n2) | Nexp_minus (n1, n2) -> IdSet.union (nexp_ids' n1) (nexp_ids' n2)
+  | Nexp_if (i, t, e) -> IdSet.union (constraint_ids' i) (IdSet.union (nexp_ids' t) (nexp_ids' e))
 
 and typ_ids' (Typ_aux (aux, _)) =
   match aux with

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -595,6 +595,12 @@ let rec chunk_atyp comments chunks (ATyp_aux (aux, l)) =
   | ATyp_neg arg ->
       let arg_chunks = rec_chunk_atyp arg in
       Queue.add (Unary ("-", arg_chunks)) chunks
+  | ATyp_if (i, t, e) ->
+      let if_format = { then_brace = false; else_brace = false } in
+      let i_chunks = rec_chunk_atyp i in
+      let t_chunks = rec_chunk_atyp t in
+      let e_chunks = rec_chunk_atyp e in
+      Queue.add (If_then_else (if_format, i_chunks, t_chunks, e_chunks)) chunks
   | ATyp_inc -> Queue.add (Atom "inc") chunks
   | ATyp_dec -> Queue.add (Atom "dec") chunks
   | ATyp_fn (lhs, rhs, _) ->

--- a/src/lib/constraint.ml
+++ b/src/lib/constraint.ml
@@ -237,8 +237,8 @@ let to_smt l abstract vars constr =
             sfun "to_int" [sfun "^" [Atom "2"; exp]]
       end
     | Nexp_neg nexp -> sfun "-" [smt_nexp nexp]
-  in
-  let rec smt_constraint (NC_aux (aux, _) : n_constraint) : sexpr =
+    | Nexp_if (i, t, e) -> sfun "ite" [smt_constraint i; smt_nexp t; smt_nexp e]
+  and smt_constraint (NC_aux (aux, _) : n_constraint) : sexpr =
     match aux with
     | NC_id id -> Atom (Util.zencode_string (string_of_id id))
     | NC_equal (nexp1, nexp2) -> sfun "=" [smt_nexp nexp1; smt_nexp nexp2]

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -400,6 +400,7 @@ and to_ast_nexp ctx atyp =
   | P.ATyp_minus (t1, t2) -> Nexp_aux (Nexp_minus (to_ast_nexp ctx t1, to_ast_nexp ctx t2), l)
   | P.ATyp_app (id, ts) -> Nexp_aux (Nexp_app (to_ast_id ctx id, List.map (to_ast_nexp ctx) ts), l)
   | P.ATyp_parens atyp -> to_ast_nexp ctx atyp
+  | P.ATyp_if (i, t, e) -> Nexp_aux (Nexp_if (to_ast_constraint ctx i, to_ast_nexp ctx t, to_ast_nexp ctx e), l)
   | _ -> raise (Reporting.err_typ l "Invalid numeric expression in type")
 
 and to_ast_bitfield_index_nexp ctx atyp =
@@ -1447,6 +1448,7 @@ let initial_ctx =
           ("implicit", [Some K_int]);
           ("itself", [Some K_int]);
           ("not", [Some K_bool]);
+          ("ite", [Some K_bool; Some K_int; Some K_int]);
         ];
     kinds = KBindings.empty;
     scattereds = Bindings.empty;

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -145,6 +145,7 @@ type atyp_aux =
   | ATyp_wild
   | ATyp_tuple of atyp list (* Tuple type *)
   | ATyp_app of id * atyp list (* type constructor application *)
+  | ATyp_if of atyp * atyp * atyp
   | ATyp_exist of kinded_id list * atyp * atyp
   | ATyp_parens of atyp
 

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -386,6 +386,12 @@ typ_no_caret:
                              $endpos) }
 
 typ:
+  | If_; cond_t = infix_typ; Then; then_t = infix_typ; Else; else_t = infix_typ
+    { mk_typ (ATyp_if (cond_t, then_t, else_t)) $startpos $endpos }
+  | t = infix_typ
+    { t }
+
+infix_typ:
   | prefix = prefix_typ_op;
     x = postfix_typ;
     xs = list(op = op; prefix = prefix_typ_op; y = postfix_typ { (IT_op op, $startpos(op), $endpos(op)) :: prefix @ y })

--- a/src/lib/specialize.ml
+++ b/src/lib/specialize.ml
@@ -177,9 +177,9 @@ let string_of_instantiation instantiation =
     | Nexp_app (id, nexps) -> string_of_id id ^ "(" ^ Util.string_of_list "," string_of_nexp nexps ^ ")"
     | Nexp_exp n -> "2 ^ " ^ string_of_nexp n
     | Nexp_neg n -> "- " ^ string_of_nexp n
-  in
-
-  let rec string_of_typ = function Typ_aux (typ, l) -> string_of_typ_aux typ
+    | Nexp_if (i, t, e) ->
+        "(if " ^ string_of_n_constraint i ^ " then " ^ string_of_nexp t ^ " else " ^ string_of_nexp e ^ ")"
+  and string_of_typ = function Typ_aux (typ, l) -> string_of_typ_aux typ
   and string_of_typ_aux = function
     | Typ_id id -> string_of_id id
     | Typ_var kid -> kid_name (mk_kopt K_type kid)

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -679,6 +679,10 @@ module Well_formedness = struct
         wf_nexp exs env nexp2
     | Nexp_exp nexp -> wf_nexp exs env nexp (* MAYBE: Could put restrictions on what is allowed here *)
     | Nexp_neg nexp -> wf_nexp exs env nexp
+    | Nexp_if (i, t, e) ->
+        wf_constraint exs env i;
+        wf_nexp exs env t;
+        wf_nexp exs env e
 
   and wf_constraint exs env (NC_aux (nc_aux, l) as nc) =
     wf_debug "constraint" string_of_n_constraint nc exs;
@@ -798,6 +802,8 @@ and expand_nexp_synonyms env (Nexp_aux (aux, l) as nexp) =
   | Nexp_neg nexp -> Nexp_aux (Nexp_neg (expand_nexp_synonyms env nexp), l)
   | Nexp_var kid -> Nexp_aux (Nexp_var kid, l)
   | Nexp_constant n -> Nexp_aux (Nexp_constant n, l)
+  | Nexp_if (i, t, e) ->
+      Nexp_aux (Nexp_if (expand_constraint_synonyms env i, expand_nexp_synonyms env t, expand_nexp_synonyms env e), l)
 
 and expand_synonyms env (Typ_aux (typ, l)) =
   match typ with

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -140,6 +140,7 @@ and unloc_nexp_aux = function
   | Nexp_minus (nexp1, nexp2) -> Nexp_minus (unloc_nexp nexp1, unloc_nexp nexp2)
   | Nexp_exp nexp -> Nexp_exp (unloc_nexp nexp)
   | Nexp_neg nexp -> Nexp_neg (unloc_nexp nexp)
+  | Nexp_if (i, t, e) -> Nexp_if (unloc_n_constraint i, unloc_nexp t, unloc_nexp e)
 
 and unloc_nexp = function Nexp_aux (nexp_aux, _) -> Nexp_aux (unloc_nexp_aux nexp_aux, Parse_ast.Unknown)
 
@@ -238,8 +239,10 @@ let rec nexp_power_variables (Nexp_aux (aux, _)) =
   | Nexp_id _ | Nexp_var _ | Nexp_constant _ -> KidSet.empty
   | Nexp_app (_, ns) -> List.fold_left KidSet.union KidSet.empty (List.map nexp_power_variables ns)
   | Nexp_exp n -> tyvars_of_nexp n
+  | Nexp_if (i, t, e) ->
+      KidSet.union (constraint_power_variables i) (KidSet.union (nexp_power_variables t) (nexp_power_variables e))
 
-let constraint_power_variables nc =
+and constraint_power_variables nc =
   List.fold_left KidSet.union KidSet.empty (List.map nexp_power_variables (constraint_nexps nc))
 
 let ex_counter = ref 0

--- a/test/typecheck/pass/type_if_then_else.sail
+++ b/test/typecheck/pass/type_if_then_else.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+val test : forall 'n. int('n) -> int(if 'n == 0 then 32 else 64)
+
+function test(n) = {
+    if n == 0 then 32 else 64
+}

--- a/test/typecheck/pass/type_if_then_else_alt.sail
+++ b/test/typecheck/pass/type_if_then_else_alt.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+val test : forall 'n. int('n) -> {'m, ('n == 0 & 'm == 32) | ('n != 0 & 'm == 64). int('m)}
+
+function test(n) = {
+    if n == 0 then 32 else 64
+}


### PR DESCRIPTION
Allows if-then-else in types, i.e:
```
default Order dec

$include <prelude.sail>

val test : forall 'n. int('n) -> int(if 'n == 0 then 32 else 64)

function test(n) = {
    if n == 0 then 32 else 64
}
```
as a simpler alternative to
```
default Order dec

$include <prelude.sail>

val test : forall 'n. int('n) -> {'m, ('n == 0 & 'm == 32) | ('n != 0 & 'm == 64). int('m)}

function test(n) = {
    if n == 0 then 32 else 64
}
```