### PR TITLE
Update macOS build to use pkgconf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: System dependencies (macOS)
       if: startsWith(matrix.os, 'macOS')
       run: |
-        brew install --force --overwrite gpatch gmp z3 pkg-config opam
+        brew install --force --overwrite gpatch gmp z3 pkgconf opam
 
     - name: Restore cached opam
       id: cache-opam-restore


### PR DESCRIPTION
This package was renamed from `pkg-config` to `pkgconf`. Update the package name to avoid redirection or other issues.