### PR TITLE
fix(lean/run_tests): "cd" into the lean project to build it

### DIFF
--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -29,7 +29,8 @@ def test_lean():
                 step('rm -r {} || true'.format(basename))
                 step('mkdir -p {}'.format(basename))
                 step('\'{}\' {} --lean --lean-output-dir {}'.format(sail, filename, basename))
-                step(f'lake --dir {basename}/out build')
+                # NOTE: lake --dir does not behave the same as cd $dir && lake build...
+                step('lake build', cwd=f'{basename}/out')
                 step('diff {}/out/Out.lean {}.expected.lean'.format(basename, basename))
                 step('rm -r {}'.format(basename))
                 print_ok(filename)

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -113,8 +113,8 @@ def project_chunks(filenames, cores):
     ys.append(list(chunk))
     return ys
 
-def step(string, expected_status=0):
-    p = subprocess.Popen(string, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+def step(string, expected_status=0, cwd=None):
+    p = subprocess.Popen(string, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=cwd)
     out, err = p.communicate()
     status = p.wait()
     if status != expected_status:


### PR DESCRIPTION
It seems like that `lake --dir ...` does not behave the same as `cd ... && lake build`.

For example, the lean-toolchain file is ignored and therefore we do not pick up the appropriate Lean toolchain.

We extend the `step` function to support arbitrary custom working directories and move into it directly during the popen execution.

cc @javra 

Let me know if this fixes the problem you are seeing.