### PR TITLE
Update macOS installation instructions (pkgconf)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ sudo apt-get install build-essential libgmp-dev z3 pkg-config
 or [MacOS homebrew](https://brew.sh/):
 ```
 xcode-select --install # if you haven't already
-brew install gmp z3 pkg-config
+brew install gmp z3 pkgconf
 ```
 Finally, install sail from the opam package [https://opam.ocaml.org/packages/sail/](https://opam.ocaml.org/packages/sail/) and its dependencies:
 ```


### PR DESCRIPTION
Update INSTALL.md to list the new `pkgconf` package instead of the deprecated `pkg-config`.

The overall installation instructions could do with a larger update soon that suggests installing the binary version instead of using opam. That should probably wait for the macOS binary to be available though.