### PR TITLE
Make sure version number gets updated without having to run dune clean

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -1,4 +1,5 @@
 (rule
+ (deps (universe))
  (target manifest.ml)
  (mode fallback)
  (action


### PR DESCRIPTION
Adds `(deps (universe))` to the action that builds manifest.ml so it is always rebuilt (unless it was generated from manifest.ml.in by opam, as the action still has fallback mode).

Fixes #204, and based on PR #863
