### PR TITLE
Disable some nexp simplifications that confuse the Coq backend

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -692,7 +692,7 @@ let bit_typ = mk_id_typ (mk_id "bit")
 let real_typ = mk_id_typ (mk_id "real")
 let app_typ id args = mk_typ (Typ_app (id, args))
 let register_typ typ = mk_typ (Typ_app (mk_id "register", [mk_typ_arg (A_typ typ)]))
-let atom_typ nexp = mk_typ (Typ_app (mk_id "atom", [mk_typ_arg (A_nexp (nexp_simp nexp))]))
+let atom_typ nexp = mk_typ (Typ_app (mk_id "atom", [mk_typ_arg (A_nexp nexp)]))
 let implicit_typ nexp = mk_typ (Typ_app (mk_id "implicit", [mk_typ_arg (A_nexp (nexp_simp nexp))]))
 let range_typ nexp1 nexp2 =
   mk_typ (Typ_app (mk_id "range", [mk_typ_arg (A_nexp (nexp_simp nexp1)); mk_typ_arg (A_nexp (nexp_simp nexp2))]))

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -954,7 +954,7 @@ and expand_arg_synonyms env (A_aux (typ_arg, l)) =
   match typ_arg with
   | A_typ typ -> A_aux (A_typ (expand_synonyms env typ), l)
   | A_bool nc -> A_aux (A_bool (expand_constraint_synonyms env nc |> constraint_simp), l)
-  | A_nexp nexp -> A_aux (A_nexp (expand_nexp_synonyms env nexp |> nexp_simp), l)
+  | A_nexp nexp -> A_aux (A_nexp (expand_nexp_synonyms env nexp), l)
 
 and add_constraint ?(global = false) ?reason constr env =
   Well_formedness.wf_constraint Well_formedness.no_existential env constr;


### PR DESCRIPTION
Ideally we'd make the Coq backend derive enough information about how Coq/Rocq will type the output to detect when a cast is required, but for now we continue to use Sail's types as an approximation.