### PR TITLE
feat(ci): add Lean testing in the CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,26 @@ jobs:
     - name: System dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -o Acquire::Retries=3 install build-essential libgmp-dev z3 cvc4 opam cargo verilator
+        sudo apt-get -o Acquire::Retries=3 install build-essential libgmp-dev z3 cvc4 opam cargo verilator git curl
+
+    - name: Install Lean version manager
+      run: |
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | bash -s -- -y
+
+    - name: Restore cached elan
+      id: cache-elan-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: ~/.elan
+        key: ${{ matrix.os }}-${{ matrix.version }}-cov
+
+    - name: Save cached elan
+      if: steps.cache-elan-restore.outputs.cache-hit != 'true'
+      id: cache-elan-save
+      uses: actions/cache/save@v3
+      with:
+        path: ~/.elan
+        key: ${{ steps.cache-elan-restore.outputs.cache-primary-key }}
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -69,6 +88,7 @@ jobs:
     - name: Test Sail
       run: |
         eval $(opam env)
+        export PATH="~/.elan/bin:$PATH"
         export SAIL_DIR=$(pwd)
         etc/ci_coverage_tests.sh
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,16 +23,17 @@ jobs:
         sudo apt-get update
         sudo apt-get -o Acquire::Retries=3 install build-essential libgmp-dev z3 cvc4 opam cargo verilator git curl
 
-    - name: Install Lean version manager
-      run: |
-        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | bash -s -- -y
-
     - name: Restore cached elan
       id: cache-elan-restore
       uses: actions/cache/restore@v3
       with:
         path: ~/.elan
-        key: ${{ matrix.os }}-${{ matrix.version }}-cov
+        key: ${{ matrix.os }}-${{ matrix.version }}-elan
+
+    - name: Install Lean version manager
+      if: steps.cache-elan-restore.outputs.cache-hit != 'true'
+      run: |
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | bash -s -- -y
 
     - name: Save cached elan
       if: steps.cache-elan-restore.outputs.cache-hit != 'true'
@@ -41,6 +42,10 @@ jobs:
       with:
         path: ~/.elan
         key: ${{ steps.cache-elan-restore.outputs.cache-primary-key }}
+
+    - name: Set elan path
+      run: |
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
     - name: Restore cached opam
       id: cache-opam-restore
@@ -62,7 +67,7 @@ jobs:
         path: ~/.opam
         key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
 
-    - name: Install Sail
+    - name: Install Sail dependencies
       run: |
         eval $(opam env)
         opam pin --yes --no-action add .
@@ -88,7 +93,6 @@ jobs:
     - name: Test Sail
       run: |
         eval $(opam env)
-        export PATH="~/.elan/bin:$PATH"
         export SAIL_DIR=$(pwd)
         etc/ci_coverage_tests.sh
 

--- a/sail
+++ b/sail
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SAIL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export SAIL_DIR

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -26,6 +26,7 @@ def test_lean():
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
+                step('rm -r {} || true'.format(basename))
                 step('mkdir -p {}'.format(basename))
                 step('\'{}\' {} --lean --lean-output-dir {}'.format(sail, filename, basename))
                 step('diff {}/out/Out.lean {}.expected.lean'.format(basename, basename))

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -29,6 +29,7 @@ def test_lean():
                 step('rm -r {} || true'.format(basename))
                 step('mkdir -p {}'.format(basename))
                 step('\'{}\' {} --lean --lean-output-dir {}'.format(sail, filename, basename))
+                step(f'lake --dir {basename}/out build')
                 step('diff {}/out/Out.lean {}.expected.lean'.format(basename, basename))
                 step('rm -r {}'.format(basename))
                 print_ok(filename)

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -26,7 +26,7 @@ def test_lean():
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('mkdir {}'.format(basename))
+                step('mkdir -p {}'.format(basename))
                 step('\'{}\' {} --lean --lean-output-dir {}'.format(sail, filename, basename))
                 step('diff {}/out/Out.lean {}.expected.lean'.format(basename, basename))
                 step('rm -r {}'.format(basename))


### PR DESCRIPTION
This ensures that all changes to the Lean backend are tested by recompiling the Lean files with Lean itself via the coverage CI entrypoint.

I'm not exactly sure if you are fine with the solution to install Lean, I have other options:

- Bring Nix and install elan via Nix and use the Nix store caching mechanism
- Remove caching for elan
- Your preferred solution

Let me know what you prefer and I will adapt this PR. Additionally, I have a Nix scaffolding setup (default/shell) which is quite popular for people working on that environment, if you are interested into me contributing it, please let me know. I can also take maintenance ownership on that if needed, obviously.

cc @javra 

Signed-off-by: Raito Bezarius <masterancpp@gmail.com>