### PR TITLE
fix nesting mapping tuple with no location infomation when type error

### DIFF
--- a/test/pattern_completeness/nested_mapping.sail
+++ b/test/pattern_completeness/nested_mapping.sail
@@ -1,0 +1,16 @@
+mapping A : (bool, bool) <-> string = {
+  (true, true) <-> "a",
+  (true, false) <-> "b",
+}
+
+mapping B : bool <-> string = {
+  true <-> "a" ^ A(true, false, false),
+  false <-> "b" ^ A(false, false),
+}
+
+val main : unit -> unit
+
+function main() = {
+  let str = B(true);
+  ()
+}


### PR DESCRIPTION
I add a test file to recurrent the situation happend in [here](https://github.com/riscv/sail-riscv/pull/610).
I'm new with sail, so I'm not sure this is right.

```
mapping A : (bool, bool) <-> string = {
  (true, true) <-> "a",
  (true, false) <-> "b",
}

mapping B : bool <-> string = {
  true <-> "a" ^ A(true, false, false),
  false <-> "b" ^ A(false, false),
}

val main : unit -> unit

function main() = {
  let str = B(true);
  ()
}
```
The problem seems happen when there is a mapping inside mapping,
Seems like sail type checked this use the code below.
Like `A(true, false, false)` , it check true false false, one by one recursively.
But when it traverse in those args, it kind lost the location infomation of mapping A.

```
| MP_tuple [] -> begin
      match Env.expand_synonyms env typ with
      | Typ_aux (Typ_id typ_id, _) when string_of_id typ_id = "unit" -> (annot_mpat (MP_tuple []) typ, env, [])
      | _ -> typ_error l "Cannot match unit mapping-pattern against non-unit type"
    end
  | MP_tuple mpats -> begin
      match Env.expand_synonyms env typ with
      | Typ_aux (Typ_tuple typs, _) ->
          let tpats, env, guards =
            try List.fold_left2 bind_tuple_mpat ([], env, []) mpats typs
            with Invalid_argument _ -> typ_error l "Tuple mapping-pattern and tuple type have different length"
          in
          (annot_mpat (MP_tuple (List.rev tpats)) typ, env, guards)
      | _ -> typ_error l "Cannot bind tuple mapping-pattern against non tuple type"
```

before
```
Type error:
Tuple mapping-pattern and tuple type have different length
```

after
```
Type error:
/sail/test/pattern_completeness/nested_mapping.sail:7.17-38:
7 |  true <-> "a" ^ A(true, false, false),
  |                 ^-------------------^
  | Mapping A applied to 3 args, expected 2: bool, bool
```