### PR TITLE
Improve error messages for struct accesses on non-struct types

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -1155,6 +1155,7 @@ and string_of_typ_aux = function
       "int(" ^ string_of_list ", " string_of_typ_arg args ^ ")"
   | Typ_app (id, args) when Id.compare id (mk_id "atom_bool") = 0 ->
       "bool(" ^ string_of_list ", " string_of_typ_arg args ^ ")"
+  | Typ_app (id, []) -> string_of_id id
   | Typ_app (id, args) -> string_of_id id ^ "(" ^ string_of_list ", " string_of_typ_arg args ^ ")"
   | Typ_fn ([typ_arg], typ_ret) -> string_of_typ typ_arg ^ " -> " ^ string_of_typ typ_ret
   | Typ_fn (typ_args, typ_ret) -> "(" ^ string_of_list ", " string_of_typ typ_args ^ ") -> " ^ string_of_typ typ_ret

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -3412,7 +3412,11 @@ and infer_lexp env (LE_aux (lexp_aux, (l, uannot)) as lexp) =
             in
             let field_typ' = subst_unifiers unifiers field_typ in
             annot_lexp (LE_field (inferred_lexp, field_id)) field_typ'
-        | _ -> typ_error l "Field l-expression has invalid type"
+        | typ ->
+            typ_raise l
+              (Err_with_hint
+                 ("Has type " ^ string_of_typ typ, Err_other "Type set using field l-expression must be a struct type")
+              )
       end
   | LE_deref exp ->
       let inferred_exp = infer_exp env exp in
@@ -3471,8 +3475,9 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
           | _ -> assert false (* Unreachable *)
         end
       | _ ->
-          typ_error l
-            ("Field expression " ^ string_of_exp exp ^ " :: " ^ string_of_typ (typ_of inferred_exp) ^ " is not valid")
+          typ_error
+            (Hint ("Has type " ^ string_of_typ (typ_of inferred_exp), exp_loc exp, l))
+            ("Type accessed by field expression is not a struct, it has type " ^ string_of_typ (typ_of inferred_exp))
     end
   | E_tuple exps ->
       let inferred_exps = List.map (irule infer_exp env) exps in

--- a/test/typecheck/fail/union_field.expect
+++ b/test/typecheck/fail/union_field.expect
@@ -1,0 +1,8 @@
+[93mType error[0m:
+[96mfail/union_field.sail[0m:14.18-19:
+14[96m |[0m    print_endline(x.B)
+  [92m |[0m                  [92m^[0m [92mHas type Foo[0m
+[96mfail/union_field.sail[0m:14.18-21:
+14[96m |[0m    print_endline(x.B)
+  [91m |[0m                  [91m^-^[0m [91mchecking function argument has type string[0m
+  [91m |[0m Type accessed by field expression is not a struct, it has type Foo

--- a/test/typecheck/fail/union_field.sail
+++ b/test/typecheck/fail/union_field.sail
@@ -1,0 +1,15 @@
+default Order dec
+
+$include <prelude.sail>
+
+union Foo = {
+  A : int,
+  B : string
+}
+
+val main : unit -> unit
+
+function main() = {
+    var x = A(3);
+    print_endline(x.B)
+}

--- a/test/typecheck/fail/union_field_set.expect
+++ b/test/typecheck/fail/union_field_set.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mfail/union_field_set.sail[0m:14.4-5:
+14[96m |[0m    x.B = "Hello, World!"
+  [91m |[0m    [91m^[0m [91mHas type Foo[0m
+  [91m |[0m Type set using field l-expression must be a struct type

--- a/test/typecheck/fail/union_field_set.sail
+++ b/test/typecheck/fail/union_field_set.sail
@@ -1,0 +1,15 @@
+default Order dec
+
+$include <prelude.sail>
+
+union Foo = {
+  A : int,
+  B : string
+}
+
+val main : unit -> unit
+
+function main() = {
+    var x = A(3);
+    x.B = "Hello, World!"
+}


### PR DESCRIPTION
Allow attached attributes for property and counterexample