### PR TITLE
Cope with spaces in pathnames

### DIFF
--- a/sail
+++ b/sail
@@ -7,5 +7,5 @@ export SAIL_DIR
 
 # Where to find plugins
 export DUNE_DIR_LOCATIONS="libsail:share:$SAIL_DIR/_build/install/default/share/libsail"
-exec "$SAIL_DIR/_build/install/default/bin/sail" $*
+exec "$SAIL_DIR/_build/install/default/bin/sail" "$@"
 

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -158,7 +158,7 @@ let create_lake_project (out_name : string) default_sail_dir =
   let base_dir = match !opt_lean_output_dir with Some dir -> dir | None -> "." in
   let project_dir = Filename.concat base_dir out_name in
   if !opt_lean_force_output && Sys.is_directory project_dir then (
-    let _ = Unix.system ("rm -r " ^ project_dir ^ "/*") in
+    let _ = Unix.system ("rm -r " ^ Filename.quote project_dir ^ "/*") in
     ()
   )
   else Unix.mkdir project_dir 0o775;
@@ -179,7 +179,7 @@ let create_lake_project (out_name : string) default_sail_dir =
     );
   close_out lakefile;
   let sail_dir = Reporting.get_sail_dir default_sail_dir in
-  let _ = Unix.system ("cp -r " ^ sail_dir ^ "/src/sail_lean_backend/Sail " ^ project_dir) in
+  let _ = Unix.system (Filename.quote_command "cp" ["-r"; sail_dir ^ "/src/sail_lean_backend/Sail"; project_dir]) in
   let project_main = open_out (Filename.concat project_dir (out_name_camel ^ ".lean")) in
   project_main
 

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -1115,14 +1115,15 @@ let ocaml_compile default_sail_dir spec ast generator_types =
   if Sys.file_exists !opt_ocaml_build_dir then () else Unix.mkdir !opt_ocaml_build_dir 0o775;
   let cwd = Unix.getcwd () in
   Unix.chdir !opt_ocaml_build_dir;
-  let _ = Unix.system ("cp -r " ^ sail_dir ^ "/src/lib/elf_loader.ml .") in
-  let _ = Unix.system ("cp -r " ^ sail_dir ^ "/src/lib/sail_lib.ml .") in
-  let _ = Unix.system ("cp -r " ^ sail_dir ^ "/src/lib/util.ml .") in
+  let _ = Unix.system (Filename.quote_command "cp" ["-r"; sail_dir ^ "/src/lib/elf_loader.ml"; "."]) in
+  let _ = Unix.system (Filename.quote_command "cp" ["-r"; sail_dir ^ "/src/lib/sail_lib.ml"; "."]) in
+  let _ = Unix.system (Filename.quote_command "cp" ["-r"; sail_dir ^ "/src/lib/util.ml"; "."]) in
   let tags_file = if !opt_ocaml_coverage then "_tags_coverage" else "_tags" in
-  let _ = Unix.system ("cp -r " ^ sail_dir ^ "/lib/" ^ tags_file ^ " _tags") in
+  let _ = Unix.system (Filename.quote_command "cp" ["-r"; sail_dir ^ "/lib/" ^ tags_file; "_tags"]) in
   let out_chan = open_out (spec ^ ".ml") in
   if !opt_ocaml_coverage then
-    ignore (Unix.system ("cp -r " ^ sail_dir ^ "/lib/myocamlbuild_coverage.ml myocamlbuild.ml"));
+    ignore
+      (Unix.system (Filename.quote_command "cp" ["-r"; sail_dir ^ "/lib/myocamlbuild_coverage.ml"; "myocamlbuild.ml"]));
   List.iter (fun w -> output_string out_chan (Printf.sprintf "[@@@warning \"-%d\"]\n" w)) [8; 9; 11; 23; 26];
   ocaml_pp_ast out_chan ast generator_types;
   close_out out_chan;
