### PR TITLE
Lean: translate union types

### DIFF
--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -1,0 +1,39 @@
+import Out.Sail.Sail
+
+open Sail
+
+structure rectangle where
+  width : Int
+  height : Int
+
+structure circle where
+  radius : Int
+
+inductive shape where
+  | Rectangle (_ : rectangle)
+  | Circle (_ : circle)
+
+open shape
+
+inductive my_option where
+  | MySome (_ : k_a)
+  | MyNone (_ : Unit)
+
+open my_option
+
+def undefined_rectangle (lit : Unit) : SailM rectangle := do
+  (pure { width := (← sorry)
+          height := (← sorry) })
+
+def undefined_circle (lit : Unit) : SailM circle := do
+  (pure { radius := (← sorry) })
+
+/-- Type quantifiers: k_a : Type -/
+def is_none (opt : my_option) : Bool :=
+  match opt with
+  | MySome _ => false
+  | MyNone () => true
+
+def initialize_registers : Unit :=
+  ()
+

--- a/test/lean/union.sail
+++ b/test/lean/union.sail
@@ -1,0 +1,24 @@
+struct rectangle = {
+    width : int,
+    height : int,
+}
+
+struct circle = { radius : int }
+
+union shape = {
+    Rectangle : rectangle,
+    Circle : circle,
+}
+
+union my_option('a: Type) = {
+  MySome : 'a,
+  MyNone : unit
+}
+
+val is_none : forall ('a : Type). my_option('a) -> bool
+
+function is_none opt = match opt {
+  MySome(_) => false,
+  MyNone()  => true
+}
+


### PR DESCRIPTION
Translates
```sail
struct rectangle = {
    width : int,
    height : int,
}

struct circle = { radius : int }

union shape = {
    Rectangle : rectangle,
    Circle : circle,
}

union my_option('a: Type) = {
  MySome : 'a,
  MyNone : unit
}

val is_none : forall ('a : Type). my_option('a) -> bool

function is_none opt = match opt {
  MySome(_) => false,
  MyNone()  => true
}
```
to
```lean
import Out.Sail.Sail

open Sail

structure rectangle where
  width : Int
  height : Int

structure circle where
  radius : Int

inductive shape where
  | Rectangle (_ : rectangle)
  | Circle (_ : circle)

open shape

inductive my_option where
  | MySome (_ : k_a)
  | MyNone (_ : Unit)

open my_option

def undefined_rectangle (lit : Unit) : SailM rectangle := do
  (pure { width := (← sorry)
          height := (← sorry) })

def undefined_circle (lit : Unit) : SailM circle := do
  (pure { radius := (← sorry) })

/-- Type quantifiers: k_a : Type -/
def is_none (opt : my_option) : Bool :=
  match opt with
  | MySome _ => false
  | MyNone () => true

def initialize_registers : Unit :=
  ()


```