### PR TITLE
Add Sail to HTML conversion to Sail documentation plugin

### DIFF
--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -113,7 +113,9 @@ module Node = struct
     lex_ord (compare (node_kind n1) (node_kind n2)) (Id.compare (node_id n1) (node_id n2))
 end
 
-module NS = Set.Make (Node)
+module NodeSet = Set.Make (Node)
+module NS = NodeSet
+module NodeMap = Map.Make (Node)
 module G = Graph.Make (Node)
 
 let builtins =

--- a/src/lib/callgraph.mli
+++ b/src/lib/callgraph.mli
@@ -90,6 +90,14 @@ module Node : sig
   val compare : node -> node -> int
 end
 
+module NodeSet : sig
+  include Set.S with type elt = node and type t = Set.Make(Node).t
+end
+
+module NodeMap : sig
+  include Map.S with type key = node and type 'a t = 'a Map.Make(Node).t
+end
+
 module G : sig
   include Graph.S with type node = Node.t and type node_set = Set.Make(Node).t and type graph = Graph.Make(Node).graph
 end
@@ -98,7 +106,7 @@ type callgraph = G.graph
 
 val graph_of_ast : Type_check.tannot ast -> callgraph
 
-val nodes_of_def : 'a def -> Set.Make(Node).t
+val nodes_of_def : 'a def -> NodeSet.t
 
 val filter_ast_ids : IdSet.t -> IdSet.t -> Type_check.tannot ast -> Type_check.tannot ast
 

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -187,6 +187,7 @@ let load_modules ?target default_sail_dir options type_envs proj root_mod_ids =
     in
     Parse_ast.Defs files
   in
+  Option.iter (fun t -> Target.run_pre_initial_check_hook t ast) target;
   let ast = Initial_check.process_ast ~generate:true ast in
   let ast = { ast with comments } in
   process_ast target type_envs ast
@@ -203,6 +204,7 @@ let load_files ?target default_sail_dir options type_envs files =
          parsed_files
       )
   in
+  Option.iter (fun t -> Target.run_pre_initial_check_hook t ast) target;
   let ast = Initial_check.process_ast ~generate:true ast in
   let ast = { ast with comments } in
   process_ast target type_envs ast

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1731,13 +1731,13 @@ let parse_file ?loc:(l = Parse_ast.Unknown) (f : string) : Lexer.comment list * 
     end
   with Sys_error err -> raise (Reporting.err_general l err)
 
-let get_lexbuf_from_string f s =
+let get_lexbuf_from_string ~filename:f ~contents:s =
   let lexbuf = Lexing.from_string s in
   lexbuf.Lexing.lex_curr_p <- { Lexing.pos_fname = f; Lexing.pos_lnum = 1; Lexing.pos_bol = 0; Lexing.pos_cnum = 0 };
   lexbuf
 
 let parse_file_from_string ~filename:f ~contents:s =
-  let lexbuf = get_lexbuf_from_string f s in
+  let lexbuf = get_lexbuf_from_string ~filename:f ~contents:s in
   try
     let comments = ref [] in
     let defs = Parser.file (Lexer.token comments) lexbuf in

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -214,7 +214,11 @@ rule token comments = parse
   | "-"                                 { Minus }
   | "<->"                               { Bidir }
   | "=>"                                { EqGt "=>" }
-  | "/*!"       { Doc (doc_comment (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) 0 false lexbuf) }
+  | "/*!"
+    { let startpos = Lexing.lexeme_start_p lexbuf in
+      let arg = doc_comment (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) 0 false lexbuf in
+      lexbuf.lex_start_p <- startpos;
+      Doc arg }
   | "//"        { line_comment comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) lexbuf; token comments lexbuf }
   | "/*"        { block_comment comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) 0 lexbuf; token comments lexbuf }
   | "*/"        { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) "Unbalanced comment") }

