### PR TITLE
Fix for issue 853

### DIFF
--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -452,6 +452,7 @@ val pat_loc : 'a pat -> Parse_ast.l
 val mpat_loc : 'a mpat -> Parse_ast.l
 val exp_loc : 'a exp -> Parse_ast.l
 val nexp_loc : nexp -> Parse_ast.l
+val constraint_loc : n_constraint -> Parse_ast.l
 val def_loc : ('a, 'b) def -> Parse_ast.l
 
 (** {1 Printing utilities}

--- a/src/lib/flag.mli
+++ b/src/lib/flag.mli
@@ -46,6 +46,14 @@
 
 type t
 
-val create : ?prefix:string list -> ?hide_prefix:bool -> ?debug:bool -> ?hide:bool -> ?arg:string -> string -> t
+val create :
+  ?prefix:string list ->
+  ?hide_prefix:bool ->
+  ?debug:bool ->
+  ?hide:bool ->
+  ?arg:string ->
+  ?override:string ->
+  string ->
+  t
 
 val to_arg : t * Arg.spec * string -> Arg.key * Arg.spec * Arg.doc

--- a/src/lib/reporting.ml
+++ b/src/lib/reporting.ml
@@ -120,6 +120,11 @@ let rec simp_loc = function
   | Parse_ast.Hint (_, l1, l2) -> begin match simp_loc l1 with None -> simp_loc l2 | pos -> pos end
   | Parse_ast.Range (p1, p2) -> Some (p1, p2)
 
+let rec is_unknown_loc = function
+  | Parse_ast.Unknown -> true
+  | Parse_ast.Range _ -> false
+  | Parse_ast.Generated l | Parse_ast.Unique (_, l) | Parse_ast.Hint (_, _, l) -> is_unknown_loc l
+
 let loc_range_to_src (p1 : Lexing.position) (p2 : Lexing.position) =
   (fun contents -> String.sub contents p1.pos_cnum (p2.pos_cnum - p1.pos_cnum)) (Util.read_whole_file p1.pos_fname)
 

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -76,6 +76,10 @@ val loc_file : Parse_ast.l -> string option
 (** Reduce a location to a pair of positions if possible *)
 val simp_loc : Ast.l -> (Lexing.position * Lexing.position) option
 
+(** Returns true if a loc is [Unknown]. In the case of [Hint] location
+    only checks the base location. *)
+val is_unknown_loc : Ast.l -> bool
+
 (** [loc_range_to_src] returns the source code text of a range **)
 val loc_range_to_src : Lexing.position -> Lexing.position -> string
 

--- a/src/lib/type_error.ml
+++ b/src/lib/type_error.ml
@@ -370,8 +370,13 @@ let message_of_type_error type_error =
             ],
           None
         )
-    | Err_failed_constraint (check, locals, _, ncs) ->
+    | Err_failed_constraint (check, derived_from, locals, _, ncs) ->
         let simplified = constraint_simp check in
+        let add_derivation msg =
+          match derived_from with
+          | Some l -> Seq [msg; Line ""; Location ("constraint from ", Some "This type argument", l, Seq [])]
+          | None -> msg
+        in
         begin
           match simplified with
           | NC_aux (NC_false, _) ->
@@ -381,7 +386,10 @@ let message_of_type_error type_error =
                   ),
                 None
               )
-          | _ -> (Line ("Failed to prove constraint: " ^ string_of_n_constraint (constraint_simp check)), None)
+          | _ ->
+              ( Line ("Failed to prove constraint: " ^ string_of_n_constraint (constraint_simp check)) |> add_derivation,
+                None
+              )
         end
     | Err_subtype (typ1, typ2, nc, all_constraints, tyvars) ->
         let nc = Option.map constraint_simp nc in

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -72,7 +72,8 @@ type constraint_reason = (l * string) option
 type type_error =
   | Err_no_overloading of id * (id * Parse_ast.l * type_error) list
   | Err_unresolved_quants of id * quant_item list * (mut * typ) Bindings.t * type_variables * n_constraint list
-  | Err_failed_constraint of n_constraint * (mut * typ) Bindings.t * type_variables * n_constraint list
+  | Err_failed_constraint of
+      n_constraint * Parse_ast.l option * (mut * typ) Bindings.t * type_variables * n_constraint list
   | Err_subtype of typ * typ * n_constraint option * (constraint_reason * n_constraint) list * type_variables
   | Err_no_num_ident of id
   | Err_other of string

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -79,7 +79,8 @@ type type_variables = { vars : (Ast.l * kind_aux) KBindings.t; shadows : int KBi
 type type_error =
   | Err_no_overloading of id * (id * Parse_ast.l * type_error) list
   | Err_unresolved_quants of id * quant_item list * (mut * typ) Bindings.t * type_variables * n_constraint list
-  | Err_failed_constraint of n_constraint * (mut * typ) Bindings.t * type_variables * n_constraint list
+  | Err_failed_constraint of
+      n_constraint * Parse_ast.l option * (mut * typ) Bindings.t * type_variables * n_constraint list
   | Err_subtype of typ * typ * n_constraint option * (constraint_reason * n_constraint) list * type_variables
   | Err_no_num_ident of id
   | Err_other of string

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -124,7 +124,7 @@ let verilog_options =
         ),
       "Sail function to use as toplevel module"
     );
