### PR TITLE
Update libsail for SV improvements

### DIFF
--- a/language/jib.ott
+++ b/language/jib.ott
@@ -199,7 +199,7 @@ clexp :: 'CL_' ::=
   | clexp . id               :: :: field
   | * clexp                  :: :: addr
   | clexp . nat              :: :: tuple
-  | void                     :: :: void
+  | void : ctyp              :: :: void
 
 ctype_def :: 'CTD_' ::=
   {{ com C type definition }}

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -140,6 +140,8 @@ let is_public = function Public -> true | _ -> false
 
 let visibility_loc = function Private l -> l | Public -> Parse_ast.Unknown
 
+let uannot_of_def_annot (def_annot : 'a def_annot) : uannot = { attrs = def_annot.attrs }
+
 let def_annot_map_loc f (annot : 'a def_annot) = { annot with loc = f annot.loc }
 
 let def_annot_map_env (f : 'a -> 'b) (annot : 'a def_annot) =
@@ -1041,6 +1043,65 @@ let rec map_def_def_annot f (DEF_aux (aux, annot)) =
   DEF_aux (aux, f annot)
 
 let def_loc (DEF_aux (_, annot)) = annot.loc
+
+type id_chunk = Id_chunk_int of int | Id_chunk_string of string
+
+let split_id =
+  let open Ast in
+  function
+  | Id_aux (Id id, _) ->
+      let pos = ref 0 in
+      let is_number = ref false in
+      let chunks = ref [] in
+      let parse_chunk n =
+        let chunk = String.sub id !pos (n - !pos) in
+        if !is_number then (
+          match int_of_string_opt chunk with Some n -> Id_chunk_int n | None -> Id_chunk_string chunk
+        )
+        else Id_chunk_string chunk
+      in
+      String.iteri
+        (fun n c ->
+          let c = Char.code c in
+          match (!is_number, 48 <= c && c <= 57) with
+          | false, true ->
+              if n > !pos then (
+                chunks := parse_chunk n :: !chunks;
+                pos := n
+              );
+              is_number := true
+          | true, true -> ()
+          | false, false -> ()
+          | true, false ->
+              chunks := parse_chunk n :: !chunks;
+              pos := n;
+              is_number := false
+        )
+        id;
+      chunks := parse_chunk (String.length id) :: !chunks;
+      List.rev !chunks
+  | Id_aux (Operator id, _) -> [Id_chunk_string id]
+
+let rec split_id_compare x y =
+  match (x, y) with
+  | [], [] -> 0
+  | [], _ -> -1
+  | _, [] -> 1
+  | Id_chunk_int x :: xs, Id_chunk_int y :: ys ->
+      let c = Int.compare x y in
+      if c = 0 then split_id_compare xs ys else c
+  | Id_chunk_string x :: xs, Id_chunk_string y :: ys ->
+      let c = String.compare x y in
+      if c = 0 then split_id_compare xs ys else c
+  | Id_chunk_int _ :: _, Id_chunk_string _ :: _ -> -1
+  | Id_chunk_string _ :: _, Id_chunk_int _ :: _ -> 1
+
+let natural_id_compare id1 id2 = split_id_compare (split_id id1) (split_id id2)
+
+let natural_sort_ids ids =
+  let ids = List.map (fun id -> (split_id id, id)) ids in
+  let ids = List.stable_sort (fun (n1, _) (n2, _) -> split_id_compare n1 n2) ids in
+  List.map snd ids
 
 let deinfix = function Id_aux (Id v, l) -> Id_aux (Operator v, l) | Id_aux (Operator v, l) -> Id_aux (Operator v, l)
 

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -124,6 +124,8 @@ val find_attribute_opt : string -> (l * string * attribute_data option) list -> 
 val mk_def_annot :
   ?doc:string -> ?attrs:(l * string * attribute_data option) list -> ?visibility:visibility -> l -> 'a -> 'a def_annot
 
+val uannot_of_def_annot : 'a def_annot -> uannot
+
 val add_def_attribute : l -> string -> attribute_data option -> 'a def_annot -> 'a def_annot
 
 val get_def_attribute : string -> 'a def_annot -> (l * attribute_data option) option
@@ -507,6 +509,9 @@ val id_of_val_spec : 'a val_spec -> id
 val id_of_dec_spec : 'a dec_spec -> id
 
 (** {2 Functions for manipulating identifiers} *)
+
+val natural_id_compare : id -> id -> int
+val natural_sort_ids : id list -> id list
 
 val deinfix : id -> id
 val infix_swap : id -> id

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -141,7 +141,7 @@ type ctx = {
   records : (kid list * ctyp Bindings.t) Bindings.t;
   enums : IdSet.t Bindings.t;
   variants : (kid list * ctyp Bindings.t) Bindings.t;
-  valspecs : (string option * ctyp list * ctyp) Bindings.t;
+  valspecs : (string option * ctyp list * ctyp * uannot) Bindings.t;
   quants : ctyp KBindings.t;
   local_env : Env.t;
   tc_env : Env.t;
@@ -155,25 +155,33 @@ type ctx = {
 
 let ctx_is_extern id ctx =
   match Bindings.find_opt id ctx.valspecs with
-  | Some (Some _, _, _) -> true
-  | Some (None, _, _) -> false
-  | None -> Env.is_extern id ctx.tc_env "c"
+  | Some (Some _, _, _, _) -> true
+  | Some (None, _, _, _) -> false
+  | None -> (
+      match Target.get_the_target () with Some tgt -> Env.is_extern id ctx.tc_env (Target.name tgt) | None -> false
+    )
 
 let ctx_get_extern id ctx =
   match Bindings.find_opt id ctx.valspecs with
-  | Some (Some extern, _, _) -> extern
-  | Some (None, _, _) ->
+  | Some (Some extern, _, _, _) -> extern
+  | Some (None, _, _, _) ->
       Reporting.unreachable (id_loc id) __POS__
         ("Tried to get extern information for non-extern function " ^ string_of_id id)
-  | None -> Env.get_extern id ctx.tc_env "c"
+  | None -> (
+      match Target.get_the_target () with
+      | Some tgt -> Env.get_extern id ctx.tc_env (Target.name tgt)
+      | None ->
+          Reporting.unreachable (id_loc id) __POS__
+            ("Tried to get extern information without a set target for " ^ string_of_id id)
+    )
 
 let ctx_has_val_spec id ctx = Bindings.mem id ctx.valspecs || Bindings.mem id (Env.get_val_specs ctx.tc_env)
 
 let initial_ctx env effect_info =
   let initial_valspecs =
     [
-      (mk_id "size_itself_int", (Some "size_itself_int", [CT_lint], CT_lint));
-      (mk_id "make_the_value", (Some "make_the_value", [CT_lint], CT_lint));
+      (mk_id "size_itself_int", (Some "size_itself_int", [CT_lint], CT_lint, empty_uannot));
+      (mk_id "make_the_value", (Some "make_the_value", [CT_lint], CT_lint, empty_uannot));
     ]
     |> List.to_seq |> Bindings.of_seq
   in
@@ -1076,6 +1084,44 @@ module Make (C : CONFIG) = struct
           | _ -> raise (Reporting.err_unreachable l __POS__ "Field access on non-struct type in ANF representation!")
         in
         (setup, (fun clexp -> icopy l clexp (V_field (cval, id))), cleanup)
+    (* If unrolling is enabled, and all the loop bounds are fixed then just unroll the exact required amount *)
+    | AE_for
+        ( loop_var,
+          AE_aux (AE_val (AV_lit (L_aux (L_num loop_from, _), _)), _),
+          AE_aux (AE_val (AV_lit (L_aux (L_num loop_to, _), _)), _),
+          AE_aux (AE_val (AV_lit (L_aux (L_num loop_step, _), _)), _),
+          Ord_aux (ord, _),
+          body
+        )
+      when Option.is_some C.unroll_loops ->
+        let ctx = { ctx with locals = Bindings.add loop_var (Immutable, CT_fint 64) ctx.locals } in
+
+        let is_inc = match ord with Ord_inc -> true | Ord_dec -> false in
+
+        let loop_var = name loop_var in
+        let body_setup, body_call, body_cleanup = compile_aexp ctx body in
+        let body_gs = ngensym () in
+
+        let loop_iteration i =
+          let loop_body () =
+            [icopy l (CL_id (loop_var, CT_fint 64)) (V_lit (VL_int i, CT_fint 64))]
+            @ body_setup
+            @ [body_call (CL_id (body_gs, CT_unit))]
+            @ body_cleanup
+          in
+          if is_inc then
+            if Big_int.greater i loop_to then None else Some (Big_int.add i loop_step, iblock (loop_body ()))
+          else if Big_int.less i loop_to then None
+          else Some (Big_int.sub i loop_step, iblock (loop_body ()))
+        in
+        let rec unroll acc i =
+          match loop_iteration i with None -> List.rev acc | Some (next, instr) -> unroll (instr :: acc) next
+        in
+
+        ( [idecl l (CT_fint 64) loop_var; idecl l CT_unit body_gs] @ unroll [] loop_from,
+          (fun clexp -> icopy l clexp unit_cval),
+          []
+        )
     | AE_for (loop_var, loop_from, loop_to, loop_step, Ord_aux (ord, _), body) ->
         (* We assume that all loop indices are safe to put in a CT_fint. *)
         let ctx = { ctx with locals = Bindings.add loop_var (Immutable, CT_fint 64) ctx.locals } in
@@ -1151,7 +1197,7 @@ module Make (C : CONFIG) = struct
     | (AE_aux (_, { loc = l; _ }) as exp) :: exps ->
         let setup, call, cleanup = compile_aexp ctx exp in
         let rest = compile_block ctx exps in
-        if C.use_void then iblock (setup @ [call CL_void] @ cleanup) :: rest
+        if C.use_void then iblock (setup @ [call (CL_void CT_unit)] @ cleanup) :: rest
         else (
           let gs = ngensym () in
           iblock (setup @ [idecl l CT_unit gs; call (CL_id (gs, CT_unit))] @ cleanup) :: rest
@@ -1549,7 +1595,10 @@ module Make (C : CONFIG) = struct
         let ctx' = { ctx with local_env = Env.add_typquant (id_loc id) quant ctx.local_env } in
         let arg_ctyps, ret_ctyp = (List.map (ctyp_of_typ ctx') arg_typs, ctyp_of_typ ctx' ret_typ) in
         ( [CDEF_aux (CDEF_val (id, extern, arg_ctyps, ret_ctyp), def_annot)],
-          { ctx with valspecs = Bindings.add id (extern, arg_ctyps, ret_ctyp) ctx.valspecs }
+          {
+            ctx with
+            valspecs = Bindings.add id (extern, arg_ctyps, ret_ctyp, uannot_of_def_annot def_annot) ctx.valspecs;
+          }
         )
     | DEF_fundef (FD_aux (FD_function (_, _, [FCL_aux (FCL_funcl (id, Pat_aux (Pat_exp (pat, exp), _)), _)]), _)) ->
         Util.progress "Compiling " (string_of_id id) n total;
@@ -1686,8 +1735,12 @@ module Make (C : CONFIG) = struct
             List.fold_left
               (fun ctx cdef ->
                 match cdef with
-                | CDEF_aux (CDEF_val (id, _, param_ctyps, ret_ctyp), _) ->
-                    { ctx with valspecs = Bindings.add id (extern, param_ctyps, ret_ctyp) ctx.valspecs }
+                | CDEF_aux (CDEF_val (id, _, param_ctyps, ret_ctyp), def_annot) ->
+                    {
+                      ctx with
+                      valspecs =
+                        Bindings.add id (extern, param_ctyps, ret_ctyp, uannot_of_def_annot def_annot) ctx.valspecs;
+                    }
                 | cdef -> ctx
               )
               ctx specialized_specs
@@ -1754,7 +1807,39 @@ module Make (C : CONFIG) = struct
 
   let is_struct id = function CT_struct (id', _) -> Id.compare id id' = 0 | _ -> false
 
-  let is_variant id = function CT_variant (id', _) -> Id.compare id id' = 0 | _ -> false
+  class contains_struct_visitor id found =
+    object
+      inherit empty_jib_visitor
+
+      method! vctyp =
+        function
+        | CT_struct (id', _) when Id.compare id id' = 0 ->
+            found := true;
+            SkipChildren
+        | _ -> DoChildren
+    end
+
+  let contains_struct id cdef =
+    let found = ref false in
+    let _ = visit_cdef (new contains_struct_visitor id found) cdef in
+    !found
+
+  class contains_variant_visitor id found =
+    object
+      inherit empty_jib_visitor
+
+      method! vctyp =
+        function
+        | CT_variant (id', _) when Id.compare id id' = 0 ->
+            found := true;
+            SkipChildren
+        | _ -> DoChildren
+    end
+
+  let contains_variant id cdef =
+    let found = ref false in
+    let _ = visit_cdef (new contains_variant_visitor id found) cdef in
+    !found
 
   class fix_variants_visitor ctx var_id =
     object
@@ -1908,16 +1993,16 @@ module Make (C : CONFIG) = struct
           |> List.concat
         in
 
-        let prior = Util.map_if (cdef_ctyps_has (is_variant var_id)) (cdef_map_ctyp (fix_variants ctx var_id)) prior in
-        let cdefs = Util.map_if (cdef_ctyps_has (is_variant var_id)) (cdef_map_ctyp (fix_variants ctx var_id)) cdefs in
+        let prior = Util.map_if (contains_variant var_id) (cdef_map_ctyp (fix_variants ctx var_id)) prior in
+        let cdefs = Util.map_if (contains_variant var_id) (cdef_map_ctyp (fix_variants ctx var_id)) cdefs in
 
         let ctx =
           {
             ctx with
             valspecs =
               Bindings.map
-                (fun (extern, param_ctyps, ret_ctyp) ->
-                  (extern, List.map (fix_variants ctx var_id) param_ctyps, fix_variants ctx var_id ret_ctyp)
+                (fun (extern, param_ctyps, ret_ctyp, uannot) ->
+                  (extern, List.map (fix_variants ctx var_id) param_ctyps, fix_variants ctx var_id ret_ctyp, uannot)
                 )
                 ctx.valspecs;
           }
@@ -1965,19 +2050,19 @@ module Make (C : CONFIG) = struct
           |> List.concat
         in
 
-        let prior =
-          Util.map_if (cdef_ctyps_has (is_struct struct_id)) (cdef_map_ctyp (fix_variants ctx struct_id)) prior
-        in
-        let cdefs =
-          Util.map_if (cdef_ctyps_has (is_struct struct_id)) (cdef_map_ctyp (fix_variants ctx struct_id)) cdefs
-        in
+        let prior = Util.map_if (contains_struct struct_id) (cdef_map_ctyp (fix_variants ctx struct_id)) prior in
+        let cdefs = Util.map_if (contains_struct struct_id) (cdef_map_ctyp (fix_variants ctx struct_id)) cdefs in
         let ctx =
           {
             ctx with
             valspecs =
               Bindings.map
-                (fun (extern, param_ctyps, ret_ctyp) ->
-                  (extern, List.map (fix_variants ctx struct_id) param_ctyps, fix_variants ctx struct_id ret_ctyp)
+                (fun (extern, param_ctyps, ret_ctyp, uannot) ->
+                  ( extern,
+                    List.map (fix_variants ctx struct_id) param_ctyps,
+                    fix_variants ctx struct_id ret_ctyp,
+                    uannot
+                  )
                 )
                 ctx.valspecs;
           }
@@ -2012,7 +2097,7 @@ module Make (C : CONFIG) = struct
     let get_function_typ id =
       match Bindings.find_opt id ctx.valspecs with
       | None -> Bindings.find_opt id !constructor_types
-      | Some (_, param_ctyps, ret_ctyp) -> Some (param_ctyps, ret_ctyp)
+      | Some (_, param_ctyps, ret_ctyp, _) -> Some (param_ctyps, ret_ctyp)
     in
 
     let precise_call call tail =

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -97,7 +97,7 @@ type ctx = {
   records : (kid list * ctyp Bindings.t) Bindings.t;
   enums : IdSet.t Bindings.t;
   variants : (kid list * ctyp Bindings.t) Bindings.t;
-  valspecs : (string option * ctyp list * ctyp) Bindings.t;
+  valspecs : (string option * ctyp list * ctyp * uannot) Bindings.t;
   quants : ctyp KBindings.t;
   local_env : Env.t;
   tc_env : Env.t;

--- a/src/lib/jib_optimize.ml
+++ b/src/lib/jib_optimize.ml
@@ -75,16 +75,16 @@ let optimize_unit instrs =
   let unit_instr = function
     | I_aux (I_funcall (CR_one clexp, extern, id, args), annot) as instr -> begin
         match clexp_ctyp clexp with
-        | CT_unit -> I_aux (I_funcall (CR_one CL_void, extern, id, List.map unit_cval args), annot)
+        | CT_unit -> I_aux (I_funcall (CR_one (CL_void CT_unit), extern, id, List.map unit_cval args), annot)
         | _ -> instr
       end
     | I_aux (I_copy (clexp, cval), annot) as instr -> begin
-        match clexp_ctyp clexp with CT_unit -> I_aux (I_copy (CL_void, unit_cval cval), annot) | _ -> instr
+        match clexp_ctyp clexp with CT_unit -> I_aux (I_copy (CL_void CT_unit, unit_cval cval), annot) | _ -> instr
       end
     | instr -> instr
   in
   let non_pointless_copy (I_aux (aux, _)) =
-    match aux with I_decl (CT_unit, _) -> false | I_copy (CL_void, _) -> false | _ -> true
+    match aux with I_decl (CT_unit, _) -> false | I_copy (CL_void _, _) -> false | _ -> true
   in
   filter_instrs non_pointless_copy (map_instr_list unit_instr instrs)
 
@@ -303,7 +303,7 @@ let rec clexp_subst id subst = function
   | CL_field (clexp, field) -> CL_field (clexp_subst id subst clexp, field)
   | CL_addr clexp -> CL_addr (clexp_subst id subst clexp)
   | CL_tuple (clexp, n) -> CL_tuple (clexp_subst id subst clexp, n)
-  | CL_void -> CL_void
+  | CL_void ctyp -> CL_void ctyp
   | CL_rmw _ -> Reporting.unreachable Parse_ast.Unknown __POS__ "Cannot substitute into read-modify-write construct"
 
 let creturn_subst id subst = function
@@ -403,6 +403,25 @@ let inline cdefs should_inline instrs =
     else instrs
   in
   go instrs
+
+let remove_mutrec cdefs =
+  let components = IdGraph.scc (callgraph cdefs) in
+  let mutrecs =
+    List.filter_map (function [] | [_] -> None | component -> Some (IdSet.of_list component)) components
+  in
+  let get_mutrec id = List.find_opt (fun component -> IdSet.mem id component) mutrecs in
+  List.map
+    (function
+      | CDEF_aux (CDEF_fundef (function_id, heap_return, args, body), annot) as cdef -> begin
+          match get_mutrec function_id with
+          | None -> cdef
+          | Some component ->
+              let body = inline cdefs (fun call -> Id.compare call function_id <> 0 && IdSet.mem call component) body in
+              CDEF_aux (CDEF_fundef (function_id, heap_return, args, body), annot)
+        end
+      | cdef -> cdef
+      )
+    cdefs
 
 let remove_pointless_goto instrs =
   let rec go acc = function
@@ -536,7 +555,7 @@ let remove_tuples cdefs ctx =
         in
         CL_field (clexp, field)
     | CL_field (clexp, field) -> CL_field (fix_clexp clexp, field)
-    | CL_void -> CL_void
+    | CL_void ctyp -> CL_void ctyp
     | CL_rmw (read, write, ctyp) -> CL_rmw (read, write, ctyp)
   in
   let fix_creturn = function
@@ -576,7 +595,9 @@ let remove_tuples cdefs ctx =
       records = Bindings.map (fun (params, fields) -> (params, Bindings.map fix_tuples fields)) ctx.records;
       variants = Bindings.map (fun (params, ctors) -> (params, Bindings.map fix_tuples ctors)) ctx.variants;
       valspecs =
-        Bindings.map (fun (extern, ctyps, ctyp) -> (extern, List.map fix_tuples ctyps, fix_tuples ctyp)) ctx.valspecs;
+        Bindings.map
+          (fun (extern, ctyps, ctyp, uannot) -> (extern, List.map fix_tuples ctyps, fix_tuples ctyp, uannot))
+          ctx.valspecs;
       locals = Bindings.map (fun (mut, ctyp) -> (mut, fix_tuples ctyp)) ctx.locals;
     }
   in

--- a/src/lib/jib_optimize.mli
+++ b/src/lib/jib_optimize.mli
@@ -84,6 +84,8 @@ val unique_per_function_ids : cdef list -> cdef list
 
 val inline : cdef list -> (Ast.id -> bool) -> instr list -> instr list
 
+val remove_mutrec : cdef list -> cdef list
+
 val remove_undefined : instr list -> instr list
 
 val remove_functions_to_references : instr list -> instr list

--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -585,7 +585,7 @@ let rename_variables globals graph root children =
     | CL_field (clexp, field) -> CL_field (fold_clexp true clexp, field)
     | CL_addr clexp -> CL_addr (fold_clexp false clexp)
     | CL_tuple (clexp, n) -> CL_tuple (fold_clexp true clexp, n)
-    | CL_void -> CL_void
+    | CL_void ctyp -> CL_void ctyp
   in
   let fold_creturn = function
     | CR_one clexp -> CR_one (fold_clexp false clexp)

--- a/src/lib/jib_util.mli
+++ b/src/lib/jib_util.mli
@@ -89,6 +89,7 @@ val icopy : l -> clexp -> cval -> instr
 val iclear : ?loc:l -> ctyp -> name -> instr
 val ireturn : ?loc:l -> cval -> instr
 val iend : l -> instr
+val iend_id : l -> id -> instr
 val iblock : ?loc:l -> instr list -> instr
 val itry_block : l -> instr list -> instr
 val ithrow : l -> cval -> instr
@@ -188,8 +189,6 @@ val cval_ctyp : cval -> ctyp
 val clexp_ctyp : clexp -> ctyp
 val creturn_ctyp : creturn -> ctyp
 val cdef_ctyps : cdef -> CTSet.t
-
-val cdef_ctyps_has : (ctyp -> bool) -> cdef -> bool
 
 (** {2 Type definitions} *)
 

--- a/src/lib/jib_visitor.ml
+++ b/src/lib/jib_visitor.ml
@@ -100,7 +100,9 @@ let rec visit_clexp vis outer_clexp =
     | CL_tuple (clexp, n) ->
         let clexp' = visit_clexp vis clexp in
         if clexp == clexp' then no_change else CL_tuple (clexp', n)
-    | CL_void -> no_change
+    | CL_void ctyp ->
+        let ctyp' = visit_ctyp vis ctyp in
+        if ctyp == ctyp' then no_change else CL_void ctyp'
   in
   do_visit vis (vis#vclexp outer_clexp) aux outer_clexp
 

--- a/src/lib/jib_visitor.mli
+++ b/src/lib/jib_visitor.mli
@@ -4,7 +4,10 @@ type 'a visit_action =
   | SkipChildren  (** Do not visit the children. Return the node as it is. *)
   | DoChildren
       (** Continue with the children of this node. Rebuild the node on
-     return if any of the children changes (use == test) *)
+          return if any of the children changes (use == test) *)
+  | DoChildrenPost of (unit -> unit)
+      (** Continue with the chuldren of the node the same as DoChildren.
+          However run the provided function after visiting the children *)
   | ChangeTo of 'a  (** Replace the expression with the given one *)
   | ChangeDoChildrenPost of 'a * ('a -> 'a)
       (** First consider that the entire exp is replaced by the first

--- a/src/lib/smt_gen.mli
+++ b/src/lib/smt_gen.mli
@@ -105,6 +105,8 @@ val iterM : ('a -> unit check_writer) -> 'a list -> unit check_writer
 
 val run : 'a check_writer -> Parse_ast.l -> 'a * checks
 
+val mk_check_writer : (Parse_ast.l -> 'a * checks) -> 'a check_writer
+
 val string_used : unit check_writer
 
 val real_used : unit check_writer
@@ -156,10 +158,10 @@ module type CONFIG = sig
 end
 
 (** Some Sail primitives we can't directly convert to pure SMT
-    bitvectors, either because they don't exist in SMTLIB (like
+    definitions, either because they don't exist in SMTLIB (like
     count_leading_zeros), or they involve input/output. In these cases
-    we provide a module so the backend can generate the required
-    implementations for these primitives. *)
+    we provide a module so the backend can provide callbacks to
+    generate the required implementations for these primitives. *)
 module type PRIMOP_GEN = sig
   val print_bits : Parse_ast.l -> ctyp -> string
   val string_of_bits : Parse_ast.l -> ctyp -> string
@@ -171,6 +173,7 @@ module type PRIMOP_GEN = sig
   val is_empty : Parse_ast.l -> ctyp -> string
   val hd : Parse_ast.l -> ctyp -> string
   val tl : Parse_ast.l -> ctyp -> string
+  val eq_list : Parse_ast.l -> (cval -> cval -> Smt_exp.smt_exp check_writer) -> ctyp -> ctyp -> string check_writer
 end
 
 (** We have various options for handling undefined bits for SMT
@@ -189,6 +192,8 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) : sig
   val bv_size : ctyp -> int
 
   val generic_vector_length : ctyp -> int
+
+  val builtin_vector_update : cval -> cval -> cval -> ctyp -> Smt_exp.smt_exp check_writer
 
   val wf_lbits : Smt_exp.smt_exp -> Smt_exp.smt_exp
 

--- a/src/lib/visitor.ml
+++ b/src/lib/visitor.ml
@@ -84,7 +84,10 @@ type 'a visit_action =
   | SkipChildren  (** Do not visit the children. Return the node as it is. *)
   | DoChildren
       (** Continue with the children of this node. Rebuild the node on
-     return if any of the children changes (use == test) *)
+          return if any of the children changes (use == test) *)
+  | DoChildrenPost of (unit -> unit)
+      (** Continue with the chuldren of the node the same as DoChildren.
+          However run the provided function after visiting the children *)
   | ChangeTo of 'a  (** Replace the expression with the given one *)
   | ChangeDoChildrenPost of 'a * ('a -> 'a)
       (** First consider that the entire exp is replaced by the first
@@ -111,11 +114,15 @@ type 'a visit_action =
 
 (*** Define the visiting engine ****)
 (* visit all the nodes in an tree *)
-let do_visit (vis : 'v) (action : 'a visit_action) (children : 'v -> 'a -> 'a) (node : 'a) : 'a =
+let rec do_visit (vis : 'v) (action : 'a visit_action) (children : 'v -> 'a -> 'a) (node : 'a) : 'a =
   match action with
   | SkipChildren -> node
   | ChangeTo node' -> node'
   | DoChildren -> children vis node
+  | DoChildrenPost f ->
+      let node' = children vis node in
+      f ();
+      node'
   | ChangeDoChildrenPost (node', f) -> f (children vis node')
 
 let change_do_children node' = ChangeDoChildrenPost (node', fun n -> n)
@@ -150,6 +157,10 @@ let do_visit_list (vis : 'v) (action : 'a list visit_action) (children : 'v -> '
   | SkipChildren -> [node]
   | ChangeTo nodes' -> nodes'
   | DoChildren -> [children vis node]
+  | DoChildrenPost f ->
+      let list = [children vis node] in
+      f ();
+      list
   | ChangeDoChildrenPost (nodes', f) -> f (map_no_copy (fun n -> children vis n) nodes')
 
 (****************************************************************

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1118,7 +1118,7 @@ let rec sgen_clexp l = function
   | CL_field (clexp, field) -> "&((" ^ sgen_clexp l clexp ^ ")->" ^ zencode_id field ^ ")"
   | CL_tuple (clexp, n) -> "&((" ^ sgen_clexp l clexp ^ ")->ztup" ^ string_of_int n ^ ")"
   | CL_addr clexp -> "(*(" ^ sgen_clexp l clexp ^ "))"
-  | CL_void -> assert false
+  | CL_void _ -> assert false
   | CL_rmw _ -> assert false
 
 let rec sgen_clexp_pure l = function
@@ -1131,7 +1131,7 @@ let rec sgen_clexp_pure l = function
   | CL_field (clexp, field) -> sgen_clexp_pure l clexp ^ "." ^ zencode_id field
   | CL_tuple (clexp, n) -> sgen_clexp_pure l clexp ^ ".ztup" ^ string_of_int n
   | CL_addr clexp -> "(*(" ^ sgen_clexp_pure l clexp ^ "))"
-  | CL_void -> assert false
+  | CL_void _ -> assert false
   | CL_rmw _ -> assert false
 
 (** Generate instructions to copy from a cval to a clexp. This will
@@ -1936,7 +1936,7 @@ let codegen_def' ctx (CDEF_aux (aux, _)) =
              (Util.string_of_list ", " sgen_const_ctyp arg_ctyps)
           )
   | CDEF_fundef (id, ret_arg, args, instrs) ->
-      let _, arg_ctyps, ret_ctyp =
+      let _, arg_ctyps, ret_ctyp, _ =
         match Bindings.find_opt id ctx.valspecs with
         | Some vs -> vs
         | None -> c_error ~loc:(id_loc id) ("No valspec found for " ^ string_of_id id)


### PR DESCRIPTION
Fix Sail->SMT and Sail->C to support these improvements

* CL_void now has a ctyp parameter

* Annotations are preserved on valspecs into the Jib ctx

* Updated SMT expression simplifier