### PR TITLE
Fix enum number conversion function generation

### DIFF
--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -116,7 +116,7 @@ val generate_undefineds : IdSet.t -> untyped_def list
 
 val generate_initialize_registers : IdSet.t -> untyped_def list -> untyped_def list
 
-val generate_enum_number_functions : untyped_def list -> untyped_def list
+val generate_enum_number_conversions : untyped_def list -> untyped_def list
 
 val generate : untyped_ast -> untyped_ast
 

--- a/src/lib/scattered.ml
+++ b/src/lib/scattered.ml
@@ -198,7 +198,7 @@ let rec descatter' accumulator funcls mapcls = function
         | _ ->
             let def_annot =
               def_annot
-              |> add_def_attribute (gen_loc l) "no_enum_functions" None
+              |> add_def_attribute (gen_loc l) "no_enum_number_conversions" None
               |> add_def_attribute (gen_loc l) "undefined_gen" (Some (AD_aux (AD_string "forbid", gen_loc l)))
             in
             let accumulator =

--- a/test/c/enum_functions.sail
+++ b/test/c/enum_functions.sail
@@ -1,7 +1,7 @@
 default Order dec
 $include <prelude.sail>
 
-$[enum_functions { to_enum = bar, from_enum = baz }]
+$[enum_number_conversions { to_enum = bar, from_enum = baz }]
 enum Foo = A | B | C
 
 val main : unit -> unit

--- a/test/typecheck/fail/enum_function_override.expect
+++ b/test/typecheck/fail/enum_function_override.expect
@@ -1,14 +1,15 @@
-[93mWarning[0m: Duplicate function type definition for bar
-[96mfail/enum_function_override.sail[0m:8.29-32:
-8[96m |[0m$[enum_functions { to_enum = bar, from_enum = baz }]
- [91m |[0m                             [91m^-^[0m
- [91m |[0m This duplicate definition is being ignored!
- [91m |[0m [96mfail/enum_function_override.sail[0m:4.4-7:
- [91m |[0m 4[96m |[0mval bar : unit -> unit
- [91m |[0m  [91m |[0m    [91m^-^[0m [91mprevious definition here[0m
+[93mWarning[0m: Cannot generate bar for enum [96mfail/enum_function_override.sail[0m:4.4-7:
+4[96m |[0mval bar : unit -> unit
+ [92m |[0m    [92m^-^[0m [92mFunction with the same name defined here[0m
+[96mfail/enum_function_override.sail[0m:9.0-20:
+9[96m |[0menum Foo = A | B | C
+ [91m |[0m[91m^------------------^[0m
+ [91m |[0m 
+Could not generate an automatic conversion function for enum Foo, as a function with the same name (bar) already exists.
+Use the $[no_enum_number_conversions] attribute to suppress the automatic generation, or rename one of the functions.
+
 [93mType error[0m:
-Code generated nearby:
-[96mfail/enum_function_override.sail[0m:8.0-52:
-8[96m |[0m$[enum_functions { to_enum = bar, from_enum = baz }]
- [91m |[0m[91m^--------------------------------------------------^[0m [91m(operator ==)[0m
- [91m |[0m No possible overloading for (operator ==)
+[96mfail/enum_function_override.sail[0m:12.17-25:
+12[96m |[0mlet x : int(0) = "string"
+  [91m |[0m                 [91m^------^[0m
+  [91m |[0m Type mismatch between int(0) and string

--- a/test/typecheck/fail/enum_function_override.sail
+++ b/test/typecheck/fail/enum_function_override.sail
@@ -5,5 +5,8 @@ val bar : unit -> unit
 
 function bar() = ()
 
-$[enum_functions { to_enum = bar, from_enum = baz }]
+$[enum_number_conversions { to_enum = bar, from_enum = baz }]
 enum Foo = A | B | C
+
+// Force a type error to check we get a warning...
+let x : int(0) = "string"

--- a/test/typecheck/fail/enum_functions_partial.expect
+++ b/test/typecheck/fail/enum_functions_partial.expect
@@ -1,5 +1,5 @@
 [93mError[0m:
-[96mfail/enum_functions_partial.sail[0m:4.0-35:
-4[96m |[0m$[enum_functions { to_enum = bar }]
- [91m |[0m[91m^---------------------------------^[0m
+[96mfail/enum_functions_partial.sail[0m:4.0-44:
+4[96m |[0m$[enum_number_conversions { to_enum = bar }]
+ [91m |[0m[91m^------------------------------------------^[0m
  [91m |[0m Expected to_enum and from_enum fields in attribute

--- a/test/typecheck/fail/enum_functions_partial.sail
+++ b/test/typecheck/fail/enum_functions_partial.sail
@@ -1,5 +1,5 @@
 default Order dec
 $include <prelude.sail>
 
-$[enum_functions { to_enum = bar }]
+$[enum_number_conversions { to_enum = bar }]
 enum Foo = A | B | C


### PR DESCRIPTION
Print a warning if a function exists with the same name as the one we are trying to generate, and suppress the generation.