### PR TITLE
Generalise constraint equality parameter types

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -278,12 +278,12 @@ typ_arg :: 'A_' ::=
 n_constraint :: 'NC_' ::=
   {{ com constraint over kind Int }}
   {{ aux _ l }}
-  | nexp == nexp'                    :: :: equal
+  | typ_arg == typ_arg'              :: :: equal
+  | typ_arg != typ_arg'              :: :: not_equal
   | nexp >= nexp'                    :: :: bounded_ge
   | nexp > nexp'                     :: :: bounded_gt
   | nexp '<=' nexp'                  :: :: bounded_le
   | nexp '<' nexp'                   :: :: bounded_lt
-  | nexp != nexp'                    :: :: not_equal
   | nexp 'IN' { num1 , ... , numn }  :: :: set
   | n_constraint & n_constraint'     :: :: or
   | n_constraint | n_constraint'     :: :: and

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -124,12 +124,8 @@ let builtins =
 
 let rec constraint_ids' (NC_aux (aux, _)) =
   match aux with
-  | NC_equal (n1, n2)
-  | NC_bounded_le (n1, n2)
-  | NC_bounded_ge (n1, n2)
-  | NC_bounded_lt (n1, n2)
-  | NC_bounded_gt (n1, n2)
-  | NC_not_equal (n1, n2) ->
+  | NC_equal (a1, a2) | NC_not_equal (a1, a2) -> IdSet.union (typ_arg_ids' a1) (typ_arg_ids' a2)
+  | NC_bounded_le (n1, n2) | NC_bounded_ge (n1, n2) | NC_bounded_lt (n1, n2) | NC_bounded_gt (n1, n2) ->
       IdSet.union (nexp_ids' n1) (nexp_ids' n2)
   | NC_or (nc1, nc2) | NC_and (nc1, nc2) -> IdSet.union (constraint_ids' nc1) (constraint_ids' nc2)
   | NC_var _ | NC_true | NC_false | NC_set _ -> IdSet.empty

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -819,7 +819,8 @@ let const_props target ast =
         let get_synonyms (kid, nexp) =
           let rec synonyms_of_nc nc =
             match unaux_constraint nc with
-            | NC_equal (Nexp_aux (Nexp_var kid1, _), Nexp_aux (Nexp_var kid2, _)) when Kid.compare kid kid1 = 0 ->
+            | NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var kid1, _)), _), A_aux (A_nexp (Nexp_aux (Nexp_var kid2, _)), _))
+              when Kid.compare kid kid1 = 0 ->
                 [(kid2, nexp)]
             | NC_and _ -> List.concat (List.map synonyms_of_nc (constraint_conj nc))
             | _ -> []

--- a/src/lib/constraint.ml
+++ b/src/lib/constraint.ml
@@ -241,12 +241,12 @@ let to_smt l abstract vars constr =
   and smt_constraint (NC_aux (aux, _) : n_constraint) : sexpr =
     match aux with
     | NC_id id -> Atom (Util.zencode_string (string_of_id id))
-    | NC_equal (nexp1, nexp2) -> sfun "=" [smt_nexp nexp1; smt_nexp nexp2]
+    | NC_equal (arg1, arg2) -> sfun "=" [smt_typ_arg arg1; smt_typ_arg arg2]
+    | NC_not_equal (arg1, arg2) -> sfun "not" [sfun "=" [smt_typ_arg arg1; smt_typ_arg arg2]]
     | NC_bounded_le (nexp1, nexp2) -> sfun "<=" [smt_nexp nexp1; smt_nexp nexp2]
     | NC_bounded_lt (nexp1, nexp2) -> sfun "<" [smt_nexp nexp1; smt_nexp nexp2]
     | NC_bounded_ge (nexp1, nexp2) -> sfun ">=" [smt_nexp nexp1; smt_nexp nexp2]
     | NC_bounded_gt (nexp1, nexp2) -> sfun ">" [smt_nexp nexp1; smt_nexp nexp2]
-    | NC_not_equal (nexp1, nexp2) -> sfun "not" [sfun "=" [smt_nexp nexp1; smt_nexp nexp2]]
     | NC_set (nexp, ints) -> sfun "or" (List.map (fun i -> sfun "=" [smt_nexp nexp; Atom (Big_int.to_string i)]) ints)
     | NC_or (nc1, nc2) -> sfun "or" [smt_constraint nc1; smt_constraint nc2]
     | NC_and (nc1, nc2) -> sfun "and" [smt_constraint nc1; smt_constraint nc2]

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -939,8 +939,8 @@ module ConvertType = struct
           match aux with
           | P.ATyp_app ((Id_aux (Operator op, _) as id), [t1; t2]) -> begin
               match op with
