### PR TITLE
Make sure Type-kinded abstract types are forbidden

### DIFF
--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -158,9 +158,7 @@ let ctx_is_extern id ctx =
   match Bindings.find_opt id ctx.valspecs with
   | Some (Some _, _, _, _) -> true
   | Some (None, _, _, _) -> false
-  | None -> (
-      match Target.get_the_target () with Some tgt -> Env.is_extern id ctx.tc_env (Target.name tgt) | None -> false
-    )
+  | None -> Env.is_extern id ctx.tc_env ctx.target_name
 
 let ctx_get_extern id ctx =
   match Bindings.find_opt id ctx.valspecs with
@@ -168,13 +166,7 @@ let ctx_get_extern id ctx =
   | Some (None, _, _, _) ->
       Reporting.unreachable (id_loc id) __POS__
         ("Tried to get extern information for non-extern function " ^ string_of_id id)
-  | None -> (
-      match Target.get_the_target () with
-      | Some tgt -> Env.get_extern id ctx.tc_env (Target.name tgt)
-      | None ->
-          Reporting.unreachable (id_loc id) __POS__
-            ("Tried to get extern information without a set target for " ^ string_of_id id)
-    )
+  | None -> Env.get_extern id ctx.tc_env ctx.target_name
 
 let ctx_has_val_spec id ctx = Bindings.mem id ctx.valspecs || Bindings.mem id (Env.get_val_specs ctx.tc_env)
 

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4729,8 +4729,12 @@ let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> typed_def l
         | _ -> ()
       end;
       ([DEF_aux (DEF_type (TD_aux (tdef, (l, empty_tannot))), def_annot)], Env.add_typ_synonym id typq typ_arg env)
-  | TD_abstract (id, kind) ->
-      ([DEF_aux (DEF_type (TD_aux (tdef, (l, empty_tannot))), def_annot)], Env.add_abstract_typ id kind env)
+  | TD_abstract (id, kind) -> begin
+      match unaux_kind kind with
+      | K_int | K_bool ->
+          ([DEF_aux (DEF_type (TD_aux (tdef, (l, empty_tannot))), def_annot)], Env.add_abstract_typ id kind env)
+      | K_type -> raise (Reporting.err_general l "Abstract type must be either a boolean or integer type")
+    end
   | TD_record (id, typq, fields, _) ->
       let env = check_record l env def_annot id typq fields in
       begin

--- a/test/typecheck/fail/abstract_type_type.expect
+++ b/test/typecheck/fail/abstract_type_type.expect
@@ -1,0 +1,5 @@
+[93mError[0m:
+[96mfail/abstract_type_type.sail[0m:3.0-13:
+3[96m |[0mtype a : Type
+ [91m |[0m[91m^-----------^[0m
+ [91m |[0m Abstract type must be either a boolean or integer type

--- a/test/typecheck/fail/abstract_type_type.sail
+++ b/test/typecheck/fail/abstract_type_type.sail
@@ -1,0 +1,3 @@
+$option --abstract-types
+
+type a : Type


### PR DESCRIPTION
For the time being, we don't want to allow this, although we could relax this restriction in the future.

Also simplify the Jib target name handing in ctx_get_extern and ctx_is_extern functions, using the target name in the Jib ctx