### PR TITLE
Lean: Translate bit vectors with constant width

### DIFF
--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -198,6 +198,7 @@ val add_bits = pure {
   interpreter: "add_vec",
   lem: "add_vec",
   coq: "add_vec",
+  lean: "Add.add",
   _: "add_bits"
 } : forall 'n. (bits('n), bits('n)) -> bits('n)
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -1,0 +1,9 @@
+def extern_const : BitVec 64 :=
+  (0xFFFF000012340000 : BitVec 64)
+
+def extern_add : BitVec 16 :=
+  (Add.add (0xFFFF : BitVec 16) (0x1234 : BitVec 16))
+
+def initialize_registers : Unit :=
+  ()
+

--- a/test/lean/extern_bitvec.sail
+++ b/test/lean/extern_bitvec.sail
@@ -1,0 +1,12 @@
+default Order dec
+
+$include <prelude.sail>
+
+function extern_const() -> bitvector(64) = {
+  return 0xFFFF_0000_1234_0000
+}
+
+function extern_add() -> bitvector(16) = {
+  return 0xFFFF + 0x1234
+}
+


### PR DESCRIPTION
Sticking to the plan of not caring too much about superfluous parentheses because we'll remove them with a Lean based formatter.

Translates
```sail
default Order dec

$include <prelude.sail>

function extern_const() -> bitvector(64) = {
  return 0xFFFF_0000_1234_0000
}

function extern_add() -> bitvector(16) = {
  return 0xFFFF + 0x1234
}

```
to
```lean
def extern_const : BitVec 64 :=
  (0xFFFF000012340000 : BitVec 64)

def extern_add : BitVec 16 :=
  (Add.add (0xFFFF : BitVec 16) (0x1234 : BitVec 16))

def initialize_registers : Unit :=
  ()

```