### PR TITLE
Check mapping completeness

### DIFF
--- a/src/lib/effects.ml
+++ b/src/lib/effects.ml
@@ -218,7 +218,9 @@ let infer_def_direct_effects asserts_termination def =
               effects := EffectSet.add IncompleteMatch !effects
         | None -> Reporting.unreachable l __POS__ "Empty funcls in infer_def_direct_effects"
       end
-    | DEF_aux (DEF_mapdef _, _) -> effects := EffectSet.add IncompleteMatch !effects
+    | DEF_aux (DEF_mapdef _, def_annot) ->
+        if Option.is_some (get_def_attribute "incomplete" def_annot) then
+          effects := EffectSet.add IncompleteMatch !effects
     | DEF_aux (DEF_scattered _, _) -> effects := EffectSet.add Scattered !effects
     | _ -> ()
   end;

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -79,6 +79,7 @@ let check_ast (asserts_termination : bool) (env : Type_check.Env.t) (ast : untyp
     Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info =
   let ast, env = Type_error.check env ast in
   let ast = Scattered.descatter ast in
+  let ast, env = Type_error.check Type_check.initial_env (Type_check.strip_ast ast) in
   let side_effects = Effects.infer_side_effects asserts_termination ast in
   Effects.check_side_effects side_effects ast;
   let () = if !opt_ddump_tc_ast then Pretty_print_sail.output_ast stdout (Type_check.strip_ast ast) else () in

--- a/src/lib/pattern_completeness.mli
+++ b/src/lib/pattern_completeness.mli
@@ -93,4 +93,5 @@ module Make (C : Config) : sig
   val is_complete_funcls_wildcarded :
     ?keyword:string -> Parse_ast.l -> ctx -> C.t funcl list -> typ -> C.t funcl list option
   val is_complete : ?keyword:string -> Parse_ast.l -> ctx -> C.t pexp list -> typ -> bool
+  val is_complete_mapcls_wildcarded : ?keyword:string -> Parse_ast.l -> ctx -> C.t mapcl list -> typ -> typ -> bool
 end

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4566,6 +4566,12 @@ let check_fundef env def_annot (FD_aux (FD_function (recopt, tannot_opt, funcls)
     env
   )
 
+let check_mapdef_completeness l env mapcls typl typr =
+  let ctx = pattern_completeness_ctx env in
+  match PC.is_complete_mapcls_wildcarded l ctx mapcls typl typr with
+  | true -> add_def_attribute (gen_loc l) "complete" None
+  | false -> add_def_attribute (gen_loc l) "incomplete" None
+
 let check_mapdef env def_annot (MD_aux (MD_mapping (id, tannot_opt, mapcls), (l, _))) =
   typ_print (lazy ("\nChecking mapping " ^ string_of_id id));
   let inline_tannot =
@@ -4582,11 +4588,11 @@ let check_mapdef env def_annot (MD_aux (MD_mapping (id, tannot_opt, mapcls), (l,
         (Some vs_l, quant, typ)
     | None, None -> typ_error l "Mapping does not have any declared type"
   in
-  begin
+  let typl, typr =
     match typ with
-    | Typ_aux (Typ_bidir (_, _), _) -> ()
+    | Typ_aux (Typ_bidir (l, r), _) -> (l, r)
     | _ -> typ_error l "Mapping type must be a bi-directional mapping"
-  end;
+  in
   (* If we have a val spec, then the mapping itself shouldn't be marked as private *)
   let fix_body_visibility =
     match (have_val_spec, def_annot.visibility) with
@@ -4607,7 +4613,16 @@ let check_mapdef env def_annot (MD_aux (MD_mapping (id, tannot_opt, mapcls), (l,
   in
   let mapcl_env = Env.add_typquant l quant env in
   let mapcls = List.map (fun mapcl -> check_mapcl mapcl_env mapcl typ) mapcls in
-  let def_annot = fix_body_visibility def_annot in
+
+  let update_attr =
+    if
+      Option.is_some (get_def_attribute "complete" def_annot)
+      || Option.is_some (get_def_attribute "incomplete" def_annot)
+    then fun attrs -> attrs
+    else check_mapdef_completeness l env mapcls typl typr
+  in
+
+  let def_annot = fix_body_visibility (update_attr def_annot) in
   let env = Env.define_val_spec id env in
   ( vs_def @ [DEF_aux (DEF_mapdef (MD_aux (MD_mapping (id, empty_tannot_opt, mapcls), (l, empty_tannot))), def_annot)],
     env

--- a/test/pattern_completeness/mapping.sail
+++ b/test/pattern_completeness/mapping.sail
@@ -1,0 +1,10 @@
+struct bool2 = {
+    field: bool,
+}
+
+mapping m : bool <-> bool2 = {
+   true <-> struct { field = true },
+   false <->  struct{ field = false },
+}
+
+let foo = m(true)

--- a/test/pattern_completeness/warn_mapping_imcomplete.expect
+++ b/test/pattern_completeness/warn_mapping_imcomplete.expect
@@ -1,0 +1,43 @@
+[93mWarning[0m: Incomplete pattern match statement at [96mwarn_mapping_imcomplete.sail[0m:10.0-7:
+10[96m |[0mmapping imcomplete_oneside : bool <-> bool2 = {
+  [91m |[0m[91m^-----^[0m
+  [91m |[0m 
+The following expression is unmatched: [93mstruct { field = true }[0m
+
+[93mWarning[0m: Incomplete pattern match statement at [96mwarn_mapping_imcomplete.sail[0m:15.0-7:
+15[96m |[0mmapping imcomplete_both_side : bool <-> bool2 = {
+  [91m |[0m[91m^-----^[0m
+  [91m |[0m 
+The following expression is unmatched: [93mfalse[0m
+
+[93mWarning[0m: Unreachable pattern match type at [96mwarn_mapping_imcomplete.sail[0m:20.0-7:
+20[96m |[0mmapping forwords_unreachable : bool <-> int = {
+  [91m |[0m[91m^-----^[0m
+  [91m |[0m 
+The following type is unreachable: [93mint[0m
+
+[93mWarning[0m: Unreachable pattern match type at [96mwarn_mapping_imcomplete.sail[0m:24.0-7:
+24[96m |[0mmapping backwords_unreachable : bool <-> int = {
+  [91m |[0m[91m^-----^[0m
+  [91m |[0m 
+The following type is unreachable: [93mbool[0m
+
+[93mWarning[0m: Unreachable pattern match type at [96mwarn_mapping_imcomplete.sail[0m:28.0-7:
+28[96m |[0mmapping multi_warning : bool <-> int = {
+  [91m |[0m[91m^-----^[0m
+  [91m |[0m 
+The following type is unreachable: [93mbool[0m
+
+[93mWarning[0m: Incomplete pattern match statement at [96mwarn_mapping_imcomplete.sail[0m:28.0-7:
+28[96m |[0mmapping multi_warning : bool <-> int = {
+  [91m |[0m[91m^-----^[0m
+  [91m |[0m 
+The following expression is unmatched: [93m3[0m
+
+[93mWarning[0m: Unreachable pattern match type at Code generated nearby:
+[96mwarn_mapping_imcomplete.sail[0m:38.0-79:
+38[96m |[0mmapping clause encdec = true if enabled <-> struct { field = false } if enabled
+  [91m |[0m[91m^-----------------------------------------------------------------------------^[0m
+  [91m |[0m 
+The following type is unreachable: [93mbool[0m
+

--- a/test/pattern_completeness/warn_mapping_imcomplete.sail
+++ b/test/pattern_completeness/warn_mapping_imcomplete.sail
@@ -1,0 +1,40 @@
+struct bool2 = {
+    field: bool,
+}
+
+mapping complete : bool <-> bool2 = {
+   true <-> struct { field = false },
+   false <->  struct{ field = true },
+}
+
+mapping imcomplete_oneside : bool <-> bool2 = {
+   true <-> struct { field = false },
+   false <-> struct { field = false },
+}
+
+mapping imcomplete_both_side : bool <-> bool2 = {
+   true <-> struct { field = false },
+   true <-> struct { field = false },
+}
+
+mapping forwords_unreachable : bool <-> int = {
+   forwards _ => 1,
+}
+
+mapping backwords_unreachable : bool <-> int = {
+   backwards _ => false,
+}
+
+mapping multi_warning : bool <-> int = {
+   backwards 2 => false,
+}
+
+register enabled : bool
+
+val encdec : bool <-> bool2
+
+scattered mapping encdec
+
+mapping clause encdec = true if enabled <-> struct { field = false } if enabled
+
+end encdec

--- a/test/typecheck/fail/issue243.expect
+++ b/test/typecheck/fail/issue243.expect
@@ -1,3 +1,9 @@
+[93mWarning[0m: Incomplete pattern match statement at [96mfail/issue243.sail[0m:6.0-7:
+6[96m |[0mmapping e_pair_bits : (E,E) <-> bits(2) =
+ [91m |[0m[91m^-----^[0m
+ [91m |[0m 
+The following expression is unmatched: [93m(EB, EA)[0m
+
 [93mType error[0m:
 [96mfail/issue243.sail[0m:17.70-72:
 17[96m |[0mmapping f_bits = { FE(struct { e1 = e1, v1 = v1 }) <-> e_pair_bits(e1,e1) @ v1 }


### PR DESCRIPTION
fix #424

Add basic mapdef completeness check

- converting mpat to pat, then to gpat, and reusing the match checking logic