### PR TITLE
Support inferring the type of if-else based on the else branch

### DIFF
--- a/test/typecheck/pass/if_infer_else.sail
+++ b/test/typecheck/pass/if_infer_else.sail
@@ -1,0 +1,17 @@
+default Order dec
+
+$include <prelude.sail>
+
+val zeros : forall 'n, 'n >= 0 . implicit('n) -> bits('n)
+function zeros (n) = sail_zeros (n)
+
+function main() -> unit = {
+  let b : bool = true;
+  let _ = if b then 0x12 else zeros();
+  let _ = if b then zeros() else 0x12;
+  let _ = if b then 1 else 2;
+
+  let _ = if true then 0x12 else zeros();
+  let _ = if true then zeros() else 0x12;
+  let _ = if true then 1 else 2;
+}


### PR DESCRIPTION
If we can't infer the type of the `then` branch but we can infer the type of the `else` branch, then use that type and check the `then` branch matches it.