-    ( Flag.create ~prefix:["sv"] ~arg:"compile|run" "verilate",
+    ( Flag.create ~prefix:["sv"; "verilate"] ~arg:"compile|run" ~override:"sv_verilate" "mode",
       Arg.String
         (fun opt ->
           if opt = "run" then opt_verilate := Verilator_run
@@ -137,23 +137,23 @@ let verilog_options =
         ),
       "Invoke verilator on generated output"
     );
-    ( Flag.create ~prefix:["sv"] ~arg:"string" "verilate_args",
+    ( Flag.create ~prefix:["sv"; "verilate"] ~arg:"string" "args",
       Arg.String (fun s -> append_flag opt_verilate_args s),
       "Extra arguments to pass to verilator"
     );
-    ( Flag.create ~prefix:["sv"] ~arg:"string" "verilate_cflags",
+    ( Flag.create ~prefix:["sv"; "verilate"] ~arg:"string" "cflags",
       Arg.String (fun s -> append_flag opt_verilate_cflags s),
       "Verilator CFLAGS argument"
     );
-    ( Flag.create ~prefix:["sv"] ~arg:"string" "verilate_ldflags",
+    ( Flag.create ~prefix:["sv"; "verilate"] ~arg:"string" "ldflags",
       Arg.String (fun s -> append_flag opt_verilate_ldflags s),
       "Verilator LDFLAGS argument"
     );
-    ( Flag.create ~prefix:["sv"] "verilate_link_sail_runtime",
+    ( Flag.create ~prefix:["sv"; "verilate"] "link_sail_runtime",
       Arg.Set opt_verilate_link_sail_runtime,
       "Link the Sail C runtime with the generated verilator C++"
     );
-    ( Flag.create ~prefix:["sv"] ~arg:"n" "verilate_jobs",
+    ( Flag.create ~prefix:["sv"; "verilate"] ~arg:"n" "jobs",
       Arg.Int (fun i -> opt_verilate_jobs := i),
       "Provide the -j option to verilator"
     );

--- a/test/typecheck/fail/issue853.expect
+++ b/test/typecheck/fail/issue853.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/issue853.sail[0m:4.30-32:
+4[96m |[0mfunction foo(addr : bitvector(64)) -> unit = ()
+ [91m |[0m                              [91m^^[0m
+ [91m |[0m Failed to prove constraint: 32 == 64
+ [91m |[0m 
+ [91m |[0m constraint from [96mfail/issue853.sail[0m:2.20-22:
+ [91m |[0m 2[96m |[0mval foo : bitvector(32) -> unit
+ [91m |[0m  [91m |[0m                    [91m^^[0m [91mThis type argument[0m

--- a/test/typecheck/fail/issue853.sail
+++ b/test/typecheck/fail/issue853.sail
@@ -1,0 +1,4 @@
+
+val foo : bitvector(32) -> unit
+
+function foo(addr : bitvector(64)) -> unit = ()

--- a/test/typecheck/fail/issue853_2.expect
+++ b/test/typecheck/fail/issue853_2.expect
@@ -1,0 +1,9 @@
+[93mType error[0m:
+[96mfail/issue853_2.sail[0m:6.25-27:
+6[96m |[0mfunction foo(addr : bits(64)) -> unit = ()
+ [91m |[0m                         [91m^^[0m
+ [91m |[0m Failed to prove constraint: 32 == 64
+ [91m |[0m 
+ [91m |[0m constraint from [96mfail/issue853_2.sail[0m:4.20-22:
+ [91m |[0m 4[96m |[0mval foo : bitvector(32) -> unit
+ [91m |[0m  [91m |[0m                    [91m^^[0m [91mThis type argument[0m

--- a/test/typecheck/fail/issue853_2.sail
+++ b/test/typecheck/fail/issue853_2.sail
@@ -1,0 +1,6 @@
+
+type bits('n) = bitvector('n)
+
+val foo : bitvector(32) -> unit
+
+function foo(addr : bits(64)) -> unit = ()


### PR DESCRIPTION
Adds context to failed constraint type errors when checking type argument subtypes. To make this work we now ensure location information is correctly propagated through type synonym expansion (otherwise the new more precise errors could point at the synonym definition site).

Also includes some updates to Sail->SV argument parsing