### PR TITLE
Various fixes

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -726,7 +726,7 @@ default_spec :: 'DT_' ::=
 scattered_def :: 'SD_' ::=
   {{ com scattered function and union type definitions }}
   {{ aux _ annot }} {{ auxparam 'a }}
-  | scattered function rec_opt tannot_opt effect_opt id   :: :: function
+  | scattered function id : tannot_opt effect_opt :: :: function
 {{ texlong }} {{ com scattered function definition header }}
 
   | function clause funcl  :: :: funcl

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -991,7 +991,7 @@ and map_valspec_annot f = function VS_aux (vs_aux, annot) -> VS_aux (vs_aux, f a
 and map_scattered_annot f = function SD_aux (sd_aux, annot) -> SD_aux (map_scattered_annot_aux f sd_aux, f annot)
 
 and map_scattered_annot_aux f = function
-  | SD_function (rec_opt, tannot_opt, name) -> SD_function (map_recopt_annot f rec_opt, tannot_opt, name)
+  | SD_function (name, tannot_opt) -> SD_function (name, tannot_opt)
   | SD_funcl fcl -> SD_funcl (map_funcl_annot f fcl)
   | SD_variant (id, typq) -> SD_variant (id, typq)
   | SD_unioncl (id, tu) -> SD_unioncl (id, tu)
@@ -1425,7 +1425,7 @@ let id_of_dec_spec (DEC_aux (DEC_reg (_, id, _), _)) = id
 
 let id_of_scattered (SD_aux (sdef, _)) =
   match sdef with
-  | SD_function (_, _, id)
+  | SD_function (id, _)
   | SD_funcl (FCL_aux (FCL_funcl (id, _), _))
   | SD_end id
   | SD_variant (id, _)

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -1137,7 +1137,7 @@ let chunk_default_typing_spec comments chunks (DT_aux (DT_order (kind, typ), l))
   chunk_atyp comments chunks typ;
   Queue.push (Spacer (true, 1)) chunks
 
-let chunk_fundef comments chunks (FD_aux (FD_function (rec_opt, tannot_opt, _, funcls), l)) =
+let chunk_fundef comments chunks (FD_aux (FD_function (rec_opt, tannot_opt, funcls), l)) =
   pop_comments comments chunks l;
   let fn_id =
     match funcls with
@@ -1276,7 +1276,7 @@ let chunk_scattered comments chunks (SD_aux (aux, l)) =
         (Function { id; clause = true; rec_opt = None; typq_opt = None; return_typ_opt = None; funcls = [funcl_chunks] })
         chunks
   | SD_end id -> build_def chunks [chunk_keyword "end"; chunk_id id comments]
-  | SD_function (_, _, _, id) -> build_def chunks [chunk_keyword "scattered function"; chunk_id id comments]
+  | SD_function (id, _) -> build_def chunks [chunk_keyword "scattered function"; chunk_id id comments]
   | _ -> Reporting.unreachable l __POS__ "unhandled scattered def"
 
 let def_spacer (_, e) (s, _) = match (e, s) with Some l_e, Some l_s -> if l_s > l_e + 1 then 1 else 0 | _, _ -> 1

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -375,7 +375,7 @@ type outcome_spec_aux = (* outcome declaration *)
 type outcome_spec = OV_aux of outcome_spec_aux * l
 
 type fundef_aux = (* Function definition *)
-  | FD_function of rec_opt * tannot_opt * effect_opt * funcl list
+  | FD_function of rec_opt * tannot_opt * funcl list
 
 type type_def_aux =
   (* Type definition body *)
@@ -395,7 +395,7 @@ type dec_spec_aux = (* Register declarations *)
 type scattered_def_aux =
   (* Function and type union definitions that can be spread across
      a file. Each one must end in $_$ *)
-  | SD_function of rec_opt * tannot_opt * effect_opt * id (* scattered function definition header *)
+  | SD_function of id * tannot_opt (* scattered function definition header *)
   | SD_funcl of funcl (* scattered function definition clause *)
   | SD_enum of id (* scattered enumeration definition header *)
   | SD_enumcl of id * id (* scattered enumeration member clause *)

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -148,7 +148,6 @@ let mk_typqn = TypQ_aux (TypQ_no_forall, Unknown)
 
 let mk_tannotn = Typ_annot_opt_aux (Typ_annot_opt_none, Unknown)
 let mk_tannot typq typ n m = Typ_annot_opt_aux (Typ_annot_opt_some (typq, typ), loc n m)
-let mk_eannotn = Effect_opt_aux (Effect_opt_none,Unknown)
 
 let mk_typq kopts nc n m = TypQ_aux (TypQ_tq (List.map qi_id_of_kopt kopts @ nc), loc n m)
 
@@ -1077,7 +1076,7 @@ rec_measure:
 
 fun_def:
   | Function_ rec_measure? funcls
-    { let funcls, tannot = $3 in mk_fun (FD_function (default_opt mk_recn $2, tannot, mk_eannotn, funcls)) $startpos $endpos }
+    { let funcls, tannot = $3 in mk_fun (FD_function (default_opt mk_recn $2, tannot, funcls)) $startpos $endpos }
 
 fun_def_list:
   | fun_def
@@ -1259,9 +1258,9 @@ scattered_def:
   | Scattered Union id typaram
     { mk_sd (SD_variant($3, $4)) $startpos $endpos }
   | Scattered Union id
-    { mk_sd (SD_variant($3, mk_typqn)) $startpos $endpos }
+    { mk_sd (SD_variant ($3, mk_typqn)) $startpos $endpos }
   | Scattered Function_ id
-    { mk_sd (SD_function(mk_recn, mk_tannotn, mk_eannotn, $3)) $startpos $endpos }
+    { mk_sd (SD_function ($3, mk_tannotn)) $startpos $endpos }
   | Scattered Mapping id
     { mk_sd (SD_mapping ($3, mk_tannotn)) $startpos $endpos }
   | Scattered Mapping id Colon funcl_typ

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -795,7 +795,7 @@ module Printer (Config : PRINT_CONFIG) = struct
 
   let doc_scattered (SD_aux (sd_aux, _)) =
     match sd_aux with
-    | SD_function (_, _, id) -> string "scattered" ^^ space ^^ string "function" ^^ space ^^ doc_id id
+    | SD_function (id, _) -> string "scattered" ^^ space ^^ string "function" ^^ space ^^ doc_id id
     | SD_funcl funcl -> string "function" ^^ space ^^ string "clause" ^^ space ^^ doc_funcl funcl
     | SD_end id -> string "end" ^^ space ^^ doc_id id
     | SD_variant (id, TypQ_aux (TypQ_no_forall, _)) ->

--- a/src/lib/scattered.ml
+++ b/src/lib/scattered.ml
@@ -95,10 +95,12 @@ let patch_funcl_loc def_annot (FCL_aux (aux, (_, tannot))) =
 let patch_mapcl_annot def_annot (MCL_aux (aux, (_, tannot))) =
   MCL_aux (aux, (Type_check.strip_def_annot def_annot, tannot))
 
-let rec descatter' accumulator funcls mapcls = function
+let rec descatter' annots accumulator funcls mapcls = function
   (* For scattered functions we collect all the seperate function
      clauses until we find the last one, then we turn that function
      clause into a DEF_fundef containing all the clauses. *)
+  | DEF_aux (DEF_scattered (SD_aux (SD_function (id, _), _)), def_annot) :: defs ->
+      descatter' (Bindings.add id def_annot annots) accumulator funcls mapcls defs
   | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, (l, tannot))), def_annot) :: defs
     when last_scattered_funcl (funcl_id funcl) defs ->
       let funcl = patch_funcl_loc def_annot funcl in
