### PR TITLE
Fix sail fmt's handling of comments

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -152,9 +152,9 @@ let add_chunk q chunk = Queue.add chunk q
 
 [@@@coverage off]
 let rec prerr_chunk indent = function
-  | Comment (comment_type, n, col, contents, tralling) ->
+  | Comment (comment_type, n, col, contents, trailing) ->
       let s, e = comment_type_delimiters comment_type in
-      Printf.eprintf "%sComment: blank=%d col=%d tralling=%b %s%s%s\n" indent n col tralling s contents e
+      Printf.eprintf "%sComment: blank=%d col=%d trailing=%b %s%s%s\n" indent n col trailing s contents e
   | Spacer (line, w) -> Printf.eprintf "%sSpacer:%b %d\n" indent line w
   | Atom str -> Printf.eprintf "%sAtom:%s\n" indent str
   | String_literal str -> Printf.eprintf "%sString_literal:%s\n" indent str
@@ -444,7 +444,7 @@ let rec pop_comments_until_loc_end comments chunks l =
   | None -> ()
   | Some (Lexer.Comment (comment_type, comment_s, comment_e, contents)) -> begin
       match Reporting.simp_loc l with
-      | Some (_, e) when comment_s.pos_cnum <= e.pos_cnum ->
+      | Some (_, e) when comment_s.pos_cnum < e.pos_cnum ->
           let _ = Stack.pop comments in
           Queue.add
             (Comment

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -87,7 +87,7 @@ val comment_type_delimiters : Lexer.comment_type -> string * string
 type infix_chunk = Infix_prefix of string | Infix_op of string | Infix_chunks of chunks
 
 and chunk =
-  | Comment of Lexer.comment_type * int * int * string
+  | Comment of Lexer.comment_type * int * int * string * bool
   | Spacer of bool * int
   | Function of {
       id : Parse_ast.id;

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -77,7 +77,7 @@ let rec map_last f = function
       let x = f false x in
       x :: map_last f xs
 
-let line_comment_opt = function Comment (Lexer.Comment_line, _, _, contents, _tralling) -> Some contents | _ -> None
+let line_comment_opt = function Comment (Lexer.Comment_line, _, _, contents, _trailing) -> Some contents | _ -> None
 
 (* Remove additional (> 1) trailing newlines at the end of a string *)
 let discard_extra_trailing_newlines s =
@@ -707,10 +707,10 @@ module Make (Config : CONFIG) = struct
             match (chunk, Queue.peek_opt chunks) with
             | Comment _, _ -> !doc_acc
             | Spacer _, _ -> !doc_acc
-            | _, Some (Comment (_, _, _, _, tralling)) ->
+            | _, Some (Comment (_, _, _, _, trailing)) ->
                 doc_acc := !doc_acc ^^ terminator;
-                (* if current is not a Comment or Spacer, and next is not tralling, then insert a hardline *)
-                if not tralling then doc_acc := !doc_acc ^^ hardline;
+                (* if current is not a Comment or Spacer, and next is not trailing, then insert a hardline *)
+                if not trailing then doc_acc := !doc_acc ^^ hardline;
                 doc_acc := !doc_acc ^^ doc_chunk opts (Queue.pop chunks);
                 if Queue.peek_opt chunks = None then requires_hardline := true;
                 !doc_acc

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -46,8 +46,6 @@ function b () -> int = {
         }// comment
     };
 
-    };
-
     1
     // comment
 }

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -1,0 +1,70 @@
+function a () -> int = {
+    *R = baz; // comment
+       // comment
+     1// comment
+    // comment
+   // comment
+                                /* com-
+                                ment */
+ }
+
+        // comment
+
+function b () -> int = {
+    let a = {
+        1;
+        // comment
+    };
+
+    let b = {
+        1;// comment
+    };
+
+    let c = {
+        1;// comment
+        // comment
+    };
+
+    let d = {
+        1;// comment
+        // comment
+    };// comment
+
+    let f = {
+        let g1 = {
+            1// comment
+        };
+
+        let g2 = {
+            1
+            // comment
+        };
+
+        let g3 = {
+            1// comment
+          // comment
+        }// comment
+    };
+
+    };
+
+    1
+    // comment
+}
+
+let c=1
+// comment
+let c2=1// comment
+
+
+let  d   ={
+        1
+    // comment
+     }// comment
+
+// comment
+
+// comment
+
+
+// comment

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -1,0 +1,81 @@
+function a () -> int = {
+    *R = baz; // comment
+
+    // comment
+    1 // comment
+    // comment
+    // comment
+    /* com-
+    ment */
+}
+
+// comment
+function b () -> int = {
+    let a = {
+        1
+        // comment
+    };
+
+    let b = {
+        1 // comment
+    };
+
+    let c = {
+        1 // comment
+        // comment
+    };
+
+    let d = {
+        1 // comment
+        // comment
+    }; // comment
+
+    let f = {
+        let g1 = {
+            1 // comment
+        };
+
+        let g2 = {
+            1
+            // comment
+        };
+
+        let g3 = {
+            1
+            // comment
+            // comment
+        }
+    };
+
+    1
+    // comment
+}
+
+let c = 1
+
+// comment
+let c2 =
+    1 // comment
+let d =
+    {
+        1
+        // comment
+    }
+
+// comment
+// comment
+// comment
+function block_return_with_tralling_space () -> int = {
+    1 // comment
+    // comment
+}
+
+function block_return_without_tralling_space () -> int = {
+    1
+    // comment
+}
+
+// comment
+// comment
+// comment
+// comment

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -41,10 +41,9 @@ function b () -> int = {
         };
 
         let g3 = {
-            1
+            1 // comment
             // comment
-            // comment
-        }
+        } // comment
     };
 
     1