-              | "==" -> NC_equal (to_ast_nexp kenv ctx t1, to_ast_nexp kenv ctx t2)
-              | "!=" -> NC_not_equal (to_ast_nexp kenv ctx t1, to_ast_nexp kenv ctx t2)
+              | "==" -> NC_equal (to_ast_typ_arg kenv ctx t1 K_int, to_ast_typ_arg kenv ctx t2 K_int)
+              | "!=" -> NC_not_equal (to_ast_typ_arg kenv ctx t1 K_int, to_ast_typ_arg kenv ctx t2 K_int)
               | ">=" -> NC_bounded_ge (to_ast_nexp kenv ctx t1, to_ast_nexp kenv ctx t2)
               | "<=" -> NC_bounded_le (to_ast_nexp kenv ctx t1, to_ast_nexp kenv ctx t2)
               | ">" -> NC_bounded_gt (to_ast_nexp kenv ctx t1, to_ast_nexp kenv ctx t2)

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -155,8 +155,8 @@ module Printer (Config : PRINT_CONFIG) = struct
       | NC_id id -> doc_id id
       | NC_true -> string "true"
       | NC_false -> string "false"
-      | NC_equal (n1, n2) -> nc_op "==" n1 n2
-      | NC_not_equal (n1, n2) -> nc_op "!=" n1 n2
+      | NC_equal (t1, t2) -> separate space [doc_typ_arg t1; string "=="; doc_typ_arg t2]
+      | NC_not_equal (t1, t2) -> separate space [doc_typ_arg t1; string "!="; doc_typ_arg t2]
       | NC_bounded_ge (n1, n2) -> nc_op ">=" n1 n2
       | NC_bounded_gt (n1, n2) -> nc_op ">" n1 n2
       | NC_bounded_le (n1, n2) -> nc_op "<=" n1 n2
@@ -173,13 +173,21 @@ module Printer (Config : PRINT_CONFIG) = struct
       let parens' = if parenthesize then parens else fun x -> x in
       let disjs = constraint_disj nc in
       let collect_constants kid = function
-        | NC_aux (NC_equal (Nexp_aux (Nexp_var kid', _), Nexp_aux (Nexp_constant c, _)), _)
+        | NC_aux
+            ( NC_equal
+                (A_aux (A_nexp (Nexp_aux (Nexp_var kid', _)), _), A_aux (A_nexp (Nexp_aux (Nexp_constant c, _)), _)),
+              _
+            )
           when Kid.compare kid kid' = 0 ->
             Some c
         | _ -> None
       in
       match disjs with
-      | NC_aux (NC_equal (Nexp_aux (Nexp_var kid, _), Nexp_aux (Nexp_constant c, _)), _) :: ncs -> begin
+      | NC_aux
+          ( NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var kid, _)), _), A_aux (A_nexp (Nexp_aux (Nexp_constant c, _)), _)),
+            _
+          )
+        :: ncs -> begin
           match Util.option_all (List.map (collect_constants kid) ncs) with
           | None | Some [] -> parens' (separate_map (space ^^ bar ^^ space) nc1 disjs)
           | Some cs ->

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -83,7 +83,8 @@ type ('a, 'b) rewriters = {
 
 let lookup_generated_kid env kid =
   let match_kid_nc kid = function
-    | NC_aux (NC_equal (Nexp_aux (Nexp_var kid1, _), Nexp_aux (Nexp_var kid2, _)), _)
+    | NC_aux
+        (NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var kid1, _)), _), A_aux (A_nexp (Nexp_aux (Nexp_var kid2, _)), _)), _)
       when Kid.compare kid kid2 = 0 && not (is_kid_generated kid1) ->
         kid1
     | _ -> kid

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -171,7 +171,10 @@ let lookup_equal_kids env =
     eqs |> KBindings.add kid1 kids |> KBindings.add kid2 kids
   in
   let add_nc eqs = function
-    | NC_aux (NC_equal (Nexp_aux (Nexp_var kid1, _), Nexp_aux (Nexp_var kid2, _)), _) -> add_eq_kids kid1 kid2 eqs
+    | NC_aux
+        (NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var kid1, _)), _), A_aux (A_nexp (Nexp_aux (Nexp_var kid2, _)), _)), _)
+      ->
+        add_eq_kids kid1 kid2 eqs
     | _ -> eqs
   in
   List.fold_left add_nc KBindings.empty (Env.get_constraints env)
