### PR TITLE
Allow handling other file types

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -646,7 +646,10 @@ let main () =
   )
 
 let () =
-  try try main () with Failure s -> raise (Reporting.err_general Parse_ast.Unknown s)
+  try
+    try main () with
+    | Sys_error s -> raise (Reporting.err_general Parse_ast.Unknown s)
+    | Failure s -> raise (Reporting.err_general Parse_ast.Unknown s)
   with Reporting.Fatal_error e ->
     Reporting.print_error e;
     if !opt_memo_z3 then Constraint.save_digests () else ();

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -75,14 +75,12 @@ let opt_ddump_tc_ast = ref false
 let opt_list_files = ref false
 let opt_reformat : string option ref = ref None
 
-let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : untyped_ast) :
-    Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info =
-  let ast, env = Type_error.check env ast in
+let finalize_ast asserts_termination ctx env ast =
   let ast = Scattered.descatter ast in
   let side_effects = Effects.infer_side_effects asserts_termination ast in
   Effects.check_side_effects side_effects ast;
   let () = if !opt_ddump_tc_ast then Pretty_print_sail.output_ast stdout (Type_check.strip_ast ast) else () in
-  (ast, env, side_effects)
+  (ctx, ast, Type_check.Env.open_all_modules env, side_effects)
 
 let instantiate_abstract_types insts ast =
   let open Ast in
@@ -109,47 +107,160 @@ let instantiate_abstract_types insts ast =
   in
   { ast with defs = List.map instantiate ast.defs }
 
