### PR TITLE
Add clarity about deprecation of "{| |}"

### DIFF
--- a/doc/asciidoc/language.adoc
+++ b/doc/asciidoc/language.adoc
@@ -130,7 +130,7 @@ set of integers. The type `{32,{nbsp}64}` is a type that can only
 contain the values `32` and `64`.
 
 NOTE: In older Sail versions the numeric set type would have been
-denoted `{|32, 64|}`.
+denoted `{|32, 64|}`. This syntax is now deprecated.
 
 === Bitvector literals
 


### PR DESCRIPTION
In "Numeric types and bits", there is a note:
```
NOTE: In older Sail versions the numeric set type would have been
denoted `{|32, 64|}`.
```

This leaves the status of this syntax for current Sail versions unsaid.

Per `src/lib/parser.mly`, this syntax is deprecated:
```
  | LcurlyBar num_list RcurlyBar
    { set_syntax_deprecated (loc $startpos $endpos);
      mk_typ (ATyp_nset $2) $startpos $endpos }
```

Add "This syntax is now deprecated" to the above note for clarity.