### PR TITLE
SMT/SV: Add more simplifications for union types

### DIFF
--- a/lib/sv/sail_modules.sv
+++ b/lib/sv/sail_modules.sv
@@ -72,4 +72,12 @@ function automatic string string_take(string str, int n);
    return str.substr(0, n - 1);
 endfunction // string_take
 
+function automatic string string_drop(string str, int n);
+   return str.substr(n, str.len() - 1);
+endfunction // string_drop
+
+function automatic logic [127:0] string_length(string str);
+   return {96'h0, str.len()};
+endfunction // string_length
+
 `endif

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -116,6 +116,8 @@ val ctx_get_extern : id -> ctx -> string
 
 val ctx_has_val_spec : id -> ctx -> bool
 
+val is_pure_aexp : ctx -> 'a aexp -> bool
+
 (** Create an inital Jib compilation context.
 
     The target is the name that would appear in a valspec extern section, i.e.
@@ -139,7 +141,7 @@ module type CONFIG = sig
   val optimize_anf : ctx -> typ aexp -> typ aexp
 
   (** Unroll all for loops a bounded number of times. Used for SMT
-       generation. *)
+      generation. *)
   val unroll_loops : int option
 
   (** A call is precise if the function arguments match the function
@@ -148,8 +150,8 @@ module type CONFIG = sig
   val make_call_precise : ctx -> id -> ctyp list -> ctyp -> bool
 
   (** If false, will ensure that fixed size bitvectors are
-       specifically less that 64-bits. If true this restriction will
-       be ignored. *)
+      specifically less that 64-bits. If true this restriction will
+      be ignored. *)
   val ignore_64 : bool
 
   (** If false we won't generate any V_struct values *)
@@ -165,11 +167,25 @@ module type CONFIG = sig
   val branch_coverage : out_channel option
 
   (** If true track the location of the last exception thrown, useful
-     for debugging C but we want to turn it off for SMT generation
-     where we can't use strings *)
+      for debugging C but we want to turn it off for SMT generation
+      where we can't use strings *)
   val track_throw : bool
 
   val use_void : bool
+
+  (** Convert control flow where all branches are pure into, into eager variants, i.e.
+
+      let x = if b else y then z
+
+      becomes
+
+      let x = eager_if(b, y, z)
+
+      so `y` and `z` are eagerly evaluated before the if-statement
+      which just becomes like a function call. Reducing the
+      control-flow like this is useful for the Sail->SV and Sail->SMT
+      backends. *)
+  val eager_control_flow : bool
 end
 
 module IdGraph : sig

--- a/src/lib/smt_gen.ml
+++ b/src/lib/smt_gen.ml
@@ -349,7 +349,7 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
     | Bvadd, args -> Fn ("bvadd", args)
     | Bvsub, args -> Fn ("bvsub", args)
     | Concat, args -> Fn ("concat", args)
-    | Ite, args -> Fn ("ite", args)
+    | Ite, [i; t; e] -> Ite (i, t, e)
     | Zero_extend _, _ -> failwith "ZE"
     | Sign_extend _, _ -> failwith "SE"
     | Slice _, _ -> failwith "slice"

--- a/src/lib/value.ml
+++ b/src/lib/value.ml
@@ -792,6 +792,7 @@ let primops =
          ("trace_memory_read", fun _ -> V_unit);
          ("trace_memory_write", fun _ -> V_unit);
          ("get_time_ns", fun _ -> V_int (Sail_lib.get_time_ns ()));
+         ("sail_assume", fun _ -> V_unit);
          ("load_raw", value_load_raw);
          ("to_real", value_to_real);
          ("eq_real", value_eq_real);

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -594,6 +594,7 @@ end) : CONFIG = struct
   let branch_coverage = Opts.branch_coverage
   let track_throw = true
   let use_void = false
+  let eager_control_flow = false
 end
 
 (** Functions that have heap-allocated return types are implemented by

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -1202,17 +1202,6 @@ end) : Jib_compile.CONFIG = struct
       end
     | aexp -> aexp
 
-  let rec is_pure_aexp ctx (AE_aux (aexp, { uannot; _ })) =
-    match get_attribute "anf_pure" uannot with
-    | Some _ -> true
-    | None -> (
-        match aexp with
-        | AE_app (f, _, _) -> Effects.function_is_pure f ctx.effect_info
-        | AE_let (Immutable, _, _, aexp1, aexp2, _) -> is_pure_aexp ctx aexp1 && is_pure_aexp ctx aexp2
-        | AE_val _ -> true
-        | _ -> false
-      )
-
   (* Map over all the functions in an aexp. *)
   let rec analyze ctx (AE_aux (aexp, ({ env; uannot; loc } as annot))) =
     let ctx = { ctx with local_env = env } in
@@ -1290,6 +1279,7 @@ end) : Jib_compile.CONFIG = struct
   let branch_coverage = None
   let track_throw = false
   let use_void = false
+  let eager_control_flow = true
 end
 
 (* In order to support register references, we need to build a map

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -326,6 +326,7 @@ module Verilog_config (C : JIB_CONFIG) : Jib_compile.CONFIG = struct
   let branch_coverage = None
   let use_real = false
   let use_void = false
+  let eager_control_flow = false
 end
 
 let register_types cdefs =

--- a/test/c/spc_mappings.sail
+++ b/test/c/spc_mappings.sail
@@ -10,45 +10,45 @@ overload operator ++ = concat_str
 function main() -> unit = {
   match " " {
     spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 1"),
   };
   match "" {
-    spc() => print_endline("fail"),
+    spc() => print_endline("fail 2"),
     _ => print_endline("ok"),
   };
   match " not spaces" {
-    spc() => print_endline("fail"),
+    spc() => print_endline("fail 3"),
     _ => print_endline("ok"),
   };
   match "    " {
     spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 4"),
   };
 
   match " " {
     opt_spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 5"),
   };
   match "" {
     opt_spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 6"),
   };
   match "    " {
     opt_spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 7"),
   };
 
   match " " {
     def_spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 8"),
   };
   match "" {
     def_spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 9"),
   };
   match "    " {
     def_spc() => print_endline("ok"),
-    _ => print_endline("fail"),
+    _ => print_endline("fail 10"),
   };
 
   match ((), (), ()) {
@@ -57,6 +57,6 @@ function main() -> unit = {
       print_endline(">" ++ s2 ++ "<");
       print_endline(">" ++ s3 ++ "<");
     },
-    _ => print_endline("fail"),
+    _ => print_endline("fail 11"),
   }
 }


### PR DESCRIPTION
Add simplification for pure matches in Sail->SMT

Make counterexample checking stricter