-type parsed_module = {
-  id : Project.mod_id;
-  included : bool;
-  files : (string * (Lexer.comment list * Parse_ast.def list)) list;
+type parse_continuation = {
+  check : Type_check.Env.t -> Type_check.typed_ast * Type_check.Env.t;
+  vs_ids : IdSet.t;
+  regs : (Ast.id * Ast.typ) list;
+  ctx : Initial_check.ctx;
 }
+
+type parsed_file =
+  | Generated of Parse_ast.def list
+  | File of { filename : string; cont : Initial_check.ctx -> parse_continuation }
+
+type parsed_module = { id : Project.mod_id; included : bool; files : parsed_file list }
+
+type processed_file =
+  | ProcessedGenerated of untyped_def list
+  | ProcessedFile of { filename : string; cont : Type_check.Env.t -> Type_check.typed_ast * Type_check.Env.t }
 
 let wrap_module proj parsed_module =
   let module P = Parse_ast in
   let open Project in
   let name, l = module_name proj parsed_module.id in
-  let bracket_pragma p = P.DEF_aux (P.DEF_pragma (p, name, 1), to_loc l) in
-  parsed_module.files
-  |> Util.update_first (fun (f, (comments, defs)) -> (f, (comments, bracket_pragma "start_module#" :: defs)))
-  |> Util.update_last (fun (f, (comments, defs)) -> (f, (comments, defs @ [bracket_pragma "end_module#"])))
+  let bracket_pragma p = [Generated [P.DEF_aux (P.DEF_pragma (p, name, 1), to_loc l)]] in
+  { parsed_module with files = bracket_pragma "start_module#" @ parsed_module.files @ bracket_pragma "end_module#" }
 
-let process_ast ctx target type_envs ast =
-  if !opt_ddump_initial_ast then Pretty_print_sail.output_ast stdout ast;
+let filter_modules proj is_included ast =
+  let open Ast in
+  let get_module_id l name =
+    match Project.get_module_id proj name with
+    | Some mod_id -> mod_id
+    | None -> Reporting.unreachable l __POS__ "Failed to get module id"
+  in
+  let rec go skipping acc = function
+    | DEF_aux (DEF_pragma ("ended_module#", name, l), def_annot) :: defs ->
+        let mod_id = get_module_id l name in
+        begin
+          match skipping with Some skip_id when mod_id = skip_id -> go None acc defs | _ -> go skipping acc defs
+        end
+    | _ :: defs when Option.is_some skipping -> go skipping acc defs
+    | DEF_aux (DEF_pragma ("started_module#", name, l), def_annot) :: defs ->
+        let mod_id = get_module_id l name in
+        if is_included mod_id then go None acc defs else go (Some mod_id) acc defs
+    | def :: defs -> go None (def :: acc) defs
+    | [] -> List.rev acc
+  in
+  { ast with defs = go None [] ast.defs }
 
-  begin
-    match !opt_reformat with
-    | Some dir ->
-        Pretty_print_sail.reformat ~into_directory:dir ast;
-        exit 0
-    | None -> ()
-  end;
+module type FILE_HANDLER = sig
+  type parsed
 
-  (* The separate loop measures declarations would be awkward to type check, so
-     move them into the definitions beforehand. *)
-  let ast = Rewrites.move_loop_measures ast in
+  type processed
 
-  let t = Profile.start () in
-  let asserts_termination = Option.fold ~none:false ~some:Target.asserts_termination target in
-  let ast, type_envs, side_effects = check_ast asserts_termination type_envs ast in
-  Profile.finish "type checking" t;
+  val parse : Parse_ast.l option -> string -> parsed
 
-  (ctx, ast, type_envs, side_effects)
+  val defines_functions : processed -> IdSet.t
 
-let load_modules ?target default_sail_dir options type_envs proj root_mod_ids =
+  val uninitialized_registers : processed -> (Ast.id * Ast.typ) list
+
+  val process :
+    default_sail_dir:string ->
+    target_name:string option ->
+    options:(Arg.key * Arg.spec * Arg.doc) list ->
+    Initial_check.ctx ->
+    parsed ->
+    processed * Initial_check.ctx
+
+  val check : Type_check.Env.t -> processed -> Type_check.typed_ast * Type_check.Env.t
+end
+
+module SailHandler : FILE_HANDLER = struct
+  type parsed = string * Lexer.comment list * Parse_ast.def list
+
+  type processed = untyped_ast
+
+  let parse loc filename =
+    let comments, defs = Initial_check.parse_file ?loc filename in
+    (filename, comments, defs)
+
+  let defines_functions ast = val_spec_ids ast.defs
+
+  let uninitialized_registers ast = Initial_check.get_uninitialized_registers ast.defs
+
+  let process ~default_sail_dir ~target_name ~options ctx (filename, comments, defs) =
+    let defs = Preprocess.preprocess default_sail_dir target_name options defs in
+    let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [(filename, defs)]) in
+    ({ ast with comments = [(filename, comments)] }, ctx)
+
+  let check env ast =
+    let ast = Rewrites.move_loop_measures ast in
+    Type_error.check env ast
+end
+
+let handlers : (string, (module FILE_HANDLER)) Hashtbl.t = Hashtbl.create 8
+
+let register_file_handler ~extension handler = Hashtbl.replace handlers extension handler
+
+let get_handler ~filename = function
+  | ".sail" -> (module SailHandler : FILE_HANDLER)
+  | extension -> (
+      match Hashtbl.find_opt handlers extension with
+      | Some h -> h
+      | None ->
+          raise
+            (Reporting.err_general Parse_ast.Unknown
+               (Printf.sprintf "No handler for file '%s' with extension '%s'" filename extension)
+            )
+    )
+
+let parse_file ?loc ~target_name ~default_sail_dir ~options filename =
+  let extension = Filename.extension filename in
+  let module Handler = (val get_handler ~filename extension : FILE_HANDLER) in
+  let parsed = Handler.parse loc filename in
+  let cont ctx =
+    let processed, ctx = Handler.process ~target_name ~default_sail_dir ~options ctx parsed in
+    {
+      check = (fun env -> Handler.check env processed);
+      vs_ids = Handler.defines_functions processed;
+      regs = Handler.uninitialized_registers processed;
+      ctx;
+    }
+  in
+  File { filename; cont }
+
+let process_files ~target_name ~default_sail_dir ~options ctx vs_ids regs files =
+  Util.fold_left_map
+    (fun (ctx, vs_ids, regs) -> function
+      | File { filename; cont } ->
+          let cont = cont ctx in
+          ((cont.ctx, IdSet.union vs_ids cont.vs_ids, regs @ cont.regs), ProcessedFile { filename; cont = cont.check })
+      | Generated defs ->
+          let defs = Preprocess.preprocess default_sail_dir target_name options defs in
+          let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [("", defs)]) in
+          ((ctx, vs_ids, regs), ProcessedGenerated ast.defs)
+    )
+    (ctx, vs_ids, regs) files
+
+let check_files env files =
+  Util.fold_left_map
+    (fun env -> function
+      | ProcessedFile { cont; _ } ->
+          let ast, env = cont env in
+          (env, ast)
+      | ProcessedGenerated defs ->
+          let defs, env = Type_error.check_defs env defs in
+          (env, { defs; comments = [] })
+    )
+    env files
+
+let load_modules ?target default_sail_dir options env proj root_mod_ids =
   let open Project in
   let mod_ids = module_order proj in
   let is_included = required_modules proj ~roots:(ModSet.of_list root_mod_ids) in
