### PR TITLE
Bugfix: Output ast for --ddump-initial-ast

### DIFF
--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -57,6 +57,7 @@ let opt_reformat : string option ref = ref None
 
 let finalize_ast asserts_termination ctx env ast =
   Lint.warn_unmodified_variables ast;
+  if !opt_ddump_initial_ast then Pretty_print_sail.output_ast stdout (Type_check.strip_ast ast);
   let ast = Scattered.descatter ast in
   let side_effects = Effects.infer_side_effects asserts_termination ast in
   if !opt_ddump_side_effect then Effects.dump_effects side_effects;


### PR DESCRIPTION
I found that `sail --ddump-initial-ast` dumps nothing instead of the initial ast. 
I think this behaviour confuses user so I make this PR to fix it.
This patch simply adds a print statement for `--ddump-initial-ast` at the beginning of function `finalize_ast`.

Could you help review this? @Alasdair 