### PR TITLE
SV: Introduce case statements where possible

### DIFF
--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -1322,12 +1322,11 @@ module Make (Config : CONFIG) = struct
         string "if" ^^ space ^^ parens (pp_smt cond) ^^ space ^^ pp_statement then_block
     | SVS_if (cond, Some then_block, Some else_block) -> empty
     | SVS_case { head_exp; cases; fallthrough } ->
-        let pp_case (ids, statement) =
-          separate space [separate_map (comma ^^ space) pp_id ids; colon; pp_statement statement]
-        in
+        let pp_case (exp, statement) = separate space [pp_smt exp; colon; pp_statement ~terminator:semi statement] in
         let pp_fallthrough = function
           | None -> empty
-          | Some statement -> hardline ^^ separate space [string "default"; colon; pp_statement statement]
+          | Some statement ->
+              hardline ^^ separate space [string "default"; colon; pp_statement ~terminator:semi statement]
         in
         string "case" ^^ space
         ^^ parens (pp_smt head_exp)

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -461,7 +461,7 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
   let svir =
     if not !opt_disable_optimizations then
       svir |> remove_unit_ports |> remove_unused_variables |> simplify_smt |> remove_unused_variables |> simplify_smt
-      |> remove_unused_variables |> remove_nulls |> simplify_smt
+      |> remove_unused_variables |> remove_nulls |> simplify_smt |> insert_case_expressions
     else svir
   in
 

--- a/src/sail_sv_backend/sv_ir.ml
+++ b/src/sail_sv_backend/sv_ir.ml
@@ -150,7 +150,7 @@ and sv_statement_aux =
   | SVS_return of smt_exp
   | SVS_assign of sv_place * smt_exp
   | SVS_call of sv_place * sv_name * smt_exp list
-  | SVS_case of { head_exp : smt_exp; cases : (Ast.id list * sv_statement) list; fallthrough : sv_statement option }
+  | SVS_case of { head_exp : smt_exp; cases : (smt_exp * sv_statement) list; fallthrough : sv_statement option }
   | SVS_if of smt_exp * sv_statement option * sv_statement option
   | SVS_block of sv_statement list
   | SVS_assert of smt_exp * smt_exp
@@ -288,9 +288,10 @@ let rec visit_sv_statement (vis : svir_visitor) outer_statement =
         let cases' =
           map_no_copy
             (function
-              | (ids, stmt) as no_change ->
+              | (exp, stmt) as no_change ->
+                  let exp' = visit_smt_exp vis exp in
                   let stmt' = visit_sv_statement vis stmt in
-                  if stmt == stmt' then no_change else (ids, stmt')
+                  if exp == exp' && stmt == stmt' then no_change else (exp', stmt')
               )
             cases
         in

--- a/src/sail_sv_backend/sv_ir.mli
+++ b/src/sail_sv_backend/sv_ir.mli
@@ -148,7 +148,7 @@ and sv_statement_aux =
   | SVS_return of smt_exp
   | SVS_assign of sv_place * smt_exp
   | SVS_call of sv_place * sv_name * smt_exp list
-  | SVS_case of { head_exp : smt_exp; cases : (Ast.id list * sv_statement) list; fallthrough : sv_statement option }
+  | SVS_case of { head_exp : smt_exp; cases : (smt_exp * sv_statement) list; fallthrough : sv_statement option }
   | SVS_if of smt_exp * sv_statement option * sv_statement option
   | SVS_block of sv_statement list
   | SVS_assert of smt_exp * smt_exp

--- a/src/sail_sv_backend/sv_optimize.mli
+++ b/src/sail_sv_backend/sv_optimize.mli
@@ -75,3 +75,5 @@ val simplify_smt : sv_def list -> sv_def list
 val remove_nulls : sv_def list -> sv_def list
 
 val remove_unused_variables : sv_def list -> sv_def list
+
+val insert_case_expressions : sv_def list -> sv_def list


### PR DESCRIPTION
Recognise certain patterns of chained ternary statements, and rewrite them into SystemVerilog case statements where possible.

Also fix some issues found in the SV output caused by some CFG simplifications added by recent Sail->SMT optimisations. As a bonus, fixing said issues makes those optimisations even more effective.