### PR TITLE
Some LSP integration features

### DIFF
--- a/editors/sail-mode.el
+++ b/editors/sail-mode.el
@@ -111,6 +111,14 @@
 	    (lambda () (add-hook 'after-save-hook 'sail-load nil 'local)))
   (run-hooks 'sail-mode-hook))
 
+;; (with-eval-after-load 'lsp-mode **/
+;;   (add-to-list 'lsp-language-id-configuration '(sail-mode . "sail")) **/
+
+;;   (lsp-register-client (make-lsp-client **/
+;;                         :new-connection (lsp-stdio-connection "sail_lsp") **/
+;;                         :activation-fn (lsp-activate-on "sail") **/
+;;                         :server-id 'sail))) **/
+
 (defun sail-project-mode ()
   "Major mode for editing Sail Language files"
   (interactive)

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -607,12 +607,20 @@ val unique : l -> l
 
 val extern_assoc : string -> extern option -> string option
 
-(** Try to find the annotation closest to the provided (simplified)
-   location. Note that this function makes no guarantees about finding
-   the closest annotation or even finding an annotation at all. This
-   is used by the Emacs mode to provide type-at-cursor functionality
-   and we don't mind if it's a bit fuzzy in that context. *)
-val find_annot_ast : (Lexing.position * Lexing.position) option -> ('a, 'b) ast -> (Ast.l * 'a) option
+(** Try to find the annotation closest to the provided location (which
+    can be in any format, as long as we can tell if it is smaller than
+    any other location). Note that this function makes no guarantees
+    about finding the closest annotation or even finding an annotation
+    at all. This is used by the LSP to provide type-at-cursor
+    functionality and we don't mind if it's a bit fuzzy in that
+    context. *)
+module Scanner (Loc : sig
+  type t
+
+  val subloc : t -> Parse_ast.l -> bool
+end) : sig
+  val find_annot_ast : Loc.t -> ('a, 'b) ast -> (Parse_ast.l * 'a) option
+end
 
 (** {1 Substitutions}
 

--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -127,7 +127,6 @@ let add_vertex data graph =
     Array.blit graph.nodes 0 new_nodes 0 (Array.length graph.nodes);
     graph.nodes <- new_nodes
   end;
-  let n = graph.next in
   graph.nodes.(n) <- Some (data, IntSet.empty, IntSet.empty);
   graph.next <- n + 1;
   n

--- a/src/lib/sail_file.ml
+++ b/src/lib/sail_file.ml
@@ -1,3 +1,70 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  Redistribution and use in source and binary forms, with or without      *)
+(*  modification, are permitted provided that the following conditions      *)
+(*  are met:                                                                *)
+(*  1. Redistributions of source code must retain the above copyright       *)
+(*     notice, this list of conditions and the following disclaimer.        *)
+(*  2. Redistributions in binary form must reproduce the above copyright    *)
+(*     notice, this list of conditions and the following disclaimer in      *)
+(*     the documentation and/or other materials provided with the           *)
+(*     distribution.                                                        *)
+(*                                                                          *)
+(*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''      *)
+(*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED       *)
+(*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A         *)
+(*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR     *)
+(*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,            *)
+(*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT        *)
+(*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF        *)
+(*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND     *)
+(*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,      *)
+(*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT      *)
+(*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF      *)
+(*  SUCH DAMAGE.                                                            *)
+(****************************************************************************)
+
 type handle = int
 
 let handles = ref 0
@@ -15,52 +82,193 @@ let set_canonicalize_function f = canonicalizer := f
 
 type owner = Compiler | Editor
 
+type editor_position = { line : int; character : int }
+
+type editor_range = editor_position * editor_position
+
+type text_edit = { range : editor_range; text : string }
+
+type text_edit_size = Single_line of int | Multiple_lines of { pre : int; newlines : int; post : int }
+
+let count_newlines s =
+  let n = ref 0 in
+  String.iter (fun c -> if c = '\n' then incr n) s;
+  !n
+
+let measure_edit edit =
+  let newlines = count_newlines edit.text in
+  if newlines = 0 then Single_line (String.length edit.text)
+  else (
+    let pre = String.index_from edit.text 0 '\n' in
+    let post = String.rindex_from edit.text (String.length edit.text - 1) '\n' in
+    Multiple_lines { pre; newlines; post }
+  )
+
 type info = {
   (* This is for LSP integration, either we (the compiler) own
      the file, otherwise the editor owns the file. *)
   owner : owner;
+  (* The path as provided by the user *)
+  given_path : string;
   canonical_path : string;
   mutable contents : string Array.t;
+  mutable next_edit : int;
+  mutable edits : (text_edit * text_edit_size) option Array.t;
 }
 
-let files : (int, info) Hashtbl.t = Hashtbl.create 100
+let new_info ~owner ~given_path ~canonical_path ~contents =
+  { owner; given_path; canonical_path; contents; next_edit = 0; edits = Array.make 64 None }
 
-let opened : (string, int) Hashtbl.t = Hashtbl.create 100
+let files : (int, info) Hashtbl.t = Hashtbl.create 64
+
+let opened : (string, int) Hashtbl.t = Hashtbl.create 64
+
+let edit_file handle edit =
+  let info = Hashtbl.find files handle in
+  let max_edits = Array.length info.edits in
+  let n = info.next_edit in
+  if n >= max_edits then (
+    let new_edits = Array.make (n * 2) None in
+    Array.blit info.edits 0 new_edits 0 max_edits;
+    info.edits <- new_edits
+  );
+  let size = measure_edit edit in
+  info.edits.(n) <- Some (edit, size);
+  info.next_edit <- n + 1
+
+let apply_edits handle =
+  let info = Hashtbl.find files handle in
+  Array.fill info.edits 0 (Array.length info.edits) None;
+  info.next_edit <- 0
+
+let fold_edits_first_to_last f handle init =
+  let info = Hashtbl.find files handle in
+  let acc = ref init in
+  for i = 0 to info.next_edit - 1 do
+    let edit, size = Option.get info.edits.(i) in
+    acc := f edit size !acc
+  done;
+  !acc
+
+let fold_edits_last_to_first f handle init =
+  let info = Hashtbl.find files handle in
+  let acc = ref init in
+  for i = info.next_edit - 1 downto 0 do
+    let edit, size = Option.get info.edits.(i) in
+    acc := f edit size !acc
+  done;
+  !acc
+
+let position_before p1 p2 = p1.line < p2.line || (p1.line = p2.line && p1.character < p2.character)
+
+let update_position edit size p =
+  let s, e = edit.range in
+  if position_before p s then Some p
+  else if position_before e p || e = p then
+    Some
+      ( match size with
+      | Multiple_lines { pre = _; newlines; post } ->
+          let line_change = newlines - (e.line - s.line) in
+          if p.line = e.line then { line = p.line + line_change; character = p.character - e.character + post }
+          else { line = p.line + line_change; character = p.character }
+      | Single_line n ->
+          if p.line = e.line then { line = p.line; character = p.character - (e.character - s.character) + n } else p
+      )
+  else None
+
+let revert_position edit size p =
+  let s, e = edit.range in
+  if position_before p s then Some p
+  else if position_before e p || e = p then
+    Some
+      ( match size with
+      | Multiple_lines { pre = _; newlines; post } ->
+          let line_change = e.line - s.line - newlines in
+          if p.line = e.line then { line = p.line + line_change; character = p.character + e.character - post }
+          else { line = p.line + line_change; character = p.character }
+      | Single_line n ->
+          if p.line = e.line then { line = p.line; character = p.character - n + (e.character - s.character) } else p
+      )
+  else None
+
+let editor_position p =
+  let open Lexing in
+  let path = canonicalize p.pos_fname in
+  match Hashtbl.find_opt opened path with
+  | Some handle ->
+      fold_edits_first_to_last
+        (fun edit size pos_opt -> match pos_opt with None -> None | Some p -> update_position edit size p)
+        handle
+        (Some { line = p.pos_lnum; character = p.pos_cnum - p.pos_bol })
+  | None -> None
+
+let lexing_position handle p =
+  let open Lexing in
+  let open Util.Option_monad in
+  let* p =
+    fold_edits_last_to_first
+      (fun edit size pos_opt ->
+        let* p = pos_opt in
+        revert_position edit size p
+      )
+      handle (Some p)
+  in
+  let info = Hashtbl.find files handle in
+  let bol = ref 0 in
+  for i = 0 to p.line - 1 do
+    bol := !bol + String.length info.contents.(i) + 1
+  done;
+  Some { pos_fname = info.given_path; pos_lnum = p.line; pos_bol = !bol; pos_cnum = !bol + p.character }
 
 let file_to_line_array filename =
   let chan = open_in filename in
+  let linebuf = Buffer.create 256 in
   let lines = Queue.create () in
+  (* Note that this has to be a little intricate, because it handles
+     trailing newlines before End_of_file. *)
   try
     let rec loop () =
-      let line = input_line chan in
-      Queue.add line lines;
+      let c = input_char chan in
+      if c = '\n' then (
+        Queue.add (Buffer.contents linebuf) lines;
+        Buffer.clear linebuf
+      )
+      else Buffer.add_char linebuf c;
       loop ()
     in
     loop ()
   with End_of_file ->
+    if Buffer.length linebuf = 0 then (
+      if
+        (* If both the linebuf and lines are empty we were given the
+           empty file. If linebuf is empty, but lines is not then we
+           just processed a newline immediately prior to End_of_file. *)
+        Queue.length lines <> 0
+      then Queue.add "" lines
+    )
+    else Queue.add (Buffer.contents linebuf) lines;
     close_in chan;
     Array.init (Queue.length lines) (fun _ -> Queue.take lines)
 
-let open_file path =
+let open_file given_path =
+  let path = canonicalize given_path in
   match Hashtbl.find_opt opened path with
   | Some handle -> handle
-  | None -> (
+  | None ->
       if not (Sys.file_exists path) then raise (Sys_error (path ^ ": No such file or directory"));
-      let canonical_path = canonicalize path in
-      let existing_handle = ref None in
-      Hashtbl.iter
-        (fun handle info -> if info.canonical_path = canonical_path then existing_handle := Some handle)
-        files;
-      match !existing_handle with
-      | Some handle -> handle
-      | None ->
-          let contents = file_to_line_array path in
-          let handle = new_handle () in
-          let info = { owner = Compiler; canonical_path; contents } in
-          Hashtbl.add files handle info;
-          Hashtbl.add opened path handle;
-          handle
-    )
+      let contents = file_to_line_array path in
+      let handle = new_handle () in
+      let info = new_info ~owner:Compiler ~given_path ~canonical_path:path ~contents in
+      Hashtbl.add files handle info;
+      Hashtbl.add opened path handle;
+      handle
+
+let write_file ~contents handle =
+  let info = Hashtbl.find files handle in
+  let contents = Array.of_list (String.split_on_char '\n' contents) in
+  Array.fill info.edits 0 (Array.length info.edits) None;
+  info.contents <- contents;
+  info.next_edit <- 0
 
 let editor_take_file ~contents path =
   let contents = Array.of_list (String.split_on_char '\n' contents) in
@@ -82,7 +290,7 @@ let editor_take_file ~contents path =
           handle
       | None ->
           let handle = new_handle () in
-          let info = { owner = Editor; canonical_path; contents } in
+          let info = new_info ~owner:Editor ~given_path:path ~canonical_path ~contents in
           Hashtbl.add files handle info;
           Hashtbl.add opened path handle;
           handle
@@ -99,7 +307,7 @@ let contents handle =
   Array.iteri
     (fun n line ->
       Buffer.add_string buf line;
-      Buffer.add_char buf '\n'
+      if n <> Array.length lines - 1 then Buffer.add_char buf '\n'
     )
     lines;
   Buffer.contents buf

--- a/src/lib/sail_file.ml
+++ b/src/lib/sail_file.ml
@@ -1,0 +1,129 @@
+type handle = int
+
+let handles = ref 0
+
+let new_handle () =
+  let handle = !handles in
+  incr handles;
+  handle
+
+let canonicalizer = ref (fun path -> path)
+
+let canonicalize path = !canonicalizer path
+
+let set_canonicalize_function f = canonicalizer := f
+
+type owner = Compiler | Editor
+
+type info = {
+  (* This is for LSP integration, either we (the compiler) own
+     the file, otherwise the editor owns the file. *)
+  owner : owner;
+  canonical_path : string;
+  mutable contents : string Array.t;
+}
+
+let files : (int, info) Hashtbl.t = Hashtbl.create 100
+
+let opened : (string, int) Hashtbl.t = Hashtbl.create 100
+
+let file_to_line_array filename =
+  let chan = open_in filename in
+  let lines = Queue.create () in
+  try
+    let rec loop () =
+      let line = input_line chan in
+      Queue.add line lines;
+      loop ()
+    in
+    loop ()
+  with End_of_file ->
+    close_in chan;
+    Array.init (Queue.length lines) (fun _ -> Queue.take lines)
+
+let open_file path =
+  match Hashtbl.find_opt opened path with
+  | Some handle -> handle
+  | None -> (
+      if not (Sys.file_exists path) then raise (Sys_error (path ^ ": No such file or directory"));
+      let canonical_path = canonicalize path in
+      let existing_handle = ref None in
+      Hashtbl.iter
+        (fun handle info -> if info.canonical_path = canonical_path then existing_handle := Some handle)
+        files;
+      match !existing_handle with
+      | Some handle -> handle
+      | None ->
+          let contents = file_to_line_array path in
+          let handle = new_handle () in
+          let info = { owner = Compiler; canonical_path; contents } in
+          Hashtbl.add files handle info;
+          Hashtbl.add opened path handle;
+          handle
+    )
+
+let editor_take_file ~contents path =
+  let contents = Array.of_list (String.split_on_char '\n' contents) in
+  match Hashtbl.find_opt opened path with
+  | Some handle ->
+      let info = Hashtbl.find files handle in
+      Hashtbl.replace files handle { info with owner = Editor; contents };
+      handle
+  | None -> (
+      let canonical_path = canonicalize path in
+      let existing = ref None in
+      Hashtbl.iter
+        (fun handle info -> if info.canonical_path = canonical_path then existing := Some (handle, info))
+        files;
+      match !existing with
+      | Some (handle, info) ->
+          Hashtbl.replace files handle { info with owner = Editor; contents };
+          Hashtbl.add opened path handle;
+          handle
+      | None ->
+          let handle = new_handle () in
+          let info = { owner = Editor; canonical_path; contents } in
+          Hashtbl.add files handle info;
+          Hashtbl.add opened path handle;
+          handle
+    )
+
+let editor_drop_file handle =
+  let info = Hashtbl.find files handle in
+  Hashtbl.replace files handle { info with owner = Compiler }
+
+let contents handle =
+  let lines = (Hashtbl.find files handle).contents in
+  let len = Array.fold_left (fun len line -> len + String.length line + 1) 0 lines in
+  let buf = Buffer.create len in
+  Array.iteri
+    (fun n line ->
+      Buffer.add_string buf line;
+      Buffer.add_char buf '\n'
+    )
+    lines;
+  Buffer.contents buf
+
+module In_channel = struct
+  type t = { mutable pos : int; buf : string }
+
+  let from_file handle = { pos = -1; buf = contents handle }
+
+  let from_string s = { pos = -1; buf = s }
+
+  let input_line_opt in_chan =
+    if in_chan.pos >= String.length in_chan.buf then None
+    else (
+      match String.index_from_opt in_chan.buf (in_chan.pos + 1) '\n' with
+      | None ->
+          let line = String.sub in_chan.buf (in_chan.pos + 1) (String.length in_chan.buf - (in_chan.pos + 1)) in
+          in_chan.pos <- String.length in_chan.buf;
+          Some line
+      | Some next_newline ->
+          let line = String.sub in_chan.buf (in_chan.pos + 1) (next_newline - (in_chan.pos + 1)) in
+          in_chan.pos <- next_newline;
+          Some line
+    )
+
+  let input_line in_chan = match input_line_opt in_chan with Some line -> line | None -> raise End_of_file
+end

--- a/src/lib/sail_file.mli
+++ b/src/lib/sail_file.mli
@@ -1,0 +1,104 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  Redistribution and use in source and binary forms, with or without      *)
+(*  modification, are permitted provided that the following conditions      *)
+(*  are met:                                                                *)
+(*  1. Redistributions of source code must retain the above copyright       *)
+(*     notice, this list of conditions and the following disclaimer.        *)
+(*  2. Redistributions in binary form must reproduce the above copyright    *)
+(*     notice, this list of conditions and the following disclaimer in      *)
+(*     the documentation and/or other materials provided with the           *)
+(*     distribution.                                                        *)
+(*                                                                          *)
+(*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''      *)
+(*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED       *)
+(*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A         *)
+(*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR     *)
+(*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,            *)
+(*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT        *)
+(*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF        *)
+(*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND     *)
+(*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,      *)
+(*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT      *)
+(*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF      *)
+(*  SUCH DAMAGE.                                                            *)
+(****************************************************************************)
+
+type handle = private int
+
+(** For the LSP, we might have Sail and the editor use slightly
+    different paths for the same file so we can set this to
+    Sys.realpath, and we will then treat files with the same canonical
+    name as the same file. *)
+val set_canonicalize_function : (string -> string) -> unit
+
+(** Open a file and return a 'handle' to it's contents. Note that the
+    file is not actually held open -- we read the contents, then close
+    the handle storing the file information and contents in memory. As
+    such there is no close_file. *)
+val open_file : string -> handle
+
+(** The the LSP takes control of a file by sending us a
+    DidOpenTextDocument message, with the contents of the file as seen
+    by the editor. *)
+val editor_take_file : contents:string -> string -> handle
+
+(** The LSP can stop editing a file using the DidCloseTextDocument
+    message, in which case we need to manage the file. *)
+val editor_drop_file : handle -> unit
+
+val contents : handle -> string
+
+(** This module aims to provide a drop-in replacement for the stdlib
+    in_channel functionality used by Sail, essentially providing an
+    iterator style interface to the file contents. *)
+module In_channel : sig
+  type t
+
+  val from_file : handle -> t
+
+  val input_line_opt : t -> string option
+
+  val input_line : t -> string
+end

--- a/src/lib/sail_file.mli
+++ b/src/lib/sail_file.mli
@@ -70,14 +70,24 @@ type handle = private int
 (** For the LSP, we might have Sail and the editor use slightly
     different paths for the same file so we can set this to
     Sys.realpath, and we will then treat files with the same canonical
-    name as the same file. *)
+    name as the same file.
+
+    We can't just use realpath directly because it would mean
+    increasing our minimum OCaml version to 4.13. *)
 val set_canonicalize_function : (string -> string) -> unit
 
 (** Open a file and return a 'handle' to it's contents. Note that the
     file is not actually held open -- we read the contents, then close
     the handle storing the file information and contents in memory. As
-    such there is no close_file. *)
+    such there is no close_file. Repeatedly calling this file on the
+    same string (as determined by [set_canonicalize_function]) will
+    return the same handle. *)
 val open_file : string -> handle
+
+(** Replace the contents of a file. Note that this only changes the
+    in-memory contents of the file, and does not flush the changes to
+    disk. *)
+val write_file : contents:string -> handle -> unit
 
 (** The the LSP takes control of a file by sending us a
     DidOpenTextDocument message, with the contents of the file as seen
@@ -88,6 +98,37 @@ val editor_take_file : contents:string -> string -> handle
     message, in which case we need to manage the file. *)
 val editor_drop_file : handle -> unit
 
+(** The LSP protocol uses line + character offsets as positions *)
+type editor_position = { line : int; character : int }
+
+type editor_range = editor_position * editor_position
+
+(** Note that the empty string represents a delete operation as per
+    LSP. *)
+type text_edit = { range : editor_range; text : string }
+
+type text_edit_size = Single_line of int | Multiple_lines of { pre : int; newlines : int; post : int }
+
+(** Store a pending text edit to a file. This is used by
+    [editor_position] and [lexing_position] to synchonize locations
+    between the last type-checked version of the file, and any changes
+    that have subsequently been made in the editor. Note that it does
+    not change the actual contents of the file. *)
+val edit_file : handle -> text_edit -> unit
+
+(** Take a Sail AST position, and return the where it will visibly
+    appear in the user's editor. Returns None if the position no
+    longer exists in the editor buffer, for example, the user may have
+    deleted the position. *)
+val editor_position : Lexing.position -> editor_position option
+
+(** Take a cursor position in the editor, and map it to a position in
+    the Sail AST. Returns None if the cursor position is within a
+    pending edit that has not yet been processed by Sail. *)
+val lexing_position : handle -> editor_position -> Lexing.position option
+
+(** The contents of a Sail file as a string, without any pending
+    edits. *)
 val contents : handle -> string
 
 (** This module aims to provide a drop-in replacement for the stdlib

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -3197,7 +3197,7 @@ and bind_assignment assign_l env (LE_aux (lexp_aux, (lexp_l, uannot)) as lexp) e
   match lexp_aux with
   | LE_app (f, xs) ->
       ( check_exp env
-          (E_aux (E_app (f, xs @ [exp]), (lexp_l, add_attribute (gen_loc lexp_l) "setter" None uannot)))
+          (E_aux (E_app (f, xs @ [exp]), (assign_l, add_attribute (gen_loc lexp_l) "setter" None uannot)))
           unit_typ,
         env
       )

--- a/test/typecheck/pass/reg_32_64/v1.expect
+++ b/test/typecheck/pass/reg_32_64/v1.expect
@@ -5,8 +5,8 @@
 Explicit effect annotations are deprecated. They are no longer used and can be removed.
 
 [93mType error[0m:
-[96mpass/reg_32_64/v1.sail[0m:35.2-6:
+[96mpass/reg_32_64/v1.sail[0m:35.2-28:
 35[96m |[0m  R(0) = 0xCAFE_CAFE_0000_00;
-  [91m |[0m  [91m^--^[0m
+  [91m |[0m  [91m^------------------------^[0m
   [91m |[0m Could not resolve quantifiers for set_R
   [91m |[0m [94m*[0m (regno(0) & 56 in {32, 64})


### PR DESCRIPTION
These commits have been on a branch since earlier this year. This PR rebases them, so they can be merged into the main branch and avoid bitrot.

Here we change how Sail loads files. Instead of just reading them from disk whenever needed, files are read into memory and then 'handles' to those files are persistently stored. These handles are marked as either being Compiler owned or Editor owned, and various functions are provided that correspond to the file/edit lifecycle expected by the language server protocol.