@@ -60,22 +59,7 @@ let d =
     {
         1
         // comment
-    }
-
-// comment
-// comment
-// comment
-function block_return_with_tralling_space () -> int = {
-    1 // comment
-    // comment
-}
-
-function block_return_without_tralling_space () -> int = {
-    1
-    // comment
-}
-
-// comment
+    } // comment
 // comment
 // comment
 // comment


### PR DESCRIPTION
This PR aims to fix? a comment problem.

## Problem:

1. comments 
	- in a block after return
		```sail
		function a () -> int = {
			let a = {
				1
				// here!
			}
			1
			// and here!
		}
		```
	
	- in the end of file
	
		```sail
		...
		
		// here!
		```

	will be deleted after fmt

2. I can't represents it specifly, `// ddd - // eee` were formatted to the wrong place.
	
	test_source:

	```sail
	function a () -> int = {
	     1//aaa
	     //bbb
	   //ccc
	
	                                /* ddd */
	
	 }
	
	// eee
	
	function b () -> int = {
	    let a = {
	         1
	         // fff
	     };
	   1 
	}
	
	let c = 1
	
	// ggg1
	// ggg2
	
	// ggg3
	
	```
	
	results:

	```txt
	function a () -> int = {
	    1 //aaa
	}
	
	//bbb
	//ccc
	/* ddd */
	// eee
	function b () -> int = {
	    let a = {
	        1
	    };
	
	    // fff
	    1
	}
	
	let c = 1
	
	```
## solution

I think it's better to keep comments, it's more user friendly, after all fmt shouldn't be able to just delete what the user writes.


## results

test_source is the same as problem2

results: 

```sail
function a () -> int = {
    1 //aaa
    //bbb
    //ccc
    /* ddd */
}

// eee
function b () -> int = {
    let a = {
        1 // fff
    };
    1
}

let c = 1

// ggg1
// ggg2
// ggg3

```

## changelog

- new function: `pop_comments_until_loc_end`
	- this will pop comments like problem 1 describes
	- used in the end of E_block parsing
- pop remaining comments after chunk_defs done