### PR TITLE
Lean: support for implicit arguments in function application

### DIFF
--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -1,0 +1,16 @@
+import Out.Sail.Sail
+
+open Sail
+
+abbrev SailM := StateM Unit
+
+/-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
+def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
+  (Sail.BitVec.zeroExtend v m)
+
+def foo (x : (BitVec 8)) : (BitVec 16) :=
+  (EXTZ x)
+
+def initialize_registers (lit : Unit) : Unit :=
+  ()
+

--- a/test/lean/implicit.sail
+++ b/test/lean/implicit.sail
@@ -1,0 +1,11 @@
+default Order dec
+
+$include <prelude.sail>
+
+val EXTZ : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+function EXTZ(m, v) = sail_zero_extend(v, m)
+
+val foo : bits(8) -> bits(16)
+function foo x = {
+  EXTZ(x)
+}


### PR DESCRIPTION
This closes #948.

Translates
```sail
default Order dec

$include <prelude.sail>

val EXTZ : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
function EXTZ(m, v) = sail_zero_extend(v, m)

val foo : bits(8) -> bits(16)
function foo x = {
  EXTZ(x)
}
```
to
```lean
import Out.Sail.Sail

open Sail

abbrev SailM := StateM Unit

/-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
  (Sail.BitVec.zeroExtend v m)

def foo (x : (BitVec 8)) : (BitVec 16) :=
  (EXTZ x)

def initialize_registers (lit : Unit) : Unit :=
  ()

```