### PR TITLE
Remove the need for the HAVE_COVERAGE check

### DIFF
--- a/lib/rts.c
+++ b/lib/rts.c
@@ -71,15 +71,14 @@
 #include <sys/types.h>
 
 #include "sail.h"
-#ifdef HAVE_COVERAGE
-#include "sail_coverage.h"
-#endif
 #include "rts.h"
 #include "elf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+extern void sail_rts_set_coverage_file(char *output_file);
 
 static uint64_t g_elf_entry;
 uint64_t g_cycle_count = 0;
@@ -726,11 +725,11 @@ int process_arguments(int argc, char *argv[])
       break;
 
     case 'c':
-#ifdef HAVE_COVERAGE
-      sail_set_coverage_file(optarg);
-#else
-      fprintf(stderr, "Ignoring flag -c %s. Requires sail arg: -c_include sail_coverage.h\n", optarg);
-#endif
+      if (&sail_rts_set_coverage_file) {
+        sail_rts_set_coverage_file(optarg);
+      } else {
+        fprintf(stderr, "Ignoring flag -c %s. Requires the model to be compiled with coverage\n", optarg);
+      }
       break;
 
     case 'v':

--- a/test/sailcov/run_tests.py
+++ b/test/sailcov/run_tests.py
@@ -39,7 +39,7 @@ def test_sailcov():
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 step('{} -no_warn -no_memo_z3 -c -c_include sail_coverage.h -c_coverage {}.branches {} -o {}'.format(sail, basename, filename, basename))
-                step('cc -DHAVE_COVERAGE {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lz -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
+                step('cc {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lz -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
                 step('./{}.bin -c {}.taken'.format(basename, basename))
                 step('{} --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
                 step('diff {}.html {}.expect'.format(basename, basename))


### PR DESCRIPTION
Have the compiler generate a hook function that is either NULL or calls the coverage function the runtime wants to use, depending on whether coverage is enabled or not.