+
+  let target_name = Option.map Target.name target in
+  let asserts_termination = Option.fold ~none:false ~some:Target.asserts_termination target in
 
   let parsed_modules =
     List.map
@@ -158,7 +269,10 @@ let load_modules ?target default_sail_dir options type_envs proj root_mod_ids =
         {
           id = mod_id;
           included = is_included mod_id;
-          files = List.map (fun f -> (fst f, Initial_check.parse_file (fst f))) files;
+          files =
+            List.map
+              (fun (filename, l) -> parse_file ~loc:(Project.to_loc l) ~target_name ~default_sail_dir ~options filename)
+              files;
         }
       )
       mod_ids
@@ -169,43 +283,75 @@ let load_modules ?target default_sail_dir options type_envs proj root_mod_ids =
       List.map (fun parsed_module -> if parsed_module.included then parsed_module.files else []) parsed_modules
       |> List.concat
     in
-    print_endline (Util.string_of_list " " fst included_files);
+    print_endline
+      (Util.string_of_list " "
+         (fun s -> s)
+         (List.filter_map (function File { filename; _ } -> Some filename | Generated _ -> None) included_files)
+      );
     exit 0
   );
 
-  let comments =
-    List.map (fun m -> List.map (fun (f, (comments, _)) -> (f, comments)) m.files) parsed_modules |> List.concat
+  let all_files =
+    List.map (fun m -> m.files) parsed_modules
+    |> List.concat
+    |> List.filter_map (function File { filename; _ } -> Some filename | Generated _ -> None)
   in
-  let target_name = Option.map Target.name target in
+  Option.iter (fun t -> Target.run_pre_initial_check_hook t all_files) target;
 
