### PR TITLE
fix typo in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -76,7 +76,7 @@ http://www.cl.cam.ac.uk/~pes20/sail/.
 
 (package
   (name sail_smt_backend)
-  (synopsis "Sail to C translation")
+  (synopsis "Sail to SMT translation")
   (depends
     (libsail (= :version))))
 


### PR DESCRIPTION
fix a typo in `dune-project` about `sail_smt_backend` package