### PR TITLE
enable use of ocamldebug

### DIFF
--- a/debug_sail
+++ b/debug_sail
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+SAIL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SAIL_BC="$SAIL_DIR/_build/default/src/bin/sail.bc"
+if [ ! -f "$SAIL_BC" ]; then
+    echo "Unable to find debug build of sail, please build it first."
+    echo "  dune build --profile debug"
+    exit 1
+fi
+export SAIL_DIR
+export DUNE_DIR_LOCATIONS="libsail:share:$SAIL_DIR/_build/install/default/share/libsail"
+exec rlwrap ocamldebug $(bash -c "find . -iname '*.cmo' ; find . -iname '*.cma'" | xargs dirname | sort | uniq | sed 's/^\(.*\)$/-I \1/' | tr '\n' ' ') "$SAIL_BC" $*

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -10,6 +10,7 @@
 
 (executable
  (name sail)
+ (modes native byte)
  (public_name sail)
  (package sail)
  (link_flags -linkall)

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -107,5 +107,6 @@
  (name libsail)
  (public_name libsail)
  (libraries lem linksem pprint dune-site yojson menhirLib)
+ (modes byte native)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/sail_c_backend/dune
+++ b/src/sail_c_backend/dune
@@ -1,7 +1,8 @@
 (executable
  (name sail_plugin_c)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (install
@@ -9,4 +10,4 @@
   (site
    (libsail plugins)))
  (package sail_c_backend)
- (files sail_plugin_c.cmxs))
+ (files sail_plugin_c.cmxs sail_plugin_c.cma))

--- a/src/sail_coq_backend/dune
+++ b/src/sail_coq_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_coq)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (install
@@ -17,4 +18,4 @@
   (site
    (libsail plugins)))
  (package sail_coq_backend)
- (files sail_plugin_coq.cmxs))
+ (files sail_plugin_coq.cmxs sail_plugin_coq.cma))

--- a/src/sail_doc_backend/dune
+++ b/src/sail_doc_backend/dune
@@ -1,7 +1,8 @@
 (executable
  (name sail_plugin_doc)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (link_flags -linkall)
  (libraries libsail omd yojson base64)
  (embed_in_plugin_libraries omd base64))
@@ -11,4 +12,4 @@
   (site
    (libsail plugins)))
  (package sail_doc_backend)
- (files sail_plugin_doc.cmxs))
+ (files sail_plugin_doc.cmxs sail_plugin_doc.cma))

--- a/src/sail_latex_backend/dune
+++ b/src/sail_latex_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_latex)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (link_flags -linkall)
  (libraries libsail omd)
  (embed_in_plugin_libraries omd))
@@ -19,4 +20,4 @@
   (site
    (libsail plugins)))
  (package sail_latex_backend)
- (files sail_plugin_latex.cmxs))
+ (files sail_plugin_latex.cmxs sail_plugin_latex.cma))

--- a/src/sail_lean_backend/dune
+++ b/src/sail_lean_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_lean)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (install
@@ -17,4 +18,4 @@
   (site
    (libsail plugins)))
  (package sail_lean_backend)
- (files sail_plugin_lean.cmxs))
+ (files sail_plugin_lean.cmxs sail_plugin_lean.cma))

--- a/src/sail_lem_backend/dune
+++ b/src/sail_lem_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_lem)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (install
@@ -17,4 +18,4 @@
   (site
    (libsail plugins)))
  (package sail_lem_backend)
- (files sail_plugin_lem.cmxs))
+ (files sail_plugin_lem.cmxs sail_plugin_lem.cma))

--- a/src/sail_ocaml_backend/dune
+++ b/src/sail_ocaml_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_ocaml)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (link_flags -linkall)
  (libraries libsail base64)
  (embed_in_plugin_libraries base64))
@@ -19,4 +20,4 @@
   (site
    (libsail plugins)))
  (package sail_ocaml_backend)
- (files sail_plugin_ocaml.cmxs))
+ (files sail_plugin_ocaml.cmxs sail_plugin_ocaml.cma))

--- a/src/sail_output/dune
+++ b/src/sail_output/dune
@@ -1,7 +1,8 @@
 (executable
  (name sail_plugin_output)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (install
@@ -9,4 +10,4 @@
   (site
    (libsail plugins)))
  (package sail_output)
- (files sail_plugin_output.cmxs))
+ (files sail_plugin_output.cmxs sail_plugin_output.cma))

--- a/src/sail_smt_backend/dune
+++ b/src/sail_smt_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_smt)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (install
@@ -17,4 +18,4 @@
   (site
    (libsail plugins)))
  (package sail_smt_backend)
- (files sail_plugin_smt.cmxs))
+ (files sail_plugin_smt.cmxs sail_plugin_smt.cma))

--- a/src/sail_sv_backend/dune
+++ b/src/sail_sv_backend/dune
@@ -9,7 +9,8 @@
 (executable
  (name sail_plugin_sv)
  (modes
-  (native plugin))
+  (native plugin)
+  (byte plugin))
  (libraries libsail))
 
 (menhir
@@ -22,4 +23,4 @@
   (site
    (libsail plugins)))
  (package sail_sv_backend)
- (files sail_plugin_sv.cmxs))
+ (files sail_plugin_sv.cmxs sail_plugin_sv.cma))


### PR DESCRIPTION
This introduces a few changes:
1. the dune config is changed to generate bytecode objects for all modules (in addition to the regular native objects)
2. an option is added that makes sail load bytecode plugins instead of native plugins (ocamldebug requires them to be bytecode)
3. adds a wrapper called `debug_sail` which runs ocamldebug with the right options and environment to make it work

Some things that are worth detailed review:
I had to change `Dynlink.loadfile_private` to `Dynlink.loadfile`. I'm not entirely sure the consequences of this, but it didn't work with the `_private` version. Is this expected? (`scr/bin/sail.ml:151`)

In `src/bin/sail.ml:588` there is some special-case parsing of command line arguments, because the full parsing normally happens after the plugins are loaded, but this particular option needs parsing before and plugins can load. Is there a better way to do this?

I'm not very familiar with dune, so I'm not sure if the changes I've made to the config are best-practice.