### PR TITLE
Add type environment annotations to top level definitions

### DIFF
--- a/language/jib.ott
+++ b/language/jib.ott
@@ -249,6 +249,8 @@ instr :: 'I_' ::=
 
 def_annot :: '' ::=
   {{ phantom }}
+  {{ lem def_annot unit }}
+  {{ ocaml unit def_annot }}
 
 cdef :: 'CDEF_' ::=
   {{ aux _ def_annot }}

--- a/language/sail.ott
+++ b/language/sail.ott
@@ -87,14 +87,15 @@ type extern = { pure : bool; bindings : (string * string) list } option
 
 type visibility = Public | Private of  l
 
-type def_annot = {
+type 'a def_annot = {
     doc_comment : string option;
     attrs : (l * string * config) list;
     visibility : visibility;
-    loc : l
+    loc : l;
+    env : 'a
 }
 
-type 'a clause_annot = def_annot * 'a
+type 'a clause_annot = unit def_annot * 'a
 
 }}
 
@@ -122,14 +123,15 @@ type extern = <| pure : bool; bindings : list (string * string) |>
 
 type visibility = Public | Private of l
 
-type def_annot = <|
+type def_annot 'a = <|
     doc_comment : maybe string;
     attrs : list (l * string * maybe attribute_data);
     visibility : visibility;
-    loc : l
+    loc : l;
+    env : 'a
 |>
 
-type clause_annot 'a = def_annot * 'a
+type clause_annot 'a = def_annot unit * 'a
 
 }}
 
@@ -176,13 +178,18 @@ external :: '' ::=
 
 def_annot :: '' ::=
   {{ phantom }}
