### PR TITLE
Add a better error message for a bitfield with a bits field

### DIFF
--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4799,6 +4799,16 @@ let rec check_typedef : Env.t -> def_annot -> uannot type_def -> tannot def list
                 let ranges =
                   List.map (fun (f, r) -> (f, expand_range_synonyms r)) ranges |> List.to_seq |> Bindings.of_seq
                 in
+                (* This would cause us to fail later, but with a potentially confusing error message *)
+                Bindings.iter
+                  (fun f _ ->
+                    if Id.compare f (mk_id "bits") = 0 then
+                      typ_error (id_loc f)
+                        "Field with name 'bits' found in bitfield definition.\n\n\
+                         This is used as the default name for all the bits in the bitfield, so should not be \
+                         overridden."
+                  )
+                  ranges;
                 let def_annot = add_def_attribute l "bitfield" (Some (AD_aux (AD_num size, l))) def_annot in
                 let defs =
                   DEF_aux (DEF_type (TD_aux (record_tdef, (l, empty_uannot))), def_annot)

--- a/test/typecheck/fail/bitfield_bits_field.expect
+++ b/test/typecheck/fail/bitfield_bits_field.expect
@@ -1,0 +1,7 @@
+[93mType error[0m:
+[96mfail/bitfield_bits_field.sail[0m:6.2-6:
+6[96m |[0m  bits : 15 .. 0,
+ [91m |[0m  [91m^--^[0m
+ [91m |[0m Field with name 'bits' found in bitfield definition.
+ [91m |[0m 
+ [91m |[0m This is used as the default name for all the bits in the bitfield, so should not be overridden.

--- a/test/typecheck/fail/bitfield_bits_field.sail
+++ b/test/typecheck/fail/bitfield_bits_field.sail
@@ -1,0 +1,7 @@
+default Order dec
+
+$include <prelude.sail>
+
+bitfield foo : bits(32) = {
+  bits : 15 .. 0,
+}


### PR DESCRIPTION
'bits' is used as the default name for all the bits in a bitfield, and this would create an error if the user tried to define it as a user-specified field. However this generated a confusing error message, as the failure happened when generating the various helper functions.

This commit checks for this earlier and prints a better error.