@@ -182,7 +185,12 @@ let lookup_constant_kid env kid =
   in
   let check_nc const nc =
     match (const, nc) with
-    | None, NC_aux (NC_equal (Nexp_aux (Nexp_var kid, _), Nexp_aux (Nexp_constant i, _)), _) when KidSet.mem kid kids ->
+    | ( None,
+        NC_aux
+          ( NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var kid, _)), _), A_aux (A_nexp (Nexp_aux (Nexp_constant i, _)), _)),
+            _
+          ) )
+      when KidSet.mem kid kids ->
         Some i
     | _, _ -> const
   in

--- a/src/lib/spec_analysis.ml
+++ b/src/lib/spec_analysis.ml
@@ -153,7 +153,9 @@ let rec flatten_constraints = function
    checking P_var patterns, so we don't do it for now. *)
 let equal_kids_ncs kid ncs =
   let rec add_equal_kids_nc s = function
-    | NC_aux (NC_equal (Nexp_aux (Nexp_var var1, _), Nexp_aux (Nexp_var var2, _)), _) ->
+    | NC_aux
+        (NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var var1, _)), _), A_aux (A_nexp (Nexp_aux (Nexp_var var2, _)), _)), _)
+      ->
         if Kid.compare kid var1 == 0 then KidSet.add var2 s
         else if Kid.compare kid var2 == 0 then KidSet.add var1 s
         else s

--- a/src/lib/specialize.ml
+++ b/src/lib/specialize.ml
@@ -198,8 +198,8 @@ let string_of_instantiation instantiation =
     | A_bool nc -> string_of_n_constraint nc
   and string_of_n_constraint = function
     | NC_aux (NC_id id, _) -> string_of_id id
-    | NC_aux (NC_equal (n1, n2), _) -> string_of_nexp n1 ^ " = " ^ string_of_nexp n2
-    | NC_aux (NC_not_equal (n1, n2), _) -> string_of_nexp n1 ^ " != " ^ string_of_nexp n2
+    | NC_aux (NC_equal (t1, t2), _) -> string_of_typ_arg t1 ^ " == " ^ string_of_typ_arg t2
+    | NC_aux (NC_not_equal (t1, t2), _) -> string_of_typ_arg t1 ^ " != " ^ string_of_typ_arg t2
     | NC_aux (NC_bounded_ge (n1, n2), _) -> string_of_nexp n1 ^ " >= " ^ string_of_nexp n2
     | NC_aux (NC_bounded_gt (n1, n2), _) -> string_of_nexp n1 ^ " > " ^ string_of_nexp n2
     | NC_aux (NC_bounded_le (n1, n2), _) -> string_of_nexp n1 ^ " <= " ^ string_of_nexp n2

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -687,13 +687,7 @@ module Well_formedness = struct
         if name = "abs" || name = "mod" || name = "div" || Bindings.mem id env.global.synonyms then
           List.iter (fun n -> wf_nexp exs env n) nexps
         else typ_error l ("Unknown type level operator or function " ^ name)
-    | Nexp_times (nexp1, nexp2) ->
-        wf_nexp exs env nexp1;
-        wf_nexp exs env nexp2
-    | Nexp_sum (nexp1, nexp2) ->
-        wf_nexp exs env nexp1;
-        wf_nexp exs env nexp2
-    | Nexp_minus (nexp1, nexp2) ->
+    | Nexp_times (nexp1, nexp2) | Nexp_sum (nexp1, nexp2) | Nexp_minus (nexp1, nexp2) ->
         wf_nexp exs env nexp1;
         wf_nexp exs env nexp2
     | Nexp_exp nexp -> wf_nexp exs env nexp (* MAYBE: Could put restrictions on what is allowed here *)
@@ -708,29 +702,14 @@ module Well_formedness = struct
     match nc_aux with
     | NC_id id when Bindings.mem id env.global.abstract_typs -> ()
     | NC_id id -> typ_error l ("Undefined type synonym " ^ string_of_id id)
