### PR TITLE
Lean: Fixing Lean style and wrong definition in Sail.lean

### DIFF
--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -144,7 +144,7 @@ val truncateLSB = pure {
   interpreter: "vector_truncateLSB",
   lem: "vector_truncateLSB",
   coq: "vector_truncateLSB",
-  lean: "Sail.BitVec.truncateLSB",
+  lean: "Sail.BitVec.truncateLsb",
   _: "sail_truncateLSB"
 } : forall 'm 'n, 'm >= 0 & 'm <= 'n. (bits('n), int('m)) -> bits('m)
 

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -1,19 +1,19 @@
 namespace Sail
 namespace BitVec
 
-def length {w: Nat} (_: BitVec w): Nat := w
+def length {w : Nat} (_ : BitVec w) : Nat := w
 
-def signExtend {w: Nat} (x: BitVec w) (w': Nat) : BitVec w' :=
+def signExtend {w : Nat} (x : BitVec w) (w' : Nat) : BitVec w' :=
   x.signExtend w'
 
-def zeroExtend {w: Nat} (x: BitVec w) (w': Nat) : BitVec w' :=
+def zeroExtend {w : Nat} (x : BitVec w) (w' : Nat) : BitVec w' :=
   x.zeroExtend w'
 
-def truncate {w: Nat} (x: BitVec w) (w': Nat) : BitVec w' :=
+def truncate {w : Nat} (x : BitVec w) (w' : Nat) : BitVec w' :=
   x.truncate w'
 
-def truncateLSB {w: Nat} (x: BitVec w) (w': Nat) : BitVec w' :=
-  x.extractLsb' 0 w'
+def truncateLsb {w : Nat} (x : BitVec w) (w' : Nat) : BitVec w' :=
+  x.extractLsb' (w-w') w'
 
 end BitVec
 end Sail

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -13,7 +13,7 @@ def truncate {w : Nat} (x : BitVec w) (w' : Nat) : BitVec w' :=
   x.truncate w'
 
 def truncateLsb {w : Nat} (x : BitVec w) (w' : Nat) : BitVec w' :=
-  x.extractLsb' (w-w') w'
+  x.extractLsb' (w - w') w'
 
 end BitVec
 end Sail

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -19,7 +19,7 @@ def bitvector_truncate (x : BitVec 32) : BitVec 16 :=
   (Sail.BitVec.truncate x 16)
 
 def bitvector_truncateLSB (x : BitVec 32) : BitVec 16 :=
-  (Sail.BitVec.truncateLSB x 16)
+  (Sail.BitVec.truncateLsb x 16)
 
 def bitvector_append (x : BitVec 16) (y : BitVec 16) : BitVec 32 :=
   (BitVec.append x y)


### PR DESCRIPTION
This fixes the style in Sail.lean (spaces before colons and camelCase function names) and fixes the definition of `truncateLsb` to actually extract the most significant bits.