@@ -1136,7 +1137,7 @@ let ocaml_compile default_sail_dir spec ast generator_types =
         system_checked
           "BISECT_COVERAGE=YES ocamlbuild -use-ocamlfind -plugin-tag 'package(bisect_ppx-ocamlbuild)' main.native"
       else system_checked "ocamlbuild -use-ocamlfind main.native";
-      ignore (Unix.system ("cp main.native " ^ cwd ^ "/" ^ spec))
+      ignore (Unix.system (Filename.quote_command "cp" ["main.native"; cwd ^ "/" ^ spec]))
     )
   end
   else if not !opt_ocaml_nobuild then system_checked ("ocamlbuild -use-ocamlfind " ^ spec ^ ".cmo");

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -687,7 +687,7 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
           sprintf
             "verilator --cc --exe --build -j %d --top-module sail_toplevel -I%s --Mdir %s_obj_dir sim_%s.cpp \
              %s.sv%s%s%s"
-            !opt_verilate_jobs sail_sv_libdir out out out extra cflags ldflags
+            !opt_verilate_jobs (Filename.quote sail_sv_libdir) out out out extra cflags ldflags
         in
         print_endline ("Verilator command: " ^ verilator_command);
         let _ = Unix.system verilator_command in

--- a/test/arm/run_tests.sh
+++ b/test/arm/run_tests.sh
@@ -2,31 +2,31 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $DIR
+cd "$DIR"
 SAILDIR="$DIR/../.."
 
-rm -f $DIR/tests.xml
+rm -f "$DIR/tests.xml"
 
 # shellcheck source=../test_helpers.sh
 source "$SAILDIR/test/test_helpers.sh"
 
 SAILLIBDIR="$DIR/../../lib/"
 
-printf "<testsuites>\n" >> $DIR/tests.xml
+printf "<testsuites>\n" >> "$DIR/tests.xml"
 
-cd $SAILDIR/aarch64
+cd "$SAILDIR/aarch64"
 
 printf "Compiling specification...\n"
 
-if $SAILDIR/sail -no_lexp_bounds_check -o aarch64_test -ocaml no_vector.sail 1> /dev/null 2> /dev/null;
+if "$SAILDIR/sail" -no_lexp_bounds_check -o aarch64_test -ocaml no_vector.sail 1> /dev/null 2> /dev/null;
 then
     green "compiled no_vector specification" "ok";
-    mv aarch64_test $DIR/;
-    cd $DIR;
+    mv aarch64_test "$DIR/";
+    cd "$DIR";
 
     for i in `ls *.elf`;
     do
-	$DIR/aarch64_test $i 2> /dev/null 1> ${i%.elf}.result
+	"$DIR/aarch64_test" $i 2> /dev/null 1> ${i%.elf}.result
 	if diff ${i%.elf}.result ${i%.elf}.expect;
 	then
 	    green "ran $i" "ok"
@@ -48,24 +48,24 @@ fi
 
 printf "\nLoading specification into interpreter...\n"
 
-cd $SAILDIR/aarch64
+cd "$SAILDIR/aarch64"
 
-if $SAILDIR/sail -undefined_gen -no_lexp_bounds_check -is $DIR/test.isail no_vector.sail 1> /dev/null 2> /dev/null;
+if "$SAILDIR/sail" -undefined_gen -no_lexp_bounds_check -is "$DIR/test.isail" no_vector.sail 1> /dev/null 2> /dev/null;
 then
     green "loaded no_vector specification" "ok";
 
-    if diff $DIR/test_O2.expect $DIR/iresult;
+    if diff "$DIR/test_O2.expect" "$DIR/iresult";
     then
 	green "interpreter success" "ok"
     else
 	red "interpreter failed" "fail"
     fi;
 
-    rm -f $DIR/iresult
+    rm -f "$DIR/iresult"
 else
     red "loading no_vector specification" "fail"
 fi
 
 finish_suite "ARM generated spec tests"
 
-printf "</testsuites>\n" >> $DIR/tests.xml
+printf "</testsuites>\n" >> "$DIR/tests.xml"

