### PR TITLE
Pattern completeness: Handle structures under union constructors

### DIFF
--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -1556,6 +1556,11 @@ module Make (C : CONFIG) = struct
   let compile_funcl ctx def_annot id pat guard exp =
     let debug_attr = get_def_attribute "jib_debug" def_annot in
 
+    if Option.is_some debug_attr then (
+      prerr_endline Util.("Rewritten source for " ^ string_of_id id ^ ":" |> yellow |> bold |> clear);
+      prerr_endline (Document.to_string (Pretty_print_sail.doc_exp (Type_check.strip_exp exp)))
+    );
+
     (* Find the function's type. *)
     let quant, Typ_aux (fn_typ, _) =
       try Env.get_val_spec id ctx.local_env with Type_error.Type_error _ -> Env.get_val_spec id ctx.tc_env

--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -488,7 +488,15 @@ module Make (C : Config) = struct
                   field_typs
               in
               (struct_id, field_typs)
-          | _ -> Reporting.unreachable l __POS__ "P_struct pattern with non-struct type"
+          | Some typ -> Reporting.unreachable l __POS__ ("P_struct pattern with non-struct type: " ^ string_of_typ typ)
+          | None ->
+              let struct_id =
+                match typ with
+                | Typ_aux (Typ_app (id, _), _) -> id
+                | Typ_aux (Typ_id id, _) -> id
+                | _ -> Reporting.unreachable l __POS__ ("P_struct pattern with non-struct type: " ^ string_of_typ typ)
+              in
+              (struct_id, [])
         in
         let field_typs = List.fold_left (fun m (typ, field) -> Bindings.add field typ m) Bindings.empty field_typs in
         GP_struct

--- a/test/pattern_completeness/warn_struct_under_option.expect
+++ b/test/pattern_completeness/warn_struct_under_option.expect
@@ -1,0 +1,6 @@
+[93mWarning[0m: Incomplete pattern match statement at [96mwarn_struct_under_option.sail[0m:14.4-9:
+14[96m |[0m    match Some(x) {
+  [91m |[0m    [91m^---^[0m
+  [91m |[0m 
+The following expression is unmatched: [93mSome(struct { bar = B })[0m
+

--- a/test/pattern_completeness/warn_struct_under_option.sail
+++ b/test/pattern_completeness/warn_struct_under_option.sail
@@ -1,0 +1,18 @@
+default Order dec
+
+$include <prelude.sail>
+$include <option.sail>
+
+enum E = {A, B}
+
+struct Foo = { bar : E }
+
+val main : unit -> unit
+
+function main() = {
+    let x : Foo = struct { bar = B };
+    match Some(x) {
+      Some(struct { bar = A }) => (),
+      None()  => (),
+    }
+}


### PR DESCRIPTION
The following now generates a correct counterexample:
```
enum E = {A, B}

struct Foo = { bar : E }

val main : unit -> unit

function main() = {
    let x : Foo = struct { bar = B };
    match Some(x) {
      Some(struct { bar = A }) => (),
      None()  => (),
    }
}
```
whereas previously it would just mark the pattern as potentially incomplete and continue.