### PR TITLE
bugfix: place_pi_functions now raises error when graph contains loop

### DIFF
--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -711,6 +711,7 @@ let place_pi_functions ~start ~finish ~post_idom ~post_df graph =
     if not (IntSet.mem n !visited) then (
       match graph.nodes.(n) with
       | Some ((ssa, cfnode), preds, succs) ->
+          visited := IntSet.add n !visited;
           let disj =
             List.map
               (fun post_frontier ->
@@ -740,7 +741,6 @@ let place_pi_functions ~start ~finish ~post_idom ~post_df graph =
             | [conj] -> Pi conj
             | conjs -> Pi [mk_disj (List.map (fun conj -> mk_conj conj) conjs)]
           in
-          visited := IntSet.add n !visited;
           graph.nodes.(n) <- Some ((mk_pi disj :: ssa, cfnode), preds, succs)
       | None -> ()
     )


### PR DESCRIPTION
I've been trying to generate System Verilog code from the RISC-V sail model.
This PR fixes one bug that I've hit so far.

Sail will hang during generation of the `pmpCheck` function, this is because it does not detect that there is a cycle in the control flow graph, and instead just keeps recursing over the graph, slowly consuming more memory until it cannot allocate any more, or gets OOM-killed.

I'm not sure if my fix is sound (I'm very new to the code base) but it appears that the set of visited nodes was updated quite late (after the recursive call), and so I made it update earlier.

With my fix, Sail now crashes with a sensible error message instead of hanging:

    Error:
    pmpCheck: control flow graph is not acyclic (node 254 is in cycle)

I don't know the underlying cause of the cycle yet, that might be another bug elsewhere.