### PR TITLE
Add count_trailing_zero primop

### DIFF
--- a/lib/sail.c
+++ b/lib/sail.c
@@ -812,6 +812,16 @@ void count_leading_zeros(sail_int *rop, const lbits op)
   }
 }
 
+void count_trailing_zeros(sail_int *rop, const lbits op)
+{
+  if (mpz_cmp_ui(*op.bits, 0) == 0) {
+    mpz_set_ui(*rop, op.len);
+  } else {
+    mp_bitcnt_t ix = mpz_scan1(*op.bits, 0);
+    mpz_set_ui(*rop, ix);
+  }
+}
+
 bool eq_bits(const lbits op1, const lbits op2)
 {
   assert(op1.len == op2.len);

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -336,6 +336,7 @@ fbits fast_sign_extend2(const sbits op, const uint64_t m);
 
 void length_lbits(sail_int *rop, const lbits op);
 void count_leading_zeros(sail_int *rop, const lbits op);
+void count_trailing_zeros(sail_int *rop, const lbits op);
 
 bool eq_bits(const lbits op1, const lbits op2);
 bool EQUAL(lbits)(const lbits op1, const lbits op2);

--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -90,6 +90,7 @@ val vector_init = pure "vector_init" : forall 'n ('a : Type), 'n >= 0. (implicit
 overload length = {bitvector_length, vector_length}
 
 val count_leading_zeros = pure "count_leading_zeros" : forall 'N , 'N >= 1. bits('N) -> {'n, 0 <= 'n <= 'N . atom('n)}
+val count_trailing_zeros = pure "count_trailing_zeros" : forall 'N , 'N >= 1. bits('N) -> {'n, 0 <= 'n <= 'N . atom('n)}
 
 $[sv_module { stdout = true }]
 val print_bits = pure "print_bits" : forall 'n. (string, bits('n)) -> unit

--- a/src/gen_lib/sail2_operators_bitlists.lem
+++ b/src/gen_lib/sail2_operators_bitlists.lem
@@ -312,3 +312,4 @@ let eq_vec    = eq_bv
 let neq_vec   = neq_bv
 
 let inline count_leading_zeros v = count_leading_zero_bits v
+let inline count_trailing_zeros v = count_trailing_zero_bits v

--- a/src/gen_lib/sail2_operators_mwords.lem
+++ b/src/gen_lib/sail2_operators_mwords.lem
@@ -336,3 +336,6 @@ let inline neq_vec   = neq_mword
 
 val count_leading_zeros : forall 'a. Size 'a => mword 'a -> integer
 let count_leading_zeros v = count_leading_zeros_bv v
+
+val count_trailing_zeros : forall 'a. Size 'a => mword 'a -> integer
+let count_trailing_zeros v = count_trailing_zeros_bv v

--- a/src/gen_lib/sail2_values.lem
+++ b/src/gen_lib/sail2_values.lem
@@ -754,6 +754,12 @@ let rec count_leading_zero_bits v =
 val count_leading_zeros_bv : forall 'a. Bitvector 'a => 'a -> integer
 let count_leading_zeros_bv v = count_leading_zero_bits (bits_of v)
 
+val count_trailing_zero_bits : list bitU -> integer
+let rec count_trailing_zero_bits v = count_leading_zeros_bv (List.reverse v)
+
+val count_trailing_zeros_bv : forall 'a. Bitvector 'a => 'a -> integer
+let count_trailing_zeros_bv v = count_trailing_zero_bits (bits_of v)
+
 val decimal_string_of_bv : forall 'a. Bitvector 'a => 'a -> string
 let decimal_string_of_bv bv =
   let place_values =

--- a/src/lib/sail_lib.ml
+++ b/src/lib/sail_lib.ml
@@ -174,6 +174,8 @@ let count_leading_zeros xs =
   let rec aux bs acc = match bs with B0 :: bs' -> aux bs' (acc + 1) | _ -> acc in
   Big_int.of_int (aux xs 0)
 
+let count_trailing_zeros xs = count_leading_zeros (List.rev xs)
+
 let subrange (list, n, m) =
   let n = Big_int.to_int n in
   let m = Big_int.to_int m in

--- a/src/lib/smt_gen.mli
+++ b/src/lib/smt_gen.mli
@@ -148,6 +148,7 @@ module type PRIMOP_GEN = sig
   val hex_str : Parse_ast.l -> ctyp -> string
   val hex_str_upper : Parse_ast.l -> ctyp -> string
   val count_leading_zeros : Parse_ast.l -> int -> string
+  val count_trailing_zeros : Parse_ast.l -> int -> string
   val fvector_store : Parse_ast.l -> int -> ctyp -> string
   val is_empty : Parse_ast.l -> ctyp -> string
   val hd : Parse_ast.l -> ctyp -> string

--- a/src/lib/value.ml
+++ b/src/lib/value.ml
@@ -383,6 +383,10 @@ let value_count_leading_zeros = function
   | [v1] -> V_int (Sail_lib.count_leading_zeros (coerce_bv v1))
   | _ -> failwith "value count_leading_zeros"
 
+let value_count_trailing_zeros = function
+  | [v1] -> V_int (Sail_lib.count_trailing_zeros (coerce_bv v1))
+  | _ -> failwith "value count_trailing_zeros"
+
 let is_member = function V_member _ -> true | _ -> false
 
 let is_ctor = function V_ctor _ -> true | _ -> false
@@ -807,6 +811,7 @@ let primops =
          ("internal_pick", value_internal_pick);
          ("replicate_bits", value_replicate_bits);
          ("count_leading_zeros", value_count_leading_zeros);
+         ("count_trailing_zeros", value_count_trailing_zeros);
          ("Elf_loader.elf_entry", fun _ -> V_int !Elf_loader.opt_elf_entry);
          ("Elf_loader.elf_tohost", fun _ -> V_int !Elf_loader.opt_elf_tohost);
          ("string_append", value_string_append);

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -247,6 +247,8 @@ module Make (Config : CONFIG) = struct
 
         let count_leading_zeros l = function _ -> Reporting.unreachable l __POS__ "count_leading_zeros"
 
+        let count_trailing_zeros l = function _ -> Reporting.unreachable l __POS__ "count_trailing_zeros"
+
         let fvector_store l _ _ = "store"
 
         let is_empty l = function _ -> Reporting.unreachable l __POS__ "is_empty"

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -634,6 +634,8 @@ module Make (Config : CONFIG) = struct
 
         let count_leading_zeros l _ = Reporting.unreachable l __POS__ "count_leading_zeros"
 
+        let count_trailing_zeros l _ = Reporting.unreachable l __POS__ "count_trailing_zeros"
+
         let fvector_store _l len ctyp = Primops.fvector_store len ctyp
 
         let is_empty l = function

--- a/test/builtins/ctz.sail
+++ b/test/builtins/ctz.sail
@@ -1,0 +1,13 @@
+default Order dec
+$include <prelude.sail>
+
+function main () : unit -> unit = {
+  assert(count_trailing_zeros(0x0) == 4);
+  assert(count_trailing_zeros(0x1) == 0);
+  assert(count_trailing_zeros(0x4) == 2);
+  assert(count_trailing_zeros(0xf) == 0);
+
+  foreach (i from 0 to 32 by 1 in inc) {
+    assert(count_trailing_zeros(sail_shiftleft(0x00000001, i)) == i);
+  }
+}

--- a/test/smt/tzcnt.unsat.sail
+++ b/test/smt/tzcnt.unsat.sail
@@ -1,0 +1,16 @@
+default Order dec
+
+$include <prelude.sail>
+
+val lzcnt = pure "count_trailing_zeros" : forall 'w. bits('w) -> range(0, 'w)
+
+$property
+function prop() -> bool = {
+  let p1 = lzcnt(0x0) == 4;
+  let p2 = lzcnt(0x00) == 8;
+  let p3 = lzcnt(0x20) == 5;
+  let p4 = lzcnt(0b10000000) == 7;
+  let p5 = lzcnt(0b1) == 0;
+  let p6 = lzcnt(0xF) == 0;
+  p1 & p2 & p3 & p4 & p5 & p6
+}

--- a/test/typecheck/fail/tuple_lexp1.expect
+++ b/test/typecheck/fail/tuple_lexp1.expect
@@ -2,7 +2,7 @@
 [96mfail/tuple_lexp1.sail[0m:10.11-20:
 10[96m |[0m  (x, y) = (2, 3, 4)
   [91m |[0m           [91m^-------^[0m
-  [91m |[0m Type mismatch between (int('ex182#), int('ex183#)) and (int(2), int(3), int(4))
+  [91m |[0m Type mismatch between (int('ex183#), int('ex184#)) and (int(2), int(3), int(4))
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mfail/tuple_lexp1.sail[0m:10.2-8:
   [91m |[0m 10[96m |[0m  (x, y) = (2, 3, 4)

--- a/test/typecheck/fail/tuple_lexp2.expect
+++ b/test/typecheck/fail/tuple_lexp2.expect
@@ -2,7 +2,7 @@
 [96mfail/tuple_lexp2.sail[0m:10.11-12:
 10[96m |[0m  (x, y) = 2
   [91m |[0m           [91m^[0m
-  [91m |[0m Type mismatch between (int('ex182#), int('ex183#)) and int(2)
+  [91m |[0m Type mismatch between (int('ex183#), int('ex184#)) and int(2)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mfail/tuple_lexp2.sail[0m:10.2-8:
   [91m |[0m 10[96m |[0m  (x, y) = 2

--- a/test/typecheck/pass/Replicate/v2.expect
+++ b/test/typecheck/pass/Replicate/v2.expect
@@ -10,4 +10,4 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m    [91m^------------------------^[0m
   [91m |[0m Could not resolve quantifiers for replicate_bits
   [91m |[0m [94m*[0m 'M >= 0
-  [91m |[0m [94m*[0m 'ex178# >= 0
+  [91m |[0m [94m*[0m 'ex179# >= 0

--- a/test/typecheck/pass/bool_constraint/v1.expect
+++ b/test/typecheck/pass/bool_constraint/v1.expect
@@ -9,13 +9,13 @@ All external bindings should be marked as either pure or impure
 12[96m |[0m  if b then n else 4
   [91m |[0m                   [91m^[0m
   [91m |[0m int(4) is not a subtype of {('m : Int), (('b & 'm == 'n) | (not('b) & 'm == 3)). int('m)}
-  [91m |[0m as (('b & 'ex173 == 'n) | (not('b) & 'ex173 == 3)) could not be proven
+  [91m |[0m as (('b & 'ex174 == 'n) | (not('b) & 'ex174 == 3)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex173:
+  [91m |[0m type variable 'ex174:
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:9.25-73:
   [91m |[0m 9[96m |[0m  (bool('b), int('n)) -> {'m, 'b & 'm == 'n | not('b) & 'm == 3. int('m)}
   [91m |[0m  [92m |[0m                         [92m^----------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:12.19-20:
   [91m |[0m 12[96m |[0m  if b then n else 4
   [91m |[0m   [93m |[0m                   [93m^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 4 == 'ex173
+  [91m |[0m   [93m |[0m has constraint: 4 == 'ex174

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -9,4 +9,4 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 26[96m |[0m  Some(Ctor1(a, x, c))
   [91m |[0m       [91m^------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
-  [91m |[0m [94m*[0m 'ex249# in {32, 64}
+  [91m |[0m [94m*[0m 'ex250# in {32, 64}

--- a/test/typecheck/pass/existential_ast3/v1.expect
+++ b/test/typecheck/pass/existential_ast3/v1.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v1.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(33), int('ex214)) is not a subtype of (int('ex209), int('ex210))
+  [91m |[0m (int(33), int('ex215)) is not a subtype of (int('ex210), int('ex211))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex209:
+  [91m |[0m type variable 'ex210:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex210:
+  [91m |[0m type variable 'ex211:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex214:
+  [91m |[0m type variable 'ex215:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v2.expect
+++ b/test/typecheck/pass/existential_ast3/v2.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v2.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(31), int('ex214)) is not a subtype of (int('ex209), int('ex210))
+  [91m |[0m (int(31), int('ex215)) is not a subtype of (int('ex210), int('ex211))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex209:
+  [91m |[0m type variable 'ex210:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex210:
+  [91m |[0m type variable 'ex211:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex214:
+  [91m |[0m type variable 'ex215:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v3.expect
+++ b/test/typecheck/pass/existential_ast3/v3.expect
@@ -3,4 +3,4 @@
 25[96m |[0m    Some(Ctor(64, unsigned(0b0 @ b @ a)))
   [91m |[0m         [91m^-----------------------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor
-  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex246# & 'ex246# < 64))
+  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex247# & 'ex247# < 64))

--- a/test/typecheck/pass/existential_ast3/v4.expect
+++ b/test/typecheck/pass/existential_ast3/v4.expect
@@ -3,13 +3,13 @@
 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m                  [91m^^[0m
   [91m |[0m int(64) is not a subtype of {('d : Int), (('is_64 & 'd == 63) | (not('is_64) & 'd == 32)). int('d)}
-  [91m |[0m as (('is_64 & 'ex258 == 63) | (not('is_64) & 'ex258 == 32)) could not be proven
+  [91m |[0m as (('is_64 & 'ex259 == 63) | (not('is_64) & 'ex259 == 32)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex258:
+  [91m |[0m type variable 'ex259:
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:35.18-79:
   [91m |[0m 35[96m |[0m  let 'datasize : {'d, ('is_64 & 'd == 63) | (not('is_64) & 'd == 32). int('d)} =
   [91m |[0m   [92m |[0m                  [92m^-----------------------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:36.18-20:
   [91m |[0m 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m   [93m |[0m                  [93m^^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 64 == 'ex258
+  [91m |[0m   [93m |[0m has constraint: 64 == 'ex259

--- a/test/typecheck/pass/existential_ast3/v5.expect
+++ b/test/typecheck/pass/existential_ast3/v5.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m                                                  [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 2))
-  [91m |[0m as (0 <= 'ex266 & 'ex266 <= ('datasize - 2)) could not be proven
+  [91m |[0m as (0 <= 'ex267 & 'ex267 <= ('datasize - 2)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex266:
+  [91m |[0m type variable 'ex267:
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.50-65:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [93m |[0m                                                  [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex266 & 'ex266 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex267 & 'ex267 <= 63)

--- a/test/typecheck/pass/existential_ast3/v6.expect
+++ b/test/typecheck/pass/existential_ast3/v6.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m                                                                       [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 1))
-  [91m |[0m as (0 <= 'ex272 & 'ex272 <= ('datasize - 1)) could not be proven
+  [91m |[0m as (0 <= 'ex273 & 'ex273 <= ('datasize - 1)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex272:
+  [91m |[0m type variable 'ex273:
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.71-86:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [93m |[0m                                                                       [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex272 & 'ex272 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex273 & 'ex273 <= 63)

--- a/test/typecheck/pass/if_infer/v1.expect
+++ b/test/typecheck/pass/if_infer/v1.expect
@@ -3,7 +3,7 @@
 10[96m |[0m  let _ = 0b100[if R then 0 else f()];
   [91m |[0m          [91m^-------------------------^[0m
   [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m [94m*[0m (0 <= 'ex174# & 'ex174# < 3)
+  [91m |[0m [94m*[0m (0 <= 'ex175# & 'ex175# < 3)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v1.sail[0m:10.10-37:
   [91m |[0m 10[96m |[0m  let _ = 0b100[if R then 0 else f()];

--- a/test/typecheck/pass/if_infer/v2.expect
+++ b/test/typecheck/pass/if_infer/v2.expect
@@ -3,7 +3,7 @@
 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];
   [91m |[0m          [91m^--------------------------^[0m
   [91m |[0m Could not resolve quantifiers for bitvector_access
-  [91m |[0m [94m*[0m (0 <= 'ex174# & 'ex174# < 4)
+  [91m |[0m [94m*[0m (0 <= 'ex175# & 'ex175# < 4)
   [91m |[0m 
   [91m |[0m [93mCaused by [0m[96mpass/if_infer/v2.sail[0m:10.10-38:
   [91m |[0m 10[96m |[0m  let _ = 0b1001[if R then 0 else f()];

--- a/test/typecheck/pass/reg_32_64/v3.expect
+++ b/test/typecheck/pass/reg_32_64/v3.expect
@@ -17,5 +17,5 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m [94m*[0m sub_int
   [91m |[0m   [96mpass/reg_32_64/v3.sail[0m:29.15-17:
   [91m |[0m   29[96m |[0m  reg_deref(R)['d - 1 .. 0]
-  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex107#)[0m
+  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex108#)[0m
   [91m |[0m     [91m |[0m Cannot re-write sizeof('d)


### PR DESCRIPTION
To go along with count_leading_zeros

This at least shows up in the riscv and CHERIoT models, and it'd be nice to have as a primop.  (As it might bitvector reversal, as that'd have given a different spelling, but that seemed like more work and I didn't, at a glance, see it in the GNU mp library.)