### PR TITLE
Pattern Completeness: Warn about future clauses in scattered enums

### DIFF
--- a/src/lib/pattern_completeness.mli
+++ b/src/lib/pattern_completeness.mli
@@ -58,6 +58,7 @@ type ctx = {
   variants : (typquant * type_union list) Bindings.t;
   structs : (typquant * (typ * id) list) Bindings.t;
   enums : IdSet.t Bindings.t;
+  is_open : id -> bool;
   constraints : n_constraint list;
   is_mapping : id -> bool;
 }

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -903,6 +903,7 @@ let pats_complete l env ps typ =
       Pattern_completeness.variants = Env.get_variants env;
       Pattern_completeness.structs = Env.get_records env;
       Pattern_completeness.enums = Env.get_enums env;
+      Pattern_completeness.is_open = (fun id -> Env.is_scattered_open id env);
       Pattern_completeness.constraints = Env.get_constraints env;
       Pattern_completeness.is_mapping = (fun id -> Env.is_mapping id env);
     }

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -2077,6 +2077,7 @@ let pattern_completeness_ctx env =
     Pattern_completeness.variants = Env.get_variants env;
     Pattern_completeness.structs = Env.get_records env;
     Pattern_completeness.enums = Env.get_enums env;
+    Pattern_completeness.is_open = (fun id -> Env.is_scattered_open id env);
     Pattern_completeness.constraints = Env.get_constraints env;
     Pattern_completeness.is_mapping = (fun id -> Env.is_mapping id env);
   }

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -198,6 +198,11 @@ module Env : sig
 
   val is_mapping : id -> t -> bool
 
+  (** A scattered definition is open if it can have new clauses added to
+      it, i.e. it exists and has not been closed by the [end]
+      keyword. *)
+  val is_scattered_open : id -> t -> bool
+
   val is_register : id -> t -> bool
 
   (** Check if the type with the given id is a bitfield type *)

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1346,6 +1346,9 @@ let add_scattered_enum id attrs env = env |> add_scattered_id id attrs |> add_en
 
 let is_scattered_id id env = Bindings.mem id env.global.scattered_ids
 
+let is_scattered_open id env =
+  match Bindings.find_opt id env.global.scattered_ids with Some (Ok _) -> true | _ -> false
+
 let end_scattered_id ~at:l id env =
   let attrs = ref [] in
   let updater = function

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -217,6 +217,7 @@ val lookup_id : id -> t -> typ lvar
 
 val add_scattered_id : id -> (l * string * Ast.attribute_data option) list -> t -> t
 val is_scattered_id : id -> t -> bool
+val is_scattered_open : id -> t -> bool
 val end_scattered_id : at:Ast.l -> id -> t -> t
 
 val expand_synonyms : t -> typ -> typ

--- a/test/pattern_completeness/enum_open_end.sail
+++ b/test/pattern_completeness/enum_open_end.sail
@@ -1,0 +1,22 @@
+default Order dec
+
+$include <prelude.sail>
+
+scattered enum E
+
+enum clause E = A
+
+register R : E = A
+
+enum clause E = B
+
+end E
+
+val foo : unit -> unit
+
+function foo() = {
+  match R {
+    A => (),
+    B => (),
+  }
+}

--- a/test/pattern_completeness/warn_enum_open.expect
+++ b/test/pattern_completeness/warn_enum_open.expect
@@ -1,0 +1,6 @@
+[93mWarning[0m: Incomplete pattern match statement at [96mwarn_enum_open.sail[0m:16.2-7:
+16[96m |[0m  match R {
+  [91m |[0m  [91m^---^[0m
+  [91m |[0m 
+The following expression is unmatched: [93m<future E clause>[0m
+

--- a/test/pattern_completeness/warn_enum_open.sail
+++ b/test/pattern_completeness/warn_enum_open.sail
@@ -1,0 +1,22 @@
+default Order dec
+
+$include <prelude.sail>
+
+scattered enum E
+
+enum clause E = A
+
+register R : E = A
+
+enum clause E = B
+
+val foo : unit -> unit
+
+function foo() = {
+  match R {
+    A => (),
+    B => (),
+  }
+}
+
+end E

--- a/test/pattern_completeness/warn_enum_open_other.expect
+++ b/test/pattern_completeness/warn_enum_open_other.expect
@@ -1,0 +1,6 @@
+[93mWarning[0m: Incomplete pattern match statement at [96mwarn_enum_open_other.sail[0m:18.2-7:
+18[96m |[0m  match R {
+  [91m |[0m  [91m^---^[0m
+  [91m |[0m 
+The following expression is unmatched: [93mC[0m
+

--- a/test/pattern_completeness/warn_enum_open_other.sail
+++ b/test/pattern_completeness/warn_enum_open_other.sail
@@ -1,0 +1,24 @@
+default Order dec
+
+$include <prelude.sail>
+
+scattered enum E
+
+enum clause E = A
+
+register R : E = A
+
+enum clause E = B
+
+enum clause E = C
+
+val foo : unit -> unit
+
+function foo() = {
+  match R {
+    A => (),
+    B => (),
+  }
+}
+
+end E


### PR DESCRIPTION
Now if matching on a scattered enum the completeness checker will warn about the possibility of future members:
```
Warning: Incomplete pattern match statement at warn_enum_open.sail:16.2-7:
16 |  match R {
   |  ^---^
   |
The following expression is unmatched: <future E clause>
```
Which effectively requires a wildcard case for such matches to be complete. After the `end` keyword closes the scattered definition this will no-longer be the case, as no new clauses can be added.