### PR TITLE
Add loop-unrolling debug rewrite for SystemVerilog

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -351,6 +351,14 @@ let rec options =
       ("-dno_cast", Arg.Unit (fun () -> ()), "");
       (* No longer does anything, preserved for backwards compatibility only *)
       ("-dallow_cast", Arg.Unit (fun () -> ()), "");
+      ("-unroll_loops", Arg.Set Rewrites.opt_unroll_loops, " turn on rewrites for unrolling loops with constant bounds.");
+      ("-unroll_loops_max_iter",
+       Arg.Int
+         (fun n ->
+           Rewrites.opt_unroll_loops_max_iter := n
+         ),
+         "<nb_iter> Don't unroll loops if they have more than <nb_iter> iterations."
+      );
       ( "-ddump_rewrite_ast",
         Arg.String
           (fun l ->

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -352,12 +352,9 @@ let rec options =
       (* No longer does anything, preserved for backwards compatibility only *)
       ("-dallow_cast", Arg.Unit (fun () -> ()), "");
       ("-unroll_loops", Arg.Set Rewrites.opt_unroll_loops, " turn on rewrites for unrolling loops with constant bounds.");
-      ("-unroll_loops_max_iter",
-       Arg.Int
-         (fun n ->
-           Rewrites.opt_unroll_loops_max_iter := n
-         ),
-         "<nb_iter> Don't unroll loops if they have more than <nb_iter> iterations."
+      ( "-unroll_loops_max_iter",
+        Arg.Int (fun n -> Rewrites.opt_unroll_loops_max_iter := n),
+        "<nb_iter> Don't unroll loops if they have more than <nb_iter> iterations."
       );
       ( "-ddump_rewrite_ast",
         Arg.String

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -459,6 +459,8 @@ val def_loc : ('a, 'b) def -> Parse_ast.l
    Note: For debugging and error messages only - not guaranteed to
    produce parseable Sail, or even print all language constructs! *)
 
+val string_of_order : order -> string
+
 val string_of_id : id -> string
 val string_of_kid : kid -> string
 val string_of_kind_aux : kind_aux -> string

--- a/src/lib/reporting.ml
+++ b/src/lib/reporting.ml
@@ -253,7 +253,7 @@ let suppressed_warning_info () =
     suppressed_warnings := 0
   )
 
-let warn ?once_from short_str l explanation =
+let warn ?once_from ?(force_show = false) short_str l explanation =
   let already_shown =
     match once_from with
     | Some (file, lnum, cnum, enum) when not !opt_all_warnings ->
@@ -268,7 +268,7 @@ let warn ?once_from short_str l explanation =
         )
     | _ -> false
   in
-  if !opt_warnings && not already_shown then (
+  if (!opt_warnings && not already_shown) || force_show then (
     match simp_loc l with
     | Some (p1, p2) when not (StringSet.mem p1.pos_fname !ignored_files) ->
         let shorts = RangeMap.find_opt (p1, p2) !seen_warnings |> Option.value ~default:[] in

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -139,7 +139,7 @@ val forbid_errors : string * int * int * int -> ('a -> 'b) -> 'a -> 'b
 
 (** Print a warning message. The first string is printed before the
    location, the second after. *)
-val warn : ?once_from:string * int * int * int -> string -> Parse_ast.l -> string -> unit
+val warn : ?once_from:string * int * int * int -> ?force_show:bool -> string -> Parse_ast.l -> string -> unit
 
 val format_warn : ?once_from:string * int * int * int -> string -> Parse_ast.l -> Error_format.message -> unit
 

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4291,18 +4291,12 @@ let rewrite_unroll_constant_loops _type_env defs =
         | _ ->
             let e' = E_aux (e, annot) in
             let (l : Parse_ast.l), _tannot = annot in
-            let string_of_position (p : Lexing.position) : string = p.pos_fname ^ ":" ^ string_of_int p.pos_lnum in
-            let rec string_of_l : Parse_ast.l -> string = function
-              | Unknown -> "Unknown"
-              | Unique (i, l) -> Printf.sprintf "Unique( %s, %s)" (string_of_int i) (string_of_l l)
-              | Generated l -> Printf.sprintf "Generated( %s ) " (string_of_l l)
-              | Hint (str, l1, l2) -> Printf.sprintf "Hint( %s, %s, %s )" str (string_of_l l1) (string_of_l l2)
-              | Range (p1, p2) -> Printf.sprintf "Range( %s, %s )" (string_of_position p1) (string_of_position p2)
-            in
-            print_endline
-              "[WARNING] Cannot unroll the loop because the bounds numerical values couldn't be fully determined.";
-            print_endline ("          Expression : " ^ string_of_exp e');
-            print_endline ("          Position   : " ^ string_of_l l);
+            Reporting.warn "" l
+            @@ Printf.sprintf
+                 "Cannot unroll the loop because the bounds numerical values couldn't be fully determined on \
+                  expression :\n\
+                  %s"
+                 (string_of_exp e');
             e'
       )
     | _ -> E_aux (e, annot)

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4203,8 +4203,7 @@ let opt_unroll_loops_max_iter = ref 0
     }]
 *)
 let rewrite_unroll_constant_loops _type_env defs =
-
-  (** This pass replaces expressions like
+  (* This pass replaces expressions like
          f(k, foo, bar) + k
      with
          f(42, foo, bar) + 42
@@ -4212,13 +4211,16 @@ let rewrite_unroll_constant_loops _type_env defs =
   let rewrite_exp_replace_id_with_num (id : string) (num : Z.t) =
     let rewrite_aux (id : string) (num : Z.t) (e, annot) =
       match e with
-      | E_id (Id_aux (Id v, _)) when String.equal v id  ->  E_aux( E_lit (L_aux(L_num num, Parse_ast.Unknown)) , annot)
+      | E_id (Id_aux (Id v, _)) when String.equal v id -> E_aux (E_lit (L_aux (L_num num, Parse_ast.Unknown)), annot)
       | _ -> E_aux (e, annot)
     in
-    fun e -> rewrite_exp { rewriters_base with rewrite_exp = (fun _ -> fold_exp { id_exp_alg with e_aux = rewrite_aux id num }) } e
+    fun e ->
+      rewrite_exp
+        { rewriters_base with rewrite_exp = (fun _ -> fold_exp { id_exp_alg with e_aux = rewrite_aux id num }) }
+        e
   in
 
-  (** Builds a list of integers from a start, end, step and direction
+  (* Builds a list of integers from a start, end, step and direction
 
      [list_of_ord_range 0 10 2 inc = 0, 2, 4, 6, 8, 10]
 
@@ -4226,18 +4228,13 @@ let rewrite_unroll_constant_loops _type_env defs =
   *)
   let list_of_ord_range (Ord_aux (ord, _)) (n_start : Z.t) (n_end : Z.t) (n_step : Z.t) : Z.t list =
     let list_of_range ns ne =
-      let rec aux n acc =
-        if (Z.gt n ne) then acc
-        else aux (Z.add n n_step) (n :: acc)
-      in
+      let rec aux n acc = if Z.gt n ne then acc else aux (Z.add n n_step) (n :: acc) in
       aux ns []
     in
-    match ord with
-    | Ord_inc -> List.rev @@ list_of_range n_start n_end
-    | Ord_dec -> list_of_range n_end n_start
+    match ord with Ord_inc -> List.rev @@ list_of_range n_start n_end | Ord_dec -> list_of_range n_end n_start
   in
 
-  (** This is the main rewrite function of the pass.
+  (* This is the main rewrite function of the pass.
      Replacing :
      {[
        foreach k in 0 to 3 by 1 increasing:
@@ -4253,34 +4250,30 @@ let rewrite_unroll_constant_loops _type_env defs =
   *)
   let rewrite_aux (e, annot) =
     match e with
-    | E_for ( id                      (* 'k' in our example *)
-            , E_aux (_, (_, tannot1)) (* '0' in our example *)
-            , E_aux (_, (_, tannot2)) (* '3' in our example *)
-            , E_aux (_, (_, tannot3)) (* '1' in our example *)
-            , atyp                    (* 'increasing' in our example *)
-            , e_loop_body             (* 'f(k, foo, bar) + k'  in our example *)
-            ) ->
-      (
-
+    | E_for
+        ( id (* 'k' in our example *),
+          E_aux (_, (_, tannot1)) (* '0' in our example *),
+          E_aux (_, (_, tannot2)) (* '3' in our example *),
+          E_aux (_, (_, tannot3)) (* '1' in our example *),
+          atyp (* 'increasing' in our example *),
+          e_loop_body (* 'f(k, foo, bar) + k'  in our example *)
+        ) -> (
         (* We get the int values of the bounds from their types inferred by the typer *)
         let int_of_tannot_opt tannot =
           let int_of_typ_aux_opt : typ_aux -> Z.t option = function
             | Typ_app (id, [A_aux (A_nexp nexp, _)]) when Id.compare id (mk_id "atom") = 0 ->
-              int_of_nexp_opt @@ nexp_simp nexp
+                int_of_nexp_opt @@ nexp_simp nexp
             | _ -> None
           in
-          match destruct_tannot tannot with
-          | Some (_, Typ_aux (typ, l)) -> int_of_typ_aux_opt typ
-          | None -> None
+          match destruct_tannot tannot with Some (_, Typ_aux (typ, l)) -> int_of_typ_aux_opt typ | None -> None
         in
         let n_start_opt = int_of_tannot_opt tannot1 in
-        let n_end_opt   = int_of_tannot_opt tannot2 in
-        let n_step_opt  = int_of_tannot_opt tannot3 in
+        let n_end_opt = int_of_tannot_opt tannot2 in
+        let n_step_opt = int_of_tannot_opt tannot3 in
 
         (* Abort unrolling with a warning when types infered are too complex (i.e. not immediate literals) *)
-        match n_start_opt, n_end_opt, n_step_opt with
-        | Some n_start, Some n_end, Some n_step -> (
-
+        match (n_start_opt, n_end_opt, n_step_opt) with
+        | Some n_start, Some n_end, Some n_step ->
             (* Build a range out of the bounds
                in our example, from (start=0, end=3, step=1)
                the range will be the list [0; 1; 2; 3]
@@ -4288,39 +4281,30 @@ let rewrite_unroll_constant_loops _type_env defs =
             let range = list_of_ord_range atyp n_start n_end n_step in
 
             (* Only unroll "small" loops, i.e. those with less than 'max_iter' iterations *)
-            if !opt_unroll_loops_max_iter <> 0
-               && List.length range > !opt_unroll_loops_max_iter
-            then E_aux(e, annot)
+            if !opt_unroll_loops_max_iter <> 0 && List.length range > !opt_unroll_loops_max_iter then E_aux (e, annot)
             else (
-
-                (* Build the final expression, a block of n times the body *)
-                let bodies = List.map
-                    (fun z -> rewrite_exp_replace_id_with_num "i" z e_loop_body)
-                    range
-                in
-                E_aux (E_block bodies, annot)
-            ) (* else *)
-          ) (* Some n_start... *)
-
-        | _ -> (
+              (* Build the final expression, a block of n times the body *)
+              let bodies = List.map (fun z -> rewrite_exp_replace_id_with_num "i" z e_loop_body) range in
+              E_aux (E_block bodies, annot) (* else *)
+            )
+            (* Some n_start... *)
+        | _ ->
             let e' = E_aux (e, annot) in
             let (l : Parse_ast.l), _tannot = annot in
-            let string_of_position (p : Lexing.position) : string =
-              p.pos_fname ^ ":" ^ (string_of_int p.pos_lnum)
-            in
+            let string_of_position (p : Lexing.position) : string = p.pos_fname ^ ":" ^ string_of_int p.pos_lnum in
             let rec string_of_l : Parse_ast.l -> string = function
-            | Unknown                -> "Unknown"
-            | Unique (i, l)          -> Printf.sprintf "Unique( %s, %s)" (string_of_int i) (string_of_l l)
-            | Generated l            -> Printf.sprintf "Generated( %s ) " (string_of_l l)
-            | Hint (str, l1, l2)     -> Printf.sprintf "Hint( %s, %s, %s )" str (string_of_l l1) (string_of_l l2)
-            | Range (p1, p2)         -> Printf.sprintf "Range( %s, %s )" (string_of_position p1) (string_of_position p2)
+              | Unknown -> "Unknown"
+              | Unique (i, l) -> Printf.sprintf "Unique( %s, %s)" (string_of_int i) (string_of_l l)
+              | Generated l -> Printf.sprintf "Generated( %s ) " (string_of_l l)
+              | Hint (str, l1, l2) -> Printf.sprintf "Hint( %s, %s, %s )" str (string_of_l l1) (string_of_l l2)
+              | Range (p1, p2) -> Printf.sprintf "Range( %s, %s )" (string_of_position p1) (string_of_position p2)
             in
-            print_endline  "[WARNING] Cannot unroll the loop because the bounds numerical values couldn't be fully determined.";
-            print_endline ("          Expression : " ^ string_of_exp e') ;
+            print_endline
+              "[WARNING] Cannot unroll the loop because the bounds numerical values couldn't be fully determined.";
+            print_endline ("          Expression : " ^ string_of_exp e');
             print_endline ("          Position   : " ^ string_of_l l);
             e'
-           ) (* None *)
-      ) (* E_for ... *)
+      )
     | _ -> E_aux (e, annot)
   in
   rewrite_ast_base

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4291,7 +4291,7 @@ let rewrite_unroll_constant_loops _type_env defs =
         | _ ->
             let e' = E_aux (e, annot) in
             let (l : Parse_ast.l), _tannot = annot in
-            Reporting.warn "" l
+            Reporting.warn ~force_show:true "" l
             @@ Printf.sprintf
                  "Cannot unroll the loop because the bounds numerical values couldn't be fully determined on \
                   expression :\n\

--- a/src/lib/rewrites.mli
+++ b/src/lib/rewrites.mli
@@ -59,6 +59,7 @@ val opt_dmono_continue : bool ref
 
 (** Unroll loops with constant bounds if less than 'max_iter' iterations *)
 val opt_unroll_loops : bool ref
+
 val opt_unroll_loops_max_iter : int ref
 
 (** Warn about matches where we add a default case for Coq because

--- a/src/lib/rewrites.mli
+++ b/src/lib/rewrites.mli
@@ -57,6 +57,10 @@ val opt_auto_mono : bool ref
 val opt_dall_split_errors : bool ref
 val opt_dmono_continue : bool ref
 
+(** Unroll loops with constant bounds if less than 'max_iter' iterations *)
+val opt_unroll_loops : bool ref
+val opt_unroll_loops_max_iter : int ref
+
 (** Warn about matches where we add a default case for Coq because
    they're not exhaustive *)
 val opt_coq_warn_nonexhaustive : bool ref

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -178,6 +178,7 @@ let verilog_rewrites =
     ("merge_function_clauses", []);
     ("recheck_defs", []);
     ("constant_fold", [String_arg "systemverilog"]);
+    ("unroll_constant_loops", [If_flag opt_unroll_loops]);
   ]
 
 module type JIB_CONFIG = sig


### PR DESCRIPTION
## Motivation

Loops being a source of issues in the SystemVerilog generation, being able to replace loops with their expanded equivalent helps us determine whether an issue is related to loops or not.

## Changes

It introduces two new options to the compiler :
```
  --unroll-loops                            turn on rewrites for unrolling loops with constant bounds.
  --unroll-loops-max-iter <nb_iter>         Don't unroll loops if they have more than <nb_iter> iterations.
```
The second option prevents generation of large amount of code if the loop has many iterations.

The pass first determines the actual numerical values for the loop bounds (start, end and step) in order to know the values with which to instantiate the body. It uses the values determined by the typer to do so.

If the value in the type is simple enough to be evaluated to a literal number with `nexp_simpl`, then the bounds can be known. Otherwise the unrolling is aborted with a warning message.


## Example

To see the effect of the pass, one can enable the `--ddump-rewrite-ast <prefix>` flag to have a view of the generated Sail code after each rewrite pass.

The diff before/after the loop-unrolling pass will look like below example :

```diff
3897c3897,3906
<     foreach (i from 0 to 7 by 1 in inc) ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, i, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, i)));
---
>     {
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 0, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 0)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 1, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 1)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 2, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 2)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 3, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 3)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 4, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 4)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 5, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 5)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 6, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 6)));
>         ys = $[overloaded { "name" = "vector_update", "is_infix" = false }] bitvector_update(ys, 7, $[overloaded { "name" = "vector_access", "is_infix" = false }] bitvector_access(xs, $[overloaded { "name" = "-", "is_infix" = true }] sub_atom(7, 7)))
>     };
16692,16694c16701,16717
<         foreach (i from 0 to 3 by 1 in inc) {
<             let idx = $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(n, 4), i);
<             pmpcfg_n = $[overloaded { "name" = "vector_update", "is_infix" = false }] plain_vector_update(pmpcfg_n, idx, pmpWriteCfg(idx, $[overloaded { "name" = "vector_access", "is_infix" = false }] plain_vector_access(pmpcfg_n, idx), $[overloaded { "name" = "vector_subrange", "is_infix" = false }] subrange_bits(v, $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, i), 7), $[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, i))))
---
>         {
>             {
>                 let idx = $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(n, 4), 0);
>                 pmpcfg_n = $[overloaded { "name" = "vector_update", "is_infix" = false }] plain_vector_update(pmpcfg_n, idx, pmpWriteCfg(idx, $[overloaded { "name" = "vector_access", "is_infix" = false }] plain_vector_access(pmpcfg_n, idx), $[overloaded { "name" = "vector_subrange", "is_infix" = false }] subrange_bits(v, $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 0), 7), $[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 0))))
>             };
>             {
>                 let idx = $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(n, 4), 1);
>                 pmpcfg_n = $[overloaded { "name" = "vector_update", "is_infix" = false }] plain_vector_update(pmpcfg_n, idx, pmpWriteCfg(idx, $[overloaded { "name" = "vector_access", "is_infix" = false }] plain_vector_access(pmpcfg_n, idx), $[overloaded { "name" = "vector_subrange", "is_infix" = false }] subrange_bits(v, $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 1), 7), $[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 1))))
>             };
>             {
>                 let idx = $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(n, 4), 2);
>                 pmpcfg_n = $[overloaded { "name" = "vector_update", "is_infix" = false }] plain_vector_update(pmpcfg_n, idx, pmpWriteCfg(idx, $[overloaded { "name" = "vector_access", "is_infix" = false }] plain_vector_access(pmpcfg_n, idx), $[overloaded { "name" = "vector_subrange", "is_infix" = false }] subrange_bits(v, $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 2), 7), $[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 2))))
>             };
>             {
>                 let idx = $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(n, 4), 3);
>                 pmpcfg_n = $[overloaded { "name" = "vector_update", "is_infix" = false }] plain_vector_update(pmpcfg_n, idx, pmpWriteCfg(idx, $[overloaded { "name" = "vector_access", "is_infix" = false }] plain_vector_access(pmpcfg_n, idx), $[overloaded { "name" = "vector_subrange", "is_infix" = false }] subrange_bits(v, $[overloaded { "name" = "+", "is_infix" = true }] add_atom($[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 3), 7), $[overloaded { "name" = "*", "is_infix" = true }] mult_atom(8, 3))))
>             }
19384,19385c19407,19425
...
```