### PR TITLE
Add a test for the private keyword

### DIFF
--- a/editors/sail-mode.el
+++ b/editors/sail-mode.el
@@ -34,7 +34,7 @@
   '("val" "outcome" "function" "type" "struct" "union" "enum" "let" "var" "if" "then" "by"
     "else" "match" "in" "return" "register" "ref" "forall" "operator" "effect"
     "overload" "cast" "sizeof" "constant" "constraint" "default" "assert" "newtype" "from"
-    "pure" "monadic" "infixl" "infixr" "infix" "scattered" "end" "try" "catch" "and" "to"
+    "pure" "monadic" "infixl" "infixr" "infix" "scattered" "end" "try" "catch" "and" "to" "private"
     "throw" "clause" "as" "repeat" "until" "while" "do" "foreach" "bitfield"
     "mapping" "where" "with" "implicit" "instantiation" "impl" "forwards" "backwards"))
 

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4482,7 +4482,7 @@ let check_fundef env def_annot (FD_aux (FD_function (recopt, tannot_opt, funcls)
         (* No val, so get the function type from annotations attached to clauses *)
         let bind = infer_funtyp l env tannot_opt funcls in
         (None, bind, env)
-    | exception Type_error (l, Err_not_in_scope (_, scope_l, item_scope, into_scope, priv)) ->
+    | exception Type_error (l, Err_not_in_scope (_, scope_l, item_scope, into_scope, is_opened, priv)) ->
         (* If we defined the function type with val in another module, but didn't require it. *)
         let reason = if priv then "private." else "not in scope." in
         typ_raise l
@@ -4491,6 +4491,7 @@ let check_fundef env def_annot (FD_aux (FD_function (recopt, tannot_opt, funcls)
                scope_l,
                item_scope,
                into_scope,
+               is_opened,
                priv
              )
           )

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -168,14 +168,15 @@ let filter_items_with f env bindings =
 let filter_items env bindings = filter_items_with (fun x -> x) env bindings
 
 let err_not_in_scope env msg l item =
+  let is_opened = Project.ModSet.mem item.mod_id env.opened in
   match env.global.modules with
-  | None -> Err_not_in_scope (msg, l, None, None, is_private item.visibility)
+  | None -> Err_not_in_scope (msg, l, None, None, is_opened, is_private item.visibility)
   | Some proj ->
       let module_name_opt mod_id =
         if Project.valid_module_id proj mod_id then Some (Project.module_name proj mod_id) else None
       in
       Err_not_in_scope
-        (msg, l, module_name_opt item.mod_id, module_name_opt env.current_module, is_private item.visibility)
+        (msg, l, module_name_opt item.mod_id, module_name_opt env.current_module, is_opened, is_private item.visibility)
 
 let get_item_with_loc get_loc l env item =
   if item_in_scope env item then item.item

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -78,7 +78,7 @@ type type_error =
   | Err_other of string
   | Err_inner of type_error * Parse_ast.l * string * type_error
   | Err_not_in_scope of
-      string option * Parse_ast.l option * string Project.spanned option * string Project.spanned option * bool
+      string option * Parse_ast.l option * string Project.spanned option * string Project.spanned option * bool * bool
   | Err_instantiation_info of int * type_error
   | Err_function_arg of Parse_ast.l * typ * type_error
   | Err_no_function_type of { id : id; functions : (typquant * typ) Bindings.t }

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -85,7 +85,7 @@ type type_error =
   | Err_other of string
   | Err_inner of type_error * Parse_ast.l * string * type_error
   | Err_not_in_scope of
-      string option * Parse_ast.l option * string Project.spanned option * string Project.spanned option * bool
+      string option * Parse_ast.l option * string Project.spanned option * string Project.spanned option * bool * bool
   | Err_instantiation_info of int * type_error
   | Err_function_arg of Parse_ast.l * typ * type_error
   | Err_no_function_type of { id : id; functions : (typquant * typ) Bindings.t }

--- a/test/typecheck/project/fail_private.expect
+++ b/test/typecheck/project/fail_private.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mproject/private/bmod.sail[0m:4.4-7:
+4[96m |[0m    foo("Cannot be called")
+ [91m |[0m    [91m^-^[0m
+ [91m |[0m Cannot use private definition
+ [91m |[0m 
+ [91m |[0m [96mproject/private/amod.sail[0m:3.17-20:
+ [91m |[0m 3[96m |[0mprivate function foo(message : string) -> unit = {
+ [91m |[0m  [91m |[0m                 [91m^-^[0m [91mprivate definition here in A[0m

--- a/test/typecheck/project/fail_private.sail_project
+++ b/test/typecheck/project/fail_private.sail_project
@@ -1,0 +1,9 @@
+
+A {
+  files private/amod.sail
+}
+
+B {
+  requires A
+  files private/bmod.sail
+}

--- a/test/typecheck/project/fail_private_nr.expect
+++ b/test/typecheck/project/fail_private_nr.expect
@@ -1,0 +1,10 @@
+[93mType error[0m:
+[96mproject/private/bmod.sail[0m:4.4-7:
+4[96m |[0m    foo("Cannot be called")
+ [91m |[0m    [91m^-^[0m
+ [91m |[0m Cannot use private definition
+ [91m |[0m The module containing this definition is also not required in this context
+ [91m |[0m 
+ [91m |[0m [96mproject/private/amod.sail[0m:3.17-20:
+ [91m |[0m 3[96m |[0mprivate function foo(message : string) -> unit = {
+ [91m |[0m  [91m |[0m                 [91m^-^[0m [91mprivate definition here in A[0m

--- a/test/typecheck/project/fail_private_nr.sail_project
+++ b/test/typecheck/project/fail_private_nr.sail_project
@@ -1,0 +1,8 @@
+
+A {
+  files private/amod.sail
+}
+
+B {
+  files private/bmod.sail
+}

--- a/test/typecheck/project/private/amod.sail
+++ b/test/typecheck/project/private/amod.sail
@@ -1,0 +1,5 @@
+$include <string.sail>
+
+private function foo(message : string) -> unit = {
+  print_endline(message)
+}

--- a/test/typecheck/project/private/bmod.sail
+++ b/test/typecheck/project/private/bmod.sail
@@ -1,0 +1,5 @@
+val main : unit -> unit
+
+function main() = {
+    foo("Cannot be called")
+}


### PR DESCRIPTION
Improve the error message for trying to use a private definition from a module that hasn't been required