### PR TITLE
Float: Delete error result file if test pass

### DIFF
--- a/lib/float/common.sail
+++ b/lib/float/common.sail
@@ -38,7 +38,6 @@ type fp_bits = { 'n, 'n in {16, 32, 64}. bits('n) } /* Floating-point in bits. *
 let fp_eflag_invalid : fp_exception_flags = 0b00001
 
 /* Floating point struct */
-$[undefined_gen forbid] /* Todo: temporarlly workaround a type check error. */
 struct float_bits('n : Int) = {
   sign     : bits(1),
   exp      : bits(if  'n == 16

--- a/test/float/run_tests.py
+++ b/test/float/run_tests.py
@@ -31,7 +31,7 @@ def test_float(name, sail_opts, compiler, c_opts):
                 step('{} {} {}.c {}/lib/*.c -lgmp -lz -I {}/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
                 step('./{}.bin > {}.result 2> {}.err_result'.format(basename, basename, basename), expected_status = 1 if basename.startswith('fail') else 0)
 
-                step('diff {}.err_result no_error'.format(basename))
+                step('diff {}.err_result no_error && rm {}.err_result'.format(basename, basename))
                 step('rm {}.c {}.bin {}.result'.format(basename, basename, basename))
 
                 print_ok(filename)


### PR DESCRIPTION
* To avoid noisy files, only keep the error result file of failed test.