--- a/test/builtins/run_tests.py
+++ b/test/builtins/run_tests.py
@@ -28,8 +28,8 @@ def test_c_builtins(name, sail_opts):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
-                step('gcc {}.c {}/lib/*.c -lgmp -I {}/lib -o {}'.format(basename, sail_dir, sail_dir, basename))
+                step('\'{}\' -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
+                step('gcc {}.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}'.format(basename, sail_dir, sail_dir, basename))
                 step('./{}'.format(basename))
                 step('rm {}.c'.format(basename))
                 step('rm {}'.format(basename))
@@ -48,7 +48,7 @@ def test_ocaml_builtins(name, sail_opts):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -no_warn -ocaml -ocaml_build_dir _sbuild_{} -o {} {}'.format(sail, basename, basename, filename))
+                step('\'{}\' -no_warn -ocaml -ocaml_build_dir _sbuild_{} -o {} {}'.format(sail, basename, basename, filename))
                 step('./{}'.format(basename))
                 step('rm -r _sbuild_{}'.format(basename))
                 step('rm {}'.format(basename))
@@ -68,7 +68,7 @@ def test_lem_builtins(name):
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 # Generate Lem from Sail
-                step('{} -no_warn -lem -o {} {}'.format(sail, basename, filename))
+                step('\'{}\' -no_warn -lem -o {} {}'.format(sail, basename, filename))
 
                 # Create a directory to build the generated Lem and
                 # copy/move everything we need into it, as well as
@@ -77,7 +77,7 @@ def test_lem_builtins(name):
                 step('mv {}.lem _lbuild_{}'.format(basename, basename))
                 step('mv {}_types.lem _lbuild_{}'.format(basename, basename))
                 step('cp myocamlbuild.ml _lbuild_{}'.format(basename))
-                step('cp {}/src/gen_lib/*.lem _lbuild_{}'.format(sail_dir, basename))
+                step('cp \'{}\'/src/gen_lib/*.lem _lbuild_{}'.format(sail_dir, basename))
                 os.chdir('_lbuild_{}'.format(basename))
 
                 # Use ocamlbuild to build the lem to OCaml using the
@@ -104,7 +104,7 @@ def test_coq_builtins(name):
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 # Generate Coq from Sail
-                step('{} -no_warn -coq -undefined_gen -o {} {}'.format(sail, basename, filename))
+                step('\'{}\' -no_warn -coq -undefined_gen -o {} {}'.format(sail, basename, filename))
 
                 step('mkdir -p _coqbuild_{}'.format(basename))
                 step('mv {}.v _coqbuild_{}'.format(basename, basename))
@@ -135,8 +135,8 @@ def test_isla_builtins(name):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{}/isla-sail/isla-sail {} {}/lib/vector_dec.sail {}/test/property/include/config.sail -o {}'.format(isla_dir, filename, sail_dir, isla_dir, basename))
-                step('{}/target/release/isla-execute-function -A {}.ir -C {}/configs/plain.toml main'.format(isla_dir, basename, isla_dir))
+                step('\'{}\'/isla-sail/isla-sail {} \'{}\'/lib/vector_dec.sail \'{}\'/test/property/include/config.sail -o {}'.format(isla_dir, filename, sail_dir, isla_dir, basename))
+                step('\'{}\'/target/release/isla-execute-function -A {}.ir -C \'{}\'/configs/plain.toml main'.format(isla_dir, basename, isla_dir))
                 step('rm {}.ir'.format(basename))
                 print('{} {}{}{}'.format(filename, color.PASS, 'ok', color.END))
                 sys.exit()

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -41,8 +41,8 @@ def test_c(name, c_opts, sail_opts, valgrind, compiler='cc'):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
-                step('{} {} {}.c {}/lib/*.c -lgmp -I {}/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
+                step('\'{}\' -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
+                step('{} {} {}.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
                 step('./{}.bin > {}.result 2> {}.err_result'.format(basename, basename, basename), expected_status = 1 if basename.startswith('fail') else 0)
                 step('diff {}.result {}.expect'.format(basename, basename))
                 if os.path.exists('{}.err_expect'.format(basename)):
@@ -64,8 +64,8 @@ def test_c2(name, c_opts, sail_opts, valgrind):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -no_warn -c2 {} {} -o {}'.format(sail, sail_opts, filename, basename))
-                step('gcc {} {}.c {}_emu.c {}/lib/*.c -lgmp -I {}/lib -o {}'.format(c_opts, basename, basename, sail_dir, sail_dir, basename))
+                step('\'{}\' -no_warn -c2 {} {} -o {}'.format(sail, sail_opts, filename, basename))
+                step('gcc {} {}.c {}_emu.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}'.format(c_opts, basename, basename, sail_dir, sail_dir, basename))
                 step('./{} > {}.result 2>&1'.format(basename, basename), expected_status = 1 if basename.startswith('fail') else 0)
                 step('diff {}.result {}.expect'.format(basename, basename))
                 if valgrind:
@@ -85,7 +85,7 @@ def test_interpreter(name):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -undefined_gen -is execute.isail -iout {}.iresult {}'.format(sail, basename, filename))
+                step('\'{}\' -undefined_gen -is execute.isail -iout {}.iresult {}'.format(sail, basename, filename))
                 step('diff {}.iresult {}.expect'.format(basename, basename))
                 step('rm {}.iresult'.format(basename))
                 print_ok(filename)
@@ -102,7 +102,7 @@ def test_ocaml(name):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -ocaml -ocaml_build_dir _sbuild_{} -o {}_ocaml {}'.format(sail, basename, basename, filename))
+                step('\'{}\' -ocaml -ocaml_build_dir _sbuild_{} -o {}_ocaml {}'.format(sail, basename, basename, filename))
                 step('./{}_ocaml 1> {}.oresult'.format(basename, basename), expected_status = 1 if basename.startswith('fail') else 0)
                 step('diff {}.oresult {}.expect'.format(basename, basename))
                 step('rm -r _sbuild_{}'.format(basename))
@@ -135,11 +135,11 @@ def test_lem(name):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -lem -lem_lib Undefined_override -o {} {}'.format(sail, basename, filename))
+                step('\'{}\' -lem -lem_lib Undefined_override -o {} {}'.format(sail, basename, filename))
                 step('mkdir -p _lbuild_{}'.format(basename))
                 step('cp {}*.lem _lbuild_{}'.format(basename, basename))
                 step('cp lbuild/* _lbuild_{}'.format(basename))
-                step('cp {}/src/gen_lib/*.lem _lbuild_{}'.format(sail_dir, basename))
+                step('cp \'{}\'/src/gen_lib/*.lem _lbuild_{}'.format(sail_dir, basename))
                 os.chdir('_lbuild_{}'.format(basename))
                 step('../mk_lem_ocaml_main.sh {} {}'.format(basename, basename.capitalize()))
                 step('ocamlbuild -use-ocamlfind main.native'.format(basename, basename))
@@ -180,7 +180,7 @@ def test_coq(name):
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 # Generate Coq from Sail
-                step('{} -coq -undefined_gen -o {} {}'.format(sail, basename, filename))
+                step('\'{}\' -coq -undefined_gen -o {} {}'.format(sail, basename, filename))
 
                 step('mkdir -p _coqbuild_{}'.format(basename))
                 step('mv {}.v _coqbuild_{}'.format(basename, basename))

--- a/test/float/run_tests.py
+++ b/test/float/run_tests.py
@@ -30,8 +30,8 @@ def test_float(name, sail_opts, compiler, c_opts):
 
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
-                step('{} {} {}.c {}/lib/*.c -lgmp -I {}/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
+                step('\'{}\' -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
+                step('{} {} {}.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
                 step('./{}.bin > {}.result 2> {}.err_result'.format(basename, basename, basename), expected_status = 1 if basename.startswith('fail') else 0)
 
                 step('diff {}.err_result no_error && rm {}.err_result'.format(basename, basename))

--- a/test/format/run_tests.py
+++ b/test/format/run_tests.py
@@ -27,7 +27,7 @@ def test(test_dir):
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 step('cp {} {}/{}'.format(filename, test_dir, filename))
-                step('{} -config {}/config.json -fmt {}/{}'.format(sail, test_dir, test_dir, filename))
+                step('\'{}\' -config {}/config.json -fmt {}/{}'.format(sail, test_dir, test_dir, filename))
                 step('diff {}/{} {}/{}.expect'.format(test_dir, filename, test_dir, basename))
                 step('rm {}/{}'.format(test_dir, filename))
                 print_ok(filename)

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -27,7 +27,7 @@ def test_lean():
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 step('mkdir {}'.format(basename))
-                step('{} {} --lean --lean-output-dir {}'.format(sail, filename, basename))
+                step('\'{}\' {} --lean --lean-output-dir {}'.format(sail, filename, basename))
                 step('diff {}/out/Out.lean {}.expected.lean'.format(basename, basename))
                 step('rm -r {}'.format(basename))
                 print_ok(filename)

--- a/test/lem/run_tests.py
+++ b/test/lem/run_tests.py
@@ -81,8 +81,8 @@ def test_lem(name, opts, skip_list):
                 continue
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} --lem {} --strict-bitvector -o {} {}/{}'.format(sail, opts, basename, test_dir, filename))
-                step('lem -lib {}/src/gen_lib {}_types.lem {}.lem'.format(sail_dir, basename, basename))
+                step('\'{}\' --lem {} --strict-bitvector -o {} {}/{}'.format(sail, opts, basename, test_dir, filename))
+                step('lem -lib \'{}\'/src/gen_lib {}_types.lem {}.lem'.format(sail_dir, basename, basename))
                 step('rm {}_types.lem {}.lem'.format(basename, basename))
                 print_ok(filename)
                 sys.exit(0)

--- a/test/lexing/run_tests.py
+++ b/test/lexing/run_tests.py
@@ -26,7 +26,7 @@ def test_lexing():
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} {} 2> {}.error'.format(sail, filename, basename), expected_status = 1)
+                step('\'{}\' {} 2> {}.error'.format(sail, filename, basename), expected_status = 1)
                 step('diff {}.expect {}.error'.format(basename, basename))
                 step('rm {}.error'.format(basename))
                 print_ok(filename)

--- a/test/mono/run_tests.sh
+++ b/test/mono/run_tests.sh
@@ -23,7 +23,7 @@ echo > log
 
 if [ -z "$1" ]
 then
-    TESTS=`find $TESTSDIR/pass -type f | sort`
+    TESTS=`find ./pass -type f | sort`
 else
     TESTS="$@"
 fi
@@ -81,4 +81,4 @@ done
 
 finish_suite "monomorphisation tests"
 
-printf "</testsuites>\n" >> $DIR/tests.xml
+printf "</testsuites>\n" >> "$DIR/tests.xml"

--- a/test/ocaml/run_tests.sh
+++ b/test/ocaml/run_tests.sh
@@ -2,22 +2,22 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $DIR
+cd "$DIR"
 SAIL=${SAIL:=sail}
 SAILDIR="$DIR/../.."
 
-rm -f $DIR/tests.xml
+rm -f "$DIR/tests.xml"
 
 printf "\$SAIL is $SAIL\n"
 
 # shellcheck source=../test_helpers.sh
 source "$SAILDIR/test/test_helpers.sh"
 
-printf "<testsuites>\n" >> $DIR/tests.xml
+printf "<testsuites>\n" >> "$DIR/tests.xml"
 
 for i in `ls -d */`;
 do
-    cd $DIR/$i;
+    cd "$DIR/$i";
     if "$SAIL" -no_warn -o out -ocaml ../prelude.sail `ls *.sail` 1> /dev/null;
     then
 	./out > result;
@@ -37,11 +37,11 @@ done
 
 finish_suite "Ocaml testing"
 
-cd $DIR
+cd "$DIR"
 
 for i in `ls -d */`;
 do
-    cd $DIR/$i;
+    cd "$DIR/$i";
     if "$SAIL" -no_warn -o out -ocaml -ocaml_trace ../prelude.sail `ls *.sail` 1> /dev/null;
     then
 	./out > result 2> /dev/null;
@@ -62,11 +62,11 @@ done
 finish_suite "Ocaml trace testing"
 
 # FIXME: Re-enable these!
-#cd $DIR
+#cd "$DIR"
 #
 #for i in `ls -d */`;
 #do
-#    cd $DIR/$i;
+#    cd "$DIR/$i";
 #    if "$SAIL" -no_warn -undefined_gen -is test.isail ../prelude.sail `ls *.sail` 1> /dev/null;
 #    then
 #	if diff expect result;
@@ -83,5 +83,5 @@ finish_suite "Ocaml trace testing"
 #
 #finish_suite "Interpreter testing"
 
-printf "</testsuites>\n" >> $DIR/tests.xml
+printf "</testsuites>\n" >> "$DIR/tests.xml"
 exit $returncode

--- a/test/pattern_completeness/run_tests.py
+++ b/test/pattern_completeness/run_tests.py
@@ -26,7 +26,7 @@ def test_patterns(name):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} --just-check {} 2> {}.error'.format(sail, filename, basename))
+                step('\'{}\' --just-check {} 2> {}.error'.format(sail, filename, basename))
                 if filename.startswith('warn'):
                     step('diff {}.error {}.expect'.format(basename, basename))
                 else:

--- a/test/run_core_tests.sh
+++ b/test/run_core_tests.sh
@@ -3,7 +3,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd $DIR
+cd "$DIR"
 
 # Some basic tests that don't have external tool requirements, don't
 # take too long, and don't have regressions that we haven't sorted out

--- a/test/run_coverage_tests.sh
+++ b/test/run_coverage_tests.sh
@@ -3,7 +3,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd $DIR
+cd "$DIR"
 
 returncode=0
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd $DIR
+cd "$DIR"
 
 ./run_core_tests.sh
 

--- a/test/sailcov/run_tests.py
+++ b/test/sailcov/run_tests.py
@@ -38,10 +38,10 @@ def test_sailcov():
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} -no_warn -no_memo_z3 -c -c_include sail_coverage.h -c_coverage {}.branches {} -o {}'.format(sail, basename, filename, basename))
-                step('cc {}.c {}/lib/*.c {}/lib/coverage/libsail_coverage.a -lgmp -lpthread -ldl -I {}/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
+                step('\'{}\' -no_warn -no_memo_z3 -c -c_include sail_coverage.h -c_coverage {}.branches {} -o {}'.format(sail, basename, filename, basename))
+                step('cc {}.c \'{}\'/lib/*.c \'{}\'/lib/coverage/libsail_coverage.a -lgmp -lpthread -ldl -I \'{}\'/lib -o {}.bin'.format(basename, sail_dir, sail_dir, sail_dir, basename))
                 step('./{}.bin -c {}.taken'.format(basename, basename))
-                step('{} --werror --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
+                step('\'{}\' --werror --all {}.branches --taken {}.taken {}'.format(sailcov, basename, basename, filename))
                 step('diff {}.html {}.expect'.format(basename, basename))
                 step('rm {}.taken {}.bin {}.branches'.format(basename, basename, basename))
                 print_ok(filename)

--- a/test/smt/run_tests.py
+++ b/test/smt/run_tests.py
@@ -47,7 +47,7 @@ def test_smt(name, solver, sail_opts):
                     continue
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} {} -smt {} -o {}'.format(sail, sail_opts, filename, basename))
+                step('\'{}\' {} -smt {} -o {}'.format(sail, sail_opts, filename, basename))
                 step('timeout 30s {} {}_prop.smt2 1> {}.out'.format(solver, basename, basename))
                 if re.match('.+\.sat\.sail$', filename):
                     step('grep -q ^sat$ {}.out'.format(basename))

--- a/test/sv/run_tests.py
+++ b/test/sv/run_tests.py
@@ -48,9 +48,9 @@ def test_sv(name, opts, skip_list):
             if tests[filename] == 0:
                 step('rm -rf {}_obj_dir'.format(basename));
                 if basename.startswith('fail'):
-                    step('{} --no-warn --sv ../c/{} -o {} --sv-verilate compile{} --sv-verilate-jobs 1 > {}.out'.format(sail, filename, basename, opts, basename))
+                    step('\'{}\' --no-warn --sv ../c/{} -o {} --sv-verilate compile{} --sv-verilate-jobs 1 > {}.out'.format(sail, filename, basename, opts, basename))
                 else:
-                    step('{} --no-warn --sv ../c/{} -o {} --sv-verilate run{} --sv-verilate-jobs 1 > {}.out'.format(sail, filename, basename, opts, basename))
+                    step('\'{}\' --no-warn --sv ../c/{} -o {} --sv-verilate run{} --sv-verilate-jobs 1 > {}.out'.format(sail, filename, basename, opts, basename))
                     step('awk \'/SAIL START/{{flag=1;next}}/SAIL END/{{flag=0}}flag\' {}.out > {}.result'.format(basename, basename))
                     step('diff ../c/{}.expect {}.result'.format(basename, basename))
                 print_ok(filename)

--- a/test/typecheck/run_tests.py
+++ b/test/typecheck/run_tests.py
@@ -37,15 +37,15 @@ def test_pass():
                 continue
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast pass/{} 1> rtpass/{}'.format(sail, filename, filename))
-                step('{} --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast --dmagic-hash rtpass/{} 1> rtpass2/{}'.format(sail, filename, filename))
+                step('\'{}\' --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast pass/{} 1> rtpass/{}'.format(sail, filename, filename))
+                step('\'{}\' --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast --dmagic-hash rtpass/{} 1> rtpass2/{}'.format(sail, filename, filename))
                 step('diff rtpass/{} rtpass2/{}'.format(filename, filename))
                 i = 0
                 variantdir = os.path.join('pass', basename);
                 for variantname in os.listdir(variantdir) if os.path.isdir(variantdir) else []:
                     if re.match('.+\.sail$', variantname):
                         variantbasename = os.path.splitext(os.path.basename(variantname))[0]
-                        step('{} --no-memo-z3 --strict-bitvector pass/{}/{} 2> pass/{}/{}.error'.format(sail, basename, variantname, basename, variantbasename), expected_status = 1)
+                        step('\'{}\' --no-memo-z3 --strict-bitvector pass/{}/{} 2> pass/{}/{}.error'.format(sail, basename, variantname, basename, variantbasename), expected_status = 1)
                         step('diff pass/{}/{}.error pass/{}/{}.expect'.format(basename, variantbasename, basename, variantbasename))
                         step('rm pass/{}/{}.error'.format(basename, variantbasename))
                         i = i + 1
@@ -64,11 +64,11 @@ def test_projects():
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 if filename.startswith('fail'):
-                    step('{} --no-memo-z3 project/{} --all-modules 2> project/{}.error'.format(sail, filename, basename), expected_status = 1)
+                    step('\'{}\' --no-memo-z3 project/{} --all-modules 2> project/{}.error'.format(sail, filename, basename), expected_status = 1)
                     step('diff project/{}.error project/{}.expect'.format(basename, basename))
                     step('rm project/{}.error'.format(basename))
                 else:
-                    step('{} --no-memo-z3 project/{} --all-modules'.format(sail, filename))
+                    step('\'{}\' --no-memo-z3 project/{} --all-modules'.format(sail, filename))
                 print_ok(filename)
                 sys.exit()
         results.collect(tests)
@@ -83,7 +83,7 @@ def test_fail():
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('{} --no-memo-z3 --strict-bitvector fail/{} 2> fail/{}.error'.format(sail, filename, basename), expected_status = 1)
+                step('\'{}\' --no-memo-z3 --strict-bitvector fail/{} 2> fail/{}.error'.format(sail, filename, basename), expected_status = 1)
                 step('diff fail/{}.error fail/{}.expect'.format(basename, basename))
                 step('rm fail/{}.error'.format(basename))
                 print_ok(filename)


### PR DESCRIPTION
Mostly affects testing scripts, although the OCaml and Lean backends have a couple of copy commands that had to be quoted.