### PR TITLE
Add coverage build files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ lib/hol/sail-heap
 
 /lib/isabelle/output
 
+# Sail coverage
+/lib/coverage/Cargo.lock
+/lib/coverage/target
+/lib/coverage/libsail_coverage.a
+/sailcov/sailcov
+
 # location specific things
 
 /doc/code_riscv


### PR DESCRIPTION
This includes both the coverage library in `/lib/coverage` and the Sail coverage tool in `/sailcov`.