### PR TITLE
Lean: Implement type abbreviations and introduce kid->id renaming

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -109,7 +109,9 @@ let rec doc_typ (Typ_aux (t, _) as typ) =
   | Typ_id (Id_aux (Id "bool", _)) -> string "Bool"
   | Typ_id (Id_aux (Id "bit", _)) -> parens (string "BitVec 1")
   | Typ_id (Id_aux (Id "nat", _)) -> string "Nat"
-  | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]) -> string "BitVec " ^^ doc_nexp m
+  | Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]) | Typ_app (Id_aux (Id "bits", _), [A_aux (A_nexp m, _)])
+    ->
+      string "BitVec " ^^ doc_nexp m
   | Typ_app (Id_aux (Id "atom", _), [A_aux (A_nexp (Nexp_aux (Nexp_var ki, _)), _)]) -> string "Int"
   | Typ_tuple ts -> parens (separate_map (space ^^ string "×" ^^ space) doc_typ ts)
   | Typ_id (Id_aux (Id id, _)) -> string id
@@ -281,6 +283,10 @@ let doc_typdef (TD_aux (td, tannot) as full_typdef) =
       let rectyp = doc_typ_quant tq in
       (* TODO don't ignore type quantifiers *)
       nest 2 (flow (break 1) [string "structure"; string id; string "where"] ^^ hardline ^^ enums_doc)
+  | TD_abbrev (Id_aux (Id id, _), tq, A_aux (A_typ t, _)) ->
+      nest 2 (flow (break 1) [string "def"; string id; coloneq; doc_typ t])
+  | TD_abbrev (Id_aux (Id id, _), tq, A_aux (A_nexp ne, _)) ->
+      nest 2 (flow (break 1) [string "def"; string id; colon; string "Int"; coloneq; doc_nexp ne])
   | _ -> failwith ("Type definition " ^ string_of_type_def_con full_typdef ^ " not translatable yet.")
 
 let doc_def (DEF_aux (aux, def_annot) as def) =

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -6,11 +6,14 @@ def xlen_bytes : Int := 8
 
 def xlenbits := BitVec 64
 
+/-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
 def EXTZ {m : _} (v : BitVec k_n) : BitVec m :=
   (Sail.BitVec.zeroExtend v m)
 
+/-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
 def EXTS {m : _} (v : BitVec k_n) : BitVec m :=
   (Sail.BitVec.signExtend v m)
 
 def initialize_registers : Unit :=
   ()
+

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -1,0 +1,16 @@
+import Out.Sail.Sail
+
+def xlen : Int := 64
+
+def xlen_bytes : Int := 8
+
+def xlenbits := BitVec 64
+
+def EXTZ {m : _} (v : BitVec k_n) : BitVec m :=
+  (Sail.BitVec.zeroExtend v m)
+
+def EXTS {m : _} (v : BitVec k_n) : BitVec m :=
+  (Sail.BitVec.signExtend v m)
+
+def initialize_registers : Unit :=
+  ()

--- a/test/lean/typedef.sail
+++ b/test/lean/typedef.sail
@@ -1,0 +1,13 @@
+default Order dec
+$include <prelude.sail>
+
+type xlen       : Int = 64
+type xlen_bytes : Int = 8
+type xlenbits         = bits(xlen)
+
+val EXTZ : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+function EXTZ(m, v) = sail_zero_extend(v, m)
+
+val EXTS : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+function EXTS(m, v) = sail_sign_extend(v, m)
+

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -1,8 +1,10 @@
 import Out.Sail.Sail
 
+/-- Type quantifiers: n : Int -/
 def foo (n : Int) : BitVec 4 :=
   (0xF : BitVec 4)
 
+/-- Type quantifiers: k_n : Int -/
 def bar (x : BitVec k_n) : BitVec k_n :=
   x
 


### PR DESCRIPTION
#829 takes priority

This translates
```sail
default Order dec
$include <prelude.sail>

type xlen       : Int = 64
type xlen_bytes : Int = 8
type xlenbits         = bits(xlen)

val EXTZ : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
function EXTZ(m, v) = sail_zero_extend(v, m)

val EXTS : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
function EXTS(m, v) = sail_sign_extend(v, m)

```
to
```lean
import Out.Sail.Sail

def xlen : Int := 64

def xlen_bytes : Int := 8

def xlenbits := BitVec 64

/-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
def EXTZ {m : _} (v : BitVec k_n) : BitVec m :=
  (Sail.BitVec.zeroExtend v m)

/-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
def EXTS {m : _} (v : BitVec k_n) : BitVec m :=
  (Sail.BitVec.signExtend v m)

def initialize_registers : Unit :=
  ()
```
(Yes, the type abbreviation and the context things are largely orthogonal)