### PR TITLE
Lean: Monadic lets and returns

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -299,7 +299,7 @@ let rec doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
   | E_app (Id_aux (Id "undefined_bitvector", _), _) (* TODO remove when we handle imports *)
   | E_app (Id_aux (Id "internal_pick", _), _) ->
       (* TODO replace by actual implementation of internal_pick *)
-      wrap_with_pure as_monadic (string "sorry")
+      string "sorry"
   | E_internal_plet _ -> string "sorry" (* TODO replace by actual implementation of internal_plet *)
   | E_app (f, args) ->
       let d_id =
@@ -310,7 +310,7 @@ let rec doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
       let fn_monadic = not (Effects.function_is_pure f ctx.global.effect_info) in
       nest 2 (wrap_with_pure (as_monadic && fn_monadic) (parens (flow (break 1) (d_id :: d_args))))
   | E_vector vals -> failwith "vector found"
-  | E_typ (typ, e) -> parens (separate space [doc_exp as_monadic ctx e; colon; doc_typ ctx typ])
+  | E_typ (typ, e) -> wrap_with_pure as_monadic (parens (separate space [doc_exp false ctx e; colon; doc_typ ctx typ]))
   | E_tuple es -> wrap_with_pure as_monadic (parens (separate_map (comma ^^ space) d_of_arg es))
   | E_let (LB_aux (LB_val (lpat, lexp), _), e) ->
       let id =

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -310,7 +310,10 @@ let rec doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
       let fn_monadic = not (Effects.function_is_pure f ctx.global.effect_info) in
       nest 2 (wrap_with_pure (as_monadic && fn_monadic) (parens (flow (break 1) (d_id :: d_args))))
   | E_vector vals -> failwith "vector found"
-  | E_typ (typ, e) -> wrap_with_pure as_monadic (parens (separate space [doc_exp false ctx e; colon; doc_typ ctx typ]))
+  | E_typ (typ, e) ->
+      if effectful (effect_of e) then
+        parens (separate space [doc_exp false ctx e; colon; string "SailM"; doc_typ ctx typ])
+      else wrap_with_pure as_monadic (parens (separate space [doc_exp false ctx e; colon; doc_typ ctx typ]))
   | E_tuple es -> wrap_with_pure as_monadic (parens (separate_map (comma ^^ space) d_of_arg es))
   | E_let (LB_aux (LB_val (lpat, lexp), _), e) ->
       let id =

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -274,10 +274,10 @@ let string_of_exp_con (E_aux (e, _)) =
   | E_let _ -> "E_let"
 
 let wrap_with_pure (needs_return : bool) (d : document) =
-  if needs_return then parens (nest 2 (flow (break 1) [string "pure"; d])) else d
+  if needs_return then parens (nest 2 (flow space [string "pure"; d])) else d
 
 let wrap_with_left_arrow (needs_return : bool) (d : document) =
-  if needs_return then parens (nest 2 (flow (break 1) [string "←"; d])) else d
+  if needs_return then parens (nest 2 (flow space [string "←"; d])) else d
 
 let rec doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
   let env = env_of_tannot annot in
@@ -327,7 +327,7 @@ let rec doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
   | E_internal_return e -> doc_exp false ctx e (* ??? *)
   | E_struct fexps ->
       let args = List.map d_of_field fexps in
-      wrap_with_pure as_monadic (braces (space ^^ nest 2 (separate hardline args) ^^ space))
+      wrap_with_pure as_monadic (braces (space ^^ align (separate hardline args) ^^ space))
   | E_field (exp, id) ->
       (* TODO *)
       wrap_with_pure as_monadic (doc_exp false ctx exp ^^ dot ^^ doc_id_ctor id)

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -9,7 +9,10 @@ open Rewriter
 open PPrint
 open Pretty_print_common
 
