### PR TITLE
fmt: Format documentation comments

### DIFF
--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -88,6 +88,7 @@ type infix_chunk = Infix_prefix of string | Infix_op of string | Infix_chunks of
 
 and chunk =
   | Comment of Lexer.comment_type * int * int * string * bool
+  | Doc_comment of string
   | Spacer of bool * int
   | Function of {
       id : Parse_ast.id;

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -536,6 +536,9 @@ module Make (Config : CONFIG) = struct
             | ls -> blank n ^^ group (align (string "/*" ^^ separate hardline ls ^^ string "*/")) ^^ require_hardline
           )
       end
+    | Doc_comment contents ->
+        let ls = block_comment_lines 0 contents in
+        align (string "/*!" ^^ separate hardline ls ^^ string "*/") ^^ require_hardline
     | Function f ->
         let sep = hardline ^^ string "and" ^^ space in
         let clauses =

--- a/test/format/default/doc_comment.expect
+++ b/test/format/default/doc_comment.expect
@@ -1,0 +1,4 @@
+default Order dec
+
+/** A documentation comment */
+val main : unit -> unit

--- a/test/format/doc_comment.sail
+++ b/test/format/doc_comment.sail
@@ -1,0 +1,8 @@
+default Order dec
+
+/** A documentation comment */
+
+
+
+val main :
+unit -> unit


### PR DESCRIPTION
Previously `sail --fmt` would fail on documentation comments due to how their location was stored.