### PR TITLE
Improve some error messages

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -352,6 +352,10 @@ let rec options =
         " explain all type variables in type error messages"
       );
       ("-explain_constraints", Arg.Set Type_error.opt_explain_constraints, " explain constraints in type error messages");
+      ( "-explain_all_overloads",
+        Arg.Set Type_error.opt_explain_all_overloads,
+        " explain all possible overloading failures in type errors"
+      );
       ( "-explain_verbose",
         Arg.Tuple [Arg.Set Type_error.opt_explain_all_variables; Arg.Set Type_error.opt_explain_constraints],
         " add the maximum amount of explanation to type errors"

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -83,6 +83,11 @@ val opt_explain_all_variables : bool ref
    into detail about how they were derived *)
 val opt_explain_constraints : bool ref
 
+(** If false (default), we will try to pick the most likely error to
+    have caused an overload to fail, and only show those. If true, we
+    will show all type errors that caused an overload to fail. *)
+val opt_explain_all_overloads : bool ref
+
 type constraint_reason = (l * string) option
 
 type type_error =
@@ -96,6 +101,8 @@ type type_error =
   | Err_inner of type_error * Parse_ast.l * string * string option * type_error
   | Err_not_in_scope of
       string option * Parse_ast.l option * string Project.spanned option * string Project.spanned option * bool
+  | Err_instantiation_info of int * type_error
+  | Err_function_arg of Parse_ast.l * typ * type_error
 
 exception Type_error of Parse_ast.l * type_error
 

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -111,6 +111,8 @@ type type_error =
   | Err_inner of type_error * Parse_ast.l * string * string option * type_error
   | Err_not_in_scope of
       string option * Parse_ast.l option * string Project.spanned option * string Project.spanned option * bool
+  | Err_instantiation_info of int * type_error
+  | Err_function_arg of Parse_ast.l * typ * type_error
 
 let err_because (error1, l, error2) = Err_inner (error1, l, "Caused by", None, error2)
 

