### PR TITLE
Add a HAVE_COVERAGE symbol to configure the runtime to support coverage

### DIFF
--- a/lib/rts.c
+++ b/lib/rts.c
@@ -71,6 +71,9 @@
 #include <sys/types.h>
 
 #include "sail.h"
+#ifdef HAVE_COVERAGE
+#include "sail_coverage.h"
+#endif
 #include "rts.h"
 #include "elf.h"
 
@@ -723,10 +726,10 @@ int process_arguments(int argc, char *argv[])
       break;
 
     case 'c':
-#ifdef SAIL_COVERAGE_H
+#ifdef HAVE_COVERAGE
       sail_set_coverage_file(optarg);
 #else
-      fprintf(stderr, "Ignoring flag -c %s. Requires sail arg: -c_include sail_coverage.h", optarg);
+      fprintf(stderr, "Ignoring flag -c %s. Requires sail arg: -c_include sail_coverage.h\n", optarg);
 #endif
       break;
 

--- a/test/sailcov/run_tests.py
+++ b/test/sailcov/run_tests.py
@@ -39,10 +39,11 @@ def test_sailcov():
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 step('{} -no_warn -no_memo_z3 -c -c_include sail_coverage.h -c_coverage {}.branches {} -o {}'.format(sail, basename, filename, basename))
-                step('cc {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lz -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
+                step('cc -DHAVE_COVERAGE {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lz -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
                 step('./{}.bin -c {}.taken'.format(basename, basename))
                 step('{} --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
                 step('diff {}.html {}.expect'.format(basename, basename))
+                step('rm {}.taken {}.bin'.format(basename, basename))
                 print_ok(filename)
                 sys.exit()
         results.collect(tests)


### PR DESCRIPTION
This is a slightly breaking change as now Sail with coverage must be compiled with a `-DHAVE_COVERAGE` flag to configure the runtime correctly.