### PR TITLE
Fix sail-fmt block_comment indent

### DIFF
--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -264,9 +264,7 @@ module PPrintWrapper = struct
 
   let block_comment_lines col s =
     let lines = Util.split_on_char '\n' s in
-    let lines =
-      List.mapi (fun i l -> if i + 1 == List.length lines then l else rtrim l) lines
-    in
+    let lines = List.mapi (fun i l -> if i + 1 == List.length lines then l else rtrim l) lines in
     let lines = patch_comment_lines_indent col lines in
     List.mapi
       (fun n line ->

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -236,7 +236,7 @@ module PPrintWrapper = struct
     let rec loop min_indent lines =
       match lines with
       | line :: rest_of_lines ->
-          (* ignore empty line *)
+          (* Ignore empty line *)
           if line = "" then loop min_indent rest_of_lines
           else (
             let indent = count_indent line in
@@ -249,14 +249,14 @@ module PPrintWrapper = struct
 
   let patch_comment_lines_indent col lines =
     let min_indent = count_lines_min_indent lines in
-    Printf.printf "min_ident: %d, col: %d, " min_indent col;
     let right_indent_count = col - min_indent in
-    Printf.printf "right_indent_count: %d\n" right_indent_count;
     let lines =
       List.mapi
         (fun i l ->
-          (* The first line remains unchanged *)
-          if i == 0 then l else if right_indent_count > 0 then String.make (abs right_indent_count) ' ' ^ l else l
+          (* The first_line or empty_line remains unchanged *)
+          if i == 0 || l = "" then l
+          else if right_indent_count > 0 then String.make (abs right_indent_count) ' ' ^ l
+          else l
         )
         lines
     in
@@ -264,7 +264,8 @@ module PPrintWrapper = struct
 
   let block_comment_lines col s =
     let lines = Util.split_on_char '\n' s in
-    let lines = List.mapi (fun i l -> if i + 1 == List.length lines then l else rtrim l) lines in
+    (* Last line (before */) shouldn't be rtrimed *)
+    let lines = List.mapi (fun i l -> if i + 1 = List.length lines then l else rtrim l) lines in
     let lines = patch_comment_lines_indent col lines in
     List.mapi
       (fun n line ->

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -11,6 +11,18 @@
              indent many
       last line comment*/
 function a () -> int = {
+
+/* first line comment
+             indent many
+           last line comment*/
+
+          /* first line comment
+      indent many
+           last line comment*/
+
+        /* first line comment
+             indent many
+      last line comment*/
     *R = baz; // comment
        // comment
      1// comment

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -1,3 +1,13 @@
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
+/* first line comment
+
+           */
+/* first line comment
+
+        last line comment         */
 
 /* first line comment
              indent many
@@ -11,6 +21,16 @@
              indent many
       last line comment*/
 function a () -> int = {
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
+/* first line comment
+                    
+           */
+/* first line comment
+
+        last line comment         */
 
 /* first line comment
              indent many

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -1,3 +1,15 @@
+
+/* first line comment
+             indent many
+           last line comment*/
+
+          /* first line comment
+      indent many
+           last line comment*/
+
+        /* first line comment
+             indent many
+      last line comment*/
 function a () -> int = {
     *R = baz; // comment
        // comment

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -1,3 +1,13 @@
+
+/* first line comment
+             indent many
+           last line comment*/
+/* first line comment
+indent many
+     last line comment*/
+/* first line comment
+       indent many
+last line comment*/
 function a () -> int = {
     *R = baz; // comment
 

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -9,6 +9,15 @@ indent many
        indent many
 last line comment*/
 function a () -> int = {
+    /* first line comment
+                 indent many
+               last line comment*/
+    /* first line comment
+    indent many
+         last line comment*/
+    /* first line comment
+           indent many
+    last line comment*/
     *R = baz; // comment
 
     // comment

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -1,4 +1,14 @@
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
 
+/* first line comment
+
+           */
+/* first line comment
+
+        last line comment         */
 /* first line comment
              indent many
            last line comment*/
@@ -9,6 +19,16 @@ indent many
        indent many
 last line comment*/
 function a () -> int = {
+    /*comment*/
+    /*      comment          */
+    /* first line comment
+                            */
+    /* first line comment
+
+               */
+    /* first line comment
+
+            last line comment         */
     /* first line comment
                  indent many
                last line comment*/

--- a/test/format/default/doc_comment.expect
+++ b/test/format/default/doc_comment.expect
@@ -1,4 +1,13 @@
 default Order dec
 
+/*! first line comment
+             indent many
+           last line comment*/
+/*! first line comment
+      indent many
+           last line comment*/
+/*! first line comment
+             indent many
+      last line comment*/
 /*! A documentation comment */
 val main : unit -> unit

--- a/test/format/doc_comment.sail
+++ b/test/format/doc_comment.sail
@@ -1,8 +1,17 @@
 default Order dec
 
+/*! first line comment
+             indent many
+           last line comment*/
+
+          /*! first line comment
+      indent many
+           last line comment*/
+
+        /*! first line comment
+             indent many
+      last line comment*/
+
 /*! A documentation comment */
-
-
-
-val main :
-unit -> unit
+val main : 
+    unit -> unit


### PR DESCRIPTION
Hi, I'm going to test sail-fmt on riscv-sails
like this PR did https://github.com/riscv/sail-riscv/pull/264, and then try to fix them one by one

---

This PR is for fix an error when formatting something like 

```
/*! hahaha*/

```

```
Syntax error.
. /test/format/unbalanced_comment.sail:2.0-0: | current token: .
  | current token: . 
```

seems to be related to https://github.com/rems-project/sail/issues/237

---

I have a few questions, could you explain
- why is the doc_comment here not added to the comments?
- and why `lexbuf.lex_start_p <- startpos;` it looks strange
- what is the Doc, I can't find it in any other code (I am just a newbie to ocamllex :|).