### PR TITLE
Rewrite termination measures sooner

### DIFF
--- a/src/lib/callgraph.mli
+++ b/src/lib/callgraph.mli
@@ -96,3 +96,11 @@ val filter_ast_extra : Set.Make(Node).t -> callgraph -> ('a, 'b) ast -> bool -> 
 val top_sort_defs : Type_check.typed_ast -> Type_check.typed_ast
 
 val slice_instantiation_types : string -> Type_check.typed_ast -> Type_check.typed_ast
+
+(** Callgraph consisting *only* of calls, not other dependencies.  Doesn't rely on types. *)
+
+module FCG : sig
+  include Graph.S with type node = id and type node_set = IdSet.t and type graph = Graph.Make(Id).graph
+end
+
+val function_call_graph : ('a, 'b) Ast_defs.ast -> FCG.graph

--- a/src/sail_coq_backend/sail_plugin_coq.ml
+++ b/src/sail_coq_backend/sail_plugin_coq.ml
@@ -119,6 +119,7 @@ let coq_options =
 let coq_rewrites =
   let open Rewrites in
   [
+    ("move_termination_measures", []);
     ("instantiate_outcomes", [String_arg "coq"]);
     ("realize_mappings", []);
     ("remove_vector_subrange_pats", []);
@@ -151,7 +152,6 @@ let coq_rewrites =
           like this again, this is where it would go.
        ("prover_regstate", [Bool_arg true]);*)
     (* ("remove_assert", rewrite_ast_remove_assert); *)
-    ("move_termination_measures", []);
     ("top_sort_defs", []);
     ("const_prop_mutrec", [String_arg "coq"]);
     ("exp_lift_assign", []);

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -91,6 +91,7 @@ let lean_options =
 let lean_rewrites =
   let open Rewrites in
   [
+    ("move_termination_measures", []);
     ("instantiate_outcomes", [String_arg "coq"]);
     ("realize_mappings", []);
     ("remove_vector_subrange_pats", []);
@@ -121,7 +122,6 @@ let lean_rewrites =
        which has to be followed by type checking *)
     (* ("prover_regstate", [Bool_arg false]); *)
     (* ("remove_assert", rewrite_ast_remove_assert); *)
-    ("move_termination_measures", []);
     ("top_sort_defs", []);
     ("const_prop_mutrec", [String_arg "coq"]);
     ("exp_lift_assign", []);

--- a/src/sail_lem_backend/sail_plugin_lem.ml
+++ b/src/sail_lem_backend/sail_plugin_lem.ml
@@ -90,6 +90,7 @@ let lem_options =
 let lem_rewrites =
   let open Rewrites in
   [
+    ("move_termination_measures", []);
     ("instantiate_outcomes", [String_arg "lem"]);
     ("realize_mappings", []);
     ("remove_vector_subrange_pats", []);
@@ -127,7 +128,6 @@ let lem_rewrites =
     (* Put prover regstate generation after removing bitfield records,
        which has to be followed by type checking *)
     ("prover_regstate", [Flag_arg Monomorphise.opt_mwords]);
-    ("move_termination_measures", []);
     ("top_sort_defs", []);
     ("const_prop_mutrec", [String_arg "lem"]);
     ("vector_string_pats_to_bit_list", []);

--- a/test/coq/pass/move_measure.sail
+++ b/test/coq/pass/move_measure.sail
@@ -1,0 +1,24 @@
+default Order dec
+$include <prelude.sail>
+
+union foo = {
+  A : int,
+  B : nat,
+  C : bool,
+}
+
+function f(x : foo) -> int =
+  match x {
+    A(i) => i,
+    B(n) => f(A(n)),
+    C(b) => if b then 1 else 0,
+  }
+
+function f_measure(x : foo) -> int =
+  match x {
+    A(_) => 1,
+    B(_) => 2,
+    C(_) => 1,
+  }
+
+termination_measure f(x) = f_measure(x)


### PR DESCRIPTION
This used to happen after parsing, but now happens later in a rewrite. However, if it happens after other rewrites that rename variables, the measures might no longer type-check, so perform the measure rewrite as soon as possible.