### PR TITLE
TC: Look through if-statements when constructing overload trees

### DIFF
--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1772,6 +1772,15 @@ and build_overload_tree_arg env (E_aux (aux, annot) as exp) =
       | L_aux (L_undef, _) -> OT_leaf (exp, OL_unknown)
       | _ -> OT_leaf (exp, overload_leaf_type (infer_lit lit))
     end
+  | E_if (_, then_branch, else_branch) ->
+      let then_tree = build_overload_tree_arg env then_branch in
+      let else_tree = build_overload_tree_arg env else_branch in
+      begin
+        match (then_tree, else_tree) with
+        | OT_leaf (_, OL_unknown), OT_leaf (_, ot) -> OT_leaf (exp, ot)
+        | OT_leaf (_, ot), OT_leaf _ -> OT_leaf (exp, ot)
+        | _ -> OT_leaf (exp, OL_unknown)
+      end
   | _ -> OT_leaf (exp, OL_unknown)
 
 let string_of_overload_leaf = function

--- a/test/typecheck/pass/if_overload.sail
+++ b/test/typecheck/pass/if_overload.sail
@@ -1,0 +1,30 @@
+default Order dec
+
+$include <prelude.sail>
+$include <string.sail>
+
+overload operator ^ = {xor_vec}
+overload operator ^ = {add_bits}
+overload operator ^ = {concat_str}
+
+register R : vector(10, bool)
+
+val main : unit -> unit
+
+function main() = {
+  R = vector_init(false);
+
+  let x =
+    (if R[0] then "0" else "1")
+    ^ (if R[1] then "0" else "1")
+    ^ (if R[2] then "0" else "1")
+    ^ (if R[3] then "0" else "1")
+    ^ (if R[4] then "0" else "1")
+    ^ (if R[5] then "0" else "1")
+    ^ (if R[6] then "0" else "1")
+    ^ (if R[7] then "0" else "1")
+    ^ (if R[8] then "0" else "1")
+    ^ (if R[9] then "0" else "1");
+
+  print_endline(x)
+}


### PR DESCRIPTION
Fixes a performance issue where a sequence of overloaded operator arguments are just if-statements with no simpler expressions that would reduce the search space, and we create the full  possible overload tree for all combinations of operators.