### PR TITLE
sailcov: fix missing last line in output when using --colour-by-count

### DIFF
--- a/sailcov/main.ml
+++ b/sailcov/main.ml
@@ -515,7 +515,7 @@ let main () =
                   output_html_char chan source.(line - 1).(i).char
                 done;
               output_string chan "<br>\n";
-              if line + 1 < Array.length source then finish (stack, line + 1, 0) else ()
+              if line < Array.length source then finish (stack, line + 1, 0) else ()
         in
         let stack, line, char = SpanMap.fold process combined ([], 1, 0) in
         finish (stack, line, char)


### PR DESCRIPTION
There was an off by one in the code for producing html when using the --colour-by-count that resulting in producing no output for the last line of each sail source file. Line numbers are numbered from 1 so no need to add one when comparing against array length.