### PR TITLE
Fix issue with enum members shadowing other definitions

### DIFF
--- a/test/typecheck/fail/enum_shadow.expect
+++ b/test/typecheck/fail/enum_shadow.expect
@@ -1,0 +1,8 @@
+[93mType error[0m:
+[96mfail/enum_shadow.sail[0m:3.5-6:
+3[96m |[0menum X = {A, B, C}
+ [92m |[0m     [92m^[0m [92mPreviously defined as part of enum X here[0m
+[96mfail/enum_shadow.sail[0m:5.10-11:
+5[96m |[0menum Y = {A, D}
+ [91m |[0m          [91m^[0m
+ [91m |[0m Enum member A is already part of another enum

--- a/test/typecheck/fail/enum_shadow.sail
+++ b/test/typecheck/fail/enum_shadow.sail
@@ -1,0 +1,5 @@
+default Order dec
+
+enum X = {A, B, C}
+
+enum Y = {A, D}

--- a/test/typecheck/fail/enum_shadow_let.expect
+++ b/test/typecheck/fail/enum_shadow_let.expect
@@ -1,0 +1,8 @@
+[93mType error[0m:
+[96mfail/enum_shadow_let.sail[0m:3.4-5:
+3[96m |[0mlet A : int = 1
+ [92m |[0m    [92m^[0m [92mPreviously bound here [0m
+[96mfail/enum_shadow_let.sail[0m:5.10-11:
+5[96m |[0menum Y = {A, D}
+ [91m |[0m          [91m^[0m
+ [91m |[0m Enumeration member A is already bound as a global let-binding

--- a/test/typecheck/fail/enum_shadow_let.sail
+++ b/test/typecheck/fail/enum_shadow_let.sail
@@ -1,0 +1,5 @@
+default Order dec
+
+let A : int = 1
+
+enum Y = {A, D}

--- a/test/typecheck/fail/enum_shadow_reg.expect
+++ b/test/typecheck/fail/enum_shadow_reg.expect
@@ -1,0 +1,8 @@
+[93mType error[0m:
+[96mfail/enum_shadow_reg.sail[0m:3.9-10:
+3[96m |[0mregister A : int = 1
+ [92m |[0m         [92m^[0m [92mRegister defined here [0m
+[96mfail/enum_shadow_reg.sail[0m:5.10-11:
+5[96m |[0menum Y = {A, D}
+ [91m |[0m          [91m^[0m
+ [91m |[0m Enumeration member A is already bound as a register

--- a/test/typecheck/fail/enum_shadow_reg.sail
+++ b/test/typecheck/fail/enum_shadow_reg.sail
@@ -1,0 +1,5 @@
+default Order dec
+
+register A : int = 1
+
+enum Y = {A, D}


### PR DESCRIPTION
Previously enumeration members could shadow other top-level bindings without an error, which was not intended. This would cause subsequent issues. Now this gives an error explaining the problem.
