### PR TITLE
Switch from Omd to Cmarkit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [4.08.1, 5.2.1]
+        version: [4.14.2, 5.2.1]
         os: [ubuntu-latest, macos-latest]
         exclude:
         - os: macos-latest
-          version: 4.08.1
+          version: 4.14.2
 
     runs-on: ${{ matrix.os }}
 

--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,7 @@
   (synopsis "Helper tool for compiling Sail")
   (name sail_manifest)
   (depends
-    (ocaml (>= 4.08.1))))
+    (ocaml (>= 4.14.0))))
 
 (package
   (sites (share plugins))
@@ -114,7 +114,7 @@ http://www.cl.cam.ac.uk/~pes20/sail/.
   (synopsis "Sail to LaTeX formatting")
   (depends
     (libsail (= :version))
-    (omd (and (>= 1.3.1) (< 1.4.0)))))
+    (cmarkit (>= 0.3.0))))
 
 (package
   (name sail_doc_backend)
@@ -122,7 +122,7 @@ http://www.cl.cam.ac.uk/~pes20/sail/.
   (depends
     (libsail (= :version))
     (base64 (>= 3.1.0))
-    (omd (and (>= 1.3.1) (< 1.4.0)))))
+    (cmarkit (>= 0.3.0))))
 
 (package
   (name sail)

--- a/language/sail.ott
+++ b/language/sail.ott
@@ -88,7 +88,7 @@ type extern = { pure : bool; bindings : (string * string) list } option
 type visibility = Public | Private of  l
 
 type 'a def_annot = {
-    doc_comment : string option;
+    doc_comment : (l * string) option;
     attrs : (l * string * config) list;
     visibility : visibility;
     loc : l;
@@ -124,7 +124,7 @@ type extern = <| pure : bool; bindings : list (string * string) |>
 type visibility = Public | Private of l
 
 type def_annot 'a = <|
-    doc_comment : maybe string;
+    doc_comment : maybe (l * string);
     attrs : list (l * string * maybe attribute_data);
     visibility : visibility;
     loc : l;

--- a/sail_doc_backend.opam
+++ b/sail_doc_backend.opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.0"}
   "libsail" {= version}
   "base64" {>= "3.1.0"}
-  "omd" {>= "1.3.1" & < "1.4.0"}
+  "cmarkit" {>= "0.3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/sail_latex_backend.opam
+++ b/sail_latex_backend.opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
   "dune" {>= "3.0"}
   "libsail" {= version}
-  "omd" {>= "1.3.1" & < "1.4.0"}
+  "cmarkit" {>= "0.3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/sail_manifest.opam
+++ b/sail_manifest.opam
@@ -20,7 +20,7 @@ homepage: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08.1"}
+  "ocaml" {>= "4.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -103,7 +103,12 @@ val get_attributes : uannot -> (l * string * attribute_data option) list
 val find_attribute_opt : string -> (l * string * attribute_data option) list -> (l * attribute_data option) option
 
 val mk_def_annot :
-  ?doc:string -> ?attrs:(l * string * attribute_data option) list -> ?visibility:visibility -> l -> 'a -> 'a def_annot
+  ?doc:l * string ->
+  ?attrs:(l * string * attribute_data option) list ->
+  ?visibility:visibility ->
+  l ->
+  'a ->
+  'a def_annot
 
 val uannot_of_def_annot : 'a def_annot -> uannot
 

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1065,7 +1065,7 @@ module ConvertType = struct
     | P.Tu_aux (P.Tu_doc (doc_comment, tu), l) -> begin
         match doc with
         | Some _ -> raise (Reporting.err_general l "Union constructor has multiple documentation comments")
-        | None -> to_ast_type_union kenv (Some doc_comment) attrs vis ctx tu
+        | None -> to_ast_type_union kenv (Some (l, doc_comment)) attrs vis ctx tu
       end
     | P.Tu_aux (P.Tu_attribute (attr, arg, tu), l) -> to_ast_type_union kenv doc (attrs @ [(l, attr, arg)]) vis ctx tu
     | P.Tu_aux (P.Tu_ty_id (atyp, id), l) ->
@@ -1743,7 +1743,7 @@ let rec to_ast_funcl doc attrs ctx (P.FCL_aux (fcl, l) : P.funcl) : uannot funcl
   | P.FCL_doc (doc_comment, fcl) -> begin
       match doc with
       | Some _ -> raise (Reporting.err_general l "Function clause has multiple documentation comments")
-      | None -> to_ast_funcl (Some doc_comment) attrs ctx fcl
+      | None -> to_ast_funcl (Some (l, doc_comment)) attrs ctx fcl
     end
   | P.FCL_funcl (id, pexp) ->
       let id = to_ast_id ctx id in
@@ -1813,7 +1813,7 @@ let rec to_ast_mapcl doc attrs ctx (P.MCL_aux (mapcl, l)) =
   | P.MCL_doc (doc_comment, mcl) -> begin
       match doc with
       | Some _ -> raise (Reporting.err_general l "Function clause has multiple documentation comments")
-      | None -> to_ast_mapcl (Some doc_comment) attrs ctx mcl
+      | None -> to_ast_mapcl (Some (l, doc_comment)) attrs ctx mcl
     end
   | P.MCL_bidir (mpexp1, mpexp2) ->
       MCL_aux
@@ -1935,7 +1935,7 @@ let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : untyped_def list ctx
   | P.DEF_doc (doc_comment, def) -> begin
       match doc with
       | Some _ -> raise (Reporting.err_general l "Toplevel definition has multiple documentation comments")
-      | None -> to_ast_def (Some doc_comment) attrs vis ctx def
+      | None -> to_ast_def (Some (l, doc_comment)) attrs vis ctx def
     end
   | P.DEF_overload (id, ids) -> ([DEF_aux (DEF_overload (to_ast_id ctx id, List.map (to_ast_id ctx) ids), annot)], ctx)
   | P.DEF_fixity (prec, n, op) ->

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -67,7 +67,10 @@ module Printer (Config : PRINT_CONFIG) = struct
   let doc_attr attr arg = string (string_of_attribute attr arg) ^^ space
 
   let doc_def_annot def_annot =
-    (match def_annot.doc_comment with Some str -> string "/*!" ^^ string str ^^ string "*/" ^^ hardline | _ -> empty)
+    ( match def_annot.doc_comment with
+    | Some (_, str) -> string "/*!" ^^ string str ^^ string "*/" ^^ hardline
+    | _ -> empty
+    )
     ^^ ( match def_annot.attrs with
        | [] -> empty
        | attrs -> separate_map hardline (fun (_, attr, arg) -> doc_attr attr arg) attrs ^^ hardline

--- a/src/sail_doc_backend/docinfo.ml
+++ b/src/sail_doc_backend/docinfo.ml
@@ -436,8 +436,8 @@ module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) = struct
 
   let get_doc_comment def_annot =
     Option.map
-      (fun comment ->
-        let conf = Converter.default_config ~loc:def_annot.loc in
+      (fun (l, comment) ->
+        let conf = Converter.default_config ~loc:l in
         Converter.convert conf comment
       )
       def_annot.doc_comment
@@ -697,7 +697,10 @@ module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) = struct
           | DEF_pragma ("anchor", arg, _) ->
               let links = hyperlinks files def in
               let anchor_info =
-                { source = doc_loc l Type_check.strip_def Reformatter.doc_def def; comment = def_annot.doc_comment }
+                {
+                  source = doc_loc l Type_check.strip_def Reformatter.doc_def def;
+                  comment = Option.map snd def_annot.doc_comment;
+                }
               in
               anchored := Bindings.add (mk_id arg) (anchor_info, links) !anchored
           | _ -> ()

--- a/src/sail_doc_backend/dune
+++ b/src/sail_doc_backend/dune
@@ -4,8 +4,8 @@
   (native plugin)
   (byte plugin))
  (link_flags -linkall)
- (libraries libsail omd yojson base64)
- (embed_in_plugin_libraries omd base64))
+ (libraries libsail cmarkit yojson base64)
+ (embed_in_plugin_libraries cmarkit base64))
 
 (install
  (section

--- a/src/sail_doc_backend/markdown.ml
+++ b/src/sail_doc_backend/markdown.ml
@@ -64,35 +64,92 @@ end
 
 module AsciidocConverter : CONVERTER = struct
   open Printf
-  open Omd
+  open Cmarkit
 
   type config = { this : Ast.id option; loc : Parse_ast.l; list_depth : int }
 
   let default_config ~loc = { this = None; loc; list_depth = 1 }
 
-  let rec format_elem (conf : config) = function
-    | Paragraph elems -> format conf elems ^ "\n\n"
-    | Text str -> str
-    | Emph elems -> sprintf "_%s_" (format conf elems)
-    | Bold elems -> sprintf "*%s*" (format conf elems)
-    | Code (_, code) -> sprintf "`%s`" code
-    | Code_block (lang, code) -> sprintf "[source,%s]\n----\n%s\n----\n\n" lang code
-    | Br -> "\n"
-    | NL -> "\n"
-    | H1 header -> "= " ^ format conf header ^ "\n"
-    | H2 header -> "== " ^ format conf header ^ "\n"
-    | H3 header -> "=== " ^ format conf header ^ "\n"
-    | H4 header -> "==== " ^ format conf header ^ "\n"
-    | Ul list | Ulp list ->
-        Util.string_of_list ""
-          (fun item ->
-            let new_conf = { conf with list_depth = conf.list_depth + 1 } in
-            "\n" ^ String.make conf.list_depth '*' ^ " " ^ format new_conf item
-          )
-          list
-    | _ -> raise (Reporting.err_general conf.loc "Cannot convert markdown element to Asciidoc")
+  let comment_loc l offset =
+    let open Lexing in
+    match Reporting.simp_loc l with
+    | Some (s, _) ->
+        let s = Reporting.Position.advance_position ~trim:false "/*!" s in
+        let start_line, start_bol = Textloc.first_line offset in
+        let start_cnum = Textloc.first_byte offset in
+        let start_bol_offset = if start_line <> 1 then s.pos_cnum - s.pos_bol else 0 in
+        let end_line, end_bol = Textloc.last_line offset in
+        let end_cnum = Textloc.last_byte offset in
+        let end_bol_offset = if end_line <> 1 then s.pos_cnum - s.pos_bol else 0 in
+        print_endline (Printf.sprintf "%d %d %d" start_line start_bol start_cnum);
+        let sc =
+          {
+            s with
+            pos_lnum = s.pos_lnum + start_line - 1;
+            pos_bol = s.pos_bol + start_bol + start_bol_offset;
+            pos_cnum = s.pos_cnum + start_cnum;
+          }
+        in
+        let ec =
+          {
+            s with
+            pos_lnum = s.pos_lnum + end_line - 1;
+            pos_bol = s.pos_bol + end_bol + end_bol_offset;
+            pos_cnum = s.pos_cnum + end_cnum + 1;
+          }
+        in
+        Parse_ast.Range (sc, ec)
+    | None -> Parse_ast.Unknown
 
-  and format conf elems = String.concat "" (List.map (format_elem conf) elems)
+  let rec format_block buf conf = function
+    | Block.Blocks (blocks, _) -> List.iter (format_block buf conf) blocks
+    | Block.Paragraph (para, _) ->
+        format_inline buf conf (Block.Paragraph.inline para);
+        Buffer.add_string buf "\n"
+    | Block.Blank_line _ -> Buffer.add_string buf "\n"
+    | Block.Code_block (cb, _) -> (
+        let code = Block.Code_block.code cb |> List.map Block_line.to_string |> String.concat "\n" in
+        match Block.Code_block.info_string cb with
+        | None -> ksprintf (Buffer.add_string buf) "----\n%s\n----\n" code
+        | Some (lang, _) -> ksprintf (Buffer.add_string buf) "[source,%s]\n----\n%s\n----\n" lang code
+      )
+    | Block.Heading (h, _) ->
+        let equals = String.make (Block.Heading.level h) '=' in
+        Buffer.add_string buf equals;
+        Buffer.add_char buf ' ';
+        format_inline buf conf (Block.Heading.inline h);
+        Buffer.add_char buf '\n'
+    | Block.Block_quote (bq, _) ->
+        Buffer.add_string buf "[quote]\n----\n";
+        format_block buf conf (Block.Block_quote.block bq);
+        Buffer.add_string buf "\n----\n"
+    | b ->
+        let offset = Block.meta b |> Meta.textloc in
+        let l = comment_loc conf.loc offset in
+        raise (Reporting.err_general l "Cannot convert markdown block to Asciidoc")
 
-  let convert conf comment = format conf (Omd.of_string comment)
+  and format_inline buf conf = function
+    | Inline.Text (str, _) -> Buffer.add_string buf str
+    | Inline.Break _ -> Buffer.add_char buf '\n'
+    | Inline.Code_span (c, _) -> ksprintf (Buffer.add_string buf) "`%s`" (Inline.Code_span.code c)
+    | Inline.Emphasis (emph, _) ->
+        Buffer.add_char buf '_';
+        format_inline buf conf (Inline.Emphasis.inline emph);
+        Buffer.add_char buf '_'
+    | Inline.Strong_emphasis (emph, _) ->
+        Buffer.add_char buf '*';
+        format_inline buf conf (Inline.Emphasis.inline emph);
+        Buffer.add_char buf '*'
+    | Inline.Inlines (inlines, _) -> List.iter (format_inline buf conf) inlines
+    | i ->
+        let offset = Inline.meta i |> Meta.textloc in
+        let l = comment_loc conf.loc offset in
+        raise (Reporting.err_general l "Cannot convert inline markdown element to Asciidoc")
+
+  and format conf doc =
+    let buf = Buffer.create 1024 in
+    format_block buf conf (Doc.block doc);
+    Buffer.contents buf
+
+  let convert conf comment = format conf (Doc.of_string ~strict:true ~locs:true comment)
 end

--- a/src/sail_latex_backend/dune
+++ b/src/sail_latex_backend/dune
@@ -12,8 +12,8 @@
   (native plugin)
   (byte plugin))
  (link_flags -linkall)
- (libraries libsail omd)
- (embed_in_plugin_libraries omd))
+ (libraries libsail cmarkit)
+ (embed_in_plugin_libraries cmarkit))
 
 (install
  (section

--- a/src/sail_latex_backend/latex.ml
+++ b/src/sail_latex_backend/latex.ml
@@ -241,62 +241,157 @@ let replace_this str =
       |> Str.global_replace (Str.regexp_string "THIS") (inline_code (string_of_id id))
   | None -> str
 
-let latex_of_markdown str =
-  let open Omd in
+let latex_of_markdown l str =
+  let open Cmarkit in
   let open Printf in
-  let rec format_elem = function
-    | Paragraph elems ->
-        let prepend =
-          if state.noindent then (
-            state.noindent <- false;
-            "\\noindent "
-          )
-          else ""
+  let sail_link = Cmarkit.Meta.key () in
+
+  let comment_loc l offset =
+    let open Lexing in
+    match Reporting.simp_loc l with
+    | Some (s, _) ->
+        let s = Reporting.Position.advance_position ~trim:false "/*!" s in
+        let start_line, start_bol = Textloc.first_line offset in
+        let start_cnum = Textloc.first_byte offset in
+        let start_bol_offset = if start_line <> 1 then s.pos_cnum - s.pos_bol else 0 in
+        let end_line, end_bol = Textloc.last_line offset in
+        let end_cnum = Textloc.last_byte offset in
+        let end_bol_offset = if end_line <> 1 then s.pos_cnum - s.pos_bol else 0 in
+        print_endline (Printf.sprintf "%d %d %d" start_line start_bol start_cnum);
+        let sc =
+          {
+            s with
+            pos_lnum = s.pos_lnum + start_line - 1;
+            pos_bol = s.pos_bol + start_bol + start_bol_offset;
+            pos_cnum = s.pos_cnum + start_cnum;
+          }
         in
-        prepend ^ format elems ^ "\n\n"
-    | Text str -> text_code str
-    | Emph elems -> sprintf "\\emph{%s}" (format elems)
-    | Bold elems -> sprintf "\\textbf{%s}" (format elems)
-    | Ref (r, "THIS", alt, _) -> begin
-        match state.this with
-        | Some id -> sprintf "\\hyperref[%s]{%s}" (refcode_id id) (replace_this alt)
-        | None -> failwith "Cannot create link to THIS"
-      end
-    | Ref (r, name, alt, _) ->
-        (* special case for [id] (format as code) *)
-        let format_fn = if name = alt then inline_code else replace_this in
-        (* Do not attempt to escape link destinations wrapped in <> *)
-        if Str.string_match (Str.regexp "<.+>") name 0 then
-          sprintf "\\hyperref[%s]{%s}" (String.sub name 1 (String.length name - 2)) (format_fn alt)
-        else begin
-          match r#get_ref name with
-          | None -> sprintf "\\hyperref[%s]{%s}" (refcode_string name) (format_fn alt)
-          | Some (link, _) -> sprintf "\\hyperref[%s]{%s}" (refcode_string link) (format_fn alt)
-        end
-    | Url (href, text, "") -> sprintf "\\href{%s}{%s}" href (format text)
-    | Url (href, text, reference) -> sprintf "%s\\footnote{%s~\\url{%s}}" (format text) reference href
-    | Code (_, code) -> sprintf "\\lstinline`%s`" code
-    | Code_block (lang, code) ->
-        let lang = if lang = "" then "sail" else lang in
+        let ec =
+          {
+            s with
+            pos_lnum = s.pos_lnum + end_line - 1;
+            pos_bol = s.pos_bol + end_bol + end_bol_offset;
+            pos_cnum = s.pos_cnum + end_cnum + 1;
+          }
+        in
+        Parse_ast.Range (sc, ec)
+    | None -> Parse_ast.Unknown
+  in
+
+  let rec format_block buf defs = function
+    | Block.Blocks (blocks, _) -> List.iter (format_block buf defs) blocks
+    | Block.Paragraph (para, _) ->
+        if state.noindent then (
+          state.noindent <- false;
+          Buffer.add_string buf "\\noindent "
+        );
+        format_inline buf defs (Block.Paragraph.inline para);
+        Buffer.add_string buf "\n"
+    | Block.Blank_line _ -> Buffer.add_string buf "\n"
+    | Block.Code_block (cb, _) ->
+        let code = Block.Code_block.code cb |> List.map Block_line.to_string |> String.concat "\n" in
+        let lang = match Block.Code_block.info_string cb with None -> "sail" | Some (lang, _) -> lang in
         let uid = Digest.string str |> Digest.to_hex in
         let chan = open_out (Filename.concat !opt_directory (sprintf "block%s.%s" uid lang)) in
         output_string chan code;
         close_out chan;
-        sprintf "\\lstinputlisting[language=%s]{%s/block%s.%s}" lang !opt_directory uid lang
-    | Ul list | Ulp list ->
-        "\\begin{itemize}\n\\item " ^ Util.string_of_list "\n\\item " format list ^ "\n\\end{itemize}\n"
-    | Ol list | Olp list ->
-        "\\begin{enumerate}\n\\item " ^ Util.string_of_list "\n\\item " format list ^ "\n\\end{enumerate}\n"
-    | H1 header -> "\\section*{" ^ format header ^ "}\n"
-    | H2 header -> "\\subsection*{" ^ format header ^ "}\n"
-    | H3 header -> "\\subsubsection*{" ^ format header ^ "}\n"
-    | H4 header -> "\\paragraph*{" ^ format header ^ "}\n"
-    | Br -> "\n"
-    | NL -> "\n"
-    | elem -> failwith ("Can't convert to latex: " ^ Omd_backend.sexpr_of_md [elem])
-  and format elems = String.concat "" (List.map format_elem elems) in
+        ksprintf (Buffer.add_string buf) "\\lstinputlisting[language=%s]{%s/block%s.%s}" lang !opt_directory uid lang
+    | Block.Heading (h, _) ->
+        let l = Block.Heading.level h in
+        (match l with 1 -> "\\section*{" | 2 -> "\\subsection*{" | 3 -> "\\subsubsection*{" | _ -> "\\paragraph*{")
+        |> Buffer.add_string buf;
+        format_inline buf defs (Block.Heading.inline h);
+        Buffer.add_string buf "\\n"
+    | Block.Block_quote (bq, _) ->
+        Buffer.add_string buf "\\begin{quote}\n";
+        format_block buf defs (Block.Block_quote.block bq);
+        Buffer.add_string buf "\\end{quote}\n"
+    | Block.List (list, _) ->
+        let list_type = match Block.List'.type' list with `Unordered _ -> "itemize" | `Ordered _ -> "enumerate" in
+        ksprintf (Buffer.add_string buf) "\\begin{%s}\n" list_type;
+        List.iter
+          (fun (item, _) ->
+            Buffer.add_string buf "\\item ";
+            format_block buf defs (Block.List_item.block item)
+          )
+          (Block.List'.items list);
+        ksprintf (Buffer.add_string buf) "\\end{%s}\n" list_type
+    | Block.Link_reference_definition _ -> ()
+    | b ->
+        let offset = Block.meta b |> Meta.textloc in
+        let l = comment_loc l offset in
+        raise (Reporting.err_general l "Cannot convert markdown block to Latex")
+  and format_inline buf defs = function
+    | Inline.Text (str, _) -> Buffer.add_string buf str
+    | Inline.Break _ -> Buffer.add_char buf '\n'
+    | Inline.Code_span (c, _) -> ksprintf (Buffer.add_string buf) "\\lstinline`%s`" (Inline.Code_span.code c)
+    | Inline.Emphasis (emph, _) ->
+        Buffer.add_string buf "\\emph{";
+        format_inline buf defs (Inline.Emphasis.inline emph);
+        Buffer.add_string buf "}"
+    | Inline.Strong_emphasis (emph, _) ->
+        Buffer.add_string buf "\\textbf{";
+        format_inline buf defs (Inline.Emphasis.inline emph);
+        Buffer.add_string buf "}"
+    | Inline.Inlines (inlines, _) -> List.iter (format_inline buf defs) inlines
+    | Inline.Link (link, meta) -> (
+        let text = Inline.Link.text link in
+        let rendered =
+          let buf = Buffer.create 64 in
+          format_inline buf defs text;
+          Buffer.contents buf
+        in
+        match Inline.Link.reference link with
+        | `Inline (ld, _) -> (
+            let has_label = Option.is_some (Link_definition.label ld) in
+            match Link_definition.dest ld with
+            | Some (dest, _) ->
+                if has_label then ksprintf (Buffer.add_string buf) "\\href{%s}{%s}" dest rendered
+                else ksprintf (Buffer.add_string buf) "\\href{%s}{\\url{%s}}" dest dest
+            | None ->
+                let offset = Meta.textloc meta in
+                let l = comment_loc l offset in
+                raise (Reporting.err_general l "Markdown link with no destination")
+          )
+        | `Ref (_, _, referenced) ->
+            let to_sail = Option.is_some (Meta.find sail_link (Label.meta referenced)) in
+            let name = Label.text_to_string referenced in
+            if to_sail then
+              ksprintf (Buffer.add_string buf) "\\hyperref[%s]{%s}" (refcode_string name) (inline_code rendered)
+            else (
+              match Inline.Link.reference_definition defs link with
+              | Some (Link_definition.Def (ld, _)) ->
+                  let dest = Link_definition.dest ld |> Option.map fst |> Option.value ~default:"" in
+                  ksprintf (Buffer.add_string buf) "\\href{%s}{%s}" dest rendered
+              | _ -> ()
+            )
+      )
+    | Inline.Autolink (link, _) ->
+        let str, _ = Inline.Autolink.link link in
+        Buffer.add_string buf str
+    | i ->
+        let offset = Inline.meta i |> Meta.textloc in
+        let l = comment_loc l offset in
+        raise (Reporting.err_general l "Cannot convert inline markdown element to Latex")
+  and format doc =
+    let buf = Buffer.create 1024 in
+    let defs = Doc.defs doc in
+    format_block buf defs (Doc.block doc);
+    Buffer.contents buf
+  in
 
-  replace_this (format (of_string str))
+  let make_sail_link label =
+    let meta = Cmarkit.Meta.tag sail_link (Cmarkit.Label.meta label) in
+    Cmarkit.Label.with_meta meta label
+  in
+
+  let with_sail_links = function
+    | `Def _ as ctx -> Cmarkit.Label.default_resolver ctx
+    | `Ref (_, _, (Some _ as def)) -> def
+    | `Ref (_, ref, None) -> Some (make_sail_link ref)
+  in
+
+  replace_this (format (Doc.of_string ~resolver:with_sail_links ~strict:true ~locs:true str))
 
 let add_links str =
   let r = Str.regexp {|\([a-zA-Z0-9_]+\)\([ ]*\)(|} in
@@ -393,7 +488,7 @@ let latex_command ~docstring cat id no_loc l =
   end
 
 let latex_docstring (def_annot : 'a Ast.def_annot) =
-  match def_annot.doc_comment with Some contents -> string (latex_of_markdown contents) | None -> empty
+  match def_annot.doc_comment with Some (l, contents) -> string (latex_of_markdown l contents) | None -> empty
 
 let latex_funcls def =
   let module StringMap = Map.Make (String) in
@@ -445,7 +540,7 @@ let process_pragma l command =
   | "newcommand" ->
       let n = try String.index arg ' ' with Not_found -> failwith "No command given" in
       let name = Str.string_before arg n in
-      let body = String.trim (latex_of_markdown (Str.string_after arg n)) in
+      let body = String.trim (latex_of_markdown l (Str.string_after arg n)) in
       Some (ksprintf string "\\newcommand{\\%s}{%s}" name body)
   | _ ->
       Reporting.warn "Bad latex pragma at" l "";


### PR DESCRIPTION
We've been stuck on Omd 1 for a long time. While we could upgrade to the newer Omd version, it does not seem very actively maintained, and since we'd have to rewrite all our code using it anyway it seems like a good opportunity to switch to the newer Cmarkit library which has some nice additional features and sticks closely to the CommonMark spec.

A best effort attempt has been made to preserve `sail --doc` and `sail --latex` features, but there may be small changes in functionality and appearance.

This does require increasing our minimum OCaml version to 4.14+, but that might be overdue at this point (and we might also just want to require OCaml 5 soon anyway).
