### PR TITLE
Allow other target names to be used in Jib IR

### DIFF
--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -94,6 +94,7 @@ val opt_memo_cache : bool ref
    (global) typechecking environment given by checking the full
    AST. *)
 type ctx = {
+  target_name : string;
   records : (kid list * ctyp Bindings.t) Bindings.t;
   enums : IdSet.t Bindings.t;
   variants : (kid list * ctyp Bindings.t) Bindings.t;
@@ -115,7 +116,16 @@ val ctx_get_extern : id -> ctx -> string
 
 val ctx_has_val_spec : id -> ctx -> bool
 
-val initial_ctx : Env.t -> Effects.side_effect_info -> ctx
+(** Create an inital Jib compilation context.
+
+    The target is the name that would appear in a valspec extern section, i.e.
+
+    val foo = { systemverilog: "bar", c: "baz" } = ...
+
+    would mean "systemverilog" and "c" would be valid for_target parameters.
+    If unspecified it will get the current target name from the Target module.
+    If unspecified and there is no current target, it defaults to "c". *)
+val initial_ctx : ?for_target:string -> Env.t -> Effects.side_effect_info -> ctx
 
 (** {2 Compilation functions} *)
 

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -1285,7 +1285,7 @@ let compile ~unroll_limit env effect_info ast =
       let unroll_limit = unroll_limit
     end)) in
     let env, effect_info = Jib_compile.add_special_functions env effect_info in
-    let ctx = Jib_compile.initial_ctx env effect_info in
+    let ctx = Jib_compile.initial_ctx ~for_target:"c" env effect_info in
     let t = Profile.start () in
     let cdefs, ctx = Jibc.compile_ast ctx ast in
     let cdefs, ctx = Jib_optimize.remove_tuples cdefs ctx in


### PR DESCRIPTION
Previously the Jib IR would always use externs specified by the "c" target name. This can now be changed e.g. to "systemverilog". To avoid breaking Sail->SMT, the Jib ctx type can now be constructed with a for_target parameter.