### PR TITLE
Always generate the manifest

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -1,6 +1,6 @@
 (rule
  (target manifest.ml)
- (mode fallback)
+ (deps (universe))
  (action
   (with-outputs-to
    %{target}


### PR DESCRIPTION
This fixes an annoying issue where the `sail -version` output does not get correctly generated unless you manually delete `manifest.ml`. If you do not then Dune will see that `manifest.ml` already exists and assume it is up-to-date, which isn't the case if you've switch branch or commit since it was last generated.

This does mean that `sail_manifest` is always run, but it seems to be very fast so I don't think it's an issue.

Fixes #204