--- a/test/typecheck/fail/add_vec_lit_old.expect
+++ b/test/typecheck/fail/add_vec_lit_old.expect
@@ -10,6 +10,9 @@ Cast annotations are deprecated. They will be removed in a future version of the
   [91m |[0m                       [91m^-------^[0m
   [91m |[0m No overloading for (operator +), tried:
   [91m |[0m [94m*[0m add_vec
-  [91m |[0m    Could not unify int('ex5#) and bitvector(4)
+  [91m |[0m    Type mismatch between int('ex5#) and bitvector(4)
   [91m |[0m [94m*[0m add_range
-  [91m |[0m    Could not unify int('ex1#) and bitvector(4)
+  [91m |[0m    Type mismatch between int('ex1#) and bitvector(4)
+  [91m |[0m    [96mfail/add_vec_lit_old.sail[0m:14.23-26:
+  [91m |[0m    14[96m |[0mlet x : range(0, 30) = 0xF + 0x2
+  [91m |[0m      [91m |[0m                       [91m^-^[0m [91mwhen checking this argument has type int('ex1#)[0m

--- a/test/typecheck/fail/and_let_bool.expect
+++ b/test/typecheck/fail/and_let_bool.expect
@@ -10,3 +10,6 @@
  [91m |[0m 6[96m |[0m  and_bool(let y : bool = x in not_bool(y), x)
  [91m |[0m  [91m |[0m               [91m^[0m
  [91m |[0m  [91m |[0m Type variable 'ex16# was introduced here
+ [91m |[0m [96mfail/and_let_bool.sail[0m:6.11-42:
+ [91m |[0m 6[96m |[0m  and_bool(let y : bool = x in not_bool(y), x)
+ [91m |[0m  [91m |[0m           [91m^-----------------------------^[0m [91mwhen checking this argument has type bool('p)[0m

--- a/test/typecheck/fail/bitfield_error.expect
+++ b/test/typecheck/fail/bitfield_error.expect
@@ -10,7 +10,5 @@
  [91m |[0m [93mBitfield error [0m[96mfail/bitfield_error.sail[0m:6.6-13:
  [91m |[0m 6[96m |[0m  b : 0 .. 15,
  [91m |[0m  [91m |[0m      [91m^-----^[0m
- [91m |[0m  [91m |[0m No overloading for vector_subrange, tried:
- [91m |[0m  [91m |[0m [94m*[0m subrange_bits
- [91m |[0m  [91m |[0m    Could not resolve quantifiers for subrange_bits
- [91m |[0m  [91m |[0m    [94m*[0m (0 <= 15 & (15 <= 0 & 0 < 15))
+ [91m |[0m  [91m |[0m Could not resolve quantifiers for subrange_bits
+ [91m |[0m  [91m |[0m [94m*[0m (0 <= 15 & (15 <= 0 & 0 < 15))

--- a/test/typecheck/fail/issue277.expect
+++ b/test/typecheck/fail/issue277.expect
@@ -4,3 +4,6 @@
   [91m |[0m        [91m^----------^[0m
   [91m |[0m int(64) is not a subtype of int(32)
   [91m |[0m as 64 == 32 could not be proven
+  [91m |[0m [96mfail/issue277.sail[0m:12.8-20:
+  [91m |[0m 12[96m |[0m    foo(sizeof(xlen))
+  [91m |[0m   [91m |[0m        [91m^----------^[0m [91mwhen checking this argument has type int(32)[0m

--- a/test/typecheck/pass/existential_ast/v1.expect
+++ b/test/typecheck/pass/existential_ast/v1.expect
@@ -9,3 +9,6 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 46[96m |[0m  Some(Ctor2(y, x, c))
   [91m |[0m       [91m^------------^[0m
   [91m |[0m range(0, 31) is not contained within range(0, 31)
+  [91m |[0m [96mpass/existential_ast/v1.sail[0m:46.7-21:
+  [91m |[0m 46[96m |[0m  Some(Ctor2(y, x, c))
+  [91m |[0m   [91m |[0m       [91m^------------^[0m [91mwhen checking this argument has type (range(0, 31), int('ex262#), bitvector(4))[0m

--- a/test/typecheck/pass/existential_ast/v2.expect
+++ b/test/typecheck/pass/existential_ast/v2.expect
@@ -9,3 +9,6 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 39[96m |[0m  Some(Ctor2(y, x, c))
   [91m |[0m       [91m^------------^[0m
   [91m |[0m range(0, 30) is not contained within range(0, 30)
+  [91m |[0m [96mpass/existential_ast/v2.sail[0m:39.7-21:
+  [91m |[0m 39[96m |[0m  Some(Ctor2(y, x, c))
+  [91m |[0m   [91m |[0m       [91m^------------^[0m [91mwhen checking this argument has type (range(0, 30), int('ex262#), bitvector(4))[0m

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -10,3 +10,6 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
   [91m |[0m       [91m^------------^[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
   [91m |[0m [94m*[0m 'ex343# in {32, 64}
+  [91m |[0m [96mpass/existential_ast/v3.sail[0m:26.7-21:
+  [91m |[0m 26[96m |[0m  Some(Ctor1(a, x, c))
+  [91m |[0m   [91m |[0m       [91m^------------^[0m [91mwhen checking this argument has type ast[0m

--- a/test/typecheck/pass/existential_ast3/v3.expect
+++ b/test/typecheck/pass/existential_ast3/v3.expect
@@ -4,3 +4,6 @@
   [91m |[0m         [91m^-----------------------------^[0m
   [91m |[0m Could not resolve quantifiers for Ctor
   [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex330# & 'ex330# < 64))
+  [91m |[0m [96mpass/existential_ast3/v3.sail[0m:25.9-40:
+  [91m |[0m 25[96m |[0m    Some(Ctor(64, unsigned(0b0 @ b @ a)))
+  [91m |[0m   [91m |[0m         [91m^-----------------------------^[0m [91mwhen checking this argument has type ast[0m

--- a/test/typecheck/pass/global_type_var/v1.expect
+++ b/test/typecheck/pass/global_type_var/v1.expect
@@ -10,3 +10,6 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
   [91m |[0m             [91m^^[0m
   [91m |[0m int(32) is not a subtype of int('size)
   [91m |[0m as 32 == 'size could not be proven
+  [91m |[0m [96mpass/global_type_var/v1.sail[0m:21.13-15:
+  [91m |[0m 21[96m |[0mlet _ = test(32)
+  [91m |[0m   [91m |[0m             [91m^^[0m [91mwhen checking this argument has type int('size)[0m

--- a/test/typecheck/pass/global_type_var/v2.expect
+++ b/test/typecheck/pass/global_type_var/v2.expect
@@ -10,3 +10,6 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
   [91m |[0m             [91m^^[0m
   [91m |[0m int(64) is not a subtype of int('size)
   [91m |[0m as 64 == 'size could not be proven
+  [91m |[0m [96mpass/global_type_var/v2.sail[0m:21.13-15:
+  [91m |[0m 21[96m |[0mlet _ = test(64)
+  [91m |[0m   [91m |[0m             [91m^^[0m [91mwhen checking this argument has type int('size)[0m

--- a/test/typecheck/pass/if_infer/v1.expect
+++ b/test/typecheck/pass/if_infer/v1.expect
@@ -7,7 +7,10 @@
   [91m |[0m    Could not resolve quantifiers for bitvector_access
   [91m |[0m    [94m*[0m (0 <= 'ex241# & 'ex241# < 3)
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(3)
+  [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(3)
+  [91m |[0m    [96mpass/if_infer/v1.sail[0m:10.10-15:
+  [91m |[0m    10[96m |[0m  let _ = 0b100[if R then 0 else f()];
+  [91m |[0m      [91m |[0m          [91m^---^[0m [91mwhen checking this argument has type vector('n, 'a)[0m
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v1.sail[0m:10.10-37:
   [91m |[0m 10[96m |[0m  let _ = 0b100[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v2.expect
+++ b/test/typecheck/pass/if_infer/v2.expect
@@ -7,7 +7,10 @@
   [91m |[0m    Could not resolve quantifiers for bitvector_access
   [91m |[0m    [94m*[0m (0 <= 'ex241# & 'ex241# < 4)
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(4)
+  [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(4)
+  [91m |[0m    [96mpass/if_infer/v2.sail[0m:10.10-16:
+  [91m |[0m    10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
+  [91m |[0m      [91m |[0m          [91m^----^[0m [91mwhen checking this argument has type vector('n, 'a)[0m
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v2.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v3.expect
+++ b/test/typecheck/pass/if_infer/v3.expect
@@ -5,8 +5,12 @@
   [91m |[0m No overloading for vector_access, tried:
   [91m |[0m [94m*[0m bitvector_access
   [91m |[0m    Numeric type is non-simple
-  [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(4)
+  [91m |[0m    [96mpass/if_infer/v3.sail[0m:10.17-37:
+  [91m |[0m    10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
+  [91m |[0m      [91m |[0m                 [91m^------------------^[0m [91mwhen checking this argument has type int('m)[0m
+  [91m |[0m 
+  [91m |[0m Also tried: plain_vector_access
+  [91m |[0m These seem less likely, use --explain-all-overloads to see full details
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v3.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/poly_vector/v1.expect
+++ b/test/typecheck/pass/poly_vector/v1.expect
@@ -2,18 +2,7 @@
 [96mpass/poly_vector/v1.sail[0m:17.5-24:
 17[96m |[0m  if my_length(xs) == 32 then {
   [91m |[0m     [91m^-----------------^[0m
-  [91m |[0m No overloading for (operator ==), tried:
-  [91m |[0m [94m*[0m eq_int
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
-  [91m |[0m [94m*[0m eq_bit
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
-  [91m |[0m [94m*[0m eq_bool
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
-  [91m |[0m [94m*[0m eq_unit
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
-  [91m |[0m [94m*[0m eq_bit
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
-  [91m |[0m [94m*[0m eq_bits
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
-  [91m |[0m [94m*[0m eq_string
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(32)
+  [91m |[0m Type mismatch between vector('n, 'a) and bitvector(32)
+  [91m |[0m [96mpass/poly_vector/v1.sail[0m:17.15-17:
+  [91m |[0m 17[96m |[0m  if my_length(xs) == 32 then {
+  [91m |[0m   [91m |[0m               [91m^^[0m [91mwhen checking this argument has type vector('n, 'a)[0m

--- a/test/typecheck/pass/reg_32_64/v1.expect
+++ b/test/typecheck/pass/reg_32_64/v1.expect
@@ -13,4 +13,7 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m    Could not resolve quantifiers for set_R
   [91m |[0m    [94m*[0m (regno(0) & 56 in {32, 64})
   [91m |[0m [94m*[0m get_R
-  [91m |[0m    Could not unify int('r) and bitvector(56)
+  [91m |[0m    Type mismatch between int('r) and bitvector(56)
+  [91m |[0m    [96mpass/reg_32_64/v1.sail[0m:35.9-28:
+  [91m |[0m    35[96m |[0m  R(0) = 0xCAFE_CAFE_0000_00;
+  [91m |[0m      [91m |[0m         [91m^-----------------^[0m [91mwhen checking this argument has type int('r)[0m

--- a/test/typecheck/pass/reg_32_64/v3.expect
+++ b/test/typecheck/pass/reg_32_64/v3.expect
@@ -8,10 +8,17 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
 [96mpass/reg_32_64/v3.sail[0m:29.2-27:
 29[96m |[0m  reg_deref(R)['d - 1 .. 0]
   [91m |[0m  [91m^-----------------------^[0m
-  [91m |[0m No overloading for vector_subrange, tried:
-  [91m |[0m [94m*[0m subrange_bits
-  [91m |[0m    No overloading for (operator -), tried:
-  [91m |[0m    [94m*[0m sub_atom
-  [91m |[0m       Cannot re-write sizeof('d)
-  [91m |[0m    [94m*[0m sub_int
-  [91m |[0m       Cannot re-write sizeof('d)
+  [91m |[0m No overloading for (operator -), tried:
+  [91m |[0m [94m*[0m sub_atom
+  [91m |[0m    Cannot re-write sizeof('d)
+  [91m |[0m    [96mpass/reg_32_64/v3.sail[0m:29.15-17:
+  [91m |[0m    29[96m |[0m  reg_deref(R)['d - 1 .. 0]
+  [91m |[0m      [91m |[0m               [91m^^[0m [91mwhen checking this argument has type int('n)[0m
+  [91m |[0m [94m*[0m sub_int
+  [91m |[0m    Cannot re-write sizeof('d)
+  [91m |[0m    [96mpass/reg_32_64/v3.sail[0m:29.15-17:
+  [91m |[0m    29[96m |[0m  reg_deref(R)['d - 1 .. 0]
+  [91m |[0m      [91m |[0m               [91m^^[0m [91mwhen checking this argument has type int('ex174#)[0m
+  [91m |[0m [96mpass/reg_32_64/v3.sail[0m:29.15-21:
+  [91m |[0m 29[96m |[0m  reg_deref(R)['d - 1 .. 0]
+  [91m |[0m   [91m |[0m               [91m^----^[0m [91mwhen checking this argument has type int('m)[0m

--- a/test/typecheck/pass/shadow_let/v1.expect
+++ b/test/typecheck/pass/shadow_let/v1.expect
@@ -4,3 +4,6 @@
   [91m |[0m      [91m^[0m
   [91m |[0m int('y) is not a subtype of int(2)
   [91m |[0m as 'y == 2 could not be proven
+  [91m |[0m [96mpass/shadow_let/v1.sail[0m:13.6-7:
+  [91m |[0m 13[96m |[0m  bar(y);
+  [91m |[0m   [91m |[0m      [91m^[0m [91mwhen checking this argument has type int(2)[0m

--- a/test/typecheck/pass/string_literal_type/v1.expect
+++ b/test/typecheck/pass/string_literal_type/v1.expect
@@ -3,3 +3,6 @@
 16[96m |[0m  test(concat_str(x, z))
   [91m |[0m       [91m^--------------^[0m
   [91m |[0m string is not a subtype of string_literal
+  [91m |[0m [96mpass/string_literal_type/v1.sail[0m:16.7-23:
+  [91m |[0m 16[96m |[0m  test(concat_str(x, z))
+  [91m |[0m   [91m |[0m       [91m^--------------^[0m [91mwhen checking this argument has type string_literal[0m

--- a/test/typecheck/pass/vec_length/v1.expect
+++ b/test/typecheck/pass/vec_length/v1.expect
@@ -7,7 +7,10 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_access
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_access
- [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
+ [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m    [96mpass/vec_length/v1.sail[0m:6.10-11:
+ [91m |[0m    6[96m |[0m  let y = x[10];
+ [91m |[0m     [91m |[0m          [91m^[0m [91mwhen checking this argument has type vector('n, 'a)[0m
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v1.sail[0m:6.10-15:
  [91m |[0m 6[96m |[0m  let y = x[10];

--- a/test/typecheck/pass/vec_length/v1_inc.expect
+++ b/test/typecheck/pass/vec_length/v1_inc.expect
@@ -7,7 +7,10 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_access
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_access
- [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
+ [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m    [96mpass/vec_length/v1_inc.sail[0m:6.10-11:
+ [91m |[0m    6[96m |[0m  let y = x[10];
+ [91m |[0m     [91m |[0m          [91m^[0m [91mwhen checking this argument has type vector('n, 'a)[0m
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v1_inc.sail[0m:6.10-15:
  [91m |[0m 6[96m |[0m  let y = x[10];

--- a/test/typecheck/pass/vec_length/v2.expect
+++ b/test/typecheck/pass/vec_length/v2.expect
@@ -7,4 +7,7 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_update
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_update
- [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
+ [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m    [96mpass/vec_length/v2.sail[0m:7.11-12:
+ [91m |[0m    7[96m |[0m  let z = [x with 10 = y];
+ [91m |[0m     [91m |[0m           [91m^[0m [91mwhen checking this argument has type vector('n, 'a)[0m

--- a/test/typecheck/pass/vec_length/v2_inc.expect
+++ b/test/typecheck/pass/vec_length/v2_inc.expect
@@ -7,4 +7,7 @@
  [91m |[0m    Could not resolve quantifiers for bitvector_update
  [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m [94m*[0m plain_vector_update
- [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
+ [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m    [96mpass/vec_length/v2_inc.sail[0m:7.11-12:
+ [91m |[0m    7[96m |[0m  let z = [x with 10 = y];
+ [91m |[0m     [91m |[0m           [91m^[0m [91mwhen checking this argument has type vector('n, 'a)[0m

--- a/test/typecheck/pass/vec_length/v3.expect
+++ b/test/typecheck/pass/vec_length/v3.expect
@@ -9,7 +9,10 @@
   [91m |[0m    Could not resolve quantifiers for bitvector_access
   [91m |[0m    [94m*[0m (0 <= 10 & 10 < 8)
   [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m    Could not unify vector('n, 'a) and bitvector(8)
+  [91m |[0m    Type mismatch between vector('n, 'a) and bitvector(8)
+  [91m |[0m    [96mpass/vec_length/v3.sail[0m:6.10-11:
+  [91m |[0m    6[96m |[0m  let y = x[
+  [91m |[0m     [91m |[0m          [91m^[0m [91mwhen checking this argument has type vector('n, 'a)[0m
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/vec_length/v3.sail[0m:6.10-12.3:
   [91m |[0m 6 [96m |[0m  let y = x[


### PR DESCRIPTION
When an overloading fails, try to rank which overload is the most likely to have been intended and prioritise showing that error.

Add additional information when unification fails on function application, and replace the word 'unify' in this case with 'type mismatch'.