### PR TITLE
SV: Get RISC-V decoder through the SystemVerilog translation

### DIFF
--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -87,6 +87,7 @@ type ctx = {
   letbind_ids : IdSet.t;
   no_raw : bool;
   coverage_override : bool;
+  def_annot : unit def_annot option;
 }
 
 val ctx_is_extern : id -> ctx -> bool

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -335,7 +335,7 @@ module Verilog_config (C : JIB_CONFIG) : Jib_compile.CONFIG = struct
   let branch_coverage = None
   let use_real = false
   let use_void = false
-  let eager_control_flow = false
+  let eager_control_flow = true
 end
 
 let register_types cdefs =


### PR DESCRIPTION
The RISC-V Sail decoder is hard to generate in SystemVerilog if we try to preserve the order of every single statement, as it has a lot of guards which can read system state (like misa) to check whether certain extensions are enabled or not.

After trying a bunch of things that didn't work, this adds an attribute $[optimize_control_flow_order] which permits the Jib compilation to evaluate the expressions in control flow statements in whichever order it likes, and possibly eagerly, i.e.
```
if B then X else Y
```
can be re-written to
```
let y = Y in let x = X in if B then x else y
```
where X and Y are always evaluated.

If the function is side-effect free (as the decode is), this shouldn't change the result value, but it can change the order of side effects such as register writes or print statements.