### PR TITLE
Fix loop termination measures in separate files to the definitions

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -771,7 +771,8 @@ prec :: '' ::=
    | infixl :: :: InfixL
    | infixr :: :: InfixR
 
-loop_measure :: '' ::=
+% The measure expression will remain explicitly untyped until it is moved into the loop itself
+loop_measure :: '' ::= {{ lem (loop * exp unit) }}
    {{ auxparam 'a }}
    | loop exp :: :: Loop
 

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -1007,7 +1007,7 @@ and map_def_annot f (DEF_aux (aux, annot)) =
     | DEF_default ds -> DEF_default ds
     | DEF_scattered sd -> DEF_scattered (map_scattered_annot f sd)
     | DEF_measure (id, pat, exp) -> DEF_measure (id, map_pat_annot f pat, map_exp_annot f exp)
-    | DEF_loop_measures (id, measures) -> DEF_loop_measures (id, List.map (map_loop_measure_annot f) measures)
+    | DEF_loop_measures (id, measures) -> DEF_loop_measures (id, measures)
     | DEF_register ds -> DEF_register (map_register_annot f ds)
     | DEF_internal_mutrec fds -> DEF_internal_mutrec (List.map (map_fundef_annot f) fds)
     | DEF_pragma (name, arg, l) -> DEF_pragma (name, arg, l)
@@ -1015,8 +1015,6 @@ and map_def_annot f (DEF_aux (aux, annot)) =
   DEF_aux (aux, annot)
 
 and map_ast_annot f ast = { ast with defs = List.map (map_def_annot f) ast.defs }
-
-and map_loop_measure_annot f = function Loop (loop, exp) -> Loop (loop, map_exp_annot f exp)
 
 let rec map_def_def_annot f (DEF_aux (aux, annot)) =
   let aux =

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -269,8 +269,6 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
     match aux with TypQ_no_forall -> () | TypQ_tq quants -> List.iter (scan_quant_item self) quants
   in
 
-  let scan_loop_measure self (Loop (_, exp)) = ignore (fold_exp (rw_exp self) exp) in
-
   let add_type_def_to_graph (TD_aux (aux, (l, _))) =
     match aux with
     | TD_abbrev (id, typq, arg) ->
@@ -363,8 +361,8 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
         ignore (fold_pat (rw_pat (FunctionMeasure id)) pat);
         ignore (fold_exp (rw_exp (FunctionMeasure id)) exp)
     | DEF_loop_measures (id, measures) ->
-        graph := G.add_edges (LoopMeasures id) [Function id] !graph;
-        List.iter (scan_loop_measure (LoopMeasures id)) measures
+        (* We can't scan loop measures here because they aren't typed until they're moved into the loop expression *)
+        graph := G.add_edges (LoopMeasures id) [Function id] !graph
     | DEF_outcome (OV_aux (OV_outcome (id, TypSchm_aux (TypSchm_ts (typq, typ), _), _), l), outcome_defs) ->
         graph := G.add_edges (Outcome id) [] !graph;
         scan_typquant (Outcome id) typq;

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -193,9 +193,7 @@ module SailHandler : FILE_HANDLER = struct
     let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [(filename, defs)]) in
     ({ ast with comments = [(filename, comments)] }, ctx)
 
-  let check env ast =
-    let ast = Rewrites.move_loop_measures ast in
-    Type_error.check env ast
+  let check env ast = Type_error.check env ast
 end
 
 let handlers : (string, (module FILE_HANDLER)) Hashtbl.t = Hashtbl.create 8

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1857,9 +1857,10 @@ let to_ast_subst ctx = function
   | P.IS_aux (P.IS_id (id_from, id_to), l) -> IS_aux (IS_id (to_ast_id ctx id_from, to_ast_id ctx id_to), l)
   | P.IS_aux (P.IS_typ (kid, typ), l) -> IS_aux (IS_typ (to_ast_var kid, to_ast_typ ctx typ), l)
 
+(* To avoid awkward dependencies, loop measures don't have any annotations except locations. *)
 let to_ast_loop_measure ctx = function
-  | P.Loop (P.While, exp) -> Loop (While, to_ast_exp ctx exp)
-  | P.Loop (P.Until, exp) -> Loop (Until, to_ast_exp ctx exp)
+  | P.Loop (P.While, exp) -> (While, map_exp_annot (fun (l, _) -> (l, ())) @@ to_ast_exp ctx exp)
+  | P.Loop (P.Until, exp) -> (Until, map_exp_annot (fun (l, _) -> (l, ())) @@ to_ast_exp ctx exp)
 
 (* Annotations on some scattered constructs will not be preserved after de-scattering, so warn about this *)
 let check_annotation (DEF_aux (aux, def_annot)) =

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -808,9 +808,12 @@ module Printer (Config : PRINT_CONFIG) = struct
   let doc_prec = function Infix -> string "infix" | InfixL -> string "infixl" | InfixR -> string "infixr"
 
   let doc_loop_measures l =
+    let fixup_annot e = map_exp_annot (fun (l, _) -> (l, empty_uannot)) e in
     separate_map
       (comma ^^ break 1)
-      (function Loop (l, e) -> string (match l with While -> "while" | Until -> "until") ^^ space ^^ doc_exp e)
+      (function
+        | l, e -> string (match l with While -> "while" | Until -> "until") ^^ space ^^ doc_exp (fixup_annot e)
+        )
       l
 
   let doc_scattered (SD_aux (sd_aux, _)) =

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -341,8 +341,10 @@ let rec rewrite_def rewriters (DEF_aux (aux, def_annot)) =
     | DEF_scattered sd -> DEF_scattered (rewrite_scattered rewriters sd)
     | DEF_measure (id, pat, exp) ->
         DEF_measure (id, rewriters.rewrite_pat rewriters pat, rewriters.rewrite_exp rewriters exp)
-    | DEF_loop_measures (id, _) ->
-        raise (Reporting.err_unreachable (id_loc id) __POS__ "DEF_loop_measures survived to rewriter")
+    | DEF_loop_measures (id, measures) ->
+        (* We can't rewrite in here because the measure expressions haven't been typechecked, so
+           the rewrite needs to run early. *)
+        aux
   in
   DEF_aux (aux, def_annot)
 

--- a/src/lib/rewrites.mli
+++ b/src/lib/rewrites.mli
@@ -89,9 +89,6 @@ val opt_ddump_rewrite_ast : (string * int) option ref
 (** Generate a fresh id with the given prefix *)
 val fresh_id : string -> l -> id
 
-(** Move loop termination measures into loop AST nodes *)
-val move_loop_measures : ('a, 'b) ast -> ('a, 'b) ast
-
 (** Re-write undefined to functions created by -undefined_gen flag *)
 val rewrite_undefined : bool -> Env.t -> typed_ast -> typed_ast
 

--- a/src/lib/splice.ml
+++ b/src/lib/splice.ml
@@ -133,7 +133,6 @@ let annotate_ast ast =
 let splice ctx ast file =
   let parsed_ast = Initial_check.parse_file file |> snd in
   let repl_ast, _ = Initial_check.process_ast ctx (Parse_ast.Defs [(file, parsed_ast)]) in
-  let repl_ast = Rewrites.move_loop_measures repl_ast in
   let repl_ast = map_ast_annot (fun (l, _) -> (l, Type_check.empty_tannot)) repl_ast in
   let repl_ast = annotate_ast repl_ast in
   let repl_ids, repl_specs = scan_ast repl_ast in

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5127,9 +5127,9 @@ and check_def : Env.t -> untyped_def -> typed_def list * Env.t =
   | DEF_pragma (pragma, arg, l) -> ([DEF_aux (DEF_pragma (pragma, arg, l), def_annot)], env)
   | DEF_scattered sdef -> check_scattered env def_annot sdef
   | DEF_measure (id, pat, exp) -> ([check_termination_measure_decl env def_annot (id, pat, exp)], env)
-  | DEF_loop_measures (id, _) ->
-      Reporting.unreachable (id_loc id) __POS__
-        "Loop termination measures should have been rewritten before type checking"
+  | DEF_loop_measures (id, measures) ->
+      (* These will be checked during the move_loop_measures rewrite *)
+      ([DEF_aux (DEF_loop_measures (id, measures), def_annot)], env)
 
 and check_defs_progress : int -> int -> Env.t -> untyped_def list -> typed_def list * Env.t =
  fun n total env defs ->

--- a/test/coq/complex/move_termination.test
+++ b/test/coq/complex/move_termination.test
@@ -1,0 +1,1 @@
+complex/move_termination/defs.sail complex/move_termination/termination.sail

--- a/test/coq/complex/move_termination/defs.sail
+++ b/test/coq/complex/move_termination/defs.sail
@@ -1,0 +1,16 @@
+default Order dec
+$include <prelude.sail>
+
+function test_loop () -> int = {
+  var x : int = 0;
+  var y : int = 0;
+  while x < 10 do {
+    y = y + x;
+  };
+  y
+}
+
+function test_rec (x : int) -> int = {
+  if x < 0 then 0 else 1 + test_rec (x - 1)
+}
+

--- a/test/coq/complex/move_termination/termination.sail
+++ b/test/coq/complex/move_termination/termination.sail
@@ -1,0 +1,2 @@
+termination_measure test_loop while 10 - x
+termination_measure test_rec(x) = abs_int(x)

--- a/test/coq/complex/splice_termination.test
+++ b/test/coq/complex/splice_termination.test
@@ -1,0 +1,1 @@
+complex/splice_termination/defs.sail complex/splice_termination/termination.sail -splice complex/splice_termination/splice.sail

--- a/test/coq/complex/splice_termination/defs.sail
+++ b/test/coq/complex/splice_termination/defs.sail
@@ -1,0 +1,16 @@
+default Order dec
+$include <prelude.sail>
+
+function test_loop () -> int = {
+  var x : int = 0;
+  var y : int = 0;
+  while x < 10 do {
+    y = y + x;
+  };
+  y
+}
+
+function test_rec (x : int) -> int = {
+  if x < 0 then 0 else 1 + test_rec (x - 1)
+}
+

--- a/test/coq/complex/splice_termination/splice.sail
+++ b/test/coq/complex/splice_termination/splice.sail
@@ -1,0 +1,14 @@
+
+function test_loop () -> int = {
+  var x : int = 0;
+  var y : int = 0;
+  while x < 5 do {
+    y = y * x;
+  };
+  y
+}
+
+function test_rec (x : int) -> int = {
+  if x < 0 then 0 else 2 * test_rec (x - 1)
+}
+

--- a/test/coq/complex/splice_termination/termination.sail
+++ b/test/coq/complex/splice_termination/termination.sail
@@ -1,0 +1,2 @@
+termination_measure test_loop while 10 - x
+termination_measure test_rec(x) = abs_int(x)

--- a/test/coq/run_tests.sh
+++ b/test/coq/run_tests.sh
@@ -65,6 +65,22 @@ function check_tests_dir {
 check_tests_dir "$TYPECHECKTESTSDIR"
 check_tests_dir "$EXTRATESTSDIR"
 
+for i in `ls $DIR/complex/ | grep '\.test$'`; do
+  if $SAIL -coq -dcoq_undef_axioms -o out `cat $DIR/complex/$i` &>/dev/null;
+  then
+  if coqc $COQOPTS out_types.v &>/dev/null &&
+     coqc $COQOPTS out.v &>/dev/null;
+  then
+      green "tested $i expecting pass" "pass"
+  else
+      yellow "tested $i expecting pass" "failed to typecheck generated Coq"
+  fi
+  else
+  red "tested $i expecting pass" "failed to generate Coq"
+  fi
+done
+
+
 finish_suite "Coq tests"
 
 printf "</testsuites>\n" >> $DIR/tests.xml


### PR DESCRIPTION
Type checking is now performed per-file, so we can't easily move the loop termination measures at that point if they're in a separate file. Instead, we keep them explicitly untyped until they're moved into the loops in a normal rewrite pass.