### PR TITLE
Fmt: wrap exps into oneline if possible

### DIFF
--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -264,9 +264,7 @@ module PPrintWrapper = struct
 
   let block_comment_lines col s =
     let lines = Util.split_on_char '\n' s in
-    let lines =
-      List.mapi (fun i l -> if i + 1 == List.length lines then l else rtrim l) lines
-    in
+    let lines = List.mapi (fun i l -> if i + 1 == List.length lines then l else rtrim l) lines in
     let lines = patch_comment_lines_indent col lines in
     List.mapi
       (fun n line ->

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -236,7 +236,7 @@ module PPrintWrapper = struct
     let rec loop min_indent lines =
       match lines with
       | line :: rest_of_lines ->
-          (* ignore empty line *)
+          (* Ignore empty line *)
           if line = "" then loop min_indent rest_of_lines
           else (
             let indent = count_indent line in
@@ -249,14 +249,14 @@ module PPrintWrapper = struct
 
   let patch_comment_lines_indent col lines =
     let min_indent = count_lines_min_indent lines in
-    Printf.printf "min_ident: %d, col: %d, " min_indent col;
     let right_indent_count = col - min_indent in
-    Printf.printf "right_indent_count: %d\n" right_indent_count;
     let lines =
       List.mapi
         (fun i l ->
-          (* The first line remains unchanged *)
-          if i == 0 then l else if right_indent_count > 0 then String.make (abs right_indent_count) ' ' ^ l else l
+          (* The first_line or empty_line remains unchanged *)
+          if i == 0 || l = "" then l
+          else if right_indent_count > 0 then String.make (abs right_indent_count) ' ' ^ l
+          else l
         )
         lines
     in
@@ -264,7 +264,8 @@ module PPrintWrapper = struct
 
   let block_comment_lines col s =
     let lines = Util.split_on_char '\n' s in
-    let lines = List.mapi (fun i l -> if i + 1 == List.length lines then l else rtrim l) lines in
+    (* Last line (before */) shouldn't be rtrimed *)
+    let lines = List.mapi (fun i l -> if i + 1 = List.length lines then l else rtrim l) lines in
     let lines = patch_comment_lines_indent col lines in
     List.mapi
       (fun n line ->

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -11,6 +11,18 @@
              indent many
       last line comment*/
 function a () -> int = {
+
+/* first line comment
+             indent many
+           last line comment*/
+
+          /* first line comment
+      indent many
+           last line comment*/
+
+        /* first line comment
+             indent many
+      last line comment*/
     *R = baz; // comment
        // comment
      1// comment

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -1,3 +1,13 @@
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
+/* first line comment
+
+           */
+/* first line comment
+
+        last line comment         */
 
 /* first line comment
              indent many
@@ -11,6 +21,16 @@
              indent many
       last line comment*/
 function a () -> int = {
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
+/* first line comment
+                    
+           */
+/* first line comment
+
+        last line comment         */
 
 /* first line comment
              indent many

--- a/test/format/comments.sail
+++ b/test/format/comments.sail
@@ -1,3 +1,15 @@
+
+/* first line comment
+             indent many
+           last line comment*/
+
+          /* first line comment
+      indent many
+           last line comment*/
+
+        /* first line comment
+             indent many
+      last line comment*/
 function a () -> int = {
     *R = baz; // comment
        // comment

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -1,3 +1,13 @@
+
+/* first line comment
+             indent many
+           last line comment*/
+/* first line comment
+indent many
+     last line comment*/
+/* first line comment
+       indent many
+last line comment*/
 function a () -> int = {
     *R = baz; // comment
 

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -9,6 +9,15 @@ indent many
        indent many
 last line comment*/
 function a () -> int = {
+    /* first line comment
+                 indent many
+               last line comment*/
+    /* first line comment
+    indent many
+         last line comment*/
+    /* first line comment
+           indent many
+    last line comment*/
     *R = baz; // comment
 
     // comment

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -1,4 +1,14 @@
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
 
+/* first line comment
+
+           */
+/* first line comment
+
+        last line comment         */
 /* first line comment
              indent many
            last line comment*/
@@ -9,6 +19,16 @@ indent many
        indent many
 last line comment*/
 function a () -> int = {
+    /*comment*/
+    /*      comment          */
+    /* first line comment
+                            */
+    /* first line comment
+
+               */
+    /* first line comment
+
+            last line comment         */
     /* first line comment
                  indent many
                last line comment*/

--- a/test/format/default/doc_comment.expect
+++ b/test/format/default/doc_comment.expect
@@ -1,4 +1,13 @@
 default Order dec
 
+/*! first line comment
+             indent many
+           last line comment*/
+/*! first line comment
+      indent many
+           last line comment*/
+/*! first line comment
+             indent many
+      last line comment*/
 /*! A documentation comment */
 val main : unit -> unit

--- a/test/format/default/function_quant.expect
+++ b/test/format/default/function_quant.expect
@@ -3,26 +3,16 @@ default Order dec
 $include <prelude.sail>
 
 function foo forall 'n 'm, 'n >= 0.
-(x : int('n), y : int('m)) -> unit = {
-    ()
-}
+(x : int('n), y : int('m)) -> unit = { () }
 
 function foo /* c */ forall 'n 'm, 'n >= 0.
-(x : int('n), y : int('m)) -> unit = {
-    ()
-}
+(x : int('n), y : int('m)) -> unit = { () }
 
 function foo forall /* c */ 'n 'm, 'n >= 0.
-(x : int('n), y : int('m)) -> unit = {
-    ()
-}
+(x : int('n), y : int('m)) -> unit = { () }
 
 function foo forall 'n 'm, /* c */ 'n >= 0.
-(x : int('n), y : int('m)) -> unit = {
-    ()
-}
+(x : int('n), y : int('m)) -> unit = { () }
 
 function foo forall 'very_long_identifier_that_will_cause_a_line_break 'm, 'n >= 0.
-(x : int('very_long_identifier_that_will_cause_a_line_break), y : int('m)) -> unit = {
-    ()
-}
+(x : int('very_long_identifier_that_will_cause_a_line_break), y : int('m)) -> unit = { () }

--- a/test/format/default/struct_update.expect
+++ b/test/format/default/struct_update.expect
@@ -44,22 +44,14 @@ enum E with f -> very_long_type_that_will_trigger_a_linebreak,
 }
 
 function has_loops () = {
-    foreach (n from 1 to 3) {
-        ()
-    };
-    foreach (n from 3 downto 1) {
-        ()
-    };
-    foreach (n from 0 to 4 by 2) {
-        ()
-    };
+    foreach (n from 1 to 3) { () };
+    foreach (n from 3 downto 1) { () };
+    foreach (n from 0 to 4 by 2) { () };
     foreach (n from 10000000000000000000000000000000 to 444444444444444444444444444444444444444444444444444444444444) {
         ()
     };
     while true do ();
-    while true do {
-        ()
-    };
+    while true do { () };
     repeat termination_measure { foo } () until true
 }
 

--- a/test/format/default/wrap_into_oneline.expect
+++ b/test/format/default/wrap_into_oneline.expect
@@ -1,0 +1,93 @@
+function f b = if b == bitone then { bitzero } else { bitone }
+function f b = if b == bitone then { bitzero } else { bitone }
+function f b = if b == bitone then {
+    let a = 1;
+    bitzero
+} else { bitone }
+
+function f b = if b == bitone then { { bitzero } } else { bitone }
+function f b = if b == bitone then { { { bitzero } } } else { bitone }
+function f b = if b == bitone then {
+    {
+        let a = 1;
+        bitzero
+    }
+} else { bitone }
+function f b = if b == bitone then {
+    {
+        {
+            let a = 1;
+            bitzero
+        }
+    }
+} else { bitone }
+function f b = if b == bitone then {
+    {
+        {
+            {
+                let a = 1;
+                bitzero
+            }
+        }
+    }
+} else {
+    {
+        {
+            {
+                let a = 1;
+                bitone
+            }
+        }
+    }
+}
+function f b = if b == bitone then {
+    {
+        {
+            {
+                let a = 1;
+                bitzero
+            }
+        }
+    }
+} else { { { bitone } } }
+function f b = if b == bitone then {
+    {
+        {
+            {
+                let a = 1;
+                bitzero
+            }
+        }
+    }
+} else {
+    {
+        let a = 1;
+        { bitone }
+    }
+}
+
+/* comment */
+function f /* comment */ b = if b == bitone then { bitzero } else { bitone }
+function f /* comment */ b = if b == bitone then { bitzero } else { bitone }
+function f b = /* comment */ if b == bitone then { bitzero } else { bitone }
+function f b = /* comment */ if b == bitone then { bitzero } else { bitone }
+
+// TODO function f b =/* comment */if b == bitone then bitzero else bitone
+function f b = if /* comment */ b == bitone then { bitzero } else { bitone }
+function f b = if b == /* comment */ bitone then { bitzero } else { bitone }
+function f b = if b == /* comment */ bitone then { bitzero } else { bitone }
+
+// TODO function f b = if b ==/* comment */bitone then bitzero else bitone
+function f b = if b == bitone /* comment */  then { bitzero } else { bitone }
+function f b = if b == bitone then {
+    /* comment */ bitzero
+} else { bitone }
+function f b = if b == bitone then {
+    bitzero /* comment */
+} else { bitone }
+function f b = if b == bitone then {
+    bitzero /* comment */
+} else { bitone }
+function f b = if b == bitone then {
+    bitzero /* comment */
+} else { bitone }

--- a/test/format/doc_comment.sail
+++ b/test/format/doc_comment.sail
@@ -1,8 +1,17 @@
 default Order dec
 
+/*! first line comment
+             indent many
+           last line comment*/
+
+          /*! first line comment
+      indent many
+           last line comment*/
+
+        /*! first line comment
+             indent many
+      last line comment*/
+
 /*! A documentation comment */
-
-
-
-val main :
-unit -> unit
+val main : 
+    unit -> unit

--- a/test/format/function_quant.sail
+++ b/test/format/function_quant.sail
@@ -2,22 +2,17 @@ default Order dec
 
 $include <prelude.sail>
 
-function foo forall 'n 'm, 'n >= 0. (x: int('n), y: int('m)) -> unit = {
-    ()
-}
+function foo forall 'n 'm, 'n >= 0.
+(x : int('n), y : int('m)) -> unit = { () }
 
-function foo /* c */ forall 'n 'm, 'n >= 0. (x: int('n), y: int('m)) -> unit = {
-    ()
-}
+function foo /* c */ forall 'n 'm, 'n >= 0.
+(x : int('n), y : int('m)) -> unit = { () }
 
-function foo forall/* c */'n 'm, 'n >= 0. (x: int('n), y: int('m)) -> unit = {
-    ()
-}
+function foo forall /* c */ 'n 'm, 'n >= 0.
+(x : int('n), y : int('m)) -> unit = { () }
 
-function foo forall 'n   'm, /* c */ 'n >= 0. (x: int('n), y: int('m)) -> unit = {
-    ()
-}
+function foo forall 'n 'm, /* c */ 'n >= 0.
+(x : int('n), y : int('m)) -> unit = { () }
 
-function foo forall 'very_long_identifier_that_will_cause_a_line_break 'm, 'n >= 0. (x: int('very_long_identifier_that_will_cause_a_line_break), y: int('m)) -> unit = {
-    ()
-}
+function foo forall 'very_long_identifier_that_will_cause_a_line_break 'm, 'n >= 0.
+(x : int('very_long_identifier_that_will_cause_a_line_break), y : int('m)) -> unit = { () }

--- a/test/format/wrap_into_oneline.sail
+++ b/test/format/wrap_into_oneline.sail
@@ -1,0 +1,27 @@
+function f b = if b == bitone then bitzero else bitone
+function f b = if b == bitone then { bitzero } else { bitone }
+function f b = if b == bitone then { let a = 1;bitzero } else { bitone }
+
+function f b = if b == bitone then {  {bitzero } } else { bitone }
+function f b = if b == bitone then {  {{bitzero} } } else { bitone }
+function f b = if b == bitone then { { let a = 1; bitzero } } else { bitone }
+function f b = if b == bitone then { { {let a = 1; bitzero} } } else { bitone }
+function f b = if b == bitone then { { { {let a = 1; bitzero}} } } else { {{{let a= 1; bitone}}} }
+function f b = if b == bitone then { { { {let a = 1; bitzero}} } } else { {{bitone }}}
+function f b = if b == bitone then { { { {let a = 1; bitzero}} } } else { {let a = 1;{bitone }}}
+
+ /* comment */
+function/* comment */f b = if b == bitone then bitzero else bitone
+function f/* comment */b = if b == bitone then bitzero else bitone
+function f b/* comment */= if b == bitone then bitzero else bitone
+function f b = /* comment */if b == bitone then bitzero else bitone
+// TODO function f b =/* comment */if b == bitone then bitzero else bitone
+function f b = if/* comment */b == bitone then bitzero else bitone
+function f b = if b/* comment */== bitone then bitzero else bitone
+function f b = if b == /* comment */ bitone then bitzero else bitone
+// TODO function f b = if b ==/* comment */bitone then bitzero else bitone
+function f b = if b == bitone/* comment */then bitzero else bitone
+function f b = if b == bitone then/* comment */bitzero else bitone
+function f b = if b == bitone then bitzero/* comment */else bitone
+function f b = if b == bitone then bitzero else/* comment */bitone
+function f b = if b == bitone then bitzero else bitone/* comment */


### PR DESCRIPTION
> please check #581 first

This PR optimizes the formatting of nested single atoms.

> Possibly related to the discussion here: https://github.com/riscv/sail-riscv/pull/264#discussion_r1199143857

For example:

```ocaml
let a= {{{ 1 }} }
```

will be formatted as:

```ocaml
let a = { { { 1 } } }
```

instead of the deeply nested version:

```
let a = {
	{
		{ 
			1
		}
	}
}
```

This behavior aligns with rust-fmt.