+type global_context = { effect_info : Effects.side_effect_info }
+
 type context = {
+  global : global_context;
   env : Type_check.env;
       (** The typechecking environment of the current function. This environment is reset using [initial_context] when
           we start processing a new function.  *)
@@ -18,7 +21,13 @@ type context = {
   kid_id_renames_rev : kid Bindings.t;  (** Inverse of the [kid_id_renames] mapping. *)
 }
 
-let initial_context env = { env; kid_id_renames = KBindings.empty; kid_id_renames_rev = Bindings.empty }
+let initial_context env =
+  {
+    global = { effect_info = Effects.empty_side_effect_info };
+    env;
+    kid_id_renames = KBindings.empty;
+    kid_id_renames_rev = Bindings.empty;
+  }
 
 let add_single_kid_id_rename ctx id kid =
   let kir =
@@ -264,24 +273,45 @@ let string_of_exp_con (E_aux (e, _)) =
   | E_vector _ -> "E_vector"
   | E_let _ -> "E_let"
 
-let rec doc_exp ctx (E_aux (e, (l, annot)) as full_exp) =
+let wrap_with_pure (needs_return : bool) (d : document) =
+  if needs_return then parens (nest 2 (flow (break 1) [string "pure"; d])) else d
+
+let wrap_with_left_arrow (needs_return : bool) (d : document) =
+  if needs_return then parens (nest 2 (flow (break 1) [string "←"; d])) else d
+
+let rec doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
   let env = env_of_tannot annot in
+  let d_of_arg arg =
+    let arg_monadic = effectful (effect_of arg) in
+    wrap_with_left_arrow arg_monadic (doc_exp arg_monadic ctx arg)
+  in
+  let d_of_field (FE_aux (FE_fexp (field, e), _) as fexp) =
+    let field_monadic = effectful (effect_of e) in
+    doc_fexp field_monadic ctx fexp
+  in
   match e with
-  | E_id id -> string (string_of_id id) (* TODO replace by a translating via a binding map *)
-  | E_lit l -> doc_lit l
+  | E_id id ->
+      (* TODO replace by a translating via a binding map *)
+      wrap_with_pure as_monadic (string (string_of_id id))
+  | E_lit l -> wrap_with_pure as_monadic (doc_lit l)
+  | E_app (Id_aux (Id "undefined_int", _), _) (* TODO remove when we handle imports *)
+  | E_app (Id_aux (Id "undefined_bit", _), _) (* TODO remove when we handle imports *)
+  | E_app (Id_aux (Id "undefined_bitvector", _), _) (* TODO remove when we handle imports *)
   | E_app (Id_aux (Id "internal_pick", _), _) ->
-      string "sorry" (* TODO replace by actual implementation of internal_pick *)
+      (* TODO replace by actual implementation of internal_pick *)
+      wrap_with_pure as_monadic (string "sorry")
   | E_internal_plet _ -> string "sorry" (* TODO replace by actual implementation of internal_plet *)
   | E_app (f, args) ->
       let d_id =
         if Env.is_extern f env "lean" then string (Env.get_extern f env "lean")
-        else doc_exp ctx (E_aux (E_id f, (l, annot)))
+        else doc_exp false ctx (E_aux (E_id f, (l, annot)))
       in
-      let d_args = List.map (doc_exp ctx) args in
-      nest 2 (parens (flow (break 1) (d_id :: d_args)))
+      let d_args = List.map d_of_arg args in
+      let fn_monadic = not (Effects.function_is_pure f ctx.global.effect_info) in
+      nest 2 (wrap_with_pure (as_monadic && fn_monadic) (parens (flow (break 1) (d_id :: d_args))))
   | E_vector vals -> failwith "vector found"
-  | E_typ (typ, e) -> parens (separate space [doc_exp ctx e; colon; doc_typ ctx typ])
-  | E_tuple es -> parens (separate_map (comma ^^ space) (doc_exp ctx) es)
+  | E_typ (typ, e) -> parens (separate space [doc_exp as_monadic ctx e; colon; doc_typ ctx typ])
+  | E_tuple es -> wrap_with_pure as_monadic (parens (separate_map (comma ^^ space) d_of_arg es))
   | E_let (LB_aux (LB_val (lpat, lexp), _), e) ->
       let id =
         match pat_is_plain_binder env lpat with
@@ -289,17 +319,27 @@ let rec doc_exp ctx (E_aux (e, (l, annot)) as full_exp) =
         | Some None -> "x" (* TODO fresh name or wildcard instead of x *)
         | _ -> failwith "Let pattern not translatable yet."
       in
-      nest 2 (flow (break 1) [string "let"; string id; coloneq; doc_exp ctx lexp]) ^^ hardline ^^ doc_exp ctx e
+      let decl_val =
+        if effectful (effect_of lexp) then [string "←"; string "do"; doc_exp true ctx lexp]
+        else [coloneq; doc_exp false ctx lexp]
+      in
+      nest 2 (flow (break 1) ([string "let"; string id] @ decl_val)) ^^ hardline ^^ doc_exp as_monadic ctx e
+  | E_internal_return e -> doc_exp false ctx e (* ??? *)
   | E_struct fexps ->
-      let args = List.map (doc_fexp ctx) fexps in
-      braces (space ^^ nest 2 (separate hardline args) ^^ space)
-  | E_field (exp, id) -> doc_exp ctx exp ^^ dot ^^ doc_id_ctor id
+      let args = List.map d_of_field fexps in
+      wrap_with_pure as_monadic (braces (space ^^ nest 2 (separate hardline args) ^^ space))
+  | E_field (exp, id) ->
+      (* TODO *)
+      wrap_with_pure as_monadic (doc_exp false ctx exp ^^ dot ^^ doc_id_ctor id)
   | E_struct_update (exp, fexps) ->
-      let args = List.map (doc_fexp ctx) fexps in
-      braces (space ^^ doc_exp ctx exp ^^ string " with " ^^ separate (comma ^^ space) args ^^ space)
+      let args = List.map d_of_field fexps in
+      (* TODO *)
+      wrap_with_pure as_monadic
+        (braces (space ^^ doc_exp false ctx exp ^^ string " with " ^^ separate (comma ^^ space) args ^^ space))
   | _ -> failwith ("Expression " ^ string_of_exp_con full_exp ^ " " ^ string_of_exp full_exp ^ " not translatable yet.")
 
-and doc_fexp ctx (FE_aux (FE_fexp (field, exp), _)) = doc_id_ctor field ^^ string " := " ^^ doc_exp ctx exp
+and doc_fexp with_arrow ctx (FE_aux (FE_fexp (field, e), _)) =
+  doc_id_ctor field ^^ string " := " ^^ wrap_with_left_arrow with_arrow (doc_exp false ctx e)
 
 let doc_binder ctx i t =
   let paranthesizer =
@@ -354,17 +394,14 @@ let doc_funcl_init (FCL_aux (FCL_funcl (id, pexp), annot)) =
   let decl_val = [doc_ret_typ; coloneq] in
   (* Add do block for stateful functions *)
   let decl_val = if is_monadic then decl_val @ [string "do"] else decl_val in
-  ( typ_quant_comment,
-    separate space ([string "def"; string (string_of_id id)] @ binders @ [colon; doc_ret_typ; coloneq]),
-    env
-  )
+  (typ_quant_comment, separate space ([string "def"; string (string_of_id id)] @ binders @ [colon] @ decl_val), env)
 
 let doc_funcl_body (FCL_aux (FCL_funcl (id, pexp), annot)) =
   let env = env_of_tannot (snd annot) in
   let ctx = initial_context env in
   let _, _, exp, _ = destruct_pexp pexp in
   let is_monadic = effectful (effect_of exp) in
-  if is_monadic then nest 2 (flow (break 1) [string "return"; doc_exp ctx exp]) else doc_exp ctx exp
+  doc_exp is_monadic ctx exp
 
 let doc_funcl ctx funcl =
   let comment, signature, env = doc_funcl_init funcl in

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -141,7 +141,7 @@ let lean_rewrites =
     ("attach_effects", []);
     ("remove_blocks", []);
     ("attach_effects", []);
-    ("letbind_effects", []);
+    (*("letbind_effects", []);*)
     ("remove_e_assign", []);
     ("attach_effects", []);
     ("internal_lets", []);

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -5,7 +5,7 @@ open Sail
 def cr_type := (BitVec 8)
 
 def undefined_cr_type (lit : Unit) : SailM (BitVec 8) := do
-  (pure sorry)
+  sorry
 
 def Mk_cr_type (v : (BitVec 8)) : (BitVec 8) :=
   v

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -4,8 +4,8 @@ open Sail
 
 def cr_type := (BitVec 8)
 
-def undefined_cr_type (lit : Unit) : SailM (BitVec 8) :=
-  return ((undefined_bitvector 8) : (BitVec 8))
+def undefined_cr_type (lit : Unit) : SailM (BitVec 8) := do
+  (pure sorry)
 
 def Mk_cr_type (v : (BitVec 8)) : (BitVec 8) :=
   v
@@ -16,8 +16,8 @@ def _get_cr_type_bits (v : (BitVec 8)) : (BitVec 8) :=
 def _update_cr_type_bits (v : (BitVec 8)) (x : (BitVec 8)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v (HSub.hSub 8 1) 0 x)
 
-def _set_cr_type_bits (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 8)) : SailM Unit :=
-  return sorry
+def _set_cr_type_bits (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 8)) : SailM Unit := do
+  sorry
 
 def _get_cr_type_CR0 (v : (BitVec 8)) : (BitVec 4) :=
   (Sail.BitVec.extractLsb v 7 4)
