### PR TITLE
TC: Iterate typechecking function arguments

### DIFF
--- a/test/typecheck/fail/and_let_bool.expect
+++ b/test/typecheck/fail/and_let_bool.expect
@@ -2,11 +2,11 @@
 [96mfail/and_let_bool.sail[0m:6.11-42:
 6[96m |[0m  and_bool(let y : bool = x in not_bool(y), x)
  [91m |[0m           [91m^-----------------------------^[0m [91mchecking function argument has type bool('p)[0m
- [91m |[0m The type variable 'ex16# would leak into an outer scope.
+ [91m |[0m The type variable 'ex18# would leak into an outer scope.
  [91m |[0m 
  [91m |[0m Try adding a type annotation to this expression.
  [91m |[0m 
  [91m |[0m [93mCaused by [0m[96mfail/and_let_bool.sail[0m:6.15-16:
  [91m |[0m 6[96m |[0m  and_bool(let y : bool = x in not_bool(y), x)
  [91m |[0m  [91m |[0m               [91m^[0m
- [91m |[0m  [91m |[0m Type variable 'ex16# was introduced here
+ [91m |[0m  [91m |[0m Type variable 'ex18# was introduced here

--- a/test/typecheck/fail/tuple_lexp1.expect
+++ b/test/typecheck/fail/tuple_lexp1.expect
@@ -2,7 +2,7 @@
 [96mfail/tuple_lexp1.sail[0m:10.11-20:
 10[96m |[0m  (x, y) = (2, 3, 4)
   [91m |[0m           [91m^-------^[0m
-  [91m |[0m Type mismatch between (int('ex180#), int('ex181#)) and (int(2), int(3), int(4))
+  [91m |[0m Type mismatch between (int('ex182#), int('ex183#)) and (int(2), int(3), int(4))
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mfail/tuple_lexp1.sail[0m:10.2-8:
   [91m |[0m 10[96m |[0m  (x, y) = (2, 3, 4)

--- a/test/typecheck/fail/tuple_lexp2.expect
+++ b/test/typecheck/fail/tuple_lexp2.expect
@@ -2,7 +2,7 @@
 [96mfail/tuple_lexp2.sail[0m:10.11-12:
 10[96m |[0m  (x, y) = 2
   [91m |[0m           [91m^[0m
-  [91m |[0m Type mismatch between (int('ex180#), int('ex181#)) and int(2)
+  [91m |[0m Type mismatch between (int('ex182#), int('ex183#)) and int(2)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mfail/tuple_lexp2.sail[0m:10.2-8:
   [91m |[0m 10[96m |[0m  (x, y) = 2

--- a/test/typecheck/pass/Replicate/v2.expect
+++ b/test/typecheck/pass/Replicate/v2.expect
@@ -10,4 +10,4 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m    [91m^------------------------^[0m
   [91m |[0m Could not resolve quantifiers for replicate_bits
   [91m |[0m [94m*[0m 'M >= 0
-  [91m |[0m [94m*[0m 'ex176# >= 0
+  [91m |[0m [94m*[0m 'ex178# >= 0

--- a/test/typecheck/pass/bool_constraint/v1.expect
+++ b/test/typecheck/pass/bool_constraint/v1.expect
@@ -9,13 +9,13 @@ All external bindings should be marked as either pure or impure
 12[96m |[0m  if b then n else 4
   [91m |[0m                   [91m^[0m
   [91m |[0m int(4) is not a subtype of {('m : Int), (('b & 'm == 'n) | (not('b) & 'm == 3)). int('m)}
-  [91m |[0m as (('b & 'ex171 == 'n) | (not('b) & 'ex171 == 3)) could not be proven
+  [91m |[0m as (('b & 'ex173 == 'n) | (not('b) & 'ex173 == 3)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex171:
+  [91m |[0m type variable 'ex173:
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:9.25-73:
   [91m |[0m 9[96m |[0m  (bool('b), int('n)) -> {'m, 'b & 'm == 'n | not('b) & 'm == 3. int('m)}
   [91m |[0m  [92m |[0m                         [92m^----------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:12.19-20:
   [91m |[0m 12[96m |[0m  if b then n else 4
   [91m |[0m   [93m |[0m                   [93m^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 4 == 'ex171
+  [91m |[0m   [93m |[0m has constraint: 4 == 'ex173

--- a/test/typecheck/pass/bv_concat_implicit.sail
+++ b/test/typecheck/pass/bv_concat_implicit.sail
@@ -1,0 +1,13 @@
+default Order dec
+
+$include <prelude.sail>
+
+val zeros : forall 'n. implicit('n) -> bits('n)
+
+val main : unit -> unit
+
+function main() = {
+  let x : bits(5) = zeros() @ 0b1;
+  let y : bits(5) = 0b1 @ zeros();
+  let z : bits(5) = 0b1 @ zeros() @ 0b00;
+}

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -9,4 +9,4 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 26[96m |[0m  Some(Ctor1(a, x, c))
   [91m |[0m       [91m^------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
-  [91m |[0m [94m*[0m 'ex247# in {32, 64}
+  [91m |[0m [94m*[0m 'ex249# in {32, 64}

--- a/test/typecheck/pass/existential_ast3/v1.expect
+++ b/test/typecheck/pass/existential_ast3/v1.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v1.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(33), int('ex212)) is not a subtype of (int('ex207), int('ex208))
+  [91m |[0m (int(33), int('ex214)) is not a subtype of (int('ex209), int('ex210))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex207:
+  [91m |[0m type variable 'ex209:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex208:
+  [91m |[0m type variable 'ex210:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex212:
+  [91m |[0m type variable 'ex214:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v2.expect
+++ b/test/typecheck/pass/existential_ast3/v2.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v2.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(31), int('ex212)) is not a subtype of (int('ex207), int('ex208))
+  [91m |[0m (int(31), int('ex214)) is not a subtype of (int('ex209), int('ex210))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex207:
+  [91m |[0m type variable 'ex209:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex208:
+  [91m |[0m type variable 'ex210:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex212:
+  [91m |[0m type variable 'ex214:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v3.expect
+++ b/test/typecheck/pass/existential_ast3/v3.expect
@@ -3,4 +3,4 @@
 25[96m |[0m    Some(Ctor(64, unsigned(0b0 @ b @ a)))
   [91m |[0m         [91m^-----------------------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor
-  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex244# & 'ex244# < 64))
+  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex246# & 'ex246# < 64))

--- a/test/typecheck/pass/existential_ast3/v4.expect
+++ b/test/typecheck/pass/existential_ast3/v4.expect
@@ -3,13 +3,13 @@
 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m                  [91m^^[0m
   [91m |[0m int(64) is not a subtype of {('d : Int), (('is_64 & 'd == 63) | (not('is_64) & 'd == 32)). int('d)}
-  [91m |[0m as (('is_64 & 'ex256 == 63) | (not('is_64) & 'ex256 == 32)) could not be proven
+  [91m |[0m as (('is_64 & 'ex258 == 63) | (not('is_64) & 'ex258 == 32)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex256:
+  [91m |[0m type variable 'ex258:
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:35.18-79:
   [91m |[0m 35[96m |[0m  let 'datasize : {'d, ('is_64 & 'd == 63) | (not('is_64) & 'd == 32). int('d)} =
   [91m |[0m   [92m |[0m                  [92m^-----------------------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:36.18-20:
   [91m |[0m 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m   [93m |[0m                  [93m^^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 64 == 'ex256
+  [91m |[0m   [93m |[0m has constraint: 64 == 'ex258

--- a/test/typecheck/pass/existential_ast3/v5.expect
+++ b/test/typecheck/pass/existential_ast3/v5.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m                                                  [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 2))
-  [91m |[0m as (0 <= 'ex264 & 'ex264 <= ('datasize - 2)) could not be proven
+  [91m |[0m as (0 <= 'ex266 & 'ex266 <= ('datasize - 2)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex264:
+  [91m |[0m type variable 'ex266:
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.50-65:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [93m |[0m                                                  [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex264 & 'ex264 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex266 & 'ex266 <= 63)

--- a/test/typecheck/pass/existential_ast3/v6.expect
+++ b/test/typecheck/pass/existential_ast3/v6.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m                                                                       [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 1))
-  [91m |[0m as (0 <= 'ex270 & 'ex270 <= ('datasize - 1)) could not be proven
+  [91m |[0m as (0 <= 'ex272 & 'ex272 <= ('datasize - 1)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex270:
+  [91m |[0m type variable 'ex272:
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.71-86:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [93m |[0m                                                                       [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex270 & 'ex270 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex272 & 'ex272 <= 63)

--- a/test/typecheck/pass/if_infer/v1.expect
+++ b/test/typecheck/pass/if_infer/v1.expect
@@ -3,7 +3,7 @@
 10[96m |[0m  let _ = 0b100[if R then 0 else f()];
   [91m |[0m          [91m^-------------------------^[0m
   [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m [94m*[0m (0 <= 'ex172# & 'ex172# < 3)
+  [91m |[0m [94m*[0m (0 <= 'ex174# & 'ex174# < 3)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v1.sail[0m:10.10-37:
   [91m |[0m 10[96m |[0m  let _ = 0b100[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v2.expect
+++ b/test/typecheck/pass/if_infer/v2.expect
@@ -3,7 +3,7 @@
 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
   [91m |[0m          [91m^--------------------------^[0m
   [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m [94m*[0m (0 <= 'ex172# & 'ex172# < 4)
+  [91m |[0m [94m*[0m (0 <= 'ex174# & 'ex174# < 4)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v2.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/reg_32_64/v3.expect
+++ b/test/typecheck/pass/reg_32_64/v3.expect
@@ -17,5 +17,5 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m [94m*[0m sub_int
   [91m |[0m   [96mpass/reg_32_64/v3.sail[0m:29.15-17:
   [91m |[0m   29[96m |[0m  reg_deref(R)['d - 1 .. 0]
-  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex105#)[0m
+  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex107#)[0m
   [91m |[0m     [91m |[0m Cannot re-write sizeof('d)

--- a/test/typecheck/update_errors.sh
+++ b/test/typecheck/update_errors.sh
@@ -9,11 +9,11 @@ do
     shopt -s nullglob;
     for file in $DIR/pass/${i%.sail}/*.sail;
     do
-        $SAIL -no_memo_z3 pass/${i%.sail}/$(basename $file) 2> ${file%.sail}.expect || true;
+        $SAIL --no-memo-z3 --strict-bitvector pass/${i%.sail}/$(basename $file) 2> ${file%.sail}.expect || true;
     done
 done
 
 for file in $DIR/fail/*.sail;
 do
-    $SAIL -no_memo_z3 fail/$(basename $file) 2> ${file%.sail}.expect || true;
+    $SAIL --no-memo-z3 --strict-bitvector fail/$(basename $file) 2> ${file%.sail}.expect || true;
 done


### PR DESCRIPTION
Previously we would do a single pass over all function arguments left-to-right to instantiate the function quantifiers, but this sometimes fails in some cases, e.g.
```
val operator @ : forall 'n 'm. (bits('n), bits('m)) -> bits('n + 'm)

let x : bits(5) = zeros() @ 0b1
```
where we can instantiate the quantifiers by:

- First using the second argument to find 'm

- Using the return type bits(5) to calculate 'n

- Then checking the first argument

To solve this, we can defer any arguments where we failed to infer the type or got a unification error, then check them again. If we fail to make progress then stop.