### PR TITLE
Add a better inference rule for vector literals

### DIFF
--- a/test/lem/run_tests.py
+++ b/test/lem/run_tests.py
@@ -57,6 +57,7 @@ skip_tests_mwords = {
     'abstract_bool',
     'abstract_bool2',
     'constraint_syn',
+    'ex_vector_infer',
 }
 
 print('Sail is {}'.format(sail))

--- a/test/typecheck/pass/Replicate/v2.expect
+++ b/test/typecheck/pass/Replicate/v2.expect
@@ -8,4 +8,4 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
 [96mpass/Replicate/v2.sail[0m:13.4-30:
 13[96m |[0m    replicate_bits(x, 'N / 'M)
   [91m |[0m    [91m^------------------------^[0m
-  [91m |[0m Failed to prove constraint: ('M * 'ex249#) == 'N
+  [91m |[0m Failed to prove constraint: ('M * 'ex248#) == 'N

--- a/test/typecheck/pass/bool_constraint/v1.expect
+++ b/test/typecheck/pass/bool_constraint/v1.expect
@@ -9,13 +9,13 @@ All external bindings should be marked as either pure or impure
 12[96m |[0m  if b then n else 4
   [91m |[0m                   [91m^[0m
   [91m |[0m int(4) is not a subtype of {('m : Int), (('b & 'm == 'n) | (not('b) & 'm == 3)). int('m)}
-  [91m |[0m as (('b & 'ex240 == 'n) | (not('b) & 'ex240 == 3)) could not be proven
+  [91m |[0m as (('b & 'ex239 == 'n) | (not('b) & 'ex239 == 3)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex240:
+  [91m |[0m type variable 'ex239:
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:9.25-73:
   [91m |[0m 9[96m |[0m  (bool('b), int('n)) -> {'m, 'b & 'm == 'n | not('b) & 'm == 3. int('m)}
   [91m |[0m  [92m |[0m                         [92m^----------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:12.19-20:
   [91m |[0m 12[96m |[0m  if b then n else 4
   [91m |[0m   [93m |[0m                   [93m^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 4 == 'ex240
+  [91m |[0m   [93m |[0m has constraint: 4 == 'ex239

--- a/test/typecheck/pass/ex_vector_infer.sail
+++ b/test/typecheck/pass/ex_vector_infer.sail
@@ -1,0 +1,17 @@
+default Order dec
+
+$include <prelude.sail>
+
+register R : bool
+
+register X : bits(32)
+
+val test : unit -> {'n 'm, 'n > 1 & 'n == 'm. vector('n, bits('m))}
+
+function test() = {
+  if R then {
+    [0b00, 0b11]
+  } else {
+    [match X { _ => 0b000 }, 0b001, 0b100]
+  }
+}

--- a/test/typecheck/pass/ex_vector_infer/v1.expect
+++ b/test/typecheck/pass/ex_vector_infer/v1.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/ex_vector_infer/v1.sail[0m:13.4-9:
+13[96m |[0m    [0b1]
+  [91m |[0m    [91m^---^[0m
+  [91m |[0m This vector literal does not satisfy the constraint in {('n : Int) ('m : Int), ('n > 1 & 'n == 'm). vector('n, bitvector('m))}

--- a/test/typecheck/pass/ex_vector_infer/v1.sail
+++ b/test/typecheck/pass/ex_vector_infer/v1.sail
@@ -1,0 +1,17 @@
+default Order dec
+
+$include <prelude.sail>
+
+register R : bool
+
+register X : bits(32)
+
+val test : unit -> {'n 'm, 'n > 1 & 'n == 'm. vector('n, bits('m))}
+
+function test() = {
+  if R then {
+    [0b1]
+  } else {
+    [match X { _ => 0b000 }, 0b001, 0b100]
+  }
+}

--- a/test/typecheck/pass/ex_vector_infer/v2.expect
+++ b/test/typecheck/pass/ex_vector_infer/v2.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/ex_vector_infer/v2.sail[0m:13.11-16:
+13[96m |[0m    [0b00, 0b111]
+  [91m |[0m           [91m^---^[0m
+  [91m |[0m Failed to prove constraint: 3 == 2

--- a/test/typecheck/pass/ex_vector_infer/v2.sail
+++ b/test/typecheck/pass/ex_vector_infer/v2.sail
@@ -1,0 +1,17 @@
+default Order dec
+
+$include <prelude.sail>
+
+register R : bool
+
+register X : bits(32)
+
+val test : unit -> {'n 'm, 'n > 1 & 'n == 'm. vector('n, bits('m))}
+
+function test() = {
+  if R then {
+    [0b00, 0b111]
+  } else {
+    [match X { _ => 0b000 }, 0b001, 0b100]
+  }
+}

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -9,4 +9,4 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 26[96m |[0m  Some(Ctor1(a, x, c))
   [91m |[0m       [91m^------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
-  [91m |[0m [94m*[0m 'ex335# in {32, 64}
+  [91m |[0m [94m*[0m 'ex334# in {32, 64}

--- a/test/typecheck/pass/existential_ast3/v1.expect
+++ b/test/typecheck/pass/existential_ast3/v1.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v1.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(33), int('ex289)) is not a subtype of (int('ex284), int('ex285))
+  [91m |[0m (int(33), int('ex288)) is not a subtype of (int('ex283), int('ex284))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex284:
+  [91m |[0m type variable 'ex283:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex285:
+  [91m |[0m type variable 'ex284:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex289:
+  [91m |[0m type variable 'ex288:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v2.expect
+++ b/test/typecheck/pass/existential_ast3/v2.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v2.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(31), int('ex289)) is not a subtype of (int('ex284), int('ex285))
+  [91m |[0m (int(31), int('ex288)) is not a subtype of (int('ex283), int('ex284))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex284:
+  [91m |[0m type variable 'ex283:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex285:
+  [91m |[0m type variable 'ex284:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex289:
+  [91m |[0m type variable 'ex288:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v3.expect
+++ b/test/typecheck/pass/existential_ast3/v3.expect
@@ -3,4 +3,4 @@
 25[96m |[0m    Some(Ctor(64, unsigned(0b0 @ b @ a)))
   [91m |[0m         [91m^-----------------------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor
-  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex326# & 'ex326# < 64))
+  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex325# & 'ex325# < 64))

--- a/test/typecheck/pass/existential_ast3/v4.expect
+++ b/test/typecheck/pass/existential_ast3/v4.expect
@@ -3,13 +3,13 @@
 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m                  [91m^^[0m
   [91m |[0m int(64) is not a subtype of {('d : Int), (('is_64 & 'd == 63) | (not('is_64) & 'd == 32)). int('d)}
-  [91m |[0m as (('is_64 & 'ex342 == 63) | (not('is_64) & 'ex342 == 32)) could not be proven
+  [91m |[0m as (('is_64 & 'ex341 == 63) | (not('is_64) & 'ex341 == 32)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex342:
+  [91m |[0m type variable 'ex341:
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:35.18-79:
   [91m |[0m 35[96m |[0m  let 'datasize : {'d, ('is_64 & 'd == 63) | (not('is_64) & 'd == 32). int('d)} =
   [91m |[0m   [92m |[0m                  [92m^-----------------------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:36.18-20:
   [91m |[0m 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m   [93m |[0m                  [93m^^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 64 == 'ex342
+  [91m |[0m   [93m |[0m has constraint: 64 == 'ex341

--- a/test/typecheck/pass/existential_ast3/v5.expect
+++ b/test/typecheck/pass/existential_ast3/v5.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m                                                  [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 2))
-  [91m |[0m as (0 <= 'ex350 & 'ex350 <= ('datasize - 2)) could not be proven
+  [91m |[0m as (0 <= 'ex349 & 'ex349 <= ('datasize - 2)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex350:
+  [91m |[0m type variable 'ex349:
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.50-65:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [93m |[0m                                                  [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex350 & 'ex350 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex349 & 'ex349 <= 63)

--- a/test/typecheck/pass/existential_ast3/v6.expect
+++ b/test/typecheck/pass/existential_ast3/v6.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m                                                                       [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 1))
-  [91m |[0m as (0 <= 'ex356 & 'ex356 <= ('datasize - 1)) could not be proven
+  [91m |[0m as (0 <= 'ex355 & 'ex355 <= ('datasize - 1)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex356:
+  [91m |[0m type variable 'ex355:
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.71-86:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [93m |[0m                                                                       [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex356 & 'ex356 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex355 & 'ex355 <= 63)

--- a/test/typecheck/pass/if_infer/v1.expect
+++ b/test/typecheck/pass/if_infer/v1.expect
@@ -3,7 +3,7 @@
 10[96m |[0m  let _ = 0b100[if R then 0 else f()];
   [91m |[0m          [91m^-------------------------^[0m
   [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m [94m*[0m (0 <= 'ex241# & 'ex241# < 3)
+  [91m |[0m [94m*[0m (0 <= 'ex240# & 'ex240# < 3)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v1.sail[0m:10.10-37:
   [91m |[0m 10[96m |[0m  let _ = 0b100[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v2.expect
+++ b/test/typecheck/pass/if_infer/v2.expect
@@ -3,7 +3,7 @@
 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
   [91m |[0m          [91m^--------------------------^[0m
   [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m [94m*[0m (0 <= 'ex241# & 'ex241# < 4)
+  [91m |[0m [94m*[0m (0 <= 'ex240# & 'ex240# < 4)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v2.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/reg_32_64/v3.expect
+++ b/test/typecheck/pass/reg_32_64/v3.expect
@@ -17,5 +17,5 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m [94m*[0m sub_int
   [91m |[0m   [96mpass/reg_32_64/v3.sail[0m:29.15-17:
   [91m |[0m   29[96m |[0m  reg_deref(R)['d - 1 .. 0]
-  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex174#)[0m
+  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex173#)[0m
   [91m |[0m     [91m |[0m Cannot re-write sizeof('d)


### PR DESCRIPTION
Mostly this improves typechecking in situations like the following, where we are returning a bitvector with some length that satisfies a property. In the example below, we are returning a vector of length `'n` containing bitvectors of length `'m`, where `'n == 'm` and `'n > 1`. Sail can now type-check this without any annotations.

```
register R : bool

register X : bits(32)

val test : unit -> {'n 'm, 'n > 1 & 'n == 'm. vector('n, bits('m))}

function test() = {
  if R then {
    [0b00, 0b11]
  } else {
    [match X { _ => 0b000 }, 0b001, 0b100]
  }
}
```

Previously one would need a lot of annotations to convince Sail that this was ok, one on each vector literal.

Note that we don't rely on inferring the first element (any element can be inferred), as can be seen in the second literal with the match.