@@ -25,8 +25,8 @@ def _get_cr_type_CR0 (v : (BitVec 8)) : (BitVec 4) :=
 def _update_cr_type_CR0 (v : (BitVec 8)) (x : (BitVec 4)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 7 4 x)
 
-def _set_cr_type_CR0 (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 4)) : SailM Unit :=
-  return sorry
+def _set_cr_type_CR0 (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 4)) : SailM Unit := do
+  sorry
 
 def _get_cr_type_CR1 (v : (BitVec 8)) : (BitVec 2) :=
   (Sail.BitVec.extractLsb v 3 2)
@@ -34,8 +34,8 @@ def _get_cr_type_CR1 (v : (BitVec 8)) : (BitVec 2) :=
 def _update_cr_type_CR1 (v : (BitVec 8)) (x : (BitVec 2)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 3 2 x)
 
-def _set_cr_type_CR1 (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 2)) : SailM Unit :=
-  return sorry
+def _set_cr_type_CR1 (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 2)) : SailM Unit := do
+  sorry
 
 def _get_cr_type_CR3 (v : (BitVec 8)) : (BitVec 2) :=
   (Sail.BitVec.extractLsb v 1 0)
@@ -43,8 +43,8 @@ def _get_cr_type_CR3 (v : (BitVec 8)) : (BitVec 2) :=
 def _update_cr_type_CR3 (v : (BitVec 8)) (x : (BitVec 2)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 1 0 x)
 
