### PR TITLE
Fix lexer rule to handle operator of format like `operator + comment`

### DIFF
--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -172,10 +172,12 @@ let tyvar_start = '\''
 let oper_char = ['!''%''&''*''+''-''.''/'':''<''=''>''@''^''|']
 let oper_char_no_slash = ['!''%''&''*''+''-''.'':''<''=''>''@''^''|']
 let oper_char_no_slash_star = ['!''%''&''+''-''.'':''<''=''>''@''^''|']
-let operator1 = oper_char
-let operator2 = oper_char oper_char_no_slash_star | oper_char_no_slash oper_char
-let operatorn = oper_char oper_char_no_slash_star (oper_char* ('_' ident)?) | oper_char_no_slash oper_char (oper_char* ('_' ident)?) | oper_char ('_' ident)?
-let operator = operator1 | operator2 | operatorn
+
+let operator_any_start = (oper_char (oper_char_no_slash_star oper_char)*)
+                        | (oper_char oper_char_no_slash_star)*
+let operator_no_slash_start = (oper_char_no_slash (oper_char oper_char_no_slash_star)*)
+                            | (oper_char_no_slash_star oper_char)*
+let operator = (operator_any_start | operator_no_slash_start) ('_' ident)?
 let escape_sequence = ('\\' ['\\''\"''\'''n''t''b''r']) | ('\\' digit digit digit) | ('\\' 'x' hexdigit hexdigit)
 let lchar = [^'\n']
 
@@ -188,7 +190,7 @@ rule token comments = parse
       token comments lexbuf }
   | "@"                                 { At }
   | "2" ws "^"                          { TwoCaret }
-  | "^"					{ Caret }
+  | "^"                                 { Caret }
   | "::"                                { ColonColon }
   | ":"                                 { Colon ":" }
   | ","                                 { Comma }

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -171,13 +171,10 @@ let tyvar_start = '\''
 (* Ensure an operator cannot start with comment openings *)
 let oper_char = ['!''%''&''*''+''-''.''/'':''<''=''>''@''^''|']
 let oper_char_no_slash = ['!''%''&''*''+''-''.'':''<''=''>''@''^''|']
+let oper_char_no_star = ['!''%''&''+''-''.''/'':''<''=''>''@''^''|']
 let oper_char_no_slash_star = ['!''%''&''+''-''.'':''<''=''>''@''^''|']
 
-let operator_any_start = (oper_char (oper_char_no_slash_star oper_char)*)
-                        | (oper_char oper_char_no_slash_star)*
-let operator_no_slash_start = (oper_char_no_slash (oper_char oper_char_no_slash_star)*)
-                            | (oper_char_no_slash_star oper_char)*
-let operator = (operator_any_start | operator_no_slash_start) ('_' ident)?
+let operator = ((oper_char_no_slash_star* ['/']? oper_char_no_slash_star*) | oper_char_no_slash*) ('_' ident)?
 let escape_sequence = ('\\' ['\\''\"''\'''n''t''b''r']) | ('\\' digit digit digit) | ('\\' 'x' hexdigit hexdigit)
 let lchar = [^'\n']
 

--- a/test/format/default/operator.expect
+++ b/test/format/default/operator.expect
@@ -13,7 +13,6 @@ $include <prelude.sail>
 //* line_block_comment */
 infix 4 ===_u
 infix 4 ===/_u