-  let ast =
-    let files = List.concat (List.map (wrap_module proj) parsed_modules) in
-    let files =
-      List.map
-        (fun (f, (_, file_ast)) -> (f, Preprocess.preprocess default_sail_dir target_name options file_ast))
-        files
-    in
-    Parse_ast.Defs files
-  in
-  Option.iter (fun t -> Target.run_pre_initial_check_hook t ast) target;
-  let ast, ctx = Initial_check.(process_ast initial_ctx ast) in
-  process_ast ctx target type_envs { (Initial_check.generate ast) with comments }
-
-let load_files ?target default_sail_dir options type_envs files =
-  let parsed_files = List.map (fun f -> (f, Initial_check.parse_file f)) files in
-
-  let comments = List.map (fun (f, (comments, _)) -> (f, comments)) parsed_files in
-  let target_name = Option.map Target.name target in
-  let ast =
-    Parse_ast.Defs
-      (List.map
-         (fun (f, (_, file_ast)) -> (f, Preprocess.preprocess default_sail_dir target_name options file_ast))
-         parsed_files
+  let (ctx, vs_ids, regs), processed =
+    let mods = List.map (wrap_module proj) parsed_modules in
+    Util.fold_left_map
+      (fun (ctx, vs_ids, regs) parsed_module ->
+        let (ctx, vs_ids, regs), processed =
+          process_files ~target_name ~default_sail_dir ~options ctx vs_ids regs parsed_module.files
+        in
+        (* If the module isn't being included we don't want to generate things for it's registers *)
+        ((ctx, vs_ids, if is_included parsed_module.id then regs else []), processed)
       )
+      (Initial_check.initial_ctx, IdSet.empty, [])
+      mods
   in
-  Option.iter (fun t -> Target.run_pre_initial_check_hook t ast) target;
-  let ast, ctx = Initial_check.(process_ast initial_ctx ast) in
-  process_ast ctx target type_envs { (Initial_check.generate ast) with comments }
+  let processed =
+    [ProcessedGenerated (Initial_check.generate_undefineds vs_ids)]
+    @ List.concat processed
+    @ [ProcessedGenerated (Initial_check.generate_initialize_registers vs_ids regs)]
+  in
+
+  let t = Profile.start () in
+  let env, checked = check_files env processed in
+  Profile.finish "type checking" t;
+
+  let ast = concat_ast checked in
+  let ast = filter_modules proj is_included ast in
+  finalize_ast asserts_termination ctx env ast
+
+let load_files ?target default_sail_dir options env files =
+  let target_name = Option.map Target.name target in
+  let asserts_termination = Option.fold ~none:false ~some:Target.asserts_termination target in
+
+  let parsed_files = List.map (fun filename -> parse_file ~target_name ~default_sail_dir ~options filename) files in
+
+  Option.iter
+    (fun t ->
+      Target.run_pre_initial_check_hook t
+        (List.filter_map (function File { filename; _ } -> Some filename | Generated _ -> None) parsed_files)
+    )
+    target;
+
+  let (ctx, vs_ids, regs), processed =
+    process_files ~target_name ~default_sail_dir ~options Initial_check.initial_ctx IdSet.empty [] parsed_files
+  in
+  let processed =
+    [ProcessedGenerated (Initial_check.generate_undefineds vs_ids)]
+    @ processed
+    @ [ProcessedGenerated (Initial_check.generate_initialize_registers vs_ids regs)]
+  in
+
+  let t = Profile.start () in
+  let env, checked = check_files env processed in
+  Profile.finish "type checking" t;
+
+  finalize_ast asserts_termination ctx env (concat_ast checked)
 
 let rewrite_ast_initial effect_info env =
   Rewrites.rewrite Initial_check.initial_ctx effect_info env

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -101,6 +101,8 @@ val initial_ctx : ctx
 
 (** {2 Desugar and process AST } *)
 
+val get_uninitialized_registers : untyped_def list -> (id * typ) list
+
 val generate_undefined_record_context : typquant -> (id * typ) list
 
 val generate_undefined_record : id -> typquant -> (typ * id) list -> untyped_def list
@@ -114,14 +116,12 @@ val undefined_builtin_val_specs : untyped_def list
 
 val generate_undefineds : IdSet.t -> untyped_def list
 
-val generate_initialize_registers : IdSet.t -> untyped_def list -> untyped_def list
+val generate_initialize_registers : IdSet.t -> (id * typ) list -> untyped_def list
 
 val generate_enum_number_conversions : untyped_def list -> untyped_def list
 
 val generate : untyped_ast -> untyped_ast
 
-(** If the generate flag is false, then we won't generate any
-   auxilliary definitions, like the initialize_registers function *)
 val process_ast : ctx -> Parse_ast.defs -> untyped_ast * ctx
 
 (** {2 Parsing expressions and definitions from strings} *)

--- a/src/lib/project.mli
+++ b/src/lib/project.mli
@@ -116,8 +116,6 @@ type dependency =
   | D_requires of exp spanned non_empty
   | D_after of exp spanned non_empty
   | D_before of exp spanned non_empty
-  | D_default
-  | D_optional
 
 type mdl_def = M_dep of dependency | M_directory of exp spanned | M_module of mdl | M_files of exp spanned non_empty
 

--- a/src/lib/project_lexer.mll
+++ b/src/lib/project_lexer.mll
@@ -80,21 +80,23 @@ let kw_table =
       ("__test",    (fun _ -> Test));
       ("after",     (fun _ -> After));
       ("before",    (fun _ -> Before));
-      ("default",   (fun _ -> Default));
       ("directory", (fun _ -> Directory));
       ("else",      (fun _ -> Else));
       ("false",     (fun _ -> False));
       ("files",     (fun _ -> Files));
       ("if",        (fun _ -> If));
-      ("optional",  (fun _ -> Optional));
       ("requires",  (fun _ -> Requires));
       ("then",      (fun _ -> Then));
       ("true",      (fun _ -> True));
       ("variable",  (fun _ -> Variable));
+      ("default",   (fun p -> raise (Reporting.err_lex p "default is a reserved keyword")));
+      ("extension", (fun p -> raise (Reporting.err_lex p "extension is a reserved keyword")));
       ("import",    (fun p -> raise (Reporting.err_lex p "import is a reserved keyword")));
       ("namespace", (fun p -> raise (Reporting.err_lex p "namespace is a reserved keyword")));
       ("open",      (fun p -> raise (Reporting.err_lex p "open is a reserved keyword")));
+      ("optional",  (fun p -> raise (Reporting.err_lex p "optional is a reserved keyword")));
       ("use",       (fun p -> raise (Reporting.err_lex p "use is a reserved keyword")));
+      ("version",   (fun p -> raise (Reporting.err_lex p "version is a reserved keyword")));
       ("versions",  (fun p -> raise (Reporting.err_lex p "versions is a reserved keyword")));
     ]
 

--- a/src/lib/project_parser.mly
+++ b/src/lib/project_parser.mly
@@ -75,7 +75,7 @@ let span x s e = (x, (s, e))
 
 %}
 