-def _set_cr_type_CR3 (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 2)) : SailM Unit :=
-  return sorry
+def _set_cr_type_CR3 (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 2)) : SailM Unit := do
+  sorry
 
 def _get_cr_type_GT (v : (BitVec 8)) : (BitVec 1) :=
   (Sail.BitVec.extractLsb v 6 6)
@@ -52,8 +52,8 @@ def _get_cr_type_GT (v : (BitVec 8)) : (BitVec 1) :=
 def _update_cr_type_GT (v : (BitVec 8)) (x : (BitVec 1)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 6 6 x)
 
-def _set_cr_type_GT (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 1)) : SailM Unit :=
-  return sorry
+def _set_cr_type_GT (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 1)) : SailM Unit := do
+  sorry
 
 def _get_cr_type_LT (v : (BitVec 8)) : (BitVec 1) :=
   (Sail.BitVec.extractLsb v 7 7)
@@ -61,8 +61,8 @@ def _get_cr_type_LT (v : (BitVec 8)) : (BitVec 1) :=
 def _update_cr_type_LT (v : (BitVec 8)) (x : (BitVec 1)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 7 7 x)
 
-def _set_cr_type_LT (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 1)) : SailM Unit :=
-  return sorry
+def _set_cr_type_LT (r_ref : RegisterRef Unit Unit (BitVec 8)) (v : (BitVec 1)) : SailM Unit := do
+  sorry
 
 def initialize_registers : Unit :=
   ()

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -5,8 +5,8 @@ open Sail
 inductive E where | A | B | C
   deriving Inhabited
 
