### PR TITLE
Lean: Fixing calls to effectful functions

### DIFF
--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -190,15 +190,15 @@ let create_lake_project (out_name : string) default_sail_dir =
   output_string project_main "open Sail\n\n";
   project_main
 
-let output (out_name : string) env ast default_sail_dir =
+let output (out_name : string) env effect_info ast default_sail_dir =
   let project_main = create_lake_project out_name default_sail_dir in
   (* Uncomment for debug output of the Sail code after the rewrite passes *)
   (* Pretty_print_sail.output_ast stdout (Type_check.strip_ast ast); *)
-  Pretty_print_lean.pp_ast_lean env ast project_main;
+  Pretty_print_lean.pp_ast_lean env effect_info ast project_main;
   close_out project_main
 
 let lean_target out_name { default_sail_dir; ctx; ast; effect_info; env; _ } =
   let out_name = match out_name with Some f -> f | None -> "out" in
-  output out_name env ast default_sail_dir
+  output out_name env effect_info ast default_sail_dir
 
 let _ = Target.register ~name:"lean" ~options:lean_options ~rewrites:lean_rewrites ~asserts_termination:true lean_target

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -31,7 +31,7 @@ def _update_cr_type_bits (v : (BitVec 8)) (x : (BitVec 8)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v (HSub.hSub 8 1) 0 x)
 
 def _set_cr_type_bits (r_ref : RegisterRef RegisterType (BitVec 8)) (v : (BitVec 8)) : SailM Unit := do
-  let r ← (reg_deref r_ref)
+  let r := (← (reg_deref r_ref))
   writeRegRef r_ref (_update_cr_type_bits r v)
 
 def _get_cr_type_CR0 (v : (BitVec 8)) : (BitVec 4) :=
@@ -41,7 +41,7 @@ def _update_cr_type_CR0 (v : (BitVec 8)) (x : (BitVec 4)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 7 4 x)
 
 def _set_cr_type_CR0 (r_ref : RegisterRef RegisterType (BitVec 8)) (v : (BitVec 4)) : SailM Unit := do
-  let r ← (reg_deref r_ref)
+  let r := (← (reg_deref r_ref))
   writeRegRef r_ref (_update_cr_type_CR0 r v)
 
 def _get_cr_type_CR1 (v : (BitVec 8)) : (BitVec 2) :=
@@ -51,7 +51,7 @@ def _update_cr_type_CR1 (v : (BitVec 8)) (x : (BitVec 2)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 3 2 x)
 
 def _set_cr_type_CR1 (r_ref : RegisterRef RegisterType (BitVec 8)) (v : (BitVec 2)) : SailM Unit := do
-  let r ← (reg_deref r_ref)
+  let r := (← (reg_deref r_ref))
   writeRegRef r_ref (_update_cr_type_CR1 r v)
 
 def _get_cr_type_CR3 (v : (BitVec 8)) : (BitVec 2) :=
@@ -61,7 +61,7 @@ def _update_cr_type_CR3 (v : (BitVec 8)) (x : (BitVec 2)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 1 0 x)
 
 def _set_cr_type_CR3 (r_ref : RegisterRef RegisterType (BitVec 8)) (v : (BitVec 2)) : SailM Unit := do
-  let r ← (reg_deref r_ref)
+  let r := (← (reg_deref r_ref))
   writeRegRef r_ref (_update_cr_type_CR3 r v)
 
 def _get_cr_type_GT (v : (BitVec 8)) : (BitVec 1) :=
@@ -71,7 +71,7 @@ def _update_cr_type_GT (v : (BitVec 8)) (x : (BitVec 1)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 6 6 x)
 
 def _set_cr_type_GT (r_ref : RegisterRef RegisterType (BitVec 8)) (v : (BitVec 1)) : SailM Unit := do
-  let r ← (reg_deref r_ref)
+  let r := (← (reg_deref r_ref))
   writeRegRef r_ref (_update_cr_type_GT r v)
 
 def _get_cr_type_LT (v : (BitVec 8)) : (BitVec 1) :=
@@ -81,9 +81,9 @@ def _update_cr_type_LT (v : (BitVec 8)) (x : (BitVec 1)) : (BitVec 8) :=
   (Sail.BitVec.updateSubrange v 7 7 x)
 
 def _set_cr_type_LT (r_ref : RegisterRef RegisterType (BitVec 8)) (v : (BitVec 1)) : SailM Unit := do
-  let r ← (reg_deref r_ref)
+  let r := (← (reg_deref r_ref))
   writeRegRef r_ref (_update_cr_type_LT r v)
 
 def initialize_registers : SailM Unit := do
-  writeReg R (undefined_cr_type ())
+  writeReg R (← (undefined_cr_type ()))
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -6,6 +6,20 @@ structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
 
+inductive Register : Type where
+  | r
+  deriving DecidableEq, Hashable
+open Register
+
+abbrev RegisterType : Register → Type
+  | .r => My_struct
+
+abbrev SailM := PreSailM RegisterType
+
+open RegisterRef
+instance : Inhabited (RegisterRef RegisterType My_struct) where
+  default := .Reg r
+
 def undefined_My_struct (lit : Unit) : SailM My_struct := do
   (pure { field1 := (← sorry)
           field2 := (← sorry) })
@@ -28,6 +42,6 @@ def mk_struct (i : Int) (b : (BitVec 1)) : My_struct :=
 def undef_struct (x : (BitVec 1)) : SailM My_struct := do
   ((undefined_My_struct ()) : SailM My_struct)
 
-def initialize_registers : Unit :=
-  ()
+def initialize_registers : SailM Unit := do
+  writeReg r (← (undefined_My_struct ()))
 

--- a/test/lean/struct.sail
+++ b/test/lean/struct.sail
@@ -7,6 +7,8 @@ struct My_struct = {
   field2 : bit,
 }
 
+register r : My_struct
+
 val struct_field2 : My_struct -> bit
 function struct_field2(s) = {
   s.field2


### PR DESCRIPTION
This fixes the compilation of [bitfield](https://github.com/rems-project/sail/pull/920/files#diff-7cb00e75737f28ea57bf44e19cd8517ee3db1a548a4e661b332e3eecb817fb7fR88)
It also adds a register to `struct.sail` to have a SailM definition, so it also compiles to valid lean