-%token After Before Directory If Then Else Requires Files Default Optional Variable Test True False
+%token After Before Directory If Then Else Requires Files Variable Test True False
 %token Comma DotDot Eq Gt Lt EqEq GtEq LtEq ExclEq Slash Semi
 %token Lparen Rparen Lsquare Rsquare Lcurly Rcurly
 %token Eof
@@ -174,10 +174,6 @@ dependency:
     { D_after xs }
   | Before; xs = exp_comma_block
     { D_before xs }
-  | Default
-    { D_default }
-  | Optional
-    { D_optional }
 
 mdl_def:
   | d = dependency

--- a/src/lib/target.ml
+++ b/src/lib/target.ml
@@ -75,7 +75,7 @@ type target = {
   name : string;
   options : (Arg.key * Arg.spec * Arg.doc) list;
   pre_parse_hook : unit -> unit;
-  pre_initial_check_hook : Parse_ast.defs -> unit;
+  pre_initial_check_hook : string list -> unit;
   pre_rewrites_hook : typed_ast -> Effects.side_effect_info -> Env.t -> unit;
   rewrites : (string * Rewrites.rewriter_arg list) list;
   action : string option -> istate -> unit;

--- a/src/lib/target.mli
+++ b/src/lib/target.mli
@@ -84,7 +84,7 @@ val name : target -> string
 
 val run_pre_parse_hook : target -> unit -> unit
 
-val run_pre_initial_check_hook : target -> Parse_ast.defs -> unit
+val run_pre_initial_check_hook : target -> string list -> unit
 
 val run_pre_rewrites_hook : target -> typed_ast -> Effects.side_effect_info -> Env.t -> unit
 
@@ -124,7 +124,7 @@ val register :
   ?description:string ->
   ?options:(Arg.key * Arg.spec * Arg.doc) list ->
   ?pre_parse_hook:(unit -> unit) ->
-  ?pre_initial_check_hook:(Parse_ast.defs -> unit) ->
+  ?pre_initial_check_hook:(string list -> unit) ->
   ?pre_rewrites_hook:(typed_ast -> Effects.side_effect_info -> Env.t -> unit) ->
   ?rewrites:(string * Rewrites.rewriter_arg list) list ->
   ?asserts_termination:bool ->

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5121,8 +5121,9 @@ and check_def : Env.t -> untyped_def -> typed_def list * Env.t =
   | DEF_pragma ("start_module#", arg, l) ->
       let mod_id = Env.get_module_id ~at:l env arg in
       typ_print (lazy (Printf.sprintf "module start %d '%s'" (Project.ModId.to_int mod_id) arg));
-      ([], Env.start_module ~at:l mod_id env)
-  | DEF_pragma ("end_module#", _, _) -> ([], Env.end_module env)
+      ([DEF_aux (DEF_pragma ("started_module#", arg, l), def_annot)], Env.start_module ~at:l mod_id env)
+  | DEF_pragma ("end_module#", arg, l) ->
+      ([DEF_aux (DEF_pragma ("ended_module#", arg, l), def_annot)], Env.end_module env)
   | DEF_pragma (pragma, arg, l) -> ([DEF_aux (DEF_pragma (pragma, arg, l), def_annot)], env)
   | DEF_scattered sdef -> check_scattered env def_annot sdef
   | DEF_measure (id, pat, exp) -> ([check_termination_measure_decl env def_annot (id, pat, exp)], env)
@@ -5168,7 +5169,7 @@ let check : Env.t -> untyped_ast -> typed_ast * Env.t =
  fun env ast ->
   let total = List.length ast.defs in
   let defs, env = check_defs_progress 1 total env ast.defs in
-  ({ ast with defs }, Env.open_all_modules env)
+  ({ ast with defs }, env)
 
 let rec check_with_envs : Env.t -> untyped_def list -> (typed_def list * Env.t) list =
  fun env defs ->

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -103,6 +103,9 @@ module Env : sig
   (** Env.t is the type of environments *)
   type t = env
 
+  (** This effectively disables all module related access control *)
+  val open_all_modules : t -> t
+
   (** Note: Most get_ functions assume the identifiers exist, and throw
      type errors if they don't. *)
 

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -264,6 +264,17 @@ let list_index p l =
   let rec aux i l = match l with [] -> None | x :: xs -> if p x then Some i else aux (i + 1) xs in
   aux 0 l
 
+let fold_left_map f acc xs =
+  let ys, result =
+    List.fold_left
+      (fun (ys, acc) x ->
+        let acc', y = f acc x in
+        (y :: ys, acc')
+      )
+      ([], acc) xs
+  in
+  (result, List.rev ys)
+
 let option_get_exn e = function Some o -> o | None -> raise e
 
 let option_cases op f1 f2 = match op with Some o -> f1 o | None -> f2 ()

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -243,6 +243,8 @@ val fold_left_index : (int -> 'a -> 'b -> 'a) -> 'a -> 'b list -> 'a
 
 val fold_left_index_last : (int -> bool -> 'a -> 'b -> 'a) -> 'a -> 'b list -> 'a
 
+val fold_left_map : ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
+
 val list_init : int -> (int -> 'a) -> 'a list
 
 (** {2 String utilities} *)

--- a/src/sail_doc_backend/sail_plugin_doc.ml
+++ b/src/sail_doc_backend/sail_plugin_doc.ml
@@ -213,17 +213,16 @@ let html_target files out_dir_opt { ast; _ } =
 let _ =
   let files : Html_source.file_info list ref = ref [] in
   Target.register ~name:"html" ~options:html_options
-    ~pre_initial_check_hook:(function
-      | Defs defs ->
-          List.iter
-            (fun (filename, _) ->
-              match Filename.chop_suffix_opt ~suffix:".sail" filename with
-              | Some prefix when Filename.is_relative filename ->
-                  let contents = Util.read_whole_file filename in
-                  let highlights = Html_source.highlights ~filename ~contents in
-                  files := { filename; prefix; contents; highlights } :: !files
-              | _ -> ()
-            )
-            defs
-      )
+    ~pre_initial_check_hook:(fun filenames ->
+      List.iter
+        (fun filename ->
+          match Filename.chop_suffix_opt ~suffix:".sail" filename with
+          | Some prefix when Filename.is_relative filename ->
+              let contents = Util.read_whole_file filename in
+              let highlights = Html_source.highlights ~filename ~contents in
+              files := { filename; prefix; contents; highlights } :: !files
+          | _ -> ()
+        )
+        filenames
+    )
     (html_target files)

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -89,6 +89,18 @@ def chunks(filenames, cores):
     ys.append(list(chunk))
     return ys
 
+def project_chunks(filenames, cores):
+    ys = []
+    chunk = []
+    for filename in filenames:
+        if re.match('.+\.sail_project$', filename):
+            chunk.append(filename)
+        if len(chunk) >= cores:
+            ys.append(list(chunk))
+            chunk = []
+    ys.append(list(chunk))
+    return ys
+
 def step(string, expected_status=0):
     p = subprocess.Popen(string, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     out, err = p.communicate()

--- a/test/typecheck/fail/private_extension.sail
+++ b/test/typecheck/fail/private_extension.sail
@@ -3,7 +3,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$project# A {} E { optional } B { requires A }
+$project# A {} E {} B { requires A }
 
 $start_module# A
 

--- a/test/typecheck/project/simple.sail_project
+++ b/test/typecheck/project/simple.sail_project
@@ -1,0 +1,9 @@
+
+A {
+  files simple/amod.sail
+}
+
+B {
+  requires A
+  files simple/bmod.sail
+}

--- a/test/typecheck/project/simple/amod.sail
+++ b/test/typecheck/project/simple/amod.sail
@@ -1,0 +1,7 @@
+default Order dec
+
+$include <prelude.sail>
+
+val hello : unit -> unit
+
+function hello() = print_endline("Hello, World")

--- a/test/typecheck/project/simple/bmod.sail
+++ b/test/typecheck/project/simple/bmod.sail
@@ -1,0 +1,3 @@
+val main : unit -> unit
+
+function main() = hello()

--- a/test/typecheck/run_tests.py
+++ b/test/typecheck/run_tests.py
@@ -54,6 +54,20 @@ def test_pass():
         results.collect(tests)
     return results.finish()
 
+def test_projects():
+    banner('Testing passing projects')
+    results = Results('projects')
+    for filenames in project_chunks(os.listdir('project'), parallel()):
+        tests = {}
+        for filename in filenames:
+            tests[filename] = os.fork()
+            if tests[filename] == 0:
+                step('{} --no-memo-z3 project/{} --all-modules'.format(sail, filename))
+                print_ok(filename)
+                sys.exit()
+        results.collect(tests)
+    return results.finish()
+
 def test_fail():
     banner('Testing failing programs')
     results = Results('fail')
@@ -74,6 +88,7 @@ def test_fail():
 xml = '<testsuites>\n'
 
 xml += test_pass()
+xml += test_projects()
 xml += test_fail()
 
 xml += '</testsuites>\n'


### PR DESCRIPTION
Plugins can use the `register_file_handler` function to register a module that will be invoked to handle files with a specific extension.

As part of this the file handling code has been made much more generic, and re-factored quite significantly. This also includes some improvements and simplifications to the module system.