### PR TITLE
Added Reporting.loc_range_to_src

### DIFF
--- a/src/lib/reporting.ml
+++ b/src/lib/reporting.ml
@@ -141,6 +141,9 @@ let rec simp_loc = function
   | Parse_ast.Hint (_, l1, l2) -> begin match simp_loc l1 with None -> simp_loc l2 | pos -> pos end
   | Parse_ast.Range (p1, p2) -> Some (p1, p2)
 
+let loc_range_to_src (p1 : Lexing.position) (p2 : Lexing.position) =
+  (fun contents -> String.sub contents p1.pos_cnum (p2.pos_cnum - p1.pos_cnum)) (Util.read_whole_file p1.pos_fname)
+
 let rec map_loc_range f = function
   | Parse_ast.Unknown -> Parse_ast.Unknown
   | Parse_ast.Unique (n, l) -> Parse_ast.Unique (n, map_loc_range f l)

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -97,6 +97,9 @@ val loc_file : Parse_ast.l -> string option
 (** Reduce a location to a pair of positions if possible *)
 val simp_loc : Ast.l -> (Lexing.position * Lexing.position) option
 
+(** [loc_range_to_src] returns the source code text of a range **)
+val loc_range_to_src : Lexing.position -> Lexing.position -> string
+
 (** Adjust the range of a location. Note that only the primary
     location is adjusted. Hint locations are unaffected. *)
 val map_loc_range :


### PR DESCRIPTION
Moved the function to `src/lib/Reporting.ml`, so the JSON backend [here](https://github.com/ThinkOpenly/sail/pull/12) can use it.