@@ -110,43 +112,46 @@ let rec descatter' accumulator funcls mapcls = function
       let clauses, update_attr =
         Type_check.(check_funcls_complete l (env_of_tannot tannot) clauses (typ_of_tannot tannot))
       in
+      let def_annot =
+        Option.value ~default:(mk_def_annot (gen_loc l) def_annot.env) (Bindings.find_opt (funcl_id funcl) annots)
+      in
       let accumulator =
         DEF_aux
           ( DEF_fundef (FD_aux (FD_function (fake_rec_opt l, no_tannot_opt l, clauses), (gen_loc l, tannot))),
-            update_attr (mk_def_annot (gen_loc l) def_annot.env)
+            update_attr def_annot
           )
         :: accumulator
       in
-      descatter' accumulator funcls mapcls defs
+      descatter' annots accumulator funcls mapcls defs
   | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, _)), def_annot) :: defs ->
       let id = funcl_id funcl in
       let funcl = patch_funcl_loc def_annot funcl in
       begin
         match Bindings.find_opt id funcls with
-        | Some clauses -> descatter' accumulator (Bindings.add id (funcl :: clauses) funcls) mapcls defs
-        | None -> descatter' accumulator (Bindings.add id [funcl] funcls) mapcls defs
+        | Some clauses -> descatter' annots accumulator (Bindings.add id (funcl :: clauses) funcls) mapcls defs
+        | None -> descatter' annots accumulator (Bindings.add id [funcl] funcls) mapcls defs
       end
   (* Scattered mappings are handled the same way as scattered functions *)
