### PR TITLE
Add parentheses in module instantiation even with no I/O mapped.

### DIFF
--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -2189,7 +2189,9 @@ module Make (Config : CONFIG) = struct
         let inputs = List.map (fun exp -> pp_smt exp) input_connections in
         let outputs = List.map pp_place output_connections in
         let connections =
-          match inputs @ outputs with [] -> empty | connections -> parens (separate (comma ^^ space) connections)
+          match inputs @ outputs with
+          | [] -> parens empty
+          | connections -> parens (separate (comma ^^ space) connections)
         in
         pp_sv_name module_name ^^ params ^^ space ^^ string instance_name ^^ connections ^^ semi
     | SVD_fundef f -> pp_fundef f


### PR DESCRIPTION
When instantiating a module, when no I/O ports are mapped,
there are no parentheses after the instance name, this creates syntax error in some EDA tools.

## Generated SV before the fix

```
    sail_setup_let_0 sail_inst_let_0(log2_xlen_bytes);
    sail_setup_let_1 sail_inst_let_1(xlen_bytes);
    sail_setup_let_2 sail_inst_let_2(xlen);
    sail_setup_let_3 sail_inst_let_3(flen_bytes);
    sail_setup_let_4 sail_inst_let_4(flen);
    sail_setup_let_5 sail_inst_let_5(VLEN);
    sail_setup_let_6 sail_inst_let_6;                   // <<<< ERRORS IN THE EDA TOOLS
    sail_setup_let_7 sail_inst_let_7(__monomorphize_reads);
    sail_setup_let_8 sail_inst_let_8(__monomorphize_writes);
    sail_setup_let_9 sail_inst_let_9;                   // <<<< ERRORS IN THE EDA TOOLS
    sail_setup_let_10 sail_inst_let_10(xlen_val);
```

## Generated SV after the fix

```
    sail_setup_let_0 sail_inst_let_0(log2_xlen_bytes);
    sail_setup_let_1 sail_inst_let_1(xlen_bytes);
    sail_setup_let_2 sail_inst_let_2(xlen);
    sail_setup_let_3 sail_inst_let_3(flen_bytes);
    sail_setup_let_4 sail_inst_let_4(flen);
    sail_setup_let_5 sail_inst_let_5(VLEN);
    sail_setup_let_6 sail_inst_let_6();                  // fixed
    sail_setup_let_7 sail_inst_let_7(__monomorphize_reads);
    sail_setup_let_8 sail_inst_let_8(__monomorphize_writes);
    sail_setup_let_9 sail_inst_let_9();                  // fixed
    sail_setup_let_10 sail_inst_let_10(xlen_val);
```