### PR TITLE
sailcov: invert condition of warn_assert

### DIFF
--- a/sailcov/main.ml
+++ b/sailcov/main.ml
@@ -107,7 +107,7 @@ let warn message =
   else prerr_endline ("Warning: " ^ message)
 
 let warn_assert where b =
-  if b then (
+  if not b then (
     let message = "assertion failed at " ^ where in
     if !opt_werror then (
       prerr_endline ("Error: " ^ message);

--- a/test/sailcov/run_tests.py
+++ b/test/sailcov/run_tests.py
@@ -41,7 +41,7 @@ def test_sailcov():
                 step('{} -no_warn -no_memo_z3 -c -c_include sail_coverage.h -c_coverage {}.branches {} -o {}'.format(sail, basename, filename, basename))
                 step('cc {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lz -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
                 step('./{}.bin -c {}.taken'.format(basename, basename))
-                step('{} --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
+                step('{} --werror --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
                 step('diff {}.html {}.expect'.format(basename, basename))
                 step('rm {}.taken {}.bin {}.branches'.format(basename, basename, basename))
                 print_ok(filename)


### PR DESCRIPTION
Assertions should fail if the condition is not true.  This was resulting in spurious warnings.  Also turn on --werror in the test case so that warnings will cause the test to fail.