### PR TITLE
Lean: Translate tuples (expressions and types)

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -67,11 +67,12 @@ let rec untuple_args_pat typs (P_aux (paux, ((l, _) as annot)) as pat) =
 let doc_nexp (Nexp_aux (n, l) as nexp) =
   match n with Nexp_constant i -> string (Big_int.to_string i) | _ -> failwith "NExp not translatable yet."
 
-let doc_typ (Typ_aux (t, _) as typ) =
+let rec doc_typ (Typ_aux (t, _) as typ) =
   match t with
   | Typ_id (Id_aux (Id "unit", _)) -> string "Unit"
   | Typ_id (Id_aux (Id "int", _)) -> string "Int"
   | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]) -> string "BitVec " ^^ doc_nexp m
+  | Typ_tuple ts -> parens (separate (space ^^ string "×" ^^ space) (List.map doc_typ ts))
   | _ -> failwith "Type not translatable yet."
 
 let lean_escape_string s = Str.global_replace (Str.regexp "\"") "\"\"" s
@@ -105,6 +106,7 @@ let rec doc_exp (E_aux (e, (l, annot)) as full_exp) =
       nest 2 (parens (flow (break 1) (d_id :: d_args)))
   | E_vector vals -> failwith "vector found"
   | E_typ (typ, e) -> parens (separate space [doc_exp e; colon; doc_typ typ])
+  | E_tuple es -> parens (separate (comma ^^ space) (List.map doc_exp es))
   | _ -> failwith "Expression not translatable yet"
 
 let doc_funcl_init (FCL_aux (FCL_funcl (id, pexp), annot)) =

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -72,7 +72,7 @@ let rec doc_typ (Typ_aux (t, _) as typ) =
   | Typ_id (Id_aux (Id "unit", _)) -> string "Unit"
   | Typ_id (Id_aux (Id "int", _)) -> string "Int"
   | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]) -> string "BitVec " ^^ doc_nexp m
-  | Typ_tuple ts -> parens (separate (space ^^ string "×" ^^ space) (List.map doc_typ ts))
+  | Typ_tuple ts -> parens (separate_map (space ^^ string "×" ^^ space) doc_typ ts)
   | _ -> failwith "Type not translatable yet."
 
 let lean_escape_string s = Str.global_replace (Str.regexp "\"") "\"\"" s
@@ -106,7 +106,7 @@ let rec doc_exp (E_aux (e, (l, annot)) as full_exp) =
       nest 2 (parens (flow (break 1) (d_id :: d_args)))
   | E_vector vals -> failwith "vector found"
   | E_typ (typ, e) -> parens (separate space [doc_exp e; colon; doc_typ typ])
-  | E_tuple es -> parens (separate (comma ^^ space) (List.map doc_exp es))
+  | E_tuple es -> parens (separate_map (comma ^^ space) doc_exp es)
   | _ -> failwith "Expression not translatable yet"
 
 let doc_funcl_init (FCL_aux (FCL_funcl (id, pexp), annot)) =
@@ -162,6 +162,6 @@ let rec remove_imports (defs : (Libsail.Type_check.tannot, Libsail.Type_check.en
 
 let pp_ast_lean ({ defs; _ } as ast : Libsail.Type_check.typed_ast) o =
   let defs = remove_imports defs 0 in
-  let output : document = separate empty (List.map doc_def defs) in
+  let output : document = separate_map empty doc_def defs in
   print o output;
   ()

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -1,0 +1,6 @@
+def tuple1 : (Int × Int × (BitVec 2 × Unit)) :=
+  (3, 5, ((0b10 : BitVec 2), ()))
+
+def initialize_registers : Unit :=
+  ()
+

--- a/test/lean/tuples.sail
+++ b/test/lean/tuples.sail
@@ -1,0 +1,6 @@
+default Order dec
+
+function tuple1() -> (int, int, (bitvector(2), unit)) = {
+  return (3, 5, (0b10, ()))
+}
+


### PR DESCRIPTION
Translates
```sail
default Order dec

function tuple1() -> (int, int, (bitvector(2), unit)) = {
  return (3, 5, (0b10, ()))
}

```
to
```lean
def tuple1 : (Int × Int × (BitVec 2 × Unit)) :=
  (3, 5, ((0b10 : BitVec 2), ()))

def initialize_registers : Unit :=
  ()

```