-infix 4 /=/=/=
 
 infix 4 ===*_u
 val operator ===/_u : forall 'n. (int('n), int('n)) -> bool
@@ -26,6 +25,9 @@ function operator =/(x, y) = x == y
 infix 4 =
 
 // comment
+infix 4 </>
+
+// comment
 infix 4 =/
 
 // comment
@@ -33,10 +35,7 @@ infix 4 ==/
 infix 4 -/-
 
 //comment
-infix 4 -/-/
-
-//comment
-infix 4 /-*
+infix 4 /--
 
 //comment
 infixl 4 =
@@ -49,10 +48,10 @@ infixl 4 ==/
 infixl 4 -/-
 
 //comment
-infixl 4 -/-/
+infixl 4 -/-
 
 //comment
-infixl 4 /-*
+infixl 4 /--
 
 //comment
 infixr 4 =
@@ -65,10 +64,10 @@ infixr 4 ==/
 infixr 4 -/-
 
 //comment
-infixr 4 -/-/
+infixr 4 -/-
 
 //comment
-infixr 4 /-*
+infixr 4 /--
 
 //comment
 function f () = {

--- a/test/format/default/operator.expect
+++ b/test/format/default/operator.expect
@@ -1,0 +1,97 @@
+default Order dec
+$include <prelude.sail>
+
+// comment
+//comment
+/// line_comment with more than two slash
+///line_comment with more than two slash
+//// line_comment with more than two slash
+////line_comment with more than two slash
+// /*/*/
+/*/ block_comment with slash near  and
+*/
+//* line_block_comment */
+infix 4 ===_u
+infix 4 ===/_u
+infix 4 /=/=/=
+
+infix 4 ===*_u
+val operator ===/_u : forall 'n. (int('n), int('n)) -> bool
+function operator ===/_u(x, y) = x == y
+
+infix 4 =/
+val operator =/ : forall 'n. (int('n), int('n)) -> bool
+function operator =/(x, y) = x == y
+
+infix 4 =
+
+// comment
+infix 4 =/
+
+// comment
+infix 4 ==/
+infix 4 -/-
+
+//comment
+infix 4 -/-/
+
+//comment
+infix 4 /-*
+
+//comment
+infixl 4 =
+
+// comment
+infixl 4 =/
+
+// comment
+infixl 4 ==/
+infixl 4 -/-
+
+//comment
+infixl 4 -/-/
+
+//comment
+infixl 4 /-*
+
+//comment
+infixr 4 =
+
+// comment
+infixr 4 =/
+
+// comment
+infixr 4 ==/
+infixr 4 -/-
+
+//comment
+infixr 4 -/-/
+
+//comment
+infixr 4 /-*
+
+//comment
+function f () = {
+    if op_eq2_with_block_comment == /**/ /**/ 1 then { 1 };
+
+    if op_eq_slash =/ 1 then { 1 };
+    if op_eq_slash_with_block_comment =/ 1 then /**/ { 1 };
+
+    let op_eq_with_line_comment =
+        //
+        1;
+
+    let op_eq_with_line_comment =
+        ///
+        1;
+
+    if op_eq_with_line_comment =
+        // comment
+        if eq_slash = /**/ 1 then { 1 } else { 2 } then { 1 };
+
+    if eq_with_blcok_comment = /**/ 1 then { 1 };
+
+    if eq3_slash ===/_u 1 then { 1 };
+
+    0
+}

--- a/test/format/operator.sail
+++ b/test/format/operator.sail
@@ -18,7 +18,6 @@ $include <prelude.sail>
 
 infix 4 ===_u
 infix 4 ===/_u
-infix 4 /=/=/=
 
 infix 4 ===*_u
 val operator ===/_u : forall 'n. (int('n), int('n)) -> bool
@@ -29,25 +28,25 @@ val operator =/ : forall 'n. (int('n), int('n)) -> bool
 function operator =/(x, y) = x == y
 
 infix 4 = // comment
+infix 4 </> // comment
 infix 4 =/ // comment
 infix 4 ==/
 infix 4 -/- //comment
-infix 4 -/-/ //comment
-infix 4 /-*//comment
+infix 4 /-- //comment
 
 infixl 4 = // comment
 infixl 4 =/ // comment
 infixl 4 ==/
 infixl 4 -/- //comment
-infixl 4 -/-/ //comment
-infixl 4 /-*//comment
+infixl 4 -/- //comment
+infixl 4 /-- //comment
 
 infixr 4 = // comment
 infixr 4 =/ // comment
 infixr 4 ==/
 infixr 4 -/- //comment
-infixr 4 -/-/ //comment
-infixr 4 /-*//comment
+infixr 4 -/- //comment
+infixr 4 /-- //comment
 
 function f () = {
     if op_eq2_with_block_comment /**/== /**/ 1 then { 1 };

--- a/test/format/operator.sail
+++ b/test/format/operator.sail
@@ -1,0 +1,73 @@
+default Order dec
+$include <prelude.sail>
+
+// comment
+//comment
+/// line_comment with more than two slash
+///line_comment with more than two slash
+//// line_comment with more than two slash
+////line_comment with more than two slash
+
+// /*/*/
+
+/*/ block_comment with slash near /* and */ 
+*/
+
+
+//* line_block_comment */
+
+infix 4 ===_u
+infix 4 ===/_u
+infix 4 /=/=/=
+
+infix 4 ===*_u
+val operator ===/_u : forall 'n. (int('n), int('n)) -> bool
+function operator ===/_u(x, y) = x == y
+
+infix 4 =/
+val operator =/ : forall 'n. (int('n), int('n)) -> bool
+function operator =/(x, y) = x == y
+
+infix 4 = // comment
+infix 4 =/ // comment
+infix 4 ==/
+infix 4 -/- //comment
+infix 4 -/-/ //comment
+infix 4 /-*//comment
+
+infixl 4 = // comment
+infixl 4 =/ // comment
+infixl 4 ==/
+infixl 4 -/- //comment
+infixl 4 -/-/ //comment
+infixl 4 /-*//comment
+
+infixr 4 = // comment
+infixr 4 =/ // comment
+infixr 4 ==/
+infixr 4 -/- //comment
+infixr 4 -/-/ //comment
+infixr 4 /-*//comment
+
+function f () = {
+    if op_eq2_with_block_comment /**/== /**/ 1 then { 1 };
+    
+    if op_eq_slash =/1 then { 1 };
+    if op_eq_slash_with_block_comment =/1/**/ then { 1 };
+
+    let op_eq_with_line_comment = //
+    1;
+
+    let op_eq_with_line_comment = ///
+    1;
+
+    if op_eq_with_line_comment = // comment
+    (if eq_slash = /**/1 then { 1 } else {2}) then {1};
+
+    if eq_with_blcok_comment = /**/1 then { 1 };
+
+
+    if eq3_slash ===/_u 1 then { 1 };
+    
+    0
+}


### PR DESCRIPTION
try fix #627 

Maybe fixed

the basic rule here is

```
 A (B A)* (for  odd-number chars)
(B A)*    (for even-number chars)
```

then use it on both maybe_slash_start operator and no_slash_start operator trying to cover all

but I don't have a good way of checking the rules

> some format output like `if eq2_comment == /**/ /**/ 1 then {` is wrong, will be fixed in my next/other PR

---
Update

```
//////              (should be line_comment)

let a = 1 ///       (rust-fmt treat this as error)
	1;

let a = 1 / //      (!current)(slash and comment)
	1;
```

can't be handled correctly for now

---

Update 

- fixed with the following rules
	```    
	| ((oper_char* oper_char_no_slash) as op) "/*" {
	| ((oper_char* oper_char_no_slash) as op) "//" {
	```
- Add more very very tricky test cases :D

> you can push to my branch directly if needed