-    | NC_equal (n1, n2) ->
-        wf_nexp exs env n1;
-        wf_nexp exs env n2
-    | NC_not_equal (n1, n2) ->
-        wf_nexp exs env n1;
-        wf_nexp exs env n2
-    | NC_bounded_ge (n1, n2) ->
-        wf_nexp exs env n1;
-        wf_nexp exs env n2
-    | NC_bounded_gt (n1, n2) ->
-        wf_nexp exs env n1;
-        wf_nexp exs env n2
-    | NC_bounded_le (n1, n2) ->
-        wf_nexp exs env n1;
-        wf_nexp exs env n2
-    | NC_bounded_lt (n1, n2) ->
+    | NC_equal (arg1, arg2) | NC_not_equal (arg1, arg2) ->
+        wf_typ_arg exs env arg1;
+        wf_typ_arg exs env arg2
+    | NC_bounded_ge (n1, n2) | NC_bounded_gt (n1, n2) | NC_bounded_le (n1, n2) | NC_bounded_lt (n1, n2) ->
         wf_nexp exs env n1;
         wf_nexp exs env n2
     | NC_set (nexp, _) -> wf_nexp exs env nexp
-    | NC_or (nc1, nc2) ->
-        wf_constraint exs env nc1;
-        wf_constraint exs env nc2
-    | NC_and (nc1, nc2) ->
+    | NC_or (nc1, nc2) | NC_and (nc1, nc2) ->
         wf_constraint exs env nc1;
         wf_constraint exs env nc2
     | NC_app (_, args) -> List.iter (wf_typ_arg exs env) args
@@ -764,8 +743,8 @@ let rec expand_constraint_synonyms env (NC_aux (aux, l) as nc) =
   match aux with
   | NC_or (nc1, nc2) -> NC_aux (NC_or (expand_constraint_synonyms env nc1, expand_constraint_synonyms env nc2), l)
   | NC_and (nc1, nc2) -> NC_aux (NC_and (expand_constraint_synonyms env nc1, expand_constraint_synonyms env nc2), l)
-  | NC_equal (n1, n2) -> NC_aux (NC_equal (expand_nexp_synonyms env n1, expand_nexp_synonyms env n2), l)
-  | NC_not_equal (n1, n2) -> NC_aux (NC_not_equal (expand_nexp_synonyms env n1, expand_nexp_synonyms env n2), l)
+  | NC_equal (arg1, arg2) -> NC_aux (NC_equal (expand_arg_synonyms env arg1, expand_arg_synonyms env arg2), l)
+  | NC_not_equal (arg1, arg2) -> NC_aux (NC_not_equal (expand_arg_synonyms env arg1, expand_arg_synonyms env arg2), l)
   | NC_bounded_le (n1, n2) -> NC_aux (NC_bounded_le (expand_nexp_synonyms env n1, expand_nexp_synonyms env n2), l)
   | NC_bounded_lt (n1, n2) -> NC_aux (NC_bounded_lt (expand_nexp_synonyms env n1, expand_nexp_synonyms env n2), l)
   | NC_bounded_ge (n1, n2) -> NC_aux (NC_bounded_ge (expand_nexp_synonyms env n1, expand_nexp_synonyms env n2), l)

--- a/src/lib/type_error.ml
+++ b/src/lib/type_error.ml
@@ -91,10 +91,10 @@ let analyze_unresolved_quant locals ncs = function
            occurs due to how the type-checker introduces new type
            variables. *)
         let is_subst v = function
