### PR TITLE
Lean: add monad declaration in files without register use

### DIFF
--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def foo : Bool :=
   true
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -12,11 +12,10 @@ open Register
 abbrev RegisterType : Register → Type
   | .R => (BitVec 8)
 
-abbrev SailM := PreSailM RegisterType
-
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
   default := .Reg R
+abbrev SailM := PreSailM RegisterType
 
 def undefined_cr_type (lit : Unit) : SailM (BitVec 8) := do
   sorry

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def bitvector_eq (x : (BitVec 16)) (y : (BitVec 16)) : Bool :=
   (Eq x y)
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -6,6 +6,8 @@ inductive E where | A | B | C
   deriving Inhabited
 open E
 
+abbrev SailM := StateM Unit
+
 def undefined_E : SailM E := do
   sorry
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def extern_add : Int :=
   (Int.add 5 4)
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def extern_const : (BitVec 64) :=
   (0xFFFF000012340000 : (BitVec 64))
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -12,13 +12,12 @@ abbrev RegisterType : Register → Type
   | .B => Bool
   | .R => Nat
 
-abbrev SailM := PreSailM RegisterType
-
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType Bool) where
   default := .Reg B
 instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg R
+abbrev SailM := PreSailM RegisterType
 
 /-- Type quantifiers: n : Int, 0 ≤ n -/
 def elif (n : Nat) : (BitVec 1) :=

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def foo : (BitVec 16) :=
   let z := (HOr.hOr (0xFFFF : (BitVec 16)) (0xABCD : (BitVec 16)))
   (HAnd.hAnd (0x0000 : (BitVec 16)) z)

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -6,6 +6,8 @@ inductive E where | A | B | C
   deriving Inhabited
 open E
 
+abbrev SailM := StateM Unit
+
 def undefined_E : SailM E := do
   sorry
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 /-- Type quantifiers: x : Int, 0 ≤ x ∧ x ≤ 31 -/
 def f_int (x : Nat) : Int :=
   0

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -74,11 +74,10 @@ abbrev RegisterType : Register → Type
   | .R30 => (BitVec 64)
   | ._PC => (BitVec 64)
 
-abbrev SailM := PreSailM RegisterType
-
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
   default := .Reg _PC
+abbrev SailM := PreSailM RegisterType
 
 def GPRs : Vector (RegisterRef RegisterType (BitVec 64)) 31 :=
   #v[Reg R30, Reg R29, Reg R28, Reg R27, Reg R26, Reg R25, Reg R24, Reg R23, Reg R22, Reg R21,

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -20,8 +20,6 @@ abbrev RegisterType : Register → Type
   | .R1 => (BitVec 64)
   | .R0 => (BitVec 64)
 
-abbrev SailM := PreSailM RegisterType
-
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
   default := .Reg BIT
@@ -33,6 +31,7 @@ instance : Inhabited (RegisterRef RegisterType Int) where
   default := .Reg INT
 instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg NAT
+abbrev SailM := PreSailM RegisterType
 
 def test : SailM Int := do
   writeReg INT (HAdd.hAdd (← readReg INT) 1)

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -14,11 +14,10 @@ open Register
 abbrev RegisterType : Register → Type
   | .r => My_struct
 
-abbrev SailM := PreSailM RegisterType
-
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType My_struct) where
   default := .Reg r
+abbrev SailM := PreSailM RegisterType
 
 def undefined_My_struct (lit : Unit) : SailM My_struct := do
   (pure { field1 := (← sorry)

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -6,18 +6,7 @@ structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
 
-inductive Register : Type where
-  | r
-  deriving DecidableEq, Hashable
-open Register
-
-abbrev RegisterType : Register → Type
-  | .r => My_struct
-
-open RegisterRef
-instance : Inhabited (RegisterRef RegisterType My_struct) where
-  default := .Reg r
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := StateM Unit
 
 def undefined_My_struct (lit : Unit) : SailM My_struct := do
   (pure { field1 := (← sorry)
@@ -41,6 +30,6 @@ def mk_struct (i : Int) (b : (BitVec 1)) : My_struct :=
 def undef_struct (x : (BitVec 1)) : SailM My_struct := do
   ((undefined_My_struct ()) : SailM My_struct)
 
-def initialize_registers : SailM Unit := do
-  writeReg r (← (undefined_My_struct ()))
+def initialize_registers : Unit :=
+  ()
 

--- a/test/lean/struct.sail
+++ b/test/lean/struct.sail
@@ -7,8 +7,6 @@ struct My_struct = {
   field2 : bit,
 }
 
-register r : My_struct
-
 val struct_field2 : My_struct -> bit
 function struct_field2(s) = {
   s.field2

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def foo (y : Unit) : Unit :=
   y
 

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 def tuple1 : (Int × Int × ((BitVec 2) × Unit)) :=
   (3, 5, ((0b10 : (BitVec 2)), ()))
 

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 /-- Type quantifiers: k_a : Type -/
 def foo (x : k_a) : (k_a × k_a) :=
   (x, x)

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -8,6 +8,8 @@ abbrev xlen_bytes : Int := 8
 
 abbrev xlenbits := (BitVec 64)
 
+abbrev SailM := StateM Unit
+
 /-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
 def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
   (Sail.BitVec.zeroExtend v m)

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -2,6 +2,8 @@ import Out.Sail.Sail
 
 open Sail
 
+abbrev SailM := StateM Unit
+
 /-- Type quantifiers: n : Int -/
 def foo (n : Int) : (BitVec 4) :=
   (0xF : (BitVec 4))

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -21,6 +21,8 @@ inductive my_option where
 
 open my_option
 
+abbrev SailM := StateM Unit
+
 def undefined_rectangle (lit : Unit) : SailM rectangle := do
   (pure { width := (← sorry)
           height := (← sorry) })


### PR DESCRIPTION
Fixes missing monad declarations removed by #916.

Should fix #871 