### PR TITLE
REPL: Better error messages and other utilities

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -202,7 +202,7 @@ let rec is_gen_loc = function
   | Parse_ast.Hint (_, l1, l2) -> is_gen_loc l1 || is_gen_loc l2
   | Parse_ast.Range _ -> false
 
-let mk_id str = Id_aux (Id str, Parse_ast.Unknown)
+let mk_id ?loc:(l = Parse_ast.Unknown) str = Id_aux (Id str, l)
 
 let mk_nc nc_aux = NC_aux (nc_aux, Parse_ast.Unknown)
 
@@ -248,7 +248,7 @@ let mk_fundef funcls =
   let rec_opt = Rec_aux (Rec_nonrec, Parse_ast.Unknown) in
   DEF_aux (DEF_fundef (FD_aux (FD_function (rec_opt, tannot_opt, funcls), no_annot)), mk_def_annot Parse_ast.Unknown ())
 
-let mk_letbind pat exp = LB_aux (LB_val (pat, exp), no_annot)
+let mk_letbind ?loc:(l = Parse_ast.Unknown) pat exp = LB_aux (LB_val (pat, exp), (l, empty_uannot))
 
 let mk_val_spec vs_aux = DEF_aux (DEF_val (VS_aux (vs_aux, no_annot)), mk_def_annot Parse_ast.Unknown ())
 

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -176,7 +176,7 @@ val is_order_dec : order -> bool
 
 (** {2 Functions for building untyped AST elements} *)
 
-val mk_id : string -> id
+val mk_id : ?loc:l -> string -> id
 val mk_kid : string -> kid
 val mk_nc : n_constraint_aux -> n_constraint
 val mk_nexp : nexp_aux -> nexp
@@ -199,7 +199,7 @@ val mk_qi_id : kind_aux -> kid -> quant_item
 val mk_qi_nc : n_constraint -> quant_item
 val mk_qi_kopt : kinded_id -> quant_item
 val mk_fexp : id -> uannot exp -> uannot fexp
-val mk_letbind : uannot pat -> uannot exp -> uannot letbind
+val mk_letbind : ?loc:l -> uannot pat -> uannot exp -> uannot letbind
 val mk_kopt : ?loc:l -> kind_aux -> kid -> kinded_id
 val mk_def : ?loc:l -> ('a, 'b) def_aux -> 'b -> ('a, 'b) def
 

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -125,14 +125,25 @@ val process_ast : ?generate:bool -> Parse_ast.defs -> untyped_ast
 (** {2 Parsing expressions and definitions from strings} *)
 
 val extern_of_string : ?pure:bool -> id -> string -> untyped_def
+
 val val_spec_of_string : id -> string -> untyped_def
+
 val defs_of_string : string * int * int * int -> string -> untyped_def list
-val ast_of_def_string : string * int * int * int -> string -> untyped_ast
+
+val ast_of_def_string : ?inline:Lexing.position -> string * int * int * int -> string -> untyped_ast
+
 val ast_of_def_string_with :
-  string * int * int * int -> (Parse_ast.def list -> Parse_ast.def list) -> string -> untyped_ast
-val exp_of_string : string -> uannot exp
-val typ_of_string : string -> typ
-val constraint_of_string : string -> n_constraint
+  ?inline:Lexing.position ->
+  string * int * int * int ->
+  (Parse_ast.def list -> Parse_ast.def list) ->
+  string ->
+  untyped_ast
+
+val exp_of_string : ?inline:Lexing.position -> string -> uannot exp
+
+val typ_of_string : ?inline:Lexing.position -> string -> typ
+
+val constraint_of_string : ?inline:Lexing.position -> string -> n_constraint
 
 (** {2 Parsing files } *)
 

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -153,6 +153,8 @@ This is used by the interactive read-eval-print loop. The interactive mode expos
 it's possible to excute code paths from the interactive mode that would otherwise be unreachable during normal execution. *)
 val print_error : ?interactive:bool -> error -> unit
 
+val print_type_error : ?hint:string -> Parse_ast.l -> string -> unit
+
 (** This function transforms all errors raised by the provided function into internal [Err_unreachable] errors *)
 val forbid_errors : string * int * int * int -> ('a -> 'b) -> 'a -> 'b
 
@@ -176,3 +178,22 @@ val get_sail_dir : string -> string
 
 (** Run a command using Unix.system, but raise a Reporting exception if the command fails or is stopped/killed by a signal *)
 val system_checked : ?loc:Parse_ast.l -> string -> unit
+
+module Position : sig
+  (** Assuming a position is at the start of a string, move it to the
+     position of the first character that would not get removed by
+     String.trim *)
+  val trim_position : string -> Lexing.position -> Lexing.position
+
+  (** Assuming a position represents the start of a string, advance it
+     to the end of the string, plus 'after' characters (default 0). If
+     trim is true, then the position is moved to the last
+     non-whitespace character. *)
+  val advance_position : ?after:int -> trim:bool -> string -> Lexing.position -> Lexing.position
+
+  (** Assuming a position represents the start of a string, create a
+     location representing the contents of the string. If trim is
+     true, whitespace at the start and end is not included in the
+     location. *)
+  val string_location : trim:bool -> start:Lexing.position -> string -> Parse_ast.l
+end

--- a/src/lib/sail_file.mli
+++ b/src/lib/sail_file.mli
@@ -67,6 +67,13 @@
 
 type handle = private int
 
+(** This is a special handle that contains inputs to the sail -i REPL *)
+val interactive_repl : handle
+
+val repl_prompt_line : unit -> int
+
+val add_to_repl_contents : command:string -> int * int
+
 (** For the LSP, we might have Sail and the editor use slightly
     different paths for the same file so we can set this to
     Sys.realpath, and we will then treat files with the same canonical


### PR DESCRIPTION
Using the LSP file buffers introduced previously we can implement a special file `Sail_file.interactive_repl` that corresponds to the commands entered into the REPL. The error formatting code can then use this for better errors in the REPL.

Add an :edit command that opens an editor to provide longer commands