-          | NC_aux (NC_equal (Nexp_aux (Nexp_var v', _), nexp), _)
+          | NC_aux (NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var v', _)), _), A_aux (A_nexp nexp, _)), _)
             when Kid.compare v v' = 0 && not (KidSet.exists is_kid_generated (tyvars_of_nexp nexp)) ->
               [(v, nexp)]
-          | NC_aux (NC_equal (nexp, Nexp_aux (Nexp_var v', _)), _)
+          | NC_aux (NC_equal (A_aux (A_nexp nexp, _), A_aux (A_nexp (Nexp_aux (Nexp_var v', _)), _)), _)
             when Kid.compare v v' = 0 && not (KidSet.exists is_kid_generated (tyvars_of_nexp nexp)) ->
               [(v, nexp)]
           | _ -> []
@@ -142,7 +142,7 @@ let error_string_of_typ substs typ = string_of_typ (subst_kids_typ substs typ)
 
 let error_string_of_typ_arg substs arg = string_of_typ_arg (subst_kids_typ_arg substs arg)
 
-let has_variable set nexp = not (KidSet.is_empty (KidSet.inter set (tyvars_of_nexp nexp)))
+let has_variable set arg = not (KidSet.is_empty (KidSet.inter set (tyvars_of_typ_arg arg)))
 
 let rewrite_equality preferred_on_right (NC_aux (aux, l) as nc) =
   let equality =
@@ -169,9 +169,9 @@ let subst_preferred_variables prefs constraints =
   let all_substs, constraints =
     Util.map_split
       (function
-        | r, NC_aux (NC_equal (Nexp_aux (Nexp_var v, _), rhs), _)
-          when has_variable prefs rhs && not (KidSet.mem v (tyvars_of_nexp rhs)) ->
-            Ok (r, v, arg_nexp rhs)
+        | r, NC_aux (NC_equal (A_aux (A_nexp (Nexp_aux (Nexp_var v, _)), _), rhs), _)
+          when has_variable prefs rhs && not (KidSet.mem v (tyvars_of_typ_arg rhs)) ->
+            Ok (r, v, rhs)
         | r, NC_aux (NC_app (id, [A_aux (A_bool (NC_aux (NC_var v, _)), _)]), _) when string_of_id id = "not" ->
             Ok (r, v, arg_bool nc_false)
         | r, NC_aux (NC_var v, _) -> Ok (r, v, arg_bool nc_true)

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -148,12 +148,12 @@ and unloc_nexp = function Nexp_aux (nexp_aux, _) -> Nexp_aux (unloc_nexp_aux nex
 
 and unloc_n_constraint_aux = function
   | NC_id id -> NC_id (unloc_id id)
-  | NC_equal (nexp1, nexp2) -> NC_equal (unloc_nexp nexp1, unloc_nexp nexp2)
+  | NC_equal (arg1, arg2) -> NC_equal (unloc_typ_arg arg1, unloc_typ_arg arg2)
+  | NC_not_equal (arg1, arg2) -> NC_not_equal (unloc_typ_arg arg1, unloc_typ_arg arg2)
   | NC_bounded_ge (nexp1, nexp2) -> NC_bounded_ge (unloc_nexp nexp1, unloc_nexp nexp2)
   | NC_bounded_gt (nexp1, nexp2) -> NC_bounded_gt (unloc_nexp nexp1, unloc_nexp nexp2)
   | NC_bounded_le (nexp1, nexp2) -> NC_bounded_le (unloc_nexp nexp1, unloc_nexp nexp2)
   | NC_bounded_lt (nexp1, nexp2) -> NC_bounded_lt (unloc_nexp nexp1, unloc_nexp nexp2)
-  | NC_not_equal (nexp1, nexp2) -> NC_not_equal (unloc_nexp nexp1, unloc_nexp nexp2)
   | NC_set (nexp, nums) -> NC_set (unloc_nexp nexp, nums)
   | NC_or (nc1, nc2) -> NC_or (unloc_n_constraint nc1, unloc_n_constraint nc2)
   | NC_and (nc1, nc2) -> NC_and (unloc_n_constraint nc1, unloc_n_constraint nc2)
@@ -219,13 +219,8 @@ and typ_arg_nexps (A_aux (typ_arg_aux, _)) =
 
 and constraint_nexps (NC_aux (nc_aux, _)) =
   match nc_aux with
-  | NC_equal (n1, n2)
-  | NC_bounded_ge (n1, n2)
-  | NC_bounded_le (n1, n2)
-  | NC_bounded_gt (n1, n2)
-  | NC_bounded_lt (n1, n2)
-  | NC_not_equal (n1, n2) ->
-      [n1; n2]
+  | NC_equal (arg1, arg2) | NC_not_equal (arg1, arg2) -> typ_arg_nexps arg1 @ typ_arg_nexps arg2
+  | NC_bounded_ge (n1, n2) | NC_bounded_le (n1, n2) | NC_bounded_gt (n1, n2) | NC_bounded_lt (n1, n2) -> [n1; n2]
   | NC_id _ | NC_true | NC_false | NC_var _ -> []
   | NC_set (n, _) -> [n]
   | NC_or (nc1, nc2) | NC_and (nc1, nc2) -> constraint_nexps nc1 @ constraint_nexps nc2

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -491,7 +491,7 @@ and replace_typ_arg_size ctxt env (A_aux (ta, a) as targ) =
       match Type_check.solve_unique env nexp with
       | Some n -> Some (rewrap (A_nexp (nconstant n)))
       | None -> (
-          let is_equal nexp' = prove __POS__ env (NC_aux (NC_equal (nexp, nexp'), Parse_ast.Unknown)) in
+          let is_equal nexp' = prove __POS__ env (nc_eq nexp nexp') in
           match List.find is_equal (NexpSet.elements ctxt.bound_nexps) with
           | nexp' -> Some (rewrap (A_nexp nexp'))
           | exception Not_found -> None


### PR DESCRIPTION
The NC_equal and NC_not_equal constructors now take generic type arguments, so they can in theory be used to compare things other than type level integers, i.e. booleans, or in the future enumeration arguments.