### PR TITLE
Lean: translate type parameters of record types

### DIFF
--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -52,7 +52,7 @@ def bitvector_unsigned (x : (BitVec 16)) : Nat :=
 def bitvector_signed (x : (BitVec 16)) : Int :=
   (BitVec.toInt x)
 
-/-- Type quantifiers: i : Int, 0 ≤ i ∧ i ≤ 15 -/
+/-- Type quantifiers: i : Nat, 0 ≤ i ∧ i ≤ 15 -/
 def bitvector_access' (x : (BitVec 16)) (i : Nat) : (BitVec 1) :=
   (BitVec.access x i)
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -12,7 +12,7 @@ abbrev SailM := StateM Unit
 def undefined_E (lit : Unit) : SailM E := do
   sorry
 
-/-- Type quantifiers: arg_ : Int, 0 ≤ arg_ ∧ arg_ ≤ 2 -/
+/-- Type quantifiers: arg_ : Nat, 0 ≤ arg_ ∧ arg_ ≤ 2 -/
 def E_of_num (arg_ : Nat) : E :=
   match arg_ with
   | 0 => A

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -19,7 +19,7 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg R
 abbrev SailM := PreSailM RegisterType
 
-/-- Type quantifiers: n : Int, 0 ≤ n -/
+/-- Type quantifiers: n : Nat, 0 ≤ n -/
 def elif (n : Nat) : (BitVec 1) :=
   if (Eq n 0)
   then 1#1
@@ -27,14 +27,14 @@ def elif (n : Nat) : (BitVec 1) :=
        then 1#1
        else 0#1
 
-/-- Type quantifiers: n : Int, 0 ≤ n -/
+/-- Type quantifiers: n : Nat, 0 ≤ n -/
 def monadic_in_out (n : Nat) : SailM Nat := do
   if (← readReg B)
     then writeReg R n
     else (pure ())
   readReg R
 
-/-- Type quantifiers: n : Int, 0 ≤ n -/
+/-- Type quantifiers: n : Nat, 0 ≤ n -/
 def monadic_lines (n : Nat) : SailM Unit := do
   let b := (Eq n 0)
   if b

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -4,19 +4,19 @@ open Sail
 
 abbrev SailM := StateM Unit
 
-/-- Type quantifiers: x : Int, 0 ≤ x ∧ x ≤ 31 -/
+/-- Type quantifiers: x : Nat, 0 ≤ x ∧ x ≤ 31 -/
 def f_int (x : Nat) : Int :=
   0
 
-/-- Type quantifiers: x : Int, 0 ≤ x ∧ x ≤ 31 -/
+/-- Type quantifiers: x : Nat, 0 ≤ x ∧ x ≤ 31 -/
 def f_nat (x : Nat) : Nat :=
   0
 
-/-- Type quantifiers: x : Int, k_n : Int, 0 ≤ x ∧ x ≤ k_n -/
+/-- Type quantifiers: x : Nat, k_n : Nat, 0 ≤ x ∧ x ≤ k_n -/
 def f_negvar (x : Nat) : Int :=
   x
 
-/-- Type quantifiers: x : Int, k_n : Int, 0 ≤ x ∧ x ≤ k_n -/
+/-- Type quantifiers: x : Nat, k_n : Nat, 0 ≤ x ∧ x ≤ k_n -/
 def f_nnegvar (x : Nat) : Nat :=
   x
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -84,13 +84,13 @@ def GPRs : (Vector (RegisterRef RegisterType (BitVec 64)) 31) :=
     Reg R20, Reg R19, Reg R18, Reg R17, Reg R16, Reg R15, Reg R14, Reg R13, Reg R12, Reg R11,
     Reg R10, Reg R9, Reg R8, Reg R7, Reg R6, Reg R5, Reg R4, Reg R3, Reg R2, Reg R1, Reg R0]
 
-/-- Type quantifiers: n : Int, 0 ≤ n ∧ n ≤ 31 -/
+/-- Type quantifiers: n : Nat, 0 ≤ n ∧ n ≤ 31 -/
 def wX (n : Nat) (value : (BitVec 64)) : SailM Unit := do
   if (Ne n 31)
   then writeRegRef (vectorAccess GPRs n) value
   else (pure ())
 
-/-- Type quantifiers: n : Int, 0 ≤ n ∧ n ≤ 31 -/
+/-- Type quantifiers: n : Nat, 0 ≤ n ∧ n ≤ 31 -/
 def rX (n : Nat) : SailM (BitVec 64) := do
   if (Ne n 31)
   then (reg_deref (vectorAccess GPRs n))
@@ -102,7 +102,7 @@ def rPC (lit : Unit) : SailM (BitVec 64) := do
 def wPC (pc : (BitVec 64)) : SailM Unit := do
   writeReg _PC pc
 
-/-- Type quantifiers: r : Int, 0 ≤ r ∧ r ≤ 31 -/
+/-- Type quantifiers: r : Nat, 0 ≤ r ∧ r ≤ 31 -/
 def monad_test (r : Nat) : SailM (BitVec 1) := do
   if (Eq (← (rX r)) (0x0000000000000000 : (BitVec 64)))
   then (pure 1#1)

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -5,7 +5,15 @@ open Sail
 structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
-  deriving Inhabited, DecidableEq
+
+structure Mem_write_request
+  (k_n : Nat) (k_vasize : Nat) (k_pa : Type) (k_ts : Type) (k_arch_ak : Type) where
+  va : (Option (BitVec k_vasize))
+  pa : k_pa
+  translation : k_ts
+  size : Int
+  value : (Option (BitVec (8 * k_n)))
+  tag : (Option Bool)
 
 abbrev SailM := StateM Unit
 

--- a/test/lean/struct.sail
+++ b/test/lean/struct.sail
@@ -34,3 +34,13 @@ val undef_struct : bit -> My_struct
 function undef_struct (x) = {
   (undefined_My_struct(): My_struct)
 }
+
+struct Mem_write_request('n : Int, 'vasize : Int, 'pa : Type, 'ts : Type,
+                         'arch_ak : Type), 'n > 0 & 'vasize >= 0 = {
+  va : option(bits('vasize)),
+  pa : 'pa,
+  translation : 'ts,
+  size : int('n),
+  value : option(bits(8 * 'n)),
+  tag : option(bool),
+}

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -9,14 +9,13 @@ open e_test
 
 structure s_test where
   f : e_test
-  deriving Inhabited, DecidableEq
 
 abbrev SailM := StateM Unit
 
 def undefined_e_test (lit : Unit) : SailM e_test := do
   sorry
 
-/-- Type quantifiers: arg_ : Int, 0 ≤ arg_ ∧ arg_ ≤ 0 -/
+/-- Type quantifiers: arg_ : Nat, 0 ≤ arg_ ∧ arg_ ≤ 0 -/
 def e_test_of_num (arg_ : Nat) : e_test :=
   match arg_ with
   | _ => VAL

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -5,11 +5,9 @@ open Sail
 structure rectangle where
   width : Int
   height : Int
-  deriving Inhabited, DecidableEq
 
 structure circle where
   radius : Int
-  deriving Inhabited, DecidableEq
 
 inductive shape where
   | Rectangle (_ : rectangle)


### PR DESCRIPTION
This fixes part of #939 as the type `Mem_write_request` is now well defined.

A follow up PR will add type annotations to the let bindings to instantiate these parameters.