+  | DEF_aux (DEF_scattered (SD_aux (SD_mapping (id, _), _)), def_annot) :: defs ->
+      descatter' (Bindings.add id def_annot annots) accumulator funcls mapcls defs
   | DEF_aux (DEF_scattered (SD_aux (SD_mapcl (id, mapcl), (l, tannot))), def_annot) :: defs
     when last_scattered_mapcl id defs ->
       let mapcl = patch_mapcl_annot def_annot mapcl in
       let clauses =
         match Bindings.find_opt id mapcls with Some clauses -> List.rev (mapcl :: clauses) | None -> [mapcl]
       in
+      let def_annot = Option.value ~default:(mk_def_annot (gen_loc l) def_annot.env) (Bindings.find_opt id annots) in
       let accumulator =
-        DEF_aux
-          ( DEF_mapdef (MD_aux (MD_mapping (id, no_tannot_opt l, clauses), (gen_loc l, tannot))),
-            mk_def_annot (gen_loc l) def_annot.env
-          )
+        DEF_aux (DEF_mapdef (MD_aux (MD_mapping (id, no_tannot_opt l, clauses), (gen_loc l, tannot))), def_annot)
         :: accumulator
       in
-      descatter' accumulator funcls mapcls defs
+      descatter' annots accumulator funcls mapcls defs
   | DEF_aux (DEF_scattered (SD_aux (SD_mapcl (id, mapcl), _)), def_annot) :: defs ->
       let mapcl = patch_mapcl_annot def_annot mapcl in
       begin
         match Bindings.find_opt id mapcls with
-        | Some clauses -> descatter' accumulator funcls (Bindings.add id (mapcl :: clauses) mapcls) defs
-        | None -> descatter' accumulator funcls (Bindings.add id [mapcl] mapcls) defs
+        | Some clauses -> descatter' annots accumulator funcls (Bindings.add id (mapcl :: clauses) mapcls) defs
+        | None -> descatter' annots accumulator funcls (Bindings.add id [mapcl] mapcls) defs
       end
   (* For scattered unions, when we find a union declaration we
      immediately grab all the future clauses and turn it into a
@@ -164,7 +169,7 @@ let rec descatter' accumulator funcls mapcls = function
               :: records
               @ accumulator
             in
-            descatter' accumulator funcls mapcls (filter_union_clauses id defs)
+            descatter' annots accumulator funcls mapcls (filter_union_clauses id defs)
       end
   (* Therefore we should never see SD_unioncl... *)
   | DEF_aux (DEF_scattered (SD_aux (SD_unioncl _, (l, _))), _) :: _ ->
@@ -184,9 +189,9 @@ let rec descatter' accumulator funcls mapcls = function
               DEF_aux (DEF_type (TD_aux (TD_enum (id, members, false), (gen_loc l, Type_check.empty_tannot))), def_annot)
               :: accumulator
             in
-            descatter' accumulator funcls mapcls (filter_enum_clauses id defs)
+            descatter' annots accumulator funcls mapcls (filter_enum_clauses id defs)
       end
-  | def :: defs -> descatter' (def :: accumulator) funcls mapcls defs
+  | def :: defs -> descatter' annots (def :: accumulator) funcls mapcls defs
   | [] -> List.rev accumulator
 
-let descatter ast = { ast with defs = descatter' [] Bindings.empty Bindings.empty ast.defs }
+let descatter ast = { ast with defs = descatter' Bindings.empty [] Bindings.empty Bindings.empty ast.defs }

--- a/test/typecheck/fail/issue775.expect
+++ b/test/typecheck/fail/issue775.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mfail/issue775.sail[0m:12.49-51:
+12[96m |[0mmapping clause encdec = UTYPE(imm, rd) <-> imm @ rd @ 0b0010111
+  [91m |[0m                                                 [91m^^[0m
+  [91m |[0m Expected bitvector type, got regidx

--- a/test/typecheck/fail/issue775.sail
+++ b/test/typecheck/fail/issue775.sail
@@ -1,0 +1,12 @@
+default Order dec
+$include <prelude.sail>
+
+struct regidx = { regidx : bits(5) }
+
+scattered union ast
+
+val encdec : ast <-> bits(32)
+scattered mapping encdec
+
+union clause ast = UTYPE : (bits(20), regidx)
+mapping clause encdec = UTYPE(imm, rd) <-> imm @ rd @ 0b0010111


### PR DESCRIPTION
- Preserve some mapping locations better

- Preserve documentation comments and attributes on scattered mappings and functions

- Fix an issue with dead match branches when the eager_control_flow option was used in Jib compilation

- Simplify Parse_ast representation of SD_mapping and SD_function

- Re-order Ast.SD_function arguments to match surface syntax