-def undefined_E : SailM E :=
-  return (sorry : E)
+def undefined_E : SailM E := do
+  (pure sorry)
 
 def initialize_registers : Unit :=
   ()

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -6,7 +6,7 @@ inductive E where | A | B | C
   deriving Inhabited
 
 def undefined_E : SailM E := do
-  (pure sorry)
+  sorry
 
 def initialize_registers : Unit :=
   ()

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -7,9 +7,8 @@ structure My_struct where
   field2 : (BitVec 1)
 
 def undefined_My_struct (lit : Unit) : SailM My_struct := do
-  (pure
-    { field1 := (← sorry)
-      field2 := (← sorry) })
+  (pure { field1 := (← sorry)
+          field2 := (← sorry) })
 
 def struct_field2 (s : My_struct) : (BitVec 1) :=
   s.field2

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -6,8 +6,10 @@ structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
 
-def undefined_My_struct (lit : Unit) : SailM My_struct :=
-  return sorry
+def undefined_My_struct (lit : Unit) : SailM My_struct := do
+  (pure
+    { field1 := (← sorry)
+      field2 := (← sorry) })
 
 def struct_field2 (s : My_struct) : (BitVec 1) :=
   s.field2

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -25,6 +25,9 @@ def mk_struct (i : Int) (b : (BitVec 1)) : My_struct :=
   { field1 := i
     field2 := b }
 
+def undef_struct (x : (BitVec 1)) : SailM My_struct := do
+  ((undefined_My_struct ()) : SailM My_struct)
+
 def initialize_registers : Unit :=
   ()
 

--- a/test/lean/struct.sail
+++ b/test/lean/struct.sail
@@ -29,3 +29,8 @@ function mk_struct(i, b) = {
     field2 = b
   }
 }
+
+val undef_struct : bit -> My_struct
+function undef_struct (x) = {
+  (undefined_My_struct(): My_struct)
+}

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -5,6 +5,9 @@ open Sail
 def tuple1 : (Int × Int × ((BitVec 2) × Unit)) :=
   (3, 5, ((0b10 : (BitVec 2)), ()))
 
+def tuple2 : SailM (Int × Int) := do
+  (pure ((← sorry), (← sorry)))
+
 def initialize_registers : Unit :=
   ()
 

--- a/test/lean/tuples.sail
+++ b/test/lean/tuples.sail
@@ -4,3 +4,7 @@ function tuple1() -> (int, int, (bitvector(2), unit)) = {
   return (3, 5, (0b10, ()))
 }
 
+function tuple2() -> (int, int) = {
+  return (undefined_int(), undefined_int())
+}
+


### PR DESCRIPTION
Translates
```
default Order dec

$include <prelude.sail>

struct My_struct = {
  field1 : int,
  field2 : bit,
}

val struct_field2 : My_struct -> bit
function struct_field2(s) = {
  s.field2
}

val struct_update_field2 : (My_struct, bit) -> My_struct
function struct_update_field2(s, b) = {
  { s with field2 = b }
}

val struct_update_both_fields : (My_struct, int, bit) -> My_struct
function struct_update_both_fields(s, i, b) = {
  { s with field1 = i, field2 = b }
}

val mk_struct : (int, bit) -> My_struct
function mk_struct(i, b) = {
  struct { 
    field1 = i,
    field2 = b
  }
}
```
to
```lean
import Out.Sail.Sail

open Sail

structure My_struct where
  field1 : Int
  field2 : (BitVec 1)

def undefined_My_struct (lit : Unit) : SailM My_struct := do
  (pure { field1 := (← sorry)
          field2 := (← sorry) })

def struct_field2 (s : My_struct) : (BitVec 1) :=
  s.field2

def struct_update_field2 (s : My_struct) (b : (BitVec 1)) : My_struct :=
  { s with field2 := b }

/-- Type quantifiers: i : Int -/
def struct_update_both_fields (s : My_struct) (i : Int) (b : (BitVec 1)) : My_struct :=
  { s with field1 := i, field2 := b }

/-- Type quantifiers: i : Int -/
def mk_struct (i : Int) (b : (BitVec 1)) : My_struct :=
  { field1 := i
    field2 := b }

def initialize_registers : Unit :=
  ()


```