### PR TITLE
Filter the set of overloads before checking them

### DIFF
--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -215,6 +215,11 @@ val is_overload : id -> t -> bool
 val get_overload_locs : id -> t -> Ast.l list
 val add_overloads : l -> id -> id list -> t -> t
 val get_overloads : id -> t -> id list
+val get_overloads_recursive : id -> t -> id list
+
+val is_filtered_overload : id -> t -> bool
+val get_filtered_overloads : at:l -> id -> t -> id * id list
+val add_filtered_overload : id -> id list -> t -> id * t
 
 val is_extern : id -> t -> string -> bool
 val add_extern : id -> extern -> t -> t

--- a/test/typecheck/fail/add_vec_lit_old.expect
+++ b/test/typecheck/fail/add_vec_lit_old.expect
@@ -7,15 +7,5 @@ Cast annotations are deprecated. They will be removed in a future version of the
 [93mType error[0m:
 [96mfail/add_vec_lit_old.sail[0m:14.23-32:
 14[96m |[0mlet x : range(0, 30) = 0xF + 0x2
-  [91m |[0m                       [91m^-------^[0m [91m(operator +)[0m
-  [91m |[0m No overloading for (operator +), tried:
-  [91m |[0m [94m*[0m add_vec
-  [91m |[0m   [96mfail/add_vec_lit_old.sail[0m:14.23-32:
-  [91m |[0m   14[96m |[0mlet x : range(0, 30) = 0xF + 0x2
-  [91m |[0m     [91m |[0m                       [91m^-------^[0m
-  [91m |[0m     [91m |[0m Type mismatch between int('ex5#) and bitvector(4)
-  [91m |[0m [94m*[0m add_range
-  [91m |[0m   [96mfail/add_vec_lit_old.sail[0m:14.23-26:
-  [91m |[0m   14[96m |[0mlet x : range(0, 30) = 0xF + 0x2
-  [91m |[0m     [91m |[0m                       [91m^-^[0m [91mchecking function argument has type int('ex1#)[0m
-  [91m |[0m     [91m |[0m Type mismatch between int('ex1#) and bitvector(4)
+  [91m |[0m                       [91m^-------^[0m
+  [91m |[0m Type mismatch between int('ex5#) and bitvector(4)

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -9,4 +9,4 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 26[96m |[0m  Some(Ctor1(a, x, c))
   [91m |[0m       [91m^------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
-  [91m |[0m [94m*[0m 'ex343# in {32, 64}
+  [91m |[0m [94m*[0m 'ex335# in {32, 64}

--- a/test/typecheck/pass/existential_ast3/v1.expect
+++ b/test/typecheck/pass/existential_ast3/v1.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v1.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(33), int('ex291)) is not a subtype of (int('ex286), int('ex287))
+  [91m |[0m (int(33), int('ex289)) is not a subtype of (int('ex284), int('ex285))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex286:
+  [91m |[0m type variable 'ex284:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex287:
+  [91m |[0m type variable 'ex285:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex291:
+  [91m |[0m type variable 'ex289:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v2.expect
+++ b/test/typecheck/pass/existential_ast3/v2.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v2.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(31), int('ex291)) is not a subtype of (int('ex286), int('ex287))
+  [91m |[0m (int(31), int('ex289)) is not a subtype of (int('ex284), int('ex285))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex286:
+  [91m |[0m type variable 'ex284:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex287:
+  [91m |[0m type variable 'ex285:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex291:
+  [91m |[0m type variable 'ex289:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v3.expect
+++ b/test/typecheck/pass/existential_ast3/v3.expect
@@ -3,4 +3,4 @@
 25[96m |[0m    Some(Ctor(64, unsigned(0b0 @ b @ a)))
   [91m |[0m         [91m^-----------------------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor
-  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex330# & 'ex330# < 64))
+  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex326# & 'ex326# < 64))

--- a/test/typecheck/pass/existential_ast3/v4.expect
+++ b/test/typecheck/pass/existential_ast3/v4.expect
@@ -3,13 +3,13 @@
 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m                  [91m^^[0m
   [91m |[0m int(64) is not a subtype of {('d : Int), (('is_64 & 'd == 63) | (not('is_64) & 'd == 32)). int('d)}
-  [91m |[0m as (('is_64 & 'ex350 == 63) | (not('is_64) & 'ex350 == 32)) could not be proven
+  [91m |[0m as (('is_64 & 'ex342 == 63) | (not('is_64) & 'ex342 == 32)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex350:
+  [91m |[0m type variable 'ex342:
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:35.18-79:
   [91m |[0m 35[96m |[0m  let 'datasize : {'d, ('is_64 & 'd == 63) | (not('is_64) & 'd == 32). int('d)} =
   [91m |[0m   [92m |[0m                  [92m^-----------------------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:36.18-20:
   [91m |[0m 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m   [93m |[0m                  [93m^^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 64 == 'ex350
+  [91m |[0m   [93m |[0m has constraint: 64 == 'ex342

--- a/test/typecheck/pass/existential_ast3/v5.expect
+++ b/test/typecheck/pass/existential_ast3/v5.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m                                                  [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 2))
-  [91m |[0m as (0 <= 'ex356 & 'ex356 <= ('datasize - 2)) could not be proven
+  [91m |[0m as (0 <= 'ex350 & 'ex350 <= ('datasize - 2)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex356:
+  [91m |[0m type variable 'ex350:
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.50-65:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [93m |[0m                                                  [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex356 & 'ex356 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex350 & 'ex350 <= 63)

--- a/test/typecheck/pass/existential_ast3/v6.expect
+++ b/test/typecheck/pass/existential_ast3/v6.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m                                                                       [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 1))
-  [91m |[0m as (0 <= 'ex360 & 'ex360 <= ('datasize - 1)) could not be proven
+  [91m |[0m as (0 <= 'ex356 & 'ex356 <= ('datasize - 1)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex360:
+  [91m |[0m type variable 'ex356:
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.71-86:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [93m |[0m                                                                       [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex360 & 'ex360 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex356 & 'ex356 <= 63)

--- a/test/typecheck/pass/if_infer/v1.expect
+++ b/test/typecheck/pass/if_infer/v1.expect
@@ -1,19 +1,9 @@
 [93mType error[0m:
 [96mpass/if_infer/v1.sail[0m:10.10-37:
 10[96m |[0m  let _ = 0b100[if R then 0 else f()];
-  [91m |[0m          [91m^-------------------------^[0m [91mvector_access[0m
-  [91m |[0m No overloading for vector_access, tried:
-  [91m |[0m [94m*[0m bitvector_access
-  [91m |[0m   [96mpass/if_infer/v1.sail[0m:10.10-37:
-  [91m |[0m   10[96m |[0m  let _ = 0b100[if R then 0 else f()];
-  [91m |[0m     [91m |[0m          [91m^-------------------------^[0m
-  [91m |[0m     [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m     [91m |[0m [94m*[0m (0 <= 'ex241# & 'ex241# < 3)
-  [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m   [96mpass/if_infer/v1.sail[0m:10.10-15:
-  [91m |[0m   10[96m |[0m  let _ = 0b100[if R then 0 else f()];
-  [91m |[0m     [91m |[0m          [91m^---^[0m [91mchecking function argument has type vector('n, 'a)[0m
-  [91m |[0m     [91m |[0m Type mismatch between vector('n, 'a) and bitvector(3)
+  [91m |[0m          [91m^-------------------------^[0m
+  [91m |[0m Could not resolve quantifiers for bitvector_access
+  [91m |[0m [94m*[0m (0 <= 'ex241# & 'ex241# < 3)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v1.sail[0m:10.10-37:
   [91m |[0m 10[96m |[0m  let _ = 0b100[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v2.expect
+++ b/test/typecheck/pass/if_infer/v2.expect
@@ -1,19 +1,9 @@
 [93mType error[0m:
 [96mpass/if_infer/v2.sail[0m:10.10-38:
 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
-  [91m |[0m          [91m^--------------------------^[0m [91mvector_access[0m
-  [91m |[0m No overloading for vector_access, tried:
-  [91m |[0m [94m*[0m bitvector_access
-  [91m |[0m   [96mpass/if_infer/v2.sail[0m:10.10-38:
-  [91m |[0m   10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
-  [91m |[0m     [91m |[0m          [91m^--------------------------^[0m
-  [91m |[0m     [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m     [91m |[0m [94m*[0m (0 <= 'ex241# & 'ex241# < 4)
-  [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m   [96mpass/if_infer/v2.sail[0m:10.10-16:
-  [91m |[0m   10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
-  [91m |[0m     [91m |[0m          [91m^----^[0m [91mchecking function argument has type vector('n, 'a)[0m
-  [91m |[0m     [91m |[0m Type mismatch between vector('n, 'a) and bitvector(4)
+  [91m |[0m          [91m^--------------------------^[0m
+  [91m |[0m Could not resolve quantifiers for bitvector_access
+  [91m |[0m [94m*[0m (0 <= 'ex241# & 'ex241# < 4)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v2.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v3.expect
+++ b/test/typecheck/pass/if_infer/v3.expect
@@ -1,16 +1,8 @@
 [93mType error[0m:
 [96mpass/if_infer/v3.sail[0m:10.10-38:
 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
-  [91m |[0m          [91m^--------------------------^[0m [91mvector_access[0m
-  [91m |[0m No overloading for vector_access, tried:
-  [91m |[0m [94m*[0m bitvector_access
-  [91m |[0m   [96mpass/if_infer/v3.sail[0m:10.17-37:
-  [91m |[0m   10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
-  [91m |[0m     [91m |[0m                 [91m^------------------^[0m [91mchecking function argument has type int('m)[0m
-  [91m |[0m     [91m |[0m Numeric type is non-simple
-  [91m |[0m 
-  [91m |[0m Also tried plain_vector_access
-  [91m |[0m This seems less likely, use --explain-all-overloads to see full details
+  [91m |[0m          [91m^--------------------------^[0m [91mchecking function argument has type int('m)[0m
+  [91m |[0m Numeric type is non-simple
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v3.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/overload_int_nat.sail
+++ b/test/typecheck/pass/overload_int_nat.sail
@@ -1,0 +1,16 @@
+default Order dec
+
+$include <prelude.sail>
+
+val f : int -> int
+
+val g : string -> string
+
+overload h = {f, g}
+
+val main : unit -> unit
+
+function main() = {
+  let x : nat = 3;
+  let _ = h(x);
+}

--- a/test/typecheck/pass/poly_vector/v1.expect
+++ b/test/typecheck/pass/poly_vector/v1.expect
@@ -1,13 +1,5 @@
 [93mType error[0m:
 [96mpass/poly_vector/v1.sail[0m:17.5-24:
 17[96m |[0m  if my_length(xs) == 32 then {
-  [91m |[0m     [91m^-----------------^[0m [91m(operator ==)[0m
-  [91m |[0m No overloading for (operator ==), tried:
-  [91m |[0m [94m*[0m eq_int
-  [91m |[0m   [96mpass/poly_vector/v1.sail[0m:17.15-17:
-  [91m |[0m   17[96m |[0m  if my_length(xs) == 32 then {
-  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('n)[0m
-  [91m |[0m     [91m |[0m Type mismatch between vector('n, 'a) and bitvector(32)
-  [91m |[0m 
-  [91m |[0m Also tried: eq_bit, eq_bool, eq_unit, eq_bit, eq_bits, eq_string
-  [91m |[0m These seem less likely, use --explain-all-overloads to see full details
+  [91m |[0m     [91m^-----------------^[0m [91mchecking function argument has type int('n)[0m
+  [91m |[0m Type mismatch between vector('n, 'a) and bitvector(32)

--- a/test/typecheck/pass/reg_32_64/v1.expect
+++ b/test/typecheck/pass/reg_32_64/v1.expect
@@ -7,16 +7,6 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
 [93mType error[0m:
 [96mpass/reg_32_64/v1.sail[0m:35.2-6:
 35[96m |[0m  R(0) = 0xCAFE_CAFE_0000_00;
-  [91m |[0m  [91m^--^[0m [91mR[0m
-  [91m |[0m No overloading for R, tried:
-  [91m |[0m [94m*[0m set_R
-  [91m |[0m   [96mpass/reg_32_64/v1.sail[0m:35.2-6:
-  [91m |[0m   35[96m |[0m  R(0) = 0xCAFE_CAFE_0000_00;
-  [91m |[0m     [91m |[0m  [91m^--^[0m
-  [91m |[0m     [91m |[0m Could not resolve quantifiers for set_R
-  [91m |[0m     [91m |[0m [94m*[0m (regno(0) & 56 in {32, 64})
-  [91m |[0m [94m*[0m get_R
-  [91m |[0m   [96mpass/reg_32_64/v1.sail[0m:35.9-28:
-  [91m |[0m   35[96m |[0m  R(0) = 0xCAFE_CAFE_0000_00;
-  [91m |[0m     [91m |[0m         [91m^-----------------^[0m [91mchecking function argument has type int('r)[0m
-  [91m |[0m     [91m |[0m Type mismatch between int('r) and bitvector(56)
+  [91m |[0m  [91m^--^[0m
+  [91m |[0m Could not resolve quantifiers for set_R
+  [91m |[0m [94m*[0m (regno(0) & 56 in {32, 64})

--- a/test/typecheck/pass/vec_length/v1.expect
+++ b/test/typecheck/pass/vec_length/v1.expect
@@ -1,19 +1,9 @@
 [93mType error[0m:
 [96mpass/vec_length/v1.sail[0m:6.10-15:
 6[96m |[0m  let y = x[10];
- [91m |[0m          [91m^---^[0m [91mvector_access[0m
- [91m |[0m No overloading for vector_access, tried:
- [91m |[0m [94m*[0m bitvector_access
- [91m |[0m   [96mpass/vec_length/v1.sail[0m:6.10-15:
- [91m |[0m   6[96m |[0m  let y = x[10];
- [91m |[0m    [91m |[0m          [91m^---^[0m
- [91m |[0m    [91m |[0m Could not resolve quantifiers for bitvector_access
- [91m |[0m    [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
- [91m |[0m [94m*[0m plain_vector_access
- [91m |[0m   [96mpass/vec_length/v1.sail[0m:6.10-11:
- [91m |[0m   6[96m |[0m  let y = x[10];
- [91m |[0m    [91m |[0m          [91m^[0m [91mchecking function argument has type vector('n, 'a)[0m
- [91m |[0m    [91m |[0m Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m          [91m^---^[0m
+ [91m |[0m Could not resolve quantifiers for bitvector_access
+ [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v1.sail[0m:6.10-15:
  [91m |[0m 6[96m |[0m  let y = x[10];

--- a/test/typecheck/pass/vec_length/v1_inc.expect
+++ b/test/typecheck/pass/vec_length/v1_inc.expect
@@ -1,19 +1,9 @@
 [93mType error[0m:
 [96mpass/vec_length/v1_inc.sail[0m:6.10-15:
 6[96m |[0m  let y = x[10];
- [91m |[0m          [91m^---^[0m [91mvector_access[0m
- [91m |[0m No overloading for vector_access, tried:
- [91m |[0m [94m*[0m bitvector_access
- [91m |[0m   [96mpass/vec_length/v1_inc.sail[0m:6.10-15:
- [91m |[0m   6[96m |[0m  let y = x[10];
- [91m |[0m    [91m |[0m          [91m^---^[0m
- [91m |[0m    [91m |[0m Could not resolve quantifiers for bitvector_access
- [91m |[0m    [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
- [91m |[0m [94m*[0m plain_vector_access
- [91m |[0m   [96mpass/vec_length/v1_inc.sail[0m:6.10-11:
- [91m |[0m   6[96m |[0m  let y = x[10];
- [91m |[0m    [91m |[0m          [91m^[0m [91mchecking function argument has type vector('n, 'a)[0m
- [91m |[0m    [91m |[0m Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m          [91m^---^[0m
+ [91m |[0m Could not resolve quantifiers for bitvector_access
+ [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mpass/vec_length/v1_inc.sail[0m:6.10-15:
  [91m |[0m 6[96m |[0m  let y = x[10];

--- a/test/typecheck/pass/vec_length/v2.expect
+++ b/test/typecheck/pass/vec_length/v2.expect
@@ -1,16 +1,6 @@
 [93mType error[0m:
 [96mpass/vec_length/v2.sail[0m:7.10-25:
 7[96m |[0m  let z = [x with 10 = y];
- [91m |[0m          [91m^-------------^[0m [91mvector_update[0m
- [91m |[0m No overloading for vector_update, tried:
- [91m |[0m [94m*[0m bitvector_update
- [91m |[0m   [96mpass/vec_length/v2.sail[0m:7.10-25:
- [91m |[0m   7[96m |[0m  let z = [x with 10 = y];
- [91m |[0m    [91m |[0m          [91m^-------------^[0m
- [91m |[0m    [91m |[0m Could not resolve quantifiers for bitvector_update
- [91m |[0m    [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
- [91m |[0m [94m*[0m plain_vector_update
- [91m |[0m   [96mpass/vec_length/v2.sail[0m:7.11-12:
- [91m |[0m   7[96m |[0m  let z = [x with 10 = y];
- [91m |[0m    [91m |[0m           [91m^[0m [91mchecking function argument has type vector('n, 'a)[0m
- [91m |[0m    [91m |[0m Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m          [91m^-------------^[0m
+ [91m |[0m Could not resolve quantifiers for bitvector_update
+ [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)

--- a/test/typecheck/pass/vec_length/v2_inc.expect
+++ b/test/typecheck/pass/vec_length/v2_inc.expect
@@ -1,16 +1,6 @@
 [93mType error[0m:
 [96mpass/vec_length/v2_inc.sail[0m:7.10-25:
 7[96m |[0m  let z = [x with 10 = y];
- [91m |[0m          [91m^-------------^[0m [91mvector_update[0m
- [91m |[0m No overloading for vector_update, tried:
- [91m |[0m [94m*[0m bitvector_update
- [91m |[0m   [96mpass/vec_length/v2_inc.sail[0m:7.10-25:
- [91m |[0m   7[96m |[0m  let z = [x with 10 = y];
- [91m |[0m    [91m |[0m          [91m^-------------^[0m
- [91m |[0m    [91m |[0m Could not resolve quantifiers for bitvector_update
- [91m |[0m    [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
- [91m |[0m [94m*[0m plain_vector_update
- [91m |[0m   [96mpass/vec_length/v2_inc.sail[0m:7.11-12:
- [91m |[0m   7[96m |[0m  let z = [x with 10 = y];
- [91m |[0m    [91m |[0m           [91m^[0m [91mchecking function argument has type vector('n, 'a)[0m
- [91m |[0m    [91m |[0m Type mismatch between vector('n, 'a) and bitvector(8)
+ [91m |[0m          [91m^-------------^[0m
+ [91m |[0m Could not resolve quantifiers for bitvector_update
+ [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)

--- a/test/typecheck/pass/vec_length/v3.expect
+++ b/test/typecheck/pass/vec_length/v3.expect
@@ -4,20 +4,8 @@
   [91m |[0m          [91m^-[0m
 12[96m |[0m  ];
   [91m |[0m[91m--^[0m
-  [91m |[0m No overloading for vector_access, tried:
-  [91m |[0m [94m*[0m bitvector_access
-  [91m |[0m   [96mpass/vec_length/v3.sail[0m:6.10-12.3:
-  [91m |[0m   6 [96m |[0m  let y = x[
-  [91m |[0m     [91m |[0m          [91m^-[0m
-  [91m |[0m   12[96m |[0m  ];
-  [91m |[0m     [91m |[0m[91m--^[0m
-  [91m |[0m     [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m     [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
-  [91m |[0m [94m*[0m plain_vector_access
-  [91m |[0m   [96mpass/vec_length/v3.sail[0m:6.10-11:
-  [91m |[0m   6[96m |[0m  let y = x[
-  [91m |[0m    [91m |[0m          [91m^[0m [91mchecking function argument has type vector('n, 'a)[0m
-  [91m |[0m    [91m |[0m Type mismatch between vector('n, 'a) and bitvector(8)
+  [91m |[0m Could not resolve quantifiers for bitvector_access
+  [91m |[0m [94m*[0m (0 <= 10 & 10 < 8)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/vec_length/v3.sail[0m:6.10-12.3:
   [91m |[0m 6 [96m |[0m  let y = x[

--- a/test/typecheck/pass/zeros_implicit.sail
+++ b/test/typecheck/pass/zeros_implicit.sail
@@ -1,0 +1,17 @@
+default Order dec
+
+$include <prelude.sail>
+
+val zeros_implicit : forall 'n, 'n >= 0. implicit('n) -> bits('n)
+
+function zeros_implicit (n) = sail_zeros(n)
+
+overload zeros = {sail_zeros, zeros_implicit}
+
+val main : unit -> unit
+
+function main() = {
+  let _ : bits(32) = zeros();
+  let _ : bits(64) = zeros(64);
+  ()
+}


### PR DESCRIPTION
Construct a tree of possible overloadings whenever we find an E_app node that is overloaded, then filter any which are not possible. We do this by doing a simple check on the shape of the argument types. If they can't possibly match then we discard that overload.