### PR TITLE
Fix asciidoc build

### DIFF
--- a/doc/asciidoc/Makefile
+++ b/doc/asciidoc/Makefile
@@ -30,7 +30,7 @@ sail_doc/%.json: ../examples/%.sail
 	mkdir -p sail_doc
 	sail -no_color -doc -doc_file $< -doc_embed plain -doc_bundle $(notdir $@) $< 2> $(basename $@).warning
 
-lib_sail_doc/%.json: ../../lib/%.sail
+lib_sail_doc/%.json: ../examples/order_dec.sail ../../lib/%.sail
 	mkdir -p lib_sail_doc
 	mkdir -p lib_sail_doc/concurrency_interface
 	sail -doc -doc_file $< -doc_embed plain -doc_bundle $(patsubst lib_sail_doc/%,%,$@) -o lib_sail_doc $<
@@ -47,7 +47,7 @@ module_sail_doc/%.error: ../examples/%.sail_project $$(shell sail ../examples/%.
 
 module_sail_doc/%.sail_project: ../examples/%.sail_project
 	mkdir -p module_sail_doc
-	sail $< -list_files 1>/dev/null
+	sail $< -just_parse_project 1>/dev/null
 	cp $< $@
 
 ordering-tikz.pdf: latex_figures/ordering.tex

--- a/doc/examples/order_dec.sail
+++ b/doc/examples/order_dec.sail
@@ -1,0 +1,1 @@
+default Order dec

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -71,6 +71,7 @@ let opt_new_cli = ref false
 let opt_free_arguments : string list ref = ref []
 let opt_file_out : string option ref = ref None
 let opt_just_check : bool ref = ref false
+let opt_just_parse_project : bool ref = ref false
 let opt_auto_interpreter_rewrites : bool ref = ref false
 let opt_interactive_script : string option ref = ref None
 let opt_splice : string list ref = ref []
@@ -334,6 +335,7 @@ let rec options =
         Arg.Int (fun l -> Reporting.opt_backtrace_length := l),
         "<length> (debug) length of backtrace to show when reporting unreachable code"
       );
+      ("-just_parse_project", Arg.Set opt_just_parse_project, "");
       ( "-infer_effects",
         Arg.Unit (fun () -> Reporting.simple_warn "-infer_effects option is deprecated"),
         " (deprecated) ignored for compatibility with older versions; effects are always inferred now"
@@ -424,6 +426,7 @@ let run_sail (config : Yojson.Basic.t option) tgt =
               frees
         in
         Profile.finish "parsing project" t;
+        if !opt_just_parse_project then exit 0;
         let env = Type_check.initial_env_with_modules proj in
         Frontend.load_modules ~target:tgt Manifest.dir !options env proj mod_ids
     | _, _ ->


### PR DESCRIPTION
The makefile checked documentation project files were valid by calling -list_files, but a change means that we attempted to parse the listed files before displaying them. This broke some examples that were just showing syntax, so add a new option that just parses the file and exits.

We are also now stricter about having a default order set before including library files, so add a file that sets default Order dec before pulling library files into the documentation.
