### PR TITLE
Lean: naive fist translation of let expressions

### DIFF
--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -1,0 +1,7 @@
+def foo : BitVec 16 :=
+  let z := (HOr.hOr (0xFFFF : BitVec 16) (0xABCD : BitVec 16))
+  (HAnd.hAnd (0x0000 : BitVec 16) z)
+
+def initialize_registers : Unit :=
+  ()
+

--- a/test/lean/let.sail
+++ b/test/lean/let.sail
@@ -1,0 +1,9 @@
+default Order dec
+
+$include <prelude.sail>
+
+function foo() -> bits(16) = {
+  let z = 0xFFFF | 0xABCD in
+  0x0000 & z
+}
+


### PR DESCRIPTION
Translates
```sail
default Order dec

$include <prelude.sail>

function foo() -> bits(16) = {
  let z = 0xFFFF | 0xABCD in
  0x0000 & z
}

```
to
```lean
def foo : BitVec 16 :=
  let z := (HOr.hOr (0xFFFF : BitVec 16) (0xABCD : BitVec 16))
  (HAnd.hAnd (0x0000 : BitVec 16) z)

def initialize_registers : Unit :=
  ()

```