### PR TITLE
Handle errors in the SMT cache file

### DIFF
--- a/src/lib/constraint.ml
+++ b/src/lib/constraint.ml
@@ -286,7 +286,12 @@ let load_digests_err () =
       | 4 ->
           let solution = input_binary_int in_chan in
           known_uniques := DigestMap.add digest (Some solution) !known_uniques
-      | _ -> assert false
+      | _ ->
+          Reporting.warn "" Parse_ast.Unknown "SMT cache file 'z3_problems' is invalid";
+          known_problems := DigestMap.empty;
+          known_uniques := DigestMap.empty;
+          (* Exit the loop as if we reached the end of the file *)
+          raise End_of_file
     end;
     load ()
   in

--- a/test/oneoff/bad_cache/bad_cache.expect
+++ b/test/oneoff/bad_cache/bad_cache.expect
@@ -1,0 +1,3 @@
+[93mWarning[0m: 
+SMT cache file 'z3_problems' is invalid
+

--- a/test/oneoff/bad_cache/test.sh
+++ b/test/oneoff/bad_cache/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+rm -f bad_cache.result z3_problems
+echo -n -e 7fcba3a13c51ab2786c5b710e80c5f88\\x05 > z3_problems
+sail --memo-z3 2> bad_cache.result || true
+diff bad_cache.result bad_cache.expect


### PR DESCRIPTION
If we find an unexpected value in the z3_problems cache file, just ignore the contents of the file after printing a warning.

This file being corrupt/invalid has been observed in CI