-  {{ lem def_annot }}
-  {{ ocaml def_annot }}
+  {{ lem def_annot 'b }}
+  {{ ocaml 'b def_annot }}
 
 clause_annot :: '' ::=
   {{ phantom }}
   {{ lem clause_annot 'a }}
   {{ ocaml 'a clause_annot }}
+
+union_annot :: '' ::=
+  {{ phantom }}
+  {{ lem def_annot unit }}
+  {{ ocaml unit def_annot }}
 
 l :: '' ::=
   {{ phantom }}
@@ -337,7 +344,7 @@ type_def_aux  :: 'TD_' ::=
 
 type_union :: 'Tu_' ::=
   {{ com type union constructors }}
-  {{ aux _ def_annot }}
+  {{ aux _ union_annot }}
   | typ id                                              :: :: ty_id
 
 index_range :: 'BF_' ::= {{ com index specification, for bitfields in register types}}
@@ -770,7 +777,7 @@ loop_measure :: '' ::=
 
 def :: 'DEF_' ::=
   {{ com top-level definition }}
-  {{ aux _ def_annot }} {{ auxparam 'a }}
+  {{ aux _ def_annot }} {{ auxparam 'a 'b }}
   | type_def                                           :: :: type
     {{ com type definition }}
   | constraint n_constraint                            :: :: constraint

--- a/src/bin/repl.ml
+++ b/src/bin/repl.ml
@@ -78,7 +78,7 @@ module Callgraph_commands = Callgraph_commands
 type mode = Evaluation of frame | Normal
 
 type istate = {
-  ast : (Type_check.tannot, Type_check.env) ast;
+  ast : Type_check.typed_ast;
   effect_info : Effects.side_effect_info;
   env : Type_check.Env.t;
   ref_state : Interactive.istate ref;

--- a/src/bin/repl.ml
+++ b/src/bin/repl.ml
@@ -78,7 +78,7 @@ module Callgraph_commands = Callgraph_commands
 type mode = Evaluation of frame | Normal
 
 type istate = {
-  ast : Type_check.tannot ast;
+  ast : (Type_check.tannot, Type_check.env) ast;
   effect_info : Effects.side_effect_info;
   env : Type_check.Env.t;
   ref_state : Interactive.istate ref;
@@ -537,7 +537,7 @@ let handle_input' istate input =
                 | v :: "=" :: args ->
                     let exp = Initial_check.exp_of_string (String.concat " " args) in
                     let defs, env =
-                      Type_check.check_defs istate.env [mk_def (DEF_let (mk_letbind (mk_pat (P_id (mk_id v))) exp))]
+                      Type_check.check_defs istate.env [mk_def (DEF_let (mk_letbind (mk_pat (P_id (mk_id v))) exp)) ()]
                     in
                     { istate with ast = append_ast_defs istate.ast defs; env }
                 | _ -> failwith "Invalid arguments for :let"

--- a/src/bin/repl.mli
+++ b/src/bin/repl.mli
@@ -87,5 +87,5 @@ val start_repl :
   options:(Arg.key * Arg.spec * Arg.doc) list ->
   Env.t ->
   Effects.side_effect_info ->
-  tannot ast ->
+  (tannot, env) ast ->
   unit

--- a/src/bin/repl.mli
+++ b/src/bin/repl.mli
@@ -87,5 +87,5 @@ val start_repl :
   options:(Arg.key * Arg.spec * Arg.doc) list ->
   Env.t ->
   Effects.side_effect_info ->
-  (tannot, env) ast ->
+  typed_ast ->
   unit

--- a/src/lib/ast_defs.ml
+++ b/src/lib/ast_defs.ml
@@ -67,6 +67,6 @@
 
 open Ast
 
-type 'a ast = { defs : 'a def list; comments : (string * Lexer.comment list) list }
+type ('a, 'b) ast = { defs : ('a, 'b) def list; comments : (string * Lexer.comment list) list }
 
 let empty_ast = { defs = []; comments = [] }

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -74,6 +74,9 @@ module Big_int = Nat_big_num
 (* The type of annotations for untyped AST nodes *)
 type uannot = { attrs : (l * string * attribute_data option) list }
 
+type untyped_def = (uannot, unit) def
+type untyped_ast = (uannot, unit) ast
+
 let rec string_of_attribute_data (AD_aux (aux, _)) =
   match aux with
   | AD_object kvs ->

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -115,15 +115,17 @@ val get_attributes : uannot -> (l * string * attribute_data option) list
 val find_attribute_opt : string -> (l * string * attribute_data option) list -> attribute_data option option
 
 val mk_def_annot :
-  ?doc:string -> ?attrs:(l * string * attribute_data option) list -> ?visibility:visibility -> l -> def_annot
+  ?doc:string -> ?attrs:(l * string * attribute_data option) list -> ?visibility:visibility -> l -> 'a -> 'a def_annot
 
-val add_def_attribute : l -> string -> attribute_data option -> def_annot -> def_annot
+val add_def_attribute : l -> string -> attribute_data option -> 'a def_annot -> 'a def_annot
 
-val get_def_attribute : string -> def_annot -> (l * attribute_data option) option
+val get_def_attribute : string -> 'a def_annot -> (l * attribute_data option) option
 
-val remove_def_attribute : string -> def_annot -> def_annot
+val remove_def_attribute : string -> 'a def_annot -> 'a def_annot
 
-val def_annot_map_loc : (l -> l) -> def_annot -> def_annot
+val def_annot_map_loc : (l -> l) -> 'a def_annot -> 'a def_annot
+
+val def_annot_map_env : ('a -> 'b) -> 'a def_annot -> 'b def_annot
 
 (** The empty annotation (as a location + uannot pair). Should be used
    carefully because it can result in unhelpful error messgaes. However
@@ -183,8 +185,8 @@ val mk_lit : lit_aux -> lit
 val mk_lit_exp : ?loc:l -> lit_aux -> uannot exp
 val mk_typ_pat : typ_pat_aux -> typ_pat
 val mk_funcl : ?loc:l -> id -> uannot pat -> uannot exp -> uannot funcl
-val mk_fundef : uannot funcl list -> uannot def
-val mk_val_spec : val_spec_aux -> uannot def
+val mk_fundef : uannot funcl list -> (uannot, unit) def
+val mk_val_spec : val_spec_aux -> (uannot, unit) def
 val mk_typschm : typquant -> typ -> typschm
 val mk_empty_typquant : loc:l -> typquant
 val mk_typquant : quant_item list -> typquant
@@ -194,7 +196,7 @@ val mk_qi_kopt : kinded_id -> quant_item
 val mk_fexp : id -> uannot exp -> uannot fexp
 val mk_letbind : uannot pat -> uannot exp -> uannot letbind
 val mk_kopt : ?loc:l -> kind_aux -> kid -> kinded_id
-val mk_def : ?loc:l -> 'a def_aux -> 'a def
+val mk_def : ?loc:l -> ('a, 'b) def_aux -> 'b -> ('a, 'b) def
 
 (** Mapping patterns are a subset of patterns, so we can always convert one to the other *)
 val pat_of_mpat : 'a mpat -> 'a pat
@@ -445,8 +447,9 @@ val map_valspec_annot : ('a annot -> 'b annot) -> 'a val_spec -> 'b val_spec
 val map_register_annot : ('a annot -> 'b annot) -> 'a dec_spec -> 'b dec_spec
 val map_scattered_annot : ('a annot -> 'b annot) -> 'a scattered_def -> 'b scattered_def
 
-val map_def_annot : ('a annot -> 'b annot) -> 'a def -> 'b def
-val map_ast_annot : ('a annot -> 'b annot) -> 'a ast -> 'b ast
+val map_def_annot : ('a annot -> 'b annot) -> ('a, 'c) def -> ('b, 'c) def
+val map_def_def_annot : ('a def_annot -> 'b def_annot) -> ('c, 'a) def -> ('c, 'b) def
+val map_ast_annot : ('a annot -> 'b annot) -> ('a, 'c) ast -> ('b, 'c) ast
 
 (** {1 Extract locations from terms} *)
 val id_loc : id -> Parse_ast.l
@@ -458,7 +461,7 @@ val pat_loc : 'a pat -> Parse_ast.l
 val mpat_loc : 'a mpat -> Parse_ast.l
 val exp_loc : 'a exp -> Parse_ast.l
 val nexp_loc : nexp -> Parse_ast.l
-val def_loc : 'a def -> Parse_ast.l
+val def_loc : ('a, 'b) def -> Parse_ast.l
 
 (** {1 Printing utilities}
 
@@ -542,31 +545,32 @@ val construct_pexp : 'a pat * 'a exp option * 'a exp * (Ast.l * 'a) -> 'a pexp
 val destruct_mpexp : 'a mpexp -> 'a mpat * 'a exp option * (Ast.l * 'a)
 val construct_mpexp : 'a mpat * 'a exp option * (Ast.l * 'a) -> 'a mpexp
 
-val is_valspec : id -> 'a def -> bool
-val is_fundef : id -> 'a def -> bool
+val is_valspec : id -> ('a, 'b) def -> bool
+val is_fundef : id -> ('a, 'b) def -> bool
 
 val rename_valspec : id -> 'a val_spec -> 'a val_spec
 
 val rename_fundef : id -> 'a fundef -> 'a fundef
 
-val split_defs : ('a def -> bool) -> 'a def list -> ('a def list * 'a def * 'a def list) option
+val split_defs :
+  (('a, 'b) def -> bool) -> ('a, 'b) def list -> (('a, 'b) def list * ('a, 'b) def * ('a, 'b) def list) option
 
-val append_ast : 'a ast -> 'a ast -> 'a ast
-val append_ast_defs : 'a ast -> 'a def list -> 'a ast
-val concat_ast : 'a ast list -> 'a ast
+val append_ast : ('a, 'b) ast -> ('a, 'b) ast -> ('a, 'b) ast
+val append_ast_defs : ('a, 'b) ast -> ('a, 'b) def list -> ('a, 'b) ast
+val concat_ast : ('a, 'b) ast list -> ('a, 'b) ast
 
 val type_union_id : type_union -> id
 
-val ids_of_def : 'a def -> IdSet.t
-val ids_of_defs : 'a def list -> IdSet.t
-val ids_of_ast : 'a ast -> IdSet.t
+val ids_of_def : ('a, 'b) def -> IdSet.t
+val ids_of_defs : ('a, 'b) def list -> IdSet.t
+val ids_of_ast : ('a, 'b) ast -> IdSet.t
 
-val val_spec_ids : 'a def list -> IdSet.t
+val val_spec_ids : ('a, 'b) def list -> IdSet.t
 
-val record_ids : 'a def list -> IdSet.t
+val record_ids : ('a, 'b) def list -> IdSet.t
 
-val get_scattered_union_clauses : id -> 'a def list -> type_union list
-val get_scattered_enum_clauses : id -> 'a def list -> id list
+val get_scattered_union_clauses : id -> ('a, 'b) def list -> type_union list
+val get_scattered_enum_clauses : id -> ('a, 'b) def list -> id list
 
 val pat_ids : 'a pat -> IdSet.t
 
@@ -603,7 +607,7 @@ val extern_assoc : string -> extern option -> string option
    the closest annotation or even finding an annotation at all. This
    is used by the Emacs mode to provide type-at-cursor functionality
    and we don't mind if it's a bit fuzzy in that context. *)
-val find_annot_ast : (Lexing.position * Lexing.position) option -> 'a ast -> (Ast.l * 'a) option
+val find_annot_ast : (Lexing.position * Lexing.position) option -> ('a, 'b) ast -> (Ast.l * 'a) option
 
 (** {1 Substitutions}
 

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -78,6 +78,11 @@ module Big_int = Nat_big_num
    annotations {!Type_check.tannot}. *)
 type uannot
 
+(** Aliases for an untyped definitions and full AST for readability *)
+type untyped_def = (uannot, unit) def
+
+type untyped_ast = (uannot, unit) ast
+
 (** The empty annotation *)
 val empty_uannot : uannot
 
@@ -185,8 +190,8 @@ val mk_lit : lit_aux -> lit
 val mk_lit_exp : ?loc:l -> lit_aux -> uannot exp
 val mk_typ_pat : typ_pat_aux -> typ_pat
 val mk_funcl : ?loc:l -> id -> uannot pat -> uannot exp -> uannot funcl
-val mk_fundef : uannot funcl list -> (uannot, unit) def
-val mk_val_spec : val_spec_aux -> (uannot, unit) def
+val mk_fundef : uannot funcl list -> untyped_def
+val mk_val_spec : val_spec_aux -> untyped_def
 val mk_typschm : typquant -> typ -> typschm
 val mk_empty_typquant : loc:l -> typquant
 val mk_typquant : quant_item list -> typquant

--- a/src/lib/bitfield.mli
+++ b/src/lib/bitfield.mli
@@ -94,4 +94,4 @@ val field_accessor_ids : id -> id -> field_accessor_ids
 (** Bitfields work a bit like a macro, which generate a struct wrapper
    around a simple bitvector type, along with a host of accessor
    functions. *)
-val macro : id -> Big_int.num -> order -> index_range Bindings.t -> (uannot, unit) def list
+val macro : id -> Big_int.num -> order -> index_range Bindings.t -> untyped_def list

--- a/src/lib/bitfield.mli
+++ b/src/lib/bitfield.mli
@@ -94,4 +94,4 @@ val field_accessor_ids : id -> id -> field_accessor_ids
 (** Bitfields work a bit like a macro, which generate a struct wrapper
    around a simple bitvector type, along with a host of accessor
    functions. *)
-val macro : id -> Big_int.num -> order -> index_range Bindings.t -> uannot def list
+val macro : id -> Big_int.num -> order -> index_range Bindings.t -> (uannot, unit) def list

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -540,9 +540,11 @@ let top_sort_defs ast =
           in
           let fundefs = List.map get_fundefs cdefs |> List.concat in
           let other_defs = List.filter (fun d -> get_fundefs d = []) cdefs in
-          if List.length fundefs > 1 then
+          if List.length fundefs > 1 then (
+            let env = Util.last cdefs |> function DEF_aux (_, da) -> da.env in
             (* Mutrec definition, then others (including val-specs); will be reversed later *)
-            mk_def (DEF_internal_mutrec fundefs) :: other_defs
+            mk_def (DEF_internal_mutrec fundefs) env :: other_defs
+          )
           else cdefs
         in
         reorder already_seen' (cdefs' @ acc) (components, defs)

--- a/src/lib/callgraph.mli
+++ b/src/lib/callgraph.mli
@@ -104,14 +104,15 @@ end
 
 type callgraph = G.graph
 
-val graph_of_ast : Type_check.tannot ast -> callgraph
+val graph_of_ast : (Type_check.tannot, Type_check.env) ast -> callgraph
 
-val nodes_of_def : 'a def -> NodeSet.t
+val nodes_of_def : ('a, 'b) def -> NodeSet.t
 
-val filter_ast_ids : IdSet.t -> IdSet.t -> Type_check.tannot ast -> Type_check.tannot ast
+val filter_ast_ids :
+  IdSet.t -> IdSet.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
-val filter_ast : Set.Make(Node).t -> callgraph -> 'a ast -> 'a ast
+val filter_ast : Set.Make(Node).t -> callgraph -> ('a, 'b) ast -> ('a, 'b) ast
 
-val filter_ast_extra : Set.Make(Node).t -> callgraph -> 'a ast -> bool -> 'a ast
+val filter_ast_extra : Set.Make(Node).t -> callgraph -> ('a, 'b) ast -> bool -> ('a, 'b) ast
 
-val top_sort_defs : Type_check.tannot ast -> Type_check.tannot ast
+val top_sort_defs : (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast

--- a/src/lib/callgraph.mli
+++ b/src/lib/callgraph.mli
@@ -104,15 +104,14 @@ end
 
 type callgraph = G.graph
 
-val graph_of_ast : (Type_check.tannot, Type_check.env) ast -> callgraph
+val graph_of_ast : Type_check.typed_ast -> callgraph
 
 val nodes_of_def : ('a, 'b) def -> NodeSet.t
 
-val filter_ast_ids :
-  IdSet.t -> IdSet.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val filter_ast_ids : IdSet.t -> IdSet.t -> Type_check.typed_ast -> Type_check.typed_ast
 
 val filter_ast : Set.Make(Node).t -> callgraph -> ('a, 'b) ast -> ('a, 'b) ast
 
 val filter_ast_extra : Set.Make(Node).t -> callgraph -> ('a, 'b) ast -> bool -> ('a, 'b) ast
 
-val top_sort_defs : (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val top_sort_defs : Type_check.typed_ast -> Type_check.typed_ast

--- a/src/lib/constant_propagation.mli
+++ b/src/lib/constant_propagation.mli
@@ -78,7 +78,7 @@ open Type_check
 
 val const_prop :
   string ->
-  (tannot, env) ast ->
+  typed_ast ->
   IdSet.t ->
   tannot exp Bindings.t * nexp KBindings.t ->
   tannot exp Bindings.t ->
@@ -87,4 +87,4 @@ val const_prop :
 
 val referenced_vars : tannot exp -> IdSet.t
 
-val remove_impossible_int_cases : 'a -> (tannot, env) ast -> (tannot, env) ast
+val remove_impossible_int_cases : 'a -> typed_ast -> typed_ast

--- a/src/lib/constant_propagation.mli
+++ b/src/lib/constant_propagation.mli
@@ -78,7 +78,7 @@ open Type_check
 
 val const_prop :
   string ->
-  tannot ast ->
+  (tannot, env) ast ->
   IdSet.t ->
   tannot exp Bindings.t * nexp KBindings.t ->
   tannot exp Bindings.t ->
@@ -87,4 +87,4 @@ val const_prop :
 
 val referenced_vars : tannot exp -> IdSet.t
 
-val remove_impossible_int_cases : 'a -> tannot ast -> tannot ast
+val remove_impossible_int_cases : 'a -> (tannot, env) ast -> (tannot, env) ast

--- a/src/lib/constant_propagation_mutrec.ml
+++ b/src/lib/constant_propagation_mutrec.ml
@@ -199,8 +199,8 @@ let rewrite_ast target effect_info env ({ defs; _ } as ast) =
     | [] -> List.rev acc
     | DEF_aux (DEF_internal_mutrec mutrecs, def_annot) :: ds ->
         let mutrec_ids = IdSet.of_list (List.map id_of_fundef mutrecs) in
-        let valspecs = ref ([] : (uannot, unit) def list) in
-        let fundefs = ref ([] : (uannot, unit) def list) in
+        let valspecs = ref ([] : untyped_def list) in
+        let fundefs = ref ([] : untyped_def list) in
         (* Try to replace mutually recursive calls that have some constant arguments *)
         let rec e_app (id, args) (l, annot) =
           if IdSet.mem id mutrec_ids && List.exists is_const_exp args then (

--- a/src/lib/constant_propagation_mutrec.ml
+++ b/src/lib/constant_propagation_mutrec.ml
@@ -199,8 +199,8 @@ let rewrite_ast target effect_info env ({ defs; _ } as ast) =
     | [] -> List.rev acc
     | DEF_aux (DEF_internal_mutrec mutrecs, def_annot) :: ds ->
         let mutrec_ids = IdSet.of_list (List.map id_of_fundef mutrecs) in
-        let valspecs = ref ([] : uannot def list) in
-        let fundefs = ref ([] : uannot def list) in
+        let valspecs = ref ([] : (uannot, unit) def list) in
+        let fundefs = ref ([] : (uannot, unit) def list) in
         (* Try to replace mutually recursive calls that have some constant arguments *)
         let rec e_app (id, args) (l, annot) =
           if IdSet.mem id mutrec_ids && List.exists is_const_exp args then (

--- a/src/lib/effects.mli
+++ b/src/lib/effects.mli
@@ -121,12 +121,12 @@ val function_is_pure : id -> side_effect_info -> bool
    side effect information for [ast].  If [asserts_termination] is
    true then it is assumed that the backend will enforce the
    termination measures with assertions. *)
-val infer_side_effects : bool -> Type_check.tannot ast -> side_effect_info
+val infer_side_effects : bool -> (Type_check.tannot, Type_check.env) ast -> side_effect_info
 
 (** Checks constraints on side effects, raising an error if they are
    violated. Currently these are that termination measures and
    top-level letbindings must be pure. *)
-val check_side_effects : side_effect_info -> Type_check.tannot ast -> unit
+val check_side_effects : side_effect_info -> (Type_check.tannot, Type_check.env) ast -> unit
 
 (** [copy_function_effect id_from info id_to] copies the effect
    information from id_from to id_to in the side effect
@@ -151,7 +151,8 @@ val add_monadic_built_in : id -> side_effect_info -> side_effect_info
    attaches effect info into to the AST. Note that the effect info is
    simplified in its annotated form - it just becomes a boolean
    representing effectful/non-effectful *)
-val rewrite_attach_effects : side_effect_info -> Type_check.tannot ast -> Type_check.tannot ast
+val rewrite_attach_effects :
+  side_effect_info -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
 (** Dumps the given side effect information to stderr. *)
 val dump_effects : side_effect_info -> unit

--- a/src/lib/effects.mli
+++ b/src/lib/effects.mli
@@ -121,12 +121,12 @@ val function_is_pure : id -> side_effect_info -> bool
    side effect information for [ast].  If [asserts_termination] is
    true then it is assumed that the backend will enforce the
    termination measures with assertions. *)
-val infer_side_effects : bool -> (Type_check.tannot, Type_check.env) ast -> side_effect_info
+val infer_side_effects : bool -> Type_check.typed_ast -> side_effect_info
 
 (** Checks constraints on side effects, raising an error if they are
    violated. Currently these are that termination measures and
    top-level letbindings must be pure. *)
-val check_side_effects : side_effect_info -> (Type_check.tannot, Type_check.env) ast -> unit
+val check_side_effects : side_effect_info -> Type_check.typed_ast -> unit
 
 (** [copy_function_effect id_from info id_to] copies the effect
    information from id_from to id_to in the side effect
@@ -151,8 +151,7 @@ val add_monadic_built_in : id -> side_effect_info -> side_effect_info
    attaches effect info into to the AST. Note that the effect info is
    simplified in its annotated form - it just becomes a boolean
    representing effectful/non-effectful *)
-val rewrite_attach_effects :
-  side_effect_info -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val rewrite_attach_effects : side_effect_info -> Type_check.typed_ast -> Type_check.typed_ast
 
 (** Dumps the given side effect information to stderr. *)
 val dump_effects : side_effect_info -> unit

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -75,8 +75,8 @@ let opt_ddump_tc_ast = ref false
 let opt_list_files = ref false
 let opt_reformat : string option ref = ref None
 
-let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : (uannot, unit) ast) :
-    (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info =
+let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : untyped_ast) :
+    Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info =
   let ast, env = Type_error.check env ast in
   let ast = Scattered.descatter ast in
   let side_effects = Effects.infer_side_effects asserts_termination ast in

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -75,8 +75,8 @@ let opt_ddump_tc_ast = ref false
 let opt_list_files = ref false
 let opt_reformat : string option ref = ref None
 
-let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : uannot ast) :
-    Type_check.tannot ast * Type_check.Env.t * Effects.side_effect_info =
+let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : (uannot, unit) ast) :
+    (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info =
   let ast, env = Type_error.check env ast in
   let ast = Scattered.descatter ast in
   let side_effects = Effects.infer_side_effects asserts_termination ast in

--- a/src/lib/frontend.mli
+++ b/src/lib/frontend.mli
@@ -75,9 +75,13 @@ val opt_list_files : bool ref
 val opt_reformat : string option ref
 
 val check_ast :
-  bool -> Type_check.Env.t -> uannot ast -> Type_check.tannot ast * Type_check.Env.t * Effects.side_effect_info
+  bool ->
+  Type_check.Env.t ->
+  (uannot, unit) ast ->
+  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info
 
-val instantiate_abstract_types : typ_arg Bindings.t -> Type_check.tannot ast -> Type_check.tannot ast
+val instantiate_abstract_types :
+  typ_arg Bindings.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
 val load_modules :
   ?target:Target.target ->
@@ -86,7 +90,7 @@ val load_modules :
   Type_check.Env.t ->
   Project.project_structure ->
   Project.mod_id list ->
-  Type_check.tannot ast * Type_check.Env.t * Effects.side_effect_info
+  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info
 
 val load_files :
   ?target:Target.target ->
@@ -94,7 +98,10 @@ val load_files :
   (Arg.key * Arg.spec * Arg.doc) list ->
   Type_check.Env.t ->
   string list ->
-  Type_check.tannot ast * Type_check.Env.t * Effects.side_effect_info
+  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info
 
 val initial_rewrite :
-  Effects.side_effect_info -> Type_check.Env.t -> Type_check.tannot ast -> Type_check.tannot ast * Type_check.Env.t
+  Effects.side_effect_info ->
+  Type_check.Env.t ->
+  (Type_check.tannot, Type_check.env) ast ->
+  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t

--- a/src/lib/frontend.mli
+++ b/src/lib/frontend.mli
@@ -75,13 +75,9 @@ val opt_list_files : bool ref
 val opt_reformat : string option ref
 
 val check_ast :
-  bool ->
-  Type_check.Env.t ->
-  (uannot, unit) ast ->
-  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info
+  bool -> Type_check.Env.t -> untyped_ast -> Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info
 
-val instantiate_abstract_types :
-  typ_arg Bindings.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val instantiate_abstract_types : typ_arg Bindings.t -> Type_check.typed_ast -> Type_check.typed_ast
 
 val load_modules :
   ?target:Target.target ->
@@ -90,7 +86,7 @@ val load_modules :
   Type_check.Env.t ->
   Project.project_structure ->
   Project.mod_id list ->
-  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info
+  Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info
 
 val load_files :
   ?target:Target.target ->
@@ -98,10 +94,7 @@ val load_files :
   (Arg.key * Arg.spec * Arg.doc) list ->
   Type_check.Env.t ->
   string list ->
-  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t * Effects.side_effect_info
+  Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info
 
 val initial_rewrite :
-  Effects.side_effect_info ->
-  Type_check.Env.t ->
-  (Type_check.tannot, Type_check.env) ast ->
-  (Type_check.tannot, Type_check.env) ast * Type_check.Env.t
+  Effects.side_effect_info -> Type_check.Env.t -> Type_check.typed_ast -> Type_check.typed_ast * Type_check.Env.t

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1010,7 +1010,7 @@ let to_ast_record ctx id typq fields =
   let fields = List.map (fun (atyp, id) -> (to_ast_typ typq_ctx atyp, to_ast_id ctx id)) fields in
   (id, typq, fields, add_constructor id typq ctx)
 
-let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : (uannot, unit) def list ctx_out =
+let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : untyped_def list ctx_out =
   match aux with
   | P.TD_abbrev (id, typq, kind, typ_arg) ->
       let id = to_ast_reserved_type_id ctx id in
@@ -1293,7 +1293,7 @@ let pragma_arg_loc pragma arg_left_trim l =
     )
     l
 
-let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : (uannot, unit) def list ctx_out =
+let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : untyped_def list ctx_out =
   let annot = mk_def_annot ?doc ~attrs ?visibility:vis l () in
   match def with
   | P.DEF_private def -> begin

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -874,7 +874,7 @@ let rec to_ast_type_union doc attrs vis ctx = function
   | P.Tu_aux (P.Tu_attribute (attr, arg, tu), l) -> to_ast_type_union doc (attrs @ [(l, attr, arg)]) vis ctx tu
   | P.Tu_aux (P.Tu_ty_id (atyp, id), l) ->
       let typ = to_ast_typ ctx atyp in
-      Tu_aux (Tu_ty_id (typ, to_ast_id ctx id), mk_def_annot ?doc ~attrs ?visibility:vis l)
+      Tu_aux (Tu_ty_id (typ, to_ast_id ctx id), mk_def_annot ?doc ~attrs ?visibility:vis l ())
   | P.Tu_aux (_, l) ->
       raise (Reporting.err_unreachable l __POS__ "Anonymous record type should have been rewritten by now")
 
@@ -1010,7 +1010,7 @@ let to_ast_record ctx id typq fields =
   let fields = List.map (fun (atyp, id) -> (to_ast_typ typq_ctx atyp, to_ast_id ctx id)) fields in
   (id, typq, fields, add_constructor id typq ctx)
 
-let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : uannot def list ctx_out =
+let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : (uannot, unit) def list ctx_out =
   match aux with
   | P.TD_abbrev (id, typq, kind, typ_arg) ->
       let id = to_ast_reserved_type_id ctx id in
@@ -1039,7 +1039,7 @@ let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : uannot d
       let generated_records, ctx =
         List.fold_left
           (fun (prev, ctx) td ->
-            let td, ctx = to_ast_typedef ctx (mk_def_annot (gen_loc l)) td in
+            let td, ctx = to_ast_typedef ctx (mk_def_annot (gen_loc l) ()) td in
             (prev @ td, ctx)
           )
           ([], ctx) generated_records
@@ -1112,7 +1112,7 @@ let rec to_ast_funcl doc attrs ctx (P.FCL_aux (fcl, l) : P.funcl) : uannot funcl
       | None -> to_ast_funcl (Some doc_comment) attrs ctx fcl
     end
   | P.FCL_funcl (id, pexp) ->
-      FCL_aux (FCL_funcl (to_ast_id ctx id, to_ast_case ctx pexp), (mk_def_annot ?doc ~attrs l, empty_uannot))
+      FCL_aux (FCL_funcl (to_ast_id ctx id, to_ast_case ctx pexp), (mk_def_annot ?doc ~attrs l (), empty_uannot))
 
 let to_ast_impl_funcls ctx (P.FCL_aux (fcl, l) : P.funcl) : uannot funcl list =
   match fcl with
@@ -1122,10 +1122,12 @@ let to_ast_impl_funcls ctx (P.FCL_aux (fcl, l) : P.funcl) : uannot funcl list =
           List.map
             (fun target ->
               FCL_aux
-                (FCL_funcl (Id_aux (Id target, parse_id_loc id), to_ast_case ctx pexp), (mk_def_annot l, empty_uannot))
+                ( FCL_funcl (Id_aux (Id target, parse_id_loc id), to_ast_case ctx pexp),
+                  (mk_def_annot l (), empty_uannot)
+                )
             )
             targets
-      | None -> [FCL_aux (FCL_funcl (to_ast_id ctx id, to_ast_case ctx pexp), (mk_def_annot l, empty_uannot))]
+      | None -> [FCL_aux (FCL_funcl (to_ast_id ctx id, to_ast_case ctx pexp), (mk_def_annot l (), empty_uannot))]
     )
   | _ -> raise (Reporting.err_general l "Attributes or documentation comment not permitted here")
 
@@ -1177,13 +1179,14 @@ let rec to_ast_mapcl doc attrs ctx (P.MCL_aux (mapcl, l)) =
       | None -> to_ast_mapcl (Some doc_comment) attrs ctx mcl
     end
   | P.MCL_bidir (mpexp1, mpexp2) ->
-      MCL_aux (MCL_bidir (to_ast_mpexp ctx mpexp1, to_ast_mpexp ctx mpexp2), (mk_def_annot ?doc ~attrs l, empty_uannot))
+      MCL_aux
+        (MCL_bidir (to_ast_mpexp ctx mpexp1, to_ast_mpexp ctx mpexp2), (mk_def_annot ?doc ~attrs l (), empty_uannot))
   | P.MCL_forwards_deprecated (mpexp, exp) ->
       let mpexp = to_ast_mpexp ctx mpexp in
       let exp = to_ast_exp ctx exp in
-      MCL_aux (MCL_forwards (pexp_of_mpexp mpexp exp), (mk_def_annot ?doc ~attrs l, empty_uannot))
-  | P.MCL_forwards pexp -> MCL_aux (MCL_forwards (to_ast_case ctx pexp), (mk_def_annot ?doc ~attrs l, empty_uannot))
-  | P.MCL_backwards pexp -> MCL_aux (MCL_backwards (to_ast_case ctx pexp), (mk_def_annot ?doc ~attrs l, empty_uannot))
+      MCL_aux (MCL_forwards (pexp_of_mpexp mpexp exp), (mk_def_annot ?doc ~attrs l (), empty_uannot))
+  | P.MCL_forwards pexp -> MCL_aux (MCL_forwards (to_ast_case ctx pexp), (mk_def_annot ?doc ~attrs l (), empty_uannot))
+  | P.MCL_backwards pexp -> MCL_aux (MCL_backwards (to_ast_case ctx pexp), (mk_def_annot ?doc ~attrs l (), empty_uannot))
 
 let to_ast_mapdef ctx (P.MD_aux (md, l) : P.mapdef) : uannot mapdef =
   match md with
@@ -1230,7 +1233,7 @@ let to_ast_scattered ctx (P.SD_aux (aux, l)) =
                         (DEF_aux
                            ( DEF_scattered
                                (SD_aux (SD_internal_unioncl_record (id, record_id, typq, fields), (l, empty_uannot))),
-                             mk_def_annot l
+                             mk_def_annot l ()
                            )
                         ),
                       scattered_ctx
@@ -1290,8 +1293,8 @@ let pragma_arg_loc pragma arg_left_trim l =
     )
     l
 
-let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : uannot def list ctx_out =
-  let annot = mk_def_annot ?doc ~attrs ?visibility:vis l in
+let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : (uannot, unit) def list ctx_out =
+  let annot = mk_def_annot ?doc ~attrs ?visibility:vis l () in
   match def with
   | P.DEF_private def -> begin
       match vis with
@@ -1412,7 +1415,9 @@ let to_ast ctx (P.Defs files) =
     (List.rev defs, ctx)
   in
   let wrap_file file defs =
-    [mk_def (DEF_pragma ("file_start", file, P.Unknown))] @ defs @ [mk_def (DEF_pragma ("file_end", file, P.Unknown))]
+    [mk_def (DEF_pragma ("file_start", file, P.Unknown)) ()]
+    @ defs
+    @ [mk_def (DEF_pragma ("file_end", file, P.Unknown)) ()]
   in
   let defs, ctx =
     List.fold_left

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -107,29 +107,29 @@ val have_undefined_builtins : bool ref
 (** Val specs of undefined functions for builtin types that get added to
     the AST if opt_undefined_gen is set (minus those functions that already
     exist in the AST). *)
-val undefined_builtin_val_specs : uannot def list
+val undefined_builtin_val_specs : (uannot, unit) def list
 
 (** {2 Desugar and process AST } *)
 
 val generate_undefined_record_context : typquant -> (id * typ) list
-val generate_undefined_record : id -> typquant -> (typ * id) list -> uannot def list
-val generate_undefined_enum : id -> id list -> uannot def list
+val generate_undefined_record : id -> typquant -> (typ * id) list -> (uannot, unit) def list
+val generate_undefined_enum : id -> id list -> (uannot, unit) def list
 
-val generate_undefineds : IdSet.t -> uannot def list -> uannot def list
-val generate_enum_functions : IdSet.t -> uannot def list -> uannot def list
+val generate_undefineds : IdSet.t -> (uannot, unit) def list -> (uannot, unit) def list
+val generate_enum_functions : IdSet.t -> (uannot, unit) def list -> (uannot, unit) def list
 
 (** If the generate flag is false, then we won't generate any
    auxilliary definitions, like the initialize_registers function *)
-val process_ast : ?generate:bool -> Parse_ast.defs -> uannot ast
+val process_ast : ?generate:bool -> Parse_ast.defs -> (uannot, unit) ast
 
 (** {2 Parsing expressions and definitions from strings} *)
 
-val extern_of_string : ?pure:bool -> id -> string -> uannot def
-val val_spec_of_string : id -> string -> uannot def
-val defs_of_string : string * int * int * int -> string -> uannot def list
-val ast_of_def_string : string * int * int * int -> string -> uannot ast
+val extern_of_string : ?pure:bool -> id -> string -> (uannot, unit) def
+val val_spec_of_string : id -> string -> (uannot, unit) def
+val defs_of_string : string * int * int * int -> string -> (uannot, unit) def list
+val ast_of_def_string : string * int * int * int -> string -> (uannot, unit) ast
 val ast_of_def_string_with :
-  string * int * int * int -> (Parse_ast.def list -> Parse_ast.def list) -> string -> uannot ast
+  string * int * int * int -> (Parse_ast.def list -> Parse_ast.def list) -> string -> (uannot, unit) ast
 val exp_of_string : string -> uannot exp
 val typ_of_string : string -> typ
 val constraint_of_string : string -> n_constraint

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -107,29 +107,29 @@ val have_undefined_builtins : bool ref
 (** Val specs of undefined functions for builtin types that get added to
     the AST if opt_undefined_gen is set (minus those functions that already
     exist in the AST). *)
-val undefined_builtin_val_specs : (uannot, unit) def list
+val undefined_builtin_val_specs : untyped_def list
 
 (** {2 Desugar and process AST } *)
 
 val generate_undefined_record_context : typquant -> (id * typ) list
-val generate_undefined_record : id -> typquant -> (typ * id) list -> (uannot, unit) def list
-val generate_undefined_enum : id -> id list -> (uannot, unit) def list
+val generate_undefined_record : id -> typquant -> (typ * id) list -> untyped_def list
+val generate_undefined_enum : id -> id list -> untyped_def list
 
-val generate_undefineds : IdSet.t -> (uannot, unit) def list -> (uannot, unit) def list
-val generate_enum_functions : IdSet.t -> (uannot, unit) def list -> (uannot, unit) def list
+val generate_undefineds : IdSet.t -> untyped_def list -> untyped_def list
+val generate_enum_functions : IdSet.t -> untyped_def list -> untyped_def list
 
 (** If the generate flag is false, then we won't generate any
    auxilliary definitions, like the initialize_registers function *)
-val process_ast : ?generate:bool -> Parse_ast.defs -> (uannot, unit) ast
+val process_ast : ?generate:bool -> Parse_ast.defs -> untyped_ast
 
 (** {2 Parsing expressions and definitions from strings} *)
 
-val extern_of_string : ?pure:bool -> id -> string -> (uannot, unit) def
-val val_spec_of_string : id -> string -> (uannot, unit) def
-val defs_of_string : string * int * int * int -> string -> (uannot, unit) def list
-val ast_of_def_string : string * int * int * int -> string -> (uannot, unit) ast
+val extern_of_string : ?pure:bool -> id -> string -> untyped_def
+val val_spec_of_string : id -> string -> untyped_def
+val defs_of_string : string * int * int * int -> string -> untyped_def list
+val ast_of_def_string : string * int * int * int -> string -> untyped_ast
 val ast_of_def_string_with :
-  string * int * int * int -> (Parse_ast.def list -> Parse_ast.def list) -> string -> (uannot, unit) ast
+  string * int * int * int -> (Parse_ast.def list -> Parse_ast.def list) -> string -> untyped_ast
 val exp_of_string : string -> uannot exp
 val typ_of_string : string -> typ
 val constraint_of_string : string -> n_constraint

--- a/src/lib/interactive.ml
+++ b/src/lib/interactive.ml
@@ -73,7 +73,7 @@ open Printf
 let opt_interactive = ref false
 
 type istate = {
-  ast : Type_check.tannot ast;
+  ast : (Type_check.tannot, Type_check.env) ast;
   effect_info : Effects.side_effect_info;
   env : Type_check.Env.t;
   default_sail_dir : string;

--- a/src/lib/interactive.ml
+++ b/src/lib/interactive.ml
@@ -73,7 +73,7 @@ open Printf
 let opt_interactive = ref false
 
 type istate = {
-  ast : (Type_check.tannot, Type_check.env) ast;
+  ast : Type_check.typed_ast;
   effect_info : Effects.side_effect_info;
   env : Type_check.Env.t;
   default_sail_dir : string;

--- a/src/lib/interactive.mli
+++ b/src/lib/interactive.mli
@@ -75,7 +75,7 @@ val opt_interactive : bool ref
    abstract syntax tree, effect info and the type-checking
    environment. Also contains the default Sail directory *)
 type istate = {
-  ast : Type_check.tannot ast;
+  ast : (Type_check.tannot, Type_check.env) ast;
   effect_info : Effects.side_effect_info;
   env : Type_check.Env.t;
   default_sail_dir : string;

--- a/src/lib/interactive.mli
+++ b/src/lib/interactive.mli
@@ -75,7 +75,7 @@ val opt_interactive : bool ref
    abstract syntax tree, effect info and the type-checking
    environment. Also contains the default Sail directory *)
 type istate = {
-  ast : (Type_check.tannot, Type_check.env) ast;
+  ast : Type_check.typed_ast;
   effect_info : Effects.side_effect_info;
   env : Type_check.Env.t;
   default_sail_dir : string;

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -171,9 +171,9 @@ module Make (C : CONFIG) : sig
        arguments are is the current definition number and the total
        number of definitions, and can be used to drive a progress bar
        (see Util.progress). *)
-  val compile_def : int -> int -> ctx -> (tannot, env) def -> cdef list * ctx
+  val compile_def : int -> int -> ctx -> typed_def -> cdef list * ctx
 
-  val compile_ast : ctx -> (tannot, env) ast -> cdef list * ctx
+  val compile_ast : ctx -> typed_ast -> cdef list * ctx
 end
 
 (** Adds some special functions to the environment that are used to

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -171,9 +171,9 @@ module Make (C : CONFIG) : sig
        arguments are is the current definition number and the total
        number of definitions, and can be used to drive a progress bar
        (see Util.progress). *)
-  val compile_def : int -> int -> ctx -> tannot def -> cdef list * ctx
+  val compile_def : int -> int -> ctx -> (tannot, env) def -> cdef list * ctx
 
-  val compile_ast : ctx -> tannot ast -> cdef list * ctx
+  val compile_ast : ctx -> (tannot, env) ast -> cdef list * ctx
 end
 
 (** Adds some special functions to the environment that are used to

--- a/src/lib/jib_optimize.ml
+++ b/src/lib/jib_optimize.ml
@@ -528,7 +528,7 @@ let remove_tuples cdefs ctx =
         let name = "tuple#" ^ Util.string_of_list "_" string_of_ctyp ctyps in
         let fields = List.mapi (fun n ctyp -> (mk_id (name ^ string_of_int n), ctyp)) ctyps in
         [
-          CDEF_aux (CDEF_type (CTD_struct (mk_id name, fields)), mk_def_annot Parse_ast.Unknown);
+          CDEF_aux (CDEF_type (CTD_struct (mk_id name, fields)), mk_def_annot Parse_ast.Unknown ());
           CDEF_aux
             ( CDEF_pragma
                 ( "tuplestruct",
@@ -536,7 +536,7 @@ let remove_tuples cdefs ctx =
                     (fun x -> x)
                     (Util.zencode_string name :: List.map (fun (id, _) -> Util.zencode_string (string_of_id id)) fields)
                 ),
-              mk_def_annot Parse_ast.Unknown
+              mk_def_annot Parse_ast.Unknown ()
             );
         ]
     | _ -> assert false

--- a/src/lib/mappings.mli
+++ b/src/lib/mappings.mli
@@ -68,4 +68,4 @@
 open Ast_defs
 open Type_check
 
-val rewrite_ast : tannot ast -> tannot ast
+val rewrite_ast : (tannot, env) ast -> (tannot, env) ast

--- a/src/lib/mappings.mli
+++ b/src/lib/mappings.mli
@@ -68,4 +68,4 @@
 open Ast_defs
 open Type_check
 
-val rewrite_ast : (tannot, env) ast -> (tannot, env) ast
+val rewrite_ast : typed_ast -> typed_ast

--- a/src/lib/monomorphise.mli
+++ b/src/lib/monomorphise.mli
@@ -84,20 +84,23 @@ val monomorphise :
   options ->
   ((string * int) * string) list ->
   (* List of splits from the command line *)
-  Type_check.tannot ast ->
-  Type_check.tannot ast
+  (Type_check.tannot, Type_check.env) ast ->
+  (Type_check.tannot, Type_check.env) ast
 
 (* Rewrite (combinations of) variable-sized operations into fixed-sized operations *)
-val mono_rewrites : Type_check.tannot ast -> Type_check.tannot ast
+val mono_rewrites : (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
 (* Move complex nexps in function signatures into constraints *)
-val rewrite_toplevel_nexps : Type_check.tannot ast -> Type_check.tannot ast
+val rewrite_toplevel_nexps : (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
 (* Move complex nexps in record fields into parameters *)
-val rewrite_complete_record_params : Type_check.Env.t -> Type_check.tannot ast -> Type_check.tannot ast
+val rewrite_complete_record_params :
+  Type_check.Env.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
 (* Add casts across case splits *)
-val add_bitvector_casts : Type_check.Env.t -> Type_check.tannot ast -> Type_check.tannot ast
+val add_bitvector_casts :
+  Type_check.Env.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
 
 (* Replace atom arguments which are fixed by a type parameter for a size with a singleton type *)
-val rewrite_atoms_to_singletons : string -> Type_check.tannot ast -> Type_check.tannot ast
+val rewrite_atoms_to_singletons :
+  string -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast

--- a/src/lib/monomorphise.mli
+++ b/src/lib/monomorphise.mli
@@ -84,23 +84,20 @@ val monomorphise :
   options ->
   ((string * int) * string) list ->
   (* List of splits from the command line *)
-  (Type_check.tannot, Type_check.env) ast ->
-  (Type_check.tannot, Type_check.env) ast
+  Type_check.typed_ast ->
+  Type_check.typed_ast
 
 (* Rewrite (combinations of) variable-sized operations into fixed-sized operations *)
-val mono_rewrites : (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val mono_rewrites : Type_check.typed_ast -> Type_check.typed_ast
 
 (* Move complex nexps in function signatures into constraints *)
-val rewrite_toplevel_nexps : (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val rewrite_toplevel_nexps : Type_check.typed_ast -> Type_check.typed_ast
 
 (* Move complex nexps in record fields into parameters *)
-val rewrite_complete_record_params :
-  Type_check.Env.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val rewrite_complete_record_params : Type_check.Env.t -> Type_check.typed_ast -> Type_check.typed_ast
 
 (* Add casts across case splits *)
-val add_bitvector_casts :
-  Type_check.Env.t -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val add_bitvector_casts : Type_check.Env.t -> Type_check.typed_ast -> Type_check.typed_ast
 
 (* Replace atom arguments which are fixed by a type parameter for a size with a singleton type *)
-val rewrite_atoms_to_singletons :
-  string -> (Type_check.tannot, Type_check.env) ast -> (Type_check.tannot, Type_check.env) ast
+val rewrite_atoms_to_singletons : string -> Type_check.typed_ast -> Type_check.typed_ast

--- a/src/lib/outcome_rewrites.ml
+++ b/src/lib/outcome_rewrites.ml
@@ -158,7 +158,7 @@ let instantiate target ast =
                      (l, empty_uannot)
                    )
                 ),
-              def_annot
+              strip_def_annot def_annot
             )
         in
         let instantiated_def =
@@ -171,7 +171,7 @@ let instantiate target ast =
           | None ->
               [
                 DEF_aux
-                  (DEF_pragma ("abstract", string_of_id id, gen_loc (id_loc id)), mk_def_annot (gen_loc (id_loc id)));
+                  (DEF_pragma ("abstract", string_of_id id, gen_loc (id_loc id)), mk_def_annot (gen_loc (id_loc id)) ());
                 valspec true;
               ]
           | Some def -> [valspec false; strip_def def]

--- a/src/lib/pretty_print_sail.mli
+++ b/src/lib/pretty_print_sail.mli
@@ -123,14 +123,14 @@ module Printer (Config : PRINT_CONFIG) : sig
 
   val doc_register : uannot dec_spec -> PPrint.document
 
-  val doc_def : (uannot, unit) def -> PPrint.document
+  val doc_def : untyped_def -> PPrint.document
 end
 
 (** This function is intended to reformat machine-generated Sail into
     something a bit more readable, it is not intended to be used as a
     general purpose code formatter. The output will be dumped as
     multiple files into the directory argument. *)
-val reformat : into_directory:string -> (uannot, unit) Ast_defs.ast -> unit
+val reformat : into_directory:string -> untyped_ast -> unit
 
 (** The default [PRINT_CONFIG] sets all the options to false, so it
     prints the AST 'as is' without modifications. *)
@@ -142,7 +142,7 @@ include module type of Printer (Default_print_config)
 
 (** This function is primarly used to dump the AST by debug options,
     such as [--ddump-tc-ast]. *)
-val output_ast : ?line_width:int -> out_channel -> (uannot, unit) Ast_defs.ast -> unit
+val output_ast : ?line_width:int -> out_channel -> untyped_ast -> unit
 
 (** Some convenience functions for outputting PPrint documents *)
 module Document : sig

--- a/src/lib/pretty_print_sail.mli
+++ b/src/lib/pretty_print_sail.mli
@@ -123,14 +123,14 @@ module Printer (Config : PRINT_CONFIG) : sig
 
   val doc_register : uannot dec_spec -> PPrint.document
 
-  val doc_def : uannot def -> PPrint.document
+  val doc_def : (uannot, unit) def -> PPrint.document
 end
 
 (** This function is intended to reformat machine-generated Sail into
     something a bit more readable, it is not intended to be used as a
     general purpose code formatter. The output will be dumped as
     multiple files into the directory argument. *)
-val reformat : into_directory:string -> uannot Ast_defs.ast -> unit
+val reformat : into_directory:string -> (uannot, unit) Ast_defs.ast -> unit
 
 (** The default [PRINT_CONFIG] sets all the options to false, so it
     prints the AST 'as is' without modifications. *)
@@ -142,7 +142,7 @@ include module type of Printer (Default_print_config)
 
 (** This function is primarly used to dump the AST by debug options,
     such as [--ddump-tc-ast]. *)
-val output_ast : ?line_width:int -> out_channel -> uannot Ast_defs.ast -> unit
+val output_ast : ?line_width:int -> out_channel -> (uannot, unit) Ast_defs.ast -> unit
 
 (** Some convenience functions for outputting PPrint documents *)
 module Document : sig

--- a/src/lib/property.mli
+++ b/src/lib/property.mli
@@ -84,7 +84,7 @@ open Type_check
    where prop_type is either "counterexample" or "property" and the
    location loc is the location that was attached to the pragma
 *)
-val find_properties : 'a ast -> (string * string * l * 'a val_spec) Bindings.t
+val find_properties : ('a, 'b) ast -> (string * string * l * 'a val_spec) Bindings.t
 
 (** For a property
 
@@ -104,7 +104,7 @@ val find_properties : 'a ast -> (string * string * l * 'a val_spec) Bindings.t
    generation/proving we want to ensure that inputs outside the
    constraints of the function are ignored.
 *)
-val rewrite : tannot ast -> tannot ast
+val rewrite : (tannot, env) ast -> (tannot, env) ast
 
 type event = Overflow | Assertion | Assumption | Match | Return
 

--- a/src/lib/property.mli
+++ b/src/lib/property.mli
@@ -104,7 +104,7 @@ val find_properties : ('a, 'b) ast -> (string * string * l * 'a val_spec) Bindin
    generation/proving we want to ensure that inputs outside the
    constraints of the function are ignored.
 *)
-val rewrite : (tannot, env) ast -> (tannot, env) ast
+val rewrite : typed_ast -> typed_ast
 
 type event = Overflow | Assertion | Assumption | Match | Return
 

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -71,14 +71,14 @@ open Ast_defs
 open Ast_util
 open Type_check
 
-type 'a rewriters = {
-  rewrite_exp : 'a rewriters -> 'a exp -> 'a exp;
-  rewrite_lexp : 'a rewriters -> 'a lexp -> 'a lexp;
-  rewrite_pat : 'a rewriters -> 'a pat -> 'a pat;
-  rewrite_let : 'a rewriters -> 'a letbind -> 'a letbind;
-  rewrite_fun : 'a rewriters -> 'a fundef -> 'a fundef;
-  rewrite_def : 'a rewriters -> 'a def -> 'a def;
-  rewrite_ast : 'a rewriters -> 'a ast -> 'a ast;
+type ('a, 'b) rewriters = {
+  rewrite_exp : ('a, 'b) rewriters -> 'a exp -> 'a exp;
+  rewrite_lexp : ('a, 'b) rewriters -> 'a lexp -> 'a lexp;
+  rewrite_pat : ('a, 'b) rewriters -> 'a pat -> 'a pat;
+  rewrite_let : ('a, 'b) rewriters -> 'a letbind -> 'a letbind;
+  rewrite_fun : ('a, 'b) rewriters -> 'a fundef -> 'a fundef;
+  rewrite_def : ('a, 'b) rewriters -> ('a, 'b) def -> ('a, 'b) def;
+  rewrite_ast : ('a, 'b) rewriters -> ('a, 'b) ast -> ('a, 'b) ast;
 }
 
 let lookup_generated_kid env kid =

--- a/src/lib/rewriter.mli
+++ b/src/lib/rewriter.mli
@@ -87,14 +87,14 @@ val rewrite_exp : (tannot, env) rewriters -> tannot exp -> tannot exp
 val rewriters_base : (tannot, env) rewriters
 
 (** The identity re-writer *)
-val rewrite_ast : (tannot, env) ast -> (tannot, env) ast
+val rewrite_ast : typed_ast -> typed_ast
 
-val rewrite_ast_defs : (tannot, env) rewriters -> (tannot, env) def list -> (tannot, env) def list
+val rewrite_ast_defs : (tannot, env) rewriters -> typed_def list -> typed_def list
 
-val rewrite_ast_base : (tannot, env) rewriters -> (tannot, env) ast -> (tannot, env) ast
+val rewrite_ast_base : (tannot, env) rewriters -> typed_ast -> typed_ast
 
 (** Same as rewrite_defs_base but display a progress bar when verbosity >= 1 *)
-val rewrite_ast_base_progress : string -> (tannot, env) rewriters -> (tannot, env) ast -> (tannot, env) ast
+val rewrite_ast_base_progress : string -> (tannot, env) rewriters -> typed_ast -> typed_ast
 
 val rewrite_lexp : (tannot, env) rewriters -> tannot lexp -> tannot lexp
 
@@ -104,7 +104,7 @@ val rewrite_pexp : (tannot, env) rewriters -> tannot pexp -> tannot pexp
 
 val rewrite_let : (tannot, env) rewriters -> tannot letbind -> tannot letbind
 
-val rewrite_def : (tannot, env) rewriters -> (tannot, env) def -> (tannot, env) def
+val rewrite_def : (tannot, env) rewriters -> typed_def -> typed_def
 
 val rewrite_fun : (tannot, env) rewriters -> tannot fundef -> tannot fundef
 

--- a/src/lib/rewriter.mli
+++ b/src/lib/rewriter.mli
@@ -72,43 +72,43 @@ open Ast
 open Ast_defs
 open Type_check
 
-type 'a rewriters = {
-  rewrite_exp : 'a rewriters -> 'a exp -> 'a exp;
-  rewrite_lexp : 'a rewriters -> 'a lexp -> 'a lexp;
-  rewrite_pat : 'a rewriters -> 'a pat -> 'a pat;
-  rewrite_let : 'a rewriters -> 'a letbind -> 'a letbind;
-  rewrite_fun : 'a rewriters -> 'a fundef -> 'a fundef;
-  rewrite_def : 'a rewriters -> 'a def -> 'a def;
-  rewrite_ast : 'a rewriters -> 'a ast -> 'a ast;
+type ('a, 'b) rewriters = {
+  rewrite_exp : ('a, 'b) rewriters -> 'a exp -> 'a exp;
+  rewrite_lexp : ('a, 'b) rewriters -> 'a lexp -> 'a lexp;
+  rewrite_pat : ('a, 'b) rewriters -> 'a pat -> 'a pat;
+  rewrite_let : ('a, 'b) rewriters -> 'a letbind -> 'a letbind;
+  rewrite_fun : ('a, 'b) rewriters -> 'a fundef -> 'a fundef;
+  rewrite_def : ('a, 'b) rewriters -> ('a, 'b) def -> ('a, 'b) def;
+  rewrite_ast : ('a, 'b) rewriters -> ('a, 'b) ast -> ('a, 'b) ast;
 }
 
-val rewrite_exp : tannot rewriters -> tannot exp -> tannot exp
+val rewrite_exp : (tannot, env) rewriters -> tannot exp -> tannot exp
 
-val rewriters_base : tannot rewriters
+val rewriters_base : (tannot, env) rewriters
 
 (** The identity re-writer *)
-val rewrite_ast : tannot ast -> tannot ast
+val rewrite_ast : (tannot, env) ast -> (tannot, env) ast
 
-val rewrite_ast_defs : tannot rewriters -> tannot def list -> tannot def list
+val rewrite_ast_defs : (tannot, env) rewriters -> (tannot, env) def list -> (tannot, env) def list
 
-val rewrite_ast_base : tannot rewriters -> tannot ast -> tannot ast
+val rewrite_ast_base : (tannot, env) rewriters -> (tannot, env) ast -> (tannot, env) ast
 
 (** Same as rewrite_defs_base but display a progress bar when verbosity >= 1 *)
-val rewrite_ast_base_progress : string -> tannot rewriters -> tannot ast -> tannot ast
+val rewrite_ast_base_progress : string -> (tannot, env) rewriters -> (tannot, env) ast -> (tannot, env) ast
 
-val rewrite_lexp : tannot rewriters -> tannot lexp -> tannot lexp
+val rewrite_lexp : (tannot, env) rewriters -> tannot lexp -> tannot lexp
 
-val rewrite_pat : tannot rewriters -> tannot pat -> tannot pat
+val rewrite_pat : (tannot, env) rewriters -> tannot pat -> tannot pat
 
-val rewrite_pexp : tannot rewriters -> tannot pexp -> tannot pexp
+val rewrite_pexp : (tannot, env) rewriters -> tannot pexp -> tannot pexp
 
-val rewrite_let : tannot rewriters -> tannot letbind -> tannot letbind
+val rewrite_let : (tannot, env) rewriters -> tannot letbind -> tannot letbind
 
-val rewrite_def : tannot rewriters -> tannot def -> tannot def
+val rewrite_def : (tannot, env) rewriters -> (tannot, env) def -> (tannot, env) def
 
-val rewrite_fun : tannot rewriters -> tannot fundef -> tannot fundef
+val rewrite_fun : (tannot, env) rewriters -> tannot fundef -> tannot fundef
 
-val rewrite_mapdef : tannot rewriters -> tannot mapdef -> tannot mapdef
+val rewrite_mapdef : (tannot, env) rewriters -> tannot mapdef -> tannot mapdef
 
 (** the type of interpretations of patterns *)
 type ('a, 'pat, 'pat_aux) pat_alg = {

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4349,8 +4349,7 @@ let if_mwords f effect_info env ast =
 let if_flag flag f effect_info env ast = if !flag then f effect_info env ast else (ast, effect_info, env)
 
 type rewriter =
-  | Base_rewriter of
-      (Effects.side_effect_info -> Env.t -> (tannot, env) ast -> (tannot, env) ast * Effects.side_effect_info * Env.t)
+  | Base_rewriter of (Effects.side_effect_info -> Env.t -> typed_ast -> typed_ast * Effects.side_effect_info * Env.t)
   | Bool_rewriter of (bool -> rewriter)
   | String_rewriter of (string -> rewriter)
   | Literal_rewriter of ((lit -> bool) -> rewriter)
@@ -4502,10 +4501,7 @@ let rewrites_interpreter =
   ]
 
 type rewrite_sequence =
-  ( string
-  * (Effects.side_effect_info -> Env.t -> (tannot, env) ast -> (tannot, env) ast * Effects.side_effect_info * Env.t)
-  )
-  list
+  (string * (Effects.side_effect_info -> Env.t -> typed_ast -> typed_ast * Effects.side_effect_info * Env.t)) list
 
 let instantiate_rewrites rws =
   let get_rewriter name =

--- a/src/lib/rewrites.mli
+++ b/src/lib/rewrites.mli
@@ -90,13 +90,14 @@ val opt_ddump_rewrite_ast : (string * int) option ref
 val fresh_id : string -> l -> id
 
 (** Move loop termination measures into loop AST nodes *)
-val move_loop_measures : 'a ast -> 'a ast
+val move_loop_measures : ('a, 'b) ast -> ('a, 'b) ast
 
 (** Re-write undefined to functions created by -undefined_gen flag *)
-val rewrite_undefined : bool -> Env.t -> tannot ast -> tannot ast
+val rewrite_undefined : bool -> Env.t -> (tannot, env) ast -> (tannot, env) ast
 
 type rewriter =
-  | Base_rewriter of (Effects.side_effect_info -> Env.t -> tannot ast -> tannot ast * Effects.side_effect_info * Env.t)
+  | Base_rewriter of
+      (Effects.side_effect_info -> Env.t -> (tannot, env) ast -> (tannot, env) ast * Effects.side_effect_info * Env.t)
   | Bool_rewriter of (bool -> rewriter)
   | String_rewriter of (string -> rewriter)
   | Literal_rewriter of ((lit -> bool) -> rewriter)
@@ -106,7 +107,10 @@ val describe_rewriter : rewriter -> string list
 val all_rewriters : (string * rewriter) list
 
 type rewrite_sequence =
-  (string * (Effects.side_effect_info -> Env.t -> tannot ast -> tannot ast * Effects.side_effect_info * Env.t)) list
+  ( string
+  * (Effects.side_effect_info -> Env.t -> (tannot, env) ast -> (tannot, env) ast * Effects.side_effect_info * Env.t)
+  )
+  list
 
 val rewrite_lit_ocaml : lit -> bool
 val rewrite_lit_lem : lit -> bool
@@ -125,7 +129,11 @@ val instantiate_rewrites : (string * rewriter_arg list) list -> rewrite_sequence
 
 (** Apply a sequence of rewrites to an AST *)
 val rewrite :
-  Effects.side_effect_info -> Env.t -> rewrite_sequence -> tannot ast -> tannot ast * Effects.side_effect_info * Env.t
+  Effects.side_effect_info ->
+  Env.t ->
+  rewrite_sequence ->
+  (tannot, env) ast ->
+  (tannot, env) ast * Effects.side_effect_info * Env.t
 
 val rewrites_interpreter : (string * rewriter_arg list) list
 

--- a/src/lib/rewrites.mli
+++ b/src/lib/rewrites.mli
@@ -93,11 +93,10 @@ val fresh_id : string -> l -> id
 val move_loop_measures : ('a, 'b) ast -> ('a, 'b) ast
 
 (** Re-write undefined to functions created by -undefined_gen flag *)
-val rewrite_undefined : bool -> Env.t -> (tannot, env) ast -> (tannot, env) ast
+val rewrite_undefined : bool -> Env.t -> typed_ast -> typed_ast
 
 type rewriter =
-  | Base_rewriter of
-      (Effects.side_effect_info -> Env.t -> (tannot, env) ast -> (tannot, env) ast * Effects.side_effect_info * Env.t)
+  | Base_rewriter of (Effects.side_effect_info -> Env.t -> typed_ast -> typed_ast * Effects.side_effect_info * Env.t)
   | Bool_rewriter of (bool -> rewriter)
   | String_rewriter of (string -> rewriter)
   | Literal_rewriter of ((lit -> bool) -> rewriter)
@@ -107,10 +106,7 @@ val describe_rewriter : rewriter -> string list
 val all_rewriters : (string * rewriter) list
 
 type rewrite_sequence =
-  ( string
-  * (Effects.side_effect_info -> Env.t -> (tannot, env) ast -> (tannot, env) ast * Effects.side_effect_info * Env.t)
-  )
-  list
+  (string * (Effects.side_effect_info -> Env.t -> typed_ast -> typed_ast * Effects.side_effect_info * Env.t)) list
 
 val rewrite_lit_ocaml : lit -> bool
 val rewrite_lit_lem : lit -> bool
@@ -129,11 +125,7 @@ val instantiate_rewrites : (string * rewriter_arg list) list -> rewrite_sequence
 
 (** Apply a sequence of rewrites to an AST *)
 val rewrite :
-  Effects.side_effect_info ->
-  Env.t ->
-  rewrite_sequence ->
-  (tannot, env) ast ->
-  (tannot, env) ast * Effects.side_effect_info * Env.t
+  Effects.side_effect_info -> Env.t -> rewrite_sequence -> typed_ast -> typed_ast * Effects.side_effect_info * Env.t
 
 val rewrites_interpreter : (string * rewriter_arg list) list
 

--- a/src/lib/scattered.ml
+++ b/src/lib/scattered.ml
@@ -110,9 +110,11 @@ let rec filter_enum_clauses id = function
   | def :: defs -> def :: filter_enum_clauses id defs
   | [] -> []
 
-let patch_funcl_loc def_annot (FCL_aux (aux, (_, tannot))) = FCL_aux (aux, (def_annot, tannot))
+let patch_funcl_loc def_annot (FCL_aux (aux, (_, tannot))) =
+  FCL_aux (aux, (Type_check.strip_def_annot def_annot, tannot))
 
-let patch_mapcl_annot def_annot (MCL_aux (aux, (_, tannot))) = MCL_aux (aux, (def_annot, tannot))
+let patch_mapcl_annot def_annot (MCL_aux (aux, (_, tannot))) =
+  MCL_aux (aux, (Type_check.strip_def_annot def_annot, tannot))
 
 let rec descatter' accumulator funcls mapcls = function
   (* For scattered functions we collect all the seperate function
@@ -132,7 +134,7 @@ let rec descatter' accumulator funcls mapcls = function
       let accumulator =
         DEF_aux
           ( DEF_fundef (FD_aux (FD_function (fake_rec_opt l, no_tannot_opt l, clauses), (gen_loc l, tannot))),
-            update_attr (mk_def_annot (gen_loc l))
+            update_attr (mk_def_annot (gen_loc l) def_annot.env)
           )
         :: accumulator
       in
@@ -155,7 +157,7 @@ let rec descatter' accumulator funcls mapcls = function
       let accumulator =
         DEF_aux
           ( DEF_mapdef (MD_aux (MD_mapping (id, no_tannot_opt l, clauses), (gen_loc l, tannot))),
-            mk_def_annot (gen_loc l)
+            mk_def_annot (gen_loc l) def_annot.env
           )
         :: accumulator
       in

--- a/src/lib/specialize.mli
+++ b/src/lib/specialize.mli
@@ -102,11 +102,7 @@ val get_initial_calls : unit -> id list
    environment to return if there is no polymorphism to remove, in
    which case specialize returns the AST unmodified. *)
 val specialize :
-  specialization ->
-  Env.t ->
-  (tannot, env) ast ->
-  Effects.side_effect_info ->
-  (tannot, env) ast * Env.t * Effects.side_effect_info
+  specialization -> Env.t -> typed_ast -> Effects.side_effect_info -> typed_ast * Env.t * Effects.side_effect_info
 
 (** specialize' n performs at most n specialization passes. Useful for
    int_specialization which is not guaranteed to terminate. *)
@@ -114,12 +110,12 @@ val specialize_passes :
   int ->
   specialization ->
   Env.t ->
-  (tannot, env) ast ->
+  typed_ast ->
   Effects.side_effect_info ->
-  (tannot, env) ast * Env.t * Effects.side_effect_info
+  typed_ast * Env.t * Effects.side_effect_info
 
 (** return all instantiations of a function id, with the
    instantiations filtered according to the specialization. *)
-val instantiations_of : specialization -> id -> (tannot, env) ast -> typ_arg KBindings.t list
+val instantiations_of : specialization -> id -> typed_ast -> typ_arg KBindings.t list
 
 val string_of_instantiation : typ_arg KBindings.t -> string

--- a/src/lib/specialize.mli
+++ b/src/lib/specialize.mli
@@ -90,7 +90,7 @@ val int_specialization_with_externs : specialization
    argument specifies what X should be - it should be one of:
    [is_int_kopt], [is_order_kopt], or [is_typ_kopt] from [Ast_util],
    or some combination of those. *)
-val polymorphic_functions : specialization -> 'a def list -> IdSet.t
+val polymorphic_functions : specialization -> ('a, 'b) def list -> IdSet.t
 
 val add_initial_calls : IdSet.t -> unit
 
@@ -102,7 +102,11 @@ val get_initial_calls : unit -> id list
    environment to return if there is no polymorphism to remove, in
    which case specialize returns the AST unmodified. *)
 val specialize :
-  specialization -> Env.t -> tannot ast -> Effects.side_effect_info -> tannot ast * Env.t * Effects.side_effect_info
+  specialization ->
+  Env.t ->
+  (tannot, env) ast ->
+  Effects.side_effect_info ->
+  (tannot, env) ast * Env.t * Effects.side_effect_info
 
 (** specialize' n performs at most n specialization passes. Useful for
    int_specialization which is not guaranteed to terminate. *)
@@ -110,12 +114,12 @@ val specialize_passes :
   int ->
   specialization ->
   Env.t ->
-  tannot ast ->
+  (tannot, env) ast ->
   Effects.side_effect_info ->
-  tannot ast * Env.t * Effects.side_effect_info
+  (tannot, env) ast * Env.t * Effects.side_effect_info
 
 (** return all instantiations of a function id, with the
    instantiations filtered according to the specialization. *)
-val instantiations_of : specialization -> id -> tannot ast -> typ_arg KBindings.t list
+val instantiations_of : specialization -> id -> (tannot, env) ast -> typ_arg KBindings.t list
 
 val string_of_instantiation : typ_arg KBindings.t -> string

--- a/src/lib/splice.ml
+++ b/src/lib/splice.ml
@@ -124,7 +124,10 @@ let move_replacement_fundefs ast =
   { ast with defs = aux [] ast.defs }
 
 let annotate_ast ast =
-  let annotate_def (DEF_aux (d, a)) = DEF_aux (d, add_def_attribute a.loc "spliced" None a) in
+  let annotate_def (DEF_aux (d, a)) =
+    DEF_aux (d, add_def_attribute a.loc "spliced" None a)
+    |> map_def_def_annot (def_annot_map_env (fun _ -> Type_check.Env.empty))
+  in
   { ast with defs = List.map annotate_def ast.defs }
 
 let splice ast file =

--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -145,7 +145,7 @@ let generate_regstate env registers =
   [
     DEF_aux
       ( DEF_type (TD_aux (regstate_def, (Unknown, empty_uannot))),
-        add_def_attribute Unknown "undefined_gen" (Some (AD_aux (AD_string "forbid", Unknown))) (mk_def_annot Unknown)
+        add_def_attribute Unknown "undefined_gen" (Some (AD_aux (AD_string "forbid", Unknown))) (mk_def_annot Unknown ())
       );
   ]
 

--- a/src/lib/target.ml
+++ b/src/lib/target.ml
@@ -75,10 +75,9 @@ type target = {
   options : (Arg.key * Arg.spec * Arg.doc) list;
   pre_parse_hook : unit -> unit;
   pre_initial_check_hook : Parse_ast.defs -> unit;
-  pre_rewrites_hook : (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit;
+  pre_rewrites_hook : typed_ast -> Effects.side_effect_info -> Env.t -> unit;
   rewrites : (string * Rewrites.rewriter_arg list) list;
-  action :
-    Yojson.Basic.t option -> string -> string option -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit;
+  action : Yojson.Basic.t option -> string -> string option -> typed_ast -> Effects.side_effect_info -> Env.t -> unit;
   asserts_termination : bool;
 }
 

--- a/src/lib/target.ml
+++ b/src/lib/target.ml
@@ -75,9 +75,10 @@ type target = {
   options : (Arg.key * Arg.spec * Arg.doc) list;
   pre_parse_hook : unit -> unit;
   pre_initial_check_hook : Parse_ast.defs -> unit;
-  pre_rewrites_hook : tannot ast -> Effects.side_effect_info -> Env.t -> unit;
+  pre_rewrites_hook : (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit;
   rewrites : (string * Rewrites.rewriter_arg list) list;
-  action : Yojson.Basic.t option -> string -> string option -> tannot ast -> Effects.side_effect_info -> Env.t -> unit;
+  action :
+    Yojson.Basic.t option -> string -> string option -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit;
   asserts_termination : bool;
 }
 

--- a/src/lib/target.mli
+++ b/src/lib/target.mli
@@ -86,19 +86,12 @@ val run_pre_parse_hook : target -> unit -> unit
 
 val run_pre_initial_check_hook : target -> Parse_ast.defs -> unit
 
-val run_pre_rewrites_hook : target -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit
+val run_pre_rewrites_hook : target -> typed_ast -> Effects.side_effect_info -> Env.t -> unit
 
 val rewrites : target -> Rewrites.rewrite_sequence
 
 val action :
-  target ->
-  Yojson.Basic.t option ->
-  string ->
-  string option ->
-  (tannot, env) ast ->
-  Effects.side_effect_info ->
-  Env.t ->
-  unit
+  target -> Yojson.Basic.t option -> string -> string option -> typed_ast -> Effects.side_effect_info -> Env.t -> unit
 
 val asserts_termination : target -> bool
 
@@ -133,15 +126,15 @@ val register :
   ?options:(Arg.key * Arg.spec * Arg.doc) list ->
   ?pre_parse_hook:(unit -> unit) ->
   ?pre_initial_check_hook:(Parse_ast.defs -> unit) ->
-  ?pre_rewrites_hook:((tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit) ->
+  ?pre_rewrites_hook:(typed_ast -> Effects.side_effect_info -> Env.t -> unit) ->
   ?rewrites:(string * Rewrites.rewriter_arg list) list ->
   ?asserts_termination:bool ->
-  (Yojson.Basic.t option -> string -> string option -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit) ->
+  (Yojson.Basic.t option -> string -> string option -> typed_ast -> Effects.side_effect_info -> Env.t -> unit) ->
   target
 
 (** Use if you want to register a target that does nothing *)
 val empty_action :
-  Yojson.Basic.t option -> string -> string option -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit
+  Yojson.Basic.t option -> string -> string option -> typed_ast -> Effects.side_effect_info -> Env.t -> unit
 
 (** Return the current target. For example, if we register a 'coq'
    target, and Sail is invoked with `sail -coq`, then this function

--- a/src/lib/target.mli
+++ b/src/lib/target.mli
@@ -86,12 +86,19 @@ val run_pre_parse_hook : target -> unit -> unit
 
 val run_pre_initial_check_hook : target -> Parse_ast.defs -> unit
 
-val run_pre_rewrites_hook : target -> tannot ast -> Effects.side_effect_info -> Env.t -> unit
+val run_pre_rewrites_hook : target -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit
 
 val rewrites : target -> Rewrites.rewrite_sequence
 
 val action :
-  target -> Yojson.Basic.t option -> string -> string option -> tannot ast -> Effects.side_effect_info -> Env.t -> unit
+  target ->
+  Yojson.Basic.t option ->
+  string ->
+  string option ->
+  (tannot, env) ast ->
+  Effects.side_effect_info ->
+  Env.t ->
+  unit
 
 val asserts_termination : target -> bool
 
@@ -126,15 +133,15 @@ val register :
   ?options:(Arg.key * Arg.spec * Arg.doc) list ->
   ?pre_parse_hook:(unit -> unit) ->
   ?pre_initial_check_hook:(Parse_ast.defs -> unit) ->
-  ?pre_rewrites_hook:(tannot ast -> Effects.side_effect_info -> Env.t -> unit) ->
+  ?pre_rewrites_hook:((tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit) ->
   ?rewrites:(string * Rewrites.rewriter_arg list) list ->
   ?asserts_termination:bool ->
-  (Yojson.Basic.t option -> string -> string option -> tannot ast -> Effects.side_effect_info -> Env.t -> unit) ->
+  (Yojson.Basic.t option -> string -> string option -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit) ->
   target
 
 (** Use if you want to register a target that does nothing *)
 val empty_action :
-  Yojson.Basic.t option -> string -> string option -> tannot ast -> Effects.side_effect_info -> Env.t -> unit
+  Yojson.Basic.t option -> string -> string option -> (tannot, env) ast -> Effects.side_effect_info -> Env.t -> unit
 
 (** Return the current target. For example, if we register a 'coq'
    target, and Sail is invoked with `sail -coq`, then this function

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1297,6 +1297,9 @@ type tannot' = {
 
 type tannot = tannot' option * uannot
 
+type typed_def = (tannot, env) def
+type typed_ast = (tannot, env) ast
+
 let untyped_annot tannot = snd tannot
 
 let mk_tannot ?(uannot = empty_uannot) env typ : tannot =
@@ -4706,7 +4709,7 @@ let check_global_constraint env def_annot nc =
 let undefined_skip l = Some (AD_aux (AD_string "skip", gen_loc l))
 let undefined_forbid l = Some (AD_aux (AD_string "forbid", gen_loc l))
 
-let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> (tannot, env) def list * Env.t =
+let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> typed_def list * Env.t =
  fun env def_annot (TD_aux (tdef, (l, _))) ->
   typ_print (lazy ("\n" ^ Util.("Check type " |> cyan |> clear) ^ string_of_id (id_of_type_def_aux tdef)));
   match tdef with
@@ -4855,7 +4858,7 @@ let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> (tannot, en
         | typ -> typ_error l ("Underlying bitfield type " ^ string_of_typ typ ^ " must be a constant-width bitvector")
       end
 
-and check_scattered : Env.t -> env def_annot -> uannot scattered_def -> (tannot, env) def list * Env.t =
+and check_scattered : Env.t -> env def_annot -> uannot scattered_def -> typed_def list * Env.t =
  fun env def_annot (SD_aux (sdef, (l, uannot))) ->
   match sdef with
   | SD_function _ | SD_end _ | SD_mapping _ -> ([], env)
@@ -4906,7 +4909,7 @@ and check_scattered : Env.t -> env def_annot -> uannot scattered_def -> (tannot,
       let mapcl = check_mapcl mapcl_env mapcl typ in
       ([DEF_aux (DEF_scattered (SD_aux (SD_mapcl (id, mapcl), (l, empty_tannot))), def_annot)], env)
 
-and check_outcome : Env.t -> outcome_spec -> (uannot, unit) def list -> outcome_spec * (tannot, env) def list * Env.t =
+and check_outcome : Env.t -> outcome_spec -> untyped_def list -> outcome_spec * typed_def list * Env.t =
  fun env (OV_aux (OV_outcome (id, typschm, params), l)) defs ->
   let valid_outcome_def = function
     | DEF_aux ((DEF_impl _ | DEF_val _), _) -> ()
@@ -4941,7 +4944,7 @@ and check_outcome : Env.t -> outcome_spec -> (uannot, unit) def list -> outcome_
       let msg = "Outcome must be declared within top-level scope" in
       typ_raise l (err_because (Err_other msg, outer_l, Err_other "Containing scope declared here"))
 
-and check_impldef : Env.t -> env def_annot -> uannot funcl -> (tannot, env) def list * Env.t =
+and check_impldef : Env.t -> env def_annot -> uannot funcl -> typed_def list * Env.t =
  fun env def_annot (FCL_aux (FCL_funcl (id, _), (fcl_def_annot, _)) as funcl) ->
   typ_print (lazy (Util.("Check impl " |> cyan |> clear) ^ string_of_id id));
   match Env.get_outcome_typschm_opt env with
@@ -4951,7 +4954,7 @@ and check_impldef : Env.t -> env def_annot -> uannot funcl -> (tannot, env) def 
   | None -> typ_error fcl_def_annot.loc "Cannot declare an implementation outside of an outcome"
 
 and check_outcome_instantiation :
-      'a. Env.t -> env def_annot -> 'a instantiation_spec -> subst list -> (tannot, env) def list * Env.t =
+      'a. Env.t -> env def_annot -> 'a instantiation_spec -> subst list -> typed_def list * Env.t =
  fun env def_annot (IN_aux (IN_id id, (l, _))) substs ->
   typ_print (lazy (Util.("Check instantiation " |> cyan |> clear) ^ string_of_id id));
   let typq, typ, params, vals, outcome_env = Env.get_outcome l id env in
@@ -5040,7 +5043,7 @@ and check_outcome_instantiation :
     Env.add_val_spec id (typq, typ) env
   )
 
-and check_def : Env.t -> (uannot, unit) def -> (tannot, env) def list * Env.t =
+and check_def : Env.t -> untyped_def -> typed_def list * Env.t =
  fun env (DEF_aux (aux, def_annot)) ->
   let def_annot = def_annot_map_env (fun _ -> env) def_annot in
   match aux with
@@ -5116,7 +5119,7 @@ and check_def : Env.t -> (uannot, unit) def -> (tannot, env) def list * Env.t =
       Reporting.unreachable (id_loc id) __POS__
         "Loop termination measures should have been rewritten before type checking"
 
-and check_defs_progress : int -> int -> Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t =
+and check_defs_progress : int -> int -> Env.t -> untyped_def list -> typed_def list * Env.t =
  fun n total env defs ->
   let rec aux n total acc env defs =
     match defs with
@@ -5145,18 +5148,18 @@ and check_defs_progress : int -> int -> Env.t -> (uannot, unit) def list -> (tan
   in
   aux n total [] env defs
 
-and check_defs : Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t =
+and check_defs : Env.t -> untyped_def list -> typed_def list * Env.t =
  fun env defs ->
   let total = List.length defs in
   check_defs_progress 1 total env defs
 
-let check : Env.t -> (uannot, unit) ast -> (tannot, env) ast * Env.t =
+let check : Env.t -> untyped_ast -> typed_ast * Env.t =
  fun env ast ->
   let total = List.length ast.defs in
   let defs, env = check_defs_progress 1 total env ast.defs in
   ({ ast with defs }, Env.open_all_modules env)
 
-let rec check_with_envs : Env.t -> (uannot, unit) def list -> ((tannot, env) def list * Env.t) list =
+let rec check_with_envs : Env.t -> untyped_def list -> (typed_def list * Env.t) list =
  fun env defs ->
   match defs with
   | [] -> []

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1943,8 +1943,10 @@ let strip_funcl funcl = map_funcl_annot (fun (l, tannot) -> (l, untyped_annot ta
 let strip_val_spec vs = map_valspec_annot (fun (l, tannot) -> (l, untyped_annot tannot)) vs
 let strip_register r = map_register_annot (fun (l, tannot) -> (l, untyped_annot tannot)) r
 let strip_typedef td = map_typedef_annot (fun (l, tannot) -> (l, untyped_annot tannot)) td
-let strip_def def = map_def_annot (fun (l, tannot) -> (l, untyped_annot tannot)) def
-let strip_ast ast = map_ast_annot (fun (l, tannot) -> (l, untyped_annot tannot)) ast
+let strip_def_annot da = def_annot_map_env (fun _ -> ()) da
+let strip_def def =
+  map_def_annot (fun (l, tannot) -> (l, untyped_annot tannot)) def |> map_def_def_annot strip_def_annot
+let strip_ast ast = { ast with defs = List.map strip_def ast.defs }
 
 (* A L-expression can either be declaring new variables, or updating existing variables, but never a mix of the two *)
 type lexp_assignment_type = Declaration | Update
@@ -4704,7 +4706,7 @@ let check_global_constraint env def_annot nc =
 let undefined_skip l = Some (AD_aux (AD_string "skip", gen_loc l))
 let undefined_forbid l = Some (AD_aux (AD_string "forbid", gen_loc l))
 
-let rec check_typedef : Env.t -> def_annot -> uannot type_def -> tannot def list * Env.t =
+let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> (tannot, env) def list * Env.t =
  fun env def_annot (TD_aux (tdef, (l, _))) ->
   typ_print (lazy ("\n" ^ Util.("Check type " |> cyan |> clear) ^ string_of_id (id_of_type_def_aux tdef)));
   match tdef with
@@ -4836,7 +4838,7 @@ let rec check_typedef : Env.t -> def_annot -> uannot type_def -> tannot def list
                   ranges;
                 let def_annot = add_def_attribute l "bitfield" (Some (AD_aux (AD_num size, l))) def_annot in
                 let defs =
-                  DEF_aux (DEF_type (TD_aux (record_tdef, (l, empty_uannot))), def_annot)
+                  DEF_aux (DEF_type (TD_aux (record_tdef, (l, empty_uannot))), strip_def_annot def_annot)
                   :: Bitfield.macro id size (Env.get_default_order env) ranges
                 in
                 let defs, env =
@@ -4853,7 +4855,7 @@ let rec check_typedef : Env.t -> def_annot -> uannot type_def -> tannot def list
         | typ -> typ_error l ("Underlying bitfield type " ^ string_of_typ typ ^ " must be a constant-width bitvector")
       end
 
-and check_scattered : Env.t -> def_annot -> uannot scattered_def -> tannot def list * Env.t =
+and check_scattered : Env.t -> env def_annot -> uannot scattered_def -> (tannot, env) def list * Env.t =
  fun env def_annot (SD_aux (sdef, (l, uannot))) ->
   match sdef with
   | SD_function _ | SD_end _ | SD_mapping _ -> ([], env)
@@ -4904,7 +4906,7 @@ and check_scattered : Env.t -> def_annot -> uannot scattered_def -> tannot def l
       let mapcl = check_mapcl mapcl_env mapcl typ in
       ([DEF_aux (DEF_scattered (SD_aux (SD_mapcl (id, mapcl), (l, empty_tannot))), def_annot)], env)
 
-and check_outcome : Env.t -> outcome_spec -> uannot def list -> outcome_spec * tannot def list * Env.t =
+and check_outcome : Env.t -> outcome_spec -> (uannot, unit) def list -> outcome_spec * (tannot, env) def list * Env.t =
  fun env (OV_aux (OV_outcome (id, typschm, params), l)) defs ->
   let valid_outcome_def = function
     | DEF_aux ((DEF_impl _ | DEF_val _), _) -> ()
@@ -4939,7 +4941,7 @@ and check_outcome : Env.t -> outcome_spec -> uannot def list -> outcome_spec * t
       let msg = "Outcome must be declared within top-level scope" in
       typ_raise l (err_because (Err_other msg, outer_l, Err_other "Containing scope declared here"))
 
-and check_impldef : Env.t -> def_annot -> uannot funcl -> tannot def list * Env.t =
+and check_impldef : Env.t -> env def_annot -> uannot funcl -> (tannot, env) def list * Env.t =
  fun env def_annot (FCL_aux (FCL_funcl (id, _), (fcl_def_annot, _)) as funcl) ->
   typ_print (lazy (Util.("Check impl " |> cyan |> clear) ^ string_of_id id));
   match Env.get_outcome_typschm_opt env with
@@ -4949,7 +4951,7 @@ and check_impldef : Env.t -> def_annot -> uannot funcl -> tannot def list * Env.
   | None -> typ_error fcl_def_annot.loc "Cannot declare an implementation outside of an outcome"
 
 and check_outcome_instantiation :
-      'a. Env.t -> def_annot -> 'a instantiation_spec -> subst list -> tannot def list * Env.t =
+      'a. Env.t -> env def_annot -> 'a instantiation_spec -> subst list -> (tannot, env) def list * Env.t =
  fun env def_annot (IN_aux (IN_id id, (l, _))) substs ->
   typ_print (lazy (Util.("Check instantiation " |> cyan |> clear) ^ string_of_id id));
   let typq, typ, params, vals, outcome_env = Env.get_outcome l id env in
@@ -5038,8 +5040,9 @@ and check_outcome_instantiation :
     Env.add_val_spec id (typq, typ) env
   )
 
-and check_def : Env.t -> uannot def -> tannot def list * Env.t =
+and check_def : Env.t -> (uannot, unit) def -> (tannot, env) def list * Env.t =
  fun env (DEF_aux (aux, def_annot)) ->
+  let def_annot = def_annot_map_env (fun _ -> env) def_annot in
   match aux with
   | DEF_fixity (prec, n, op) -> ([DEF_aux (DEF_fixity (prec, n, op), def_annot)], env)
   | DEF_type tdef -> check_typedef env def_annot tdef
@@ -5068,7 +5071,9 @@ and check_def : Env.t -> uannot def -> tannot def list * Env.t =
       | Typ_aux (Typ_app (Id_aux (Id "option", _), [_]), _) ->
           Reporting.warn "No default value" l "Registers of type option should explicitly be given a default value";
           let none_ctor = locate (fun _ -> gen_loc l) (mk_exp (E_app (mk_id "None", [mk_lit_exp L_unit]))) in
-          check_def env (DEF_aux (DEF_register (DEC_aux (DEC_reg (typ, id, Some none_ctor), (l, uannot))), def_annot))
+          check_def env
+            (DEF_aux (DEF_register (DEC_aux (DEC_reg (typ, id, Some none_ctor), (l, uannot))), strip_def_annot def_annot)
+            )
       | _ ->
           if not (can_be_undefined ~at:l env typ) then
             typ_error l ("Must provide a default register value for a register of type " ^ string_of_typ typ);
@@ -5111,7 +5116,7 @@ and check_def : Env.t -> uannot def -> tannot def list * Env.t =
       Reporting.unreachable (id_loc id) __POS__
         "Loop termination measures should have been rewritten before type checking"
 
-and check_defs_progress : int -> int -> Env.t -> uannot def list -> tannot def list * Env.t =
+and check_defs_progress : int -> int -> Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t =
  fun n total env defs ->
   let rec aux n total acc env defs =
     match defs with
@@ -5140,18 +5145,18 @@ and check_defs_progress : int -> int -> Env.t -> uannot def list -> tannot def l
   in
   aux n total [] env defs
 
-and check_defs : Env.t -> uannot def list -> tannot def list * Env.t =
+and check_defs : Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t =
  fun env defs ->
   let total = List.length defs in
   check_defs_progress 1 total env defs
 
-let check : Env.t -> uannot ast -> tannot ast * Env.t =
+let check : Env.t -> (uannot, unit) ast -> (tannot, env) ast * Env.t =
  fun env ast ->
   let total = List.length ast.defs in
   let defs, env = check_defs_progress 1 total env ast.defs in
   ({ ast with defs }, Env.open_all_modules env)
 
-let rec check_with_envs : Env.t -> uannot def list -> (tannot def list * Env.t) list =
+let rec check_with_envs : Env.t -> (uannot, unit) def list -> ((tannot, env) def list * Env.t) list =
  fun env defs ->
   match defs with
   | [] -> []

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -273,6 +273,11 @@ val dvector_typ : Env.t -> nexp -> typ -> typ
 (** The type of type annotations *)
 type tannot
 
+(** Aliases for typed definitions and ASTs for readability *)
+type typed_def = (tannot, env) def
+
+type typed_ast = (tannot, env) ast
+
 (** The canonical view of a type annotation is that it is a tuple
    containing an environment (env), a type (typ), such that check_X
    env (strip_X X) typ succeeds, where X is typically exp (i.e an
@@ -320,8 +325,8 @@ val strip_funcl : tannot funcl -> uannot funcl
 val strip_register : tannot dec_spec -> uannot dec_spec
 val strip_typedef : tannot type_def -> uannot type_def
 val strip_def_annot : env def_annot -> unit def_annot
-val strip_def : (tannot, env) def -> (uannot, unit) def
-val strip_ast : (tannot, env) ast -> (uannot, unit) ast
+val strip_def : typed_def -> untyped_def
+val strip_ast : typed_ast -> untyped_ast
 
 (** {2 Checking expressions and patterns} *)
 
@@ -343,9 +348,9 @@ val check_case : Env.t -> typ -> uannot pexp -> typ -> tannot pexp
 
 val check_funcl : Env.t -> uannot funcl -> typ -> tannot funcl
 
-val check_fundef : Env.t -> env def_annot -> uannot fundef -> (tannot, env) def list * Env.t
+val check_fundef : Env.t -> env def_annot -> uannot fundef -> typed_def list * Env.t
 
-val check_val_spec : Env.t -> env def_annot -> uannot val_spec -> (tannot, env) def list * Env.t
+val check_val_spec : Env.t -> env def_annot -> uannot val_spec -> typed_def list * Env.t
 
 val assert_constraint : Env.t -> bool -> tannot exp -> n_constraint option
 
@@ -499,13 +504,13 @@ Some invariants that will hold of a fully checked AST are:
    check throws type_errors rather than Sail generic errors from
    Reporting. For a function that uses generic errors, use
    Type_error.check *)
-val check : Env.t -> (uannot, unit) ast -> (tannot, env) ast * Env.t
+val check : Env.t -> untyped_ast -> typed_ast * Env.t
 
-val check_defs : Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t
+val check_defs : Env.t -> untyped_def list -> typed_def list * Env.t
 
 (** The same as [check], but exposes the intermediate type-checking
    environments so we don't have to always re-check the entire AST *)
-val check_with_envs : Env.t -> (uannot, unit) def list -> ((tannot, env) def list * Env.t) list
+val check_with_envs : Env.t -> untyped_def list -> (typed_def list * Env.t) list
 
 (** The initial type checking environment *)
 val initial_env : Env.t

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -319,8 +319,9 @@ val strip_val_spec : tannot val_spec -> uannot val_spec
 val strip_funcl : tannot funcl -> uannot funcl
 val strip_register : tannot dec_spec -> uannot dec_spec
 val strip_typedef : tannot type_def -> uannot type_def
-val strip_def : tannot def -> uannot def
-val strip_ast : tannot ast -> uannot ast
+val strip_def_annot : env def_annot -> unit def_annot
+val strip_def : (tannot, env) def -> (uannot, unit) def
+val strip_ast : (tannot, env) ast -> (uannot, unit) ast
 
 (** {2 Checking expressions and patterns} *)
 
@@ -342,9 +343,9 @@ val check_case : Env.t -> typ -> uannot pexp -> typ -> tannot pexp
 
 val check_funcl : Env.t -> uannot funcl -> typ -> tannot funcl
 
-val check_fundef : Env.t -> def_annot -> uannot fundef -> tannot def list * Env.t
+val check_fundef : Env.t -> env def_annot -> uannot fundef -> (tannot, env) def list * Env.t
 
-val check_val_spec : Env.t -> def_annot -> uannot val_spec -> tannot def list * Env.t
+val check_val_spec : Env.t -> env def_annot -> uannot val_spec -> (tannot, env) def list * Env.t
 
 val assert_constraint : Env.t -> bool -> tannot exp -> n_constraint option
 
@@ -357,7 +358,7 @@ val assert_constraint : Env.t -> bool -> tannot exp -> n_constraint option
    check completeness of scattered functions, and should not be called
    otherwise. *)
 val check_funcls_complete :
-  Parse_ast.l -> Env.t -> tannot funcl list -> typ -> tannot funcl list * (def_annot -> def_annot)
+  Parse_ast.l -> Env.t -> tannot funcl list -> typ -> tannot funcl list * ('a def_annot -> 'a def_annot)
 
 (** Attempt to prove a constraint using z3. Returns true if z3 can
    prove that the constraint is true, returns false if z3 cannot prove
@@ -498,13 +499,13 @@ Some invariants that will hold of a fully checked AST are:
    check throws type_errors rather than Sail generic errors from
    Reporting. For a function that uses generic errors, use
    Type_error.check *)
-val check : Env.t -> uannot ast -> tannot ast * Env.t
+val check : Env.t -> (uannot, unit) ast -> (tannot, env) ast * Env.t
 
-val check_defs : Env.t -> uannot def list -> tannot def list * Env.t
+val check_defs : Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t
 
 (** The same as [check], but exposes the intermediate type-checking
    environments so we don't have to always re-check the entire AST *)
-val check_with_envs : Env.t -> uannot def list -> (tannot def list * Env.t) list
+val check_with_envs : Env.t -> (uannot, unit) def list -> ((tannot, env) def list * Env.t) list
 
 (** The initial type checking environment *)
 val initial_env : Env.t

--- a/src/lib/type_error.ml
+++ b/src/lib/type_error.ml
@@ -541,8 +541,8 @@ let to_reporting_exn l err =
   let str, hint = string_of_type_error err in
   Reporting.err_typ ?hint l str
 
-let check_defs : Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t =
+let check_defs : Env.t -> untyped_def list -> typed_def list * Env.t =
  fun env defs -> try Type_check.check_defs env defs with Type_error (l, err) -> raise (to_reporting_exn l err)
 
-let check : Env.t -> (uannot, unit) ast -> (tannot, env) ast * Env.t =
+let check : Env.t -> untyped_ast -> typed_ast * Env.t =
  fun env defs -> try Type_check.check env defs with Type_error (l, err) -> raise (to_reporting_exn l err)

--- a/src/lib/type_error.ml
+++ b/src/lib/type_error.ml
@@ -541,8 +541,8 @@ let to_reporting_exn l err =
   let str, hint = string_of_type_error err in
   Reporting.err_typ ?hint l str
 
-let check_defs : Env.t -> uannot def list -> tannot def list * Env.t =
+let check_defs : Env.t -> (uannot, unit) def list -> (tannot, env) def list * Env.t =
  fun env defs -> try Type_check.check_defs env defs with Type_error (l, err) -> raise (to_reporting_exn l err)
 
-let check : Env.t -> uannot ast -> tannot ast * Env.t =
+let check : Env.t -> (uannot, unit) ast -> (tannot, env) ast * Env.t =
  fun env defs -> try Type_check.check env defs with Type_error (l, err) -> raise (to_reporting_exn l err)

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -123,8 +123,6 @@ val string_of_type_error : type_error -> string * string option
 (** Convert a type error into a general purpose error from the Reporting file *)
 val to_reporting_exn : Parse_ast.l -> type_error -> exn
 
-val check_defs :
-  Type_check.Env.t -> (uannot, unit) Ast.def list -> (Type_check.tannot, Type_check.env) Ast.def list * Type_check.Env.t
+val check_defs : Type_check.Env.t -> untyped_def list -> Type_check.typed_def list * Type_check.Env.t
 
-val check :
-  Type_check.Env.t -> (uannot, unit) Ast_defs.ast -> (Type_check.tannot, Type_check.env) Ast_defs.ast * Type_check.Env.t
+val check : Type_check.Env.t -> untyped_ast -> Type_check.typed_ast * Type_check.Env.t

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -123,6 +123,8 @@ val string_of_type_error : type_error -> string * string option
 (** Convert a type error into a general purpose error from the Reporting file *)
 val to_reporting_exn : Parse_ast.l -> type_error -> exn
 
-val check_defs : Type_check.Env.t -> uannot Ast.def list -> Type_check.tannot Ast.def list * Type_check.Env.t
+val check_defs :
+  Type_check.Env.t -> (uannot, unit) Ast.def list -> (Type_check.tannot, Type_check.env) Ast.def list * Type_check.Env.t
 
-val check : Type_check.Env.t -> uannot Ast_defs.ast -> Type_check.tannot Ast_defs.ast * Type_check.Env.t
+val check :
+  Type_check.Env.t -> (uannot, unit) Ast_defs.ast -> (Type_check.tannot, Type_check.env) Ast_defs.ast * Type_check.Env.t

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -739,9 +739,9 @@ let hoist_allocations recursive_functions = function
       if !decls = [] then [CDEF_aux (CDEF_fundef (function_id, heap_return, args, body), def_annot)]
       else
         [
-          CDEF_aux (CDEF_startup (function_id, List.rev !decls), mk_def_annot (gen_loc def_annot.loc));
+          CDEF_aux (CDEF_startup (function_id, List.rev !decls), mk_def_annot (gen_loc def_annot.loc) ());
           CDEF_aux (CDEF_fundef (function_id, heap_return, args, body), def_annot);
-          CDEF_aux (CDEF_finish (function_id, !cleanups), mk_def_annot (gen_loc def_annot.loc));
+          CDEF_aux (CDEF_finish (function_id, !cleanups), mk_def_annot (gen_loc def_annot.loc) ());
         ]
   | cdef -> [cdef]
 

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -120,8 +120,7 @@ val optimize_alias : bool ref
 val optimize_fixed_int : bool ref
 val optimize_fixed_bits : bool ref
 
-val jib_of_ast : Env.t -> Effects.side_effect_info -> (tannot, env) ast -> cdef list * Jib_compile.ctx
-val compile_ast : Env.t -> Effects.side_effect_info -> out_channel -> string list -> (tannot, env) ast -> unit
+val jib_of_ast : Env.t -> Effects.side_effect_info -> typed_ast -> cdef list * Jib_compile.ctx
+val compile_ast : Env.t -> Effects.side_effect_info -> out_channel -> string list -> typed_ast -> unit
 
-val compile_ast_clib :
-  Env.t -> Effects.side_effect_info -> (tannot, env) ast -> (Jib_compile.ctx -> cdef list -> unit) -> unit
+val compile_ast_clib : Env.t -> Effects.side_effect_info -> typed_ast -> (Jib_compile.ctx -> cdef list -> unit) -> unit

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -120,7 +120,8 @@ val optimize_alias : bool ref
 val optimize_fixed_int : bool ref
 val optimize_fixed_bits : bool ref
 
-val jib_of_ast : Env.t -> Effects.side_effect_info -> tannot ast -> cdef list * Jib_compile.ctx
-val compile_ast : Env.t -> Effects.side_effect_info -> out_channel -> string list -> tannot ast -> unit
+val jib_of_ast : Env.t -> Effects.side_effect_info -> (tannot, env) ast -> cdef list * Jib_compile.ctx
+val compile_ast : Env.t -> Effects.side_effect_info -> out_channel -> string list -> (tannot, env) ast -> unit
 
-val compile_ast_clib : Env.t -> Effects.side_effect_info -> tannot ast -> (Jib_compile.ctx -> cdef list -> unit) -> unit
+val compile_ast_clib :
+  Env.t -> Effects.side_effect_info -> (tannot, env) ast -> (Jib_compile.ctx -> cdef list -> unit) -> unit

--- a/src/sail_doc_backend/docinfo.ml
+++ b/src/sail_doc_backend/docinfo.ml
@@ -579,7 +579,10 @@ module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) = struct
     let clauses = List.filter (included_clause files) clauses in
     match clauses with
     | [] -> None
-    | [clause] -> Some (Single_clause (docinfo_for_funcl ~ast ~outer_annot:(def_annot, snd annot) 0 clause))
+    | [clause] ->
+        Some
+          (Single_clause (docinfo_for_funcl ~ast ~outer_annot:(Type_check.strip_def_annot def_annot, snd annot) 0 clause)
+          )
     | _ -> Some (Multiple_clauses (List.mapi (docinfo_for_funcl ~ast) clauses))
 
   let docinfo_for_mpexp (MPat_aux (aux, _)) =

--- a/src/sail_doc_backend/docinfo.mli
+++ b/src/sail_doc_backend/docinfo.mli
@@ -82,7 +82,7 @@ val hyperlink_target : hyperlink -> Callgraph.node
 
 val hyperlink_span : hyperlink -> hyper_location
 
-val hyperlinks_from_def : string list -> Type_check.tannot def -> hyperlink list
+val hyperlinks_from_def : string list -> (Type_check.tannot, Type_check.env) def -> hyperlink list
 
 type 'a docinfo
 
@@ -102,5 +102,8 @@ end
 
 module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) : sig
   val docinfo_for_ast :
-    files:string list -> hyperlinks:(string list -> tannot def -> hyperlink list) -> tannot ast -> tannot docinfo
+    files:string list ->
+    hyperlinks:(string list -> (tannot, env) def -> hyperlink list) ->
+    (tannot, env) ast ->
+    tannot docinfo
 end

--- a/src/sail_doc_backend/docinfo.mli
+++ b/src/sail_doc_backend/docinfo.mli
@@ -82,7 +82,7 @@ val hyperlink_target : hyperlink -> Callgraph.node
 
 val hyperlink_span : hyperlink -> hyper_location
 
-val hyperlinks_from_def : string list -> (Type_check.tannot, Type_check.env) def -> hyperlink list
+val hyperlinks_from_def : string list -> Type_check.typed_def -> hyperlink list
 
 type 'a docinfo
 
@@ -102,8 +102,5 @@ end
 
 module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) : sig
   val docinfo_for_ast :
-    files:string list ->
-    hyperlinks:(string list -> (tannot, env) def -> hyperlink list) ->
-    (tannot, env) ast ->
-    tannot docinfo
+    files:string list -> hyperlinks:(string list -> typed_def -> hyperlink list) -> typed_ast -> tannot docinfo
 end

--- a/src/sail_doc_backend/html_source.mli
+++ b/src/sail_doc_backend/html_source.mli
@@ -79,7 +79,7 @@ val highlights : filename:string -> contents:string -> (Highlight.t * int * int)
 
 val hyperlink_targets : ('a, 'b) ast -> Lexing.position Callgraph.NodeMap.t
 
-val hyperlinks_for_file : filename:string -> (Type_check.tannot, Type_check.env) ast -> (Callgraph.node * int * int) array
+val hyperlinks_for_file : filename:string -> Type_check.typed_ast -> (Callgraph.node * int * int) array
 
 type file_info = { filename : string; prefix : string; contents : string; highlights : (Highlight.t * int * int) array }
 

--- a/src/sail_doc_backend/html_source.mli
+++ b/src/sail_doc_backend/html_source.mli
@@ -77,9 +77,9 @@ end
 
 val highlights : filename:string -> contents:string -> (Highlight.t * int * int) array
 
-val hyperlink_targets : 'a ast -> Lexing.position Callgraph.NodeMap.t
+val hyperlink_targets : ('a, 'b) ast -> Lexing.position Callgraph.NodeMap.t
 
-val hyperlinks_for_file : filename:string -> Type_check.tannot ast -> (Callgraph.node * int * int) array
+val hyperlinks_for_file : filename:string -> (Type_check.tannot, Type_check.env) ast -> (Callgraph.node * int * int) array
 
 type file_info = { filename : string; prefix : string; contents : string; highlights : (Highlight.t * int * int) array }
 

--- a/src/sail_latex_backend/latex.ml
+++ b/src/sail_latex_backend/latex.ml
@@ -413,7 +413,7 @@ let latex_command ~docstring cat id no_loc l =
     ^^ ksprintf string "\\lstinputlisting[language=sail]{%s}}}}" (Filename.concat !opt_directory code_file)
   end
 
-let latex_docstring (def_annot : Ast.def_annot) =
+let latex_docstring (def_annot : 'a Ast.def_annot) =
   match def_annot.doc_comment with Some contents -> string (latex_of_markdown contents) | None -> empty
 
 let latex_funcls def =

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -118,7 +118,7 @@ type ctx = {
   tc_env : Type_check.Env.t;
   pragma_l : Ast.l;
   arg_stack : (int * string) Stack.t;
-  ast : Type_check.tannot ast;
+  ast : (Type_check.tannot, Type_check.env) ast;
   shared : ctyp Bindings.t;
   preserved : IdSet.t;
   events : smt_exp Stack.t EventMap.t ref;

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -118,7 +118,7 @@ type ctx = {
   tc_env : Type_check.Env.t;
   pragma_l : Ast.l;
   arg_stack : (int * string) Stack.t;
-  ast : (Type_check.tannot, Type_check.env) ast;
+  ast : Type_check.typed_ast;
   shared : ctyp Bindings.t;
   preserved : IdSet.t;
   events : smt_exp Stack.t EventMap.t ref;

--- a/src/sail_smt_backend/jib_smt.mli
+++ b/src/sail_smt_backend/jib_smt.mli
@@ -106,7 +106,7 @@ type ctx = {
       (** A location, usually the $counterexample or $property we are
        generating the SMT for. Used for error messages. *)
   arg_stack : (int * string) Stack.t;  (** Used internally to keep track of function argument names *)
-  ast : Type_check.tannot ast;  (** The fully type-checked ast *)
+  ast : (Type_check.tannot, Type_check.env) ast;  (** The fully type-checked ast *)
   shared : ctyp Bindings.t;
       (** Shared variables. These variables do not get renamed by
        Smtlib.suffix_variables_def, and their SSA number is
@@ -137,7 +137,11 @@ type ctx = {
 }
 
 (** Compile an AST into Jib suitable for SMT generation, and initialise a context. *)
-val compile : Type_check.Env.t -> Effects.side_effect_info -> Type_check.tannot ast -> cdef list * Jib_compile.ctx * ctx
+val compile :
+  Type_check.Env.t ->
+  Effects.side_effect_info ->
+  (Type_check.tannot, Type_check.env) ast ->
+  cdef list * Jib_compile.ctx * ctx
 
 (* TODO: Currently we internally use mutable stacks and queues to
    avoid any issues with stack overflows caused by some non
@@ -167,7 +171,8 @@ module Make_optimizer (S : Sequence) : sig
   val optimize : smt_def Stack.t -> smt_def S.t
 end
 
-val serialize_smt_model : string -> Type_check.Env.t -> Effects.side_effect_info -> Type_check.tannot ast -> unit
+val serialize_smt_model :
+  string -> Type_check.Env.t -> Effects.side_effect_info -> (Type_check.tannot, Type_check.env) ast -> unit
 
 val deserialize_smt_model : string -> cdef list * ctx
 
@@ -180,5 +185,5 @@ val generate_smt :
   Type_check.Env.t ->
   Effects.side_effect_info ->
   string list ->
-  Type_check.tannot ast ->
+  (Type_check.tannot, Type_check.env) ast ->
   unit

--- a/src/sail_smt_backend/jib_smt.mli
+++ b/src/sail_smt_backend/jib_smt.mli
@@ -106,7 +106,7 @@ type ctx = {
       (** A location, usually the $counterexample or $property we are
        generating the SMT for. Used for error messages. *)
   arg_stack : (int * string) Stack.t;  (** Used internally to keep track of function argument names *)
-  ast : (Type_check.tannot, Type_check.env) ast;  (** The fully type-checked ast *)
+  ast : Type_check.typed_ast;  (** The fully type-checked ast *)
   shared : ctyp Bindings.t;
       (** Shared variables. These variables do not get renamed by
        Smtlib.suffix_variables_def, and their SSA number is
@@ -137,11 +137,7 @@ type ctx = {
 }
 
 (** Compile an AST into Jib suitable for SMT generation, and initialise a context. *)
-val compile :
-  Type_check.Env.t ->
-  Effects.side_effect_info ->
-  (Type_check.tannot, Type_check.env) ast ->
-  cdef list * Jib_compile.ctx * ctx
+val compile : Type_check.Env.t -> Effects.side_effect_info -> Type_check.typed_ast -> cdef list * Jib_compile.ctx * ctx
 
 (* TODO: Currently we internally use mutable stacks and queues to
    avoid any issues with stack overflows caused by some non
@@ -171,8 +167,7 @@ module Make_optimizer (S : Sequence) : sig
   val optimize : smt_def Stack.t -> smt_def S.t
 end
 
-val serialize_smt_model :
-  string -> Type_check.Env.t -> Effects.side_effect_info -> (Type_check.tannot, Type_check.env) ast -> unit
+val serialize_smt_model : string -> Type_check.Env.t -> Effects.side_effect_info -> Type_check.typed_ast -> unit
 
 val deserialize_smt_model : string -> cdef list * ctx
 
@@ -185,5 +180,5 @@ val generate_smt :
   Type_check.Env.t ->
   Effects.side_effect_info ->
   string list ->
-  (Type_check.tannot, Type_check.env) ast ->
+  Type_check.typed_ast ->
   unit


### PR DESCRIPTION
This adds the type environment used to check each definition to its annotation, although it doesn't use them yet.

I've wanted this for a while to avoid having to find a suitable environment from deeper inside the definition, but finally came across a case where it's awkward to work around (a missing case for overloads in the top-sort rewrite).

It touches quite a lot, so I thought I'd ask for feedback before merging.  In retrospect, I might add a `typed_ast` alias to reduce the amount of visual clutter.