--- a/src/lib/target.ml
+++ b/src/lib/target.ml
@@ -74,6 +74,7 @@ type target = {
   name : string;
   options : (Arg.key * Arg.spec * Arg.doc) list;
   pre_parse_hook : unit -> unit;
+  pre_initial_check_hook : Parse_ast.defs -> unit;
   pre_rewrites_hook : tannot ast -> Effects.side_effect_info -> Env.t -> unit;
   rewrites : (string * Rewrites.rewriter_arg list) list;
   action : Yojson.Basic.t option -> string -> string option -> tannot ast -> Effects.side_effect_info -> Env.t -> unit;
@@ -85,6 +86,8 @@ let name tgt = tgt.name
 let run_pre_parse_hook tgt = tgt.pre_parse_hook
 
 let run_pre_rewrites_hook tgt = tgt.pre_rewrites_hook
+
+let run_pre_initial_check_hook tgt = tgt.pre_initial_check_hook
 
 let action tgt = tgt.action
 
@@ -98,7 +101,8 @@ let targets = ref StringMap.empty
 let the_target = ref None
 
 let register ~name ?flag ?description:desc ?(options = []) ?(pre_parse_hook = fun () -> ())
-    ?(pre_rewrites_hook = fun _ _ _ -> ()) ?(rewrites = []) ?(asserts_termination = false) action =
+    ?(pre_initial_check_hook = fun _ -> ()) ?(pre_rewrites_hook = fun _ _ _ -> ()) ?(rewrites = [])
+    ?(asserts_termination = false) action =
   let set_target () =
     match !the_target with
     | None -> the_target := Some name
@@ -113,6 +117,7 @@ let register ~name ?flag ?description:desc ?(options = []) ?(pre_parse_hook = fu
       name;
       options = ("-" ^ flag, Arg.Unit set_target, desc) :: options;
       pre_parse_hook;
+      pre_initial_check_hook;
       pre_rewrites_hook;
       rewrites;
       action;

--- a/src/lib/target.mli
+++ b/src/lib/target.mli
@@ -84,6 +84,8 @@ val name : target -> string
 
 val run_pre_parse_hook : target -> unit -> unit
 
+val run_pre_initial_check_hook : target -> Parse_ast.defs -> unit
+
 val run_pre_rewrites_hook : target -> tannot ast -> Effects.side_effect_info -> Env.t -> unit
 
 val rewrites : target -> Rewrites.rewrite_sequence
@@ -109,6 +111,7 @@ val asserts_termination : target -> bool
    @param ?description A custom description for the command line flag
    @param ?options Additional options for the Sail executable
    @param ?pre_parse_hook A function to call right at the start, before parsing
+   @param ?pre_initial_check_hook A function to call after parsing, but before de-sugaring
    @param ?pre_rewrites_hook A function to call before doing any rewrites
    @param ?rewrites A sequence of Sail to Sail rewrite passes for the target
    @param ?asserts_termination Whether termination measures are enforced by assertions in the target
@@ -122,6 +125,7 @@ val register :
   ?description:string ->
   ?options:(Arg.key * Arg.spec * Arg.doc) list ->
   ?pre_parse_hook:(unit -> unit) ->
+  ?pre_initial_check_hook:(Parse_ast.defs -> unit) ->
   ?pre_rewrites_hook:(tannot ast -> Effects.side_effect_info -> Env.t -> unit) ->
   ?rewrites:(string * Rewrites.rewriter_arg list) list ->
   ?asserts_termination:bool ->

--- a/src/sail_doc_backend/docinfo.ml
+++ b/src/sail_doc_backend/docinfo.ml
@@ -138,6 +138,10 @@ let hyper_loc l =
 
 type hyperlink = Function of id * hyper_location | Register of id * hyper_location
 
+let hyperlink_target = function Function (id, _) -> Callgraph.Function id | Register (id, _) -> Callgraph.Register id
+
+let hyperlink_span = function Function (_, l) -> l | Register (_, l) -> l
+
 let json_of_hyperlink = function
   | Function (id, (file, c1, c2)) ->
       `Assoc

--- a/src/sail_doc_backend/docinfo.mli
+++ b/src/sail_doc_backend/docinfo.mli
@@ -69,19 +69,26 @@ open Libsail
 
 open Ast
 open Ast_defs
+open Ast_util
 open Type_check
+
+type embedding = Plain | Base64
 
 type hyperlink
 
-type 'a docinfo
+type hyper_location = string * int * int
+
+val hyperlink_target : hyperlink -> Callgraph.node
+
+val hyperlink_span : hyperlink -> hyper_location
 
 val hyperlinks_from_def : string list -> Type_check.tannot def -> hyperlink list
+
+type 'a docinfo
 
 val json_of_hyperlink : hyperlink -> Yojson.Basic.t
 
 val json_of_docinfo : 'a docinfo -> Yojson.Basic.t
-
-type embedding = Plain | Base64
 
 module type CONFIG = sig
   (** If [Some] then the source code will be directly included in the

--- a/src/sail_doc_backend/html_source.ml
+++ b/src/sail_doc_backend/html_source.ml
@@ -1,0 +1,330 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  Redistribution and use in source and binary forms, with or without      *)
+(*  modification, are permitted provided that the following conditions      *)
+(*  are met:                                                                *)
+(*  1. Redistributions of source code must retain the above copyright       *)
+(*     notice, this list of conditions and the following disclaimer.        *)
+(*  2. Redistributions in binary form must reproduce the above copyright    *)
+(*     notice, this list of conditions and the following disclaimer in      *)
+(*     the documentation and/or other materials provided with the           *)
+(*     distribution.                                                        *)
+(*                                                                          *)
+(*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''      *)
+(*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED       *)
+(*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A         *)
+(*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR     *)
+(*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,            *)
+(*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT        *)
+(*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF        *)
+(*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND     *)
+(*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,      *)
+(*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT      *)
+(*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF      *)
+(*  SUCH DAMAGE.                                                            *)
+(****************************************************************************)
+
+open Libsail
+
+open Ast
+open Ast_defs
+open Ast_util
+
+module Highlight = struct
+  type t = Id | Keyword | Kind | Comment | String | Pragma | Internal | Operator | Literal | TyVar
+
+  let to_class = function
+    | Id -> "sail-id"
+    | Keyword -> "sail-keyword"
+    | Kind -> "sail-kind"
+    | Comment -> "sail-comment"
+    | String -> "sail-string"
+    | Pragma -> "sail-pragma"
+    | Internal -> "sail-internal"
+    | Operator -> "sail-operator"
+    | Literal -> "sail-literal"
+    | TyVar -> "sail-ty-var"
+end
+
+let highlights ~filename ~contents =
+  let lexbuf = Initial_check.get_lexbuf_from_string ~filename ~contents in
+  let comments = ref [] in
+  let highlights = Queue.create () in
+  let mark h = Queue.add (h, lexbuf.lex_start_p.pos_cnum, lexbuf.lex_curr_p.pos_cnum) highlights in
+  let rec go () =
+    let open Parser in
+    match Lexer.token comments lexbuf with
+    | Eof -> ()
+    | Id _ ->
+        mark Highlight.Id;
+        go ()
+    | Int | Bool | TYPE | Order ->
+        mark Highlight.Kind;
+        go ()
+    | String _ ->
+        mark Highlight.String;
+        go ()
+    | Doc _ ->
+        mark Highlight.Comment;
+        go ()
+    | And | As | Assert | By | Match | Clause | Dec | Op | Default | Effect | End | Enum | Else | Exit | Cast | Forall
+    | Foreach | Function_ | Mapping | Overload | Throw | Try | Catch | If_ | In | Inc | Var | Ref | Pure | Impure
+    | Monadic | Register | Return | Scattered | Sizeof | Constraint | Constant | Struct | Then | Typedef | Union
+    | Newtype | With | Val | Outcome | Instantiation | Impl | Private | Repeat | Until | While | Do | Mutual
+    | Configuration | TerminationMeasure | Forwards | Backwards | Let_ | Bitfield ->
+        mark Highlight.Keyword;
+        go ()
+    | Pragma _ | Attribute _ | Fixity _ ->
+        mark Highlight.Pragma;
+        go ()
+    | InternalPLet | InternalReturn | InternalAssume ->
+        mark Highlight.Internal;
+        go ()
+    | OpId _ | Star | ColonColon | Bar | Caret | Minus ->
+        mark Highlight.Operator;
+        go ()
+    | Hex _ | Bin _ | Undefined | True | False | Bitzero | Bitone | Num _ | Real _ ->
+        mark Highlight.Literal;
+        go ()
+    | TyVar _ ->
+        mark Highlight.TyVar;
+        go ()
+    | Under | Colon _ | Lcurly | Rcurly | LcurlyBar | RcurlyBar | Lsquare | Rsquare | LsquareBar | RsquareBar | Lparen
+    | Rparen | Dot | DotDot | EqGt _ | At | Unit _ | Bidir | Semi | Comma | Eq _ | TwoCaret | MinusGt ->
+        go ()
+  in
+  go ();
+  List.iter
+    (function Lexer.Comment (_, s, e, _) -> Queue.add (Highlight.Comment, s.pos_cnum, e.pos_cnum) highlights)
+    !comments;
+  let highlights = Array.init (Queue.length highlights) (fun _ -> Queue.take highlights) in
+  Array.stable_sort (fun (_, s1, _) (_, s2, _) -> Int.compare s1 s2) highlights;
+  highlights
+
+let hyperlink_targets ast =
+  let open Callgraph in
+  let targets = ref NodeMap.empty in
+  List.iter
+    (fun (DEF_aux (_, def_annot) as def) ->
+      match Reporting.simp_loc def_annot.loc with
+      | Some (p, _) -> NodeSet.iter (fun node -> targets := NodeMap.add node p !targets) (nodes_of_def def)
+      | None -> ()
+    )
+    ast.defs;
+  !targets
+
+let hyperlinks_for_file ~filename ast =
+  let hyperlinks = Queue.create () in
+  List.iter
+    (fun (DEF_aux (_, def_annot) as def) ->
+      List.iter
+        (fun link ->
+          let node = Docinfo.hyperlink_target link in
+          let f, s, e = Docinfo.hyperlink_span link in
+          if filename = f then Queue.add (node, s, e) hyperlinks
+        )
+        (Docinfo.hyperlinks_from_def [] def)
+    )
+    ast.defs;
+  let hyperlinks = Array.init (Queue.length hyperlinks) (fun _ -> Queue.take hyperlinks) in
+  Array.stable_sort (fun (_, s1, _) (_, s2, _) -> Int.compare s1 s2) hyperlinks;
+  hyperlinks
+
+let default_css =
+  [
+    ".sail-id { color: black; }";
+    ".sail-keyword { font-weight: bold; color: maroon; }";
+    ".sail-kind { color: purple; }";
+    ".sail-comment { color: green; }";
+    ".sail-string { color: red; }";
+    ".sail-pragma { font-weight: bold; color: blue; }";
+    ".sail-internal { font-weight: bold; color: red; }";
+    ".sail-operator { color: maroon; }";
+    ".sail-literal { color: teal; }";
+    ".sail-ty-var { color: blue; }";
+    "#sail-html-columns { display: flex; width: 100%; }";
+    "#sail-html-lines { padding-left: 10px; padding-right: 10px; width: min-content; text-align: right; white-space: \
+     nowrap; }";
+    "#sail-html-source { padding-left: 10px; flex: 1; }";
+    ":target { background: yellow; }";
+  ]
+  |> Util.string_of_list "" (fun line -> line ^ "\n")
+
+let output_tags out_chan tags =
+  Util.iter_last
+    (fun is_last tag ->
+      output_string out_chan tag;
+      if not is_last then output_char out_chan '\n'
+    )
+    tags
+
+type file_info = { filename : string; prefix : string; contents : string; highlights : (Highlight.t * int * int) array }
+
+let get_span ~current ~index ~access n =
+  let open Lexing in
+  match !current with
+  | Some (info, s, e) ->
+      if e = n then (
+        current := None;
+        incr index
+      );
+      Some (info, s, e)
+  | None ->
+      let rec go () =
+        match access !index with
+        | info, s, e ->
+            if s < n then (
+              incr index;
+              go ()
+            )
+            else if s = n then (
+              current := Some (info, s, e);
+              !current
+            )
+            else None
+        | exception Invalid_argument _ -> None
+      in
+      go ()
+
+let output_html_char out_chan = function
+  | '&' -> output_string out_chan "&amp;"
+  | '<' -> output_string out_chan "&lt;"
+  | '>' -> output_string out_chan "&gt;"
+  | c -> output_char out_chan c
+
+let output_html ?(css = default_css) ~file_info ~hyperlinks out_chan =
+  let outputf fmt = Printf.ksprintf (output_string out_chan) fmt in
+
+  let tags_pre_css =
+    ["<html>"; "<head>"; "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />"; "<style>"]
+  in
+  let tags_post_css =
+    ["</style>"; "</head>"; "<body>"; "<pre>"; "<div id=\"sail-html-columns\">"; "<div id=\"sail-html-lines\">"]
+  in
+  let tags_middle = ["</div>"; "<div id=\"sail-html-source\">"] in
+  let tags_end = ["</pre>"; "</div>"; "</div>"; "</body>"; "</html>"] in
+  output_tags out_chan tags_pre_css;
+  output_string out_chan css;
+  output_tags out_chan tags_post_css;
+
+  (* Output the line numbers in the first column div *)
+  let line_count = ref 1 in
+  String.iter
+    (fun c ->
+      if c = '\n' then (
+        outputf "<span id=\"L%d\">%d</span><br />" !line_count !line_count;
+        incr line_count
+      )
+    )
+    file_info.contents;
+
+  output_tags out_chan tags_middle;
+
+  let highlight_index = ref 0 in
+  let current_highlight = ref None in
+  let get_highlight =
+    get_span ~current:current_highlight ~index:highlight_index ~access:(fun i -> file_info.highlights.(i))
+  in
+
+  let link_index = ref 0 in
+  let current_link = ref None in
+  let get_link = get_span ~current:current_link ~index:link_index ~access:(fun i -> hyperlinks.(i)) in
+
+  let starts_on n = function Some (_, s, _) -> n = s | None -> false in
+
+  let ends_on n = function Some (_, _, e) -> n = e | None -> false in
+
+  let highlight_class = function Some (hl, _, _) -> Highlight.to_class hl | None -> assert false in
+
+  let link_target = function Some (t, _, _) -> t | _ -> assert false in
+
+  let highlight_ends_before_link highlight link =
+    match (highlight, link) with
+    | Some (_, _, highlight_end), Some (_, _, link_end) -> highlight_end < link_end
+    | _ -> false
+  in
+
+  String.iteri
+    (fun n c ->
+      let link = get_link n in
+      let highlight = get_highlight n in
+      (* Insert the starting tags *)
+      if starts_on n link then
+        if
+          (* If there is a current highlight, and it would end before
+             the new link ends our HTML tags would be badly nested, so
+             fix this by closing the current highlight tag and opening
+             a new one. *)
+          highlight_ends_before_link highlight link
+        then outputf "</span><a href=\"%s\"><span class=\"%s\">" (link_target link) (highlight_class highlight)
+        else outputf "<a href=\"%s\">" (link_target link);
+      if starts_on n highlight then outputf "<span class=\"%s\">" (highlight_class highlight);
+      (* Insert the ending tags *)
+      if ends_on n highlight && ends_on n link then (
+        output_string out_chan "</span></a>";
+        (* Another highlight or link span could start on the same character *)
+        match (get_highlight n, get_link n) with
+        | Some (hl, hs, _), Some (t, ls, _) when n = hs && n = ls ->
+            outputf "<a href=\"%s\"><span class=\"%s\">" t (Highlight.to_class hl)
+        | Some (hl, hs, _), _ when n = hs -> outputf "<span class=\"%s\">" (Highlight.to_class hl)
+        | _, Some (t, ls, _) when n = ls -> outputf "<a href=\"%s\">" t
+        | _, _ -> ()
+      )
+      else if ends_on n highlight then (
+        output_string out_chan "</span>";
+        (* Another highlight span could start on the same character *)
+        match get_highlight n with
+        | Some (hl, hs, _) when n = hs -> outputf "<span class=\"%s\">" (Highlight.to_class hl)
+        | _ -> ()
+      )
+      else if ends_on n link then (
+        output_string out_chan "</a>";
+        (* Another link span could start on the same character *)
+        match get_link n with Some (t, ls, _) when n = ls -> outputf "<a href=\"%s\">" t | _ -> ()
+      );
+      output_html_char out_chan c
+    )
+    file_info.contents;
+
+  output_tags out_chan tags_end

--- a/test/typecheck/pass/lexp_vec/v1.expect
+++ b/test/typecheck/pass/lexp_vec/v1.expect
@@ -9,8 +9,3 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
 12[96m |[0m  V[i] = v
   [91m |[0m  [91m^--^[0m
   [91m |[0m Failed to prove constraint: (0 <= 'i & 'i < 16)
-  [91m |[0m 
-  [91m |[0m [93mCaused by [0m[96mpass/lexp_vec/v1.sail[0m:12.2-6:
-  [91m |[0m 12[96m |[0m  V[i] = v
-  [91m |[0m   [91m |[0m  [91m^--^[0m
-  [91m |[0m   [91m |[0m Failed to prove constraint: (0 <= 'i & 'i < 16)

--- a/test/typecheck/pass/outcome_impl/v3.expect
+++ b/test/typecheck/pass/outcome_impl/v3.expect
@@ -3,8 +3,3 @@
 30[96m |[0m  to_bits = instance_to_bits2
   [91m |[0m  [91m^-------------------------^[0m
   [91m |[0m bitvector(32) is not a subtype of string
-  [91m |[0m 
-  [91m |[0m [93mAlso tried [0m[96mpass/outcome_impl/v3.sail[0m:30.2-29:
-  [91m |[0m 30[96m |[0m  to_bits = instance_to_bits2
-  [91m |[0m   [91m |[0m  [91m^-------------------------^[0m
-  [91m |[0m   [91m |[0m bitvector(32) is not a subtype of string

--- a/test/typecheck/pass/reg_32_64/v2.expect
+++ b/test/typecheck/pass/reg_32_64/v2.expect
@@ -9,8 +9,3 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
 21[96m |[0m  (*R)['d .. 0] = data
   [91m |[0m  [91m^-----------^[0m
   [91m |[0m Failed to prove constraint: (0 <= 'd & 'd < 64)
-  [91m |[0m 
-  [91m |[0m [93mCaused by [0m[96mpass/reg_32_64/v2.sail[0m:21.2-15:
-  [91m |[0m 21[96m |[0m  (*R)['d .. 0] = data
-  [91m |[0m   [91m |[0m  [91m^-----------^[0m
-  [91m |[0m   [91m |[0m Failed to prove constraint: (0 <= 'd & 'd < 64)


### PR DESCRIPTION
improve some error messages slightly by either not repeating information, or by showing unsimplified constraints when they simplify to false