### PR TITLE
Lean: add non-determinism to the monad

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -427,15 +427,8 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
       if Env.is_register id env then wrap_with_left_arrow (not as_monadic) (string "readReg " ^^ doc_id_ctor id)
       else wrap_with_pure as_monadic (doc_id_ctor id)
   | E_lit l -> wrap_with_pure as_monadic (doc_lit l)
-  | E_app (Id_aux (Id "undefined_int", _), _) (* TODO remove when we handle imports *)
-  | E_app (Id_aux (Id "undefined_bit", _), _) (* TODO remove when we handle imports *)
-  | E_app (Id_aux (Id "undefined_bitvector", _), _) (* TODO remove when we handle imports *)
-  | E_app (Id_aux (Id "undefined_bool", _), _) (* TODO remove when we handle imports *)
-  | E_app (Id_aux (Id "undefined_nat", _), _) (* TODO remove when we handle imports *)
-  | E_app (Id_aux (Id "internal_pick", _), _) ->
-      (* TODO replace by actual implementation of internal_pick *)
-      string "sorry"
-  | E_app (Id_aux (Id "None", _), _) -> string "none"
+  | E_app (Id_aux (Id "None", _), _) ->
+      string "none"
   | E_app (Id_aux (Id "Some", _), args) ->
       let d_id = string "some" in
       let d_args = List.map d_of_arg args in
@@ -734,7 +727,8 @@ let doc_reg_info env global registers =
 
 let doc_monad_abbrev (has_registers : bool) =
   let pp_register_type =
-    if has_registers then string "PreSailM RegisterType" else string "PreSailM (fun (x : PEmpty.{1}) => nomatch x)"
+    if has_registers then string "PreSailM RegisterType trivialChoiceSource"
+    else string "PreSailM (fun x : PEmpty.{1} => nomatch x) trivialChoiceSource"
   in
   separate space [string "abbrev"; string "SailM"; coloneq; pp_register_type] ^^ hardline ^^ hardline
 

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def foo (lit : Unit) : Bool :=
   true

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -15,10 +15,10 @@ abbrev RegisterType : Register → Type
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
   default := .Reg R
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := PreSailM RegisterType trivialChoiceSource
 
 def undefined_cr_type (lit : Unit) : SailM (BitVec 8) := do
-  sorry
+  (undefined_bitvector 8)
 
 def Mk_cr_type (v : (BitVec 8)) : (BitVec 8) :=
   v

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def bitvector_eq (x : (BitVec 16)) (y : (BitVec 16)) : Bool :=
   (Eq x y)

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -7,10 +7,10 @@ inductive E where | A | B | C
 
 open E
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def undefined_E (lit : Unit) : SailM E := do
-  sorry
+  (internal_pick [A, B, C])
 
 /-- Type quantifiers: arg_ : Nat, 0 ≤ arg_ ∧ arg_ ≤ 2 -/
 def E_of_num (arg_ : Nat) : E :=

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -13,7 +13,7 @@ abbrev RegisterType : Register → Type
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
   default := .Reg dummy
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := PreSailM RegisterType trivialChoiceSource
 
 /-- Type quantifiers: k_ex824# : Bool -/
 def test_exit (b : Bool) : SailM Unit := do
@@ -27,5 +27,5 @@ def test_assert (b : Bool) : SailM (BitVec 1) := do
   (pure 1#1)
 
 def initialize_registers (lit : Unit) : SailM Unit := do
-  writeReg dummy sorry
+  writeReg dummy (← (undefined_bit ()))
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def extern_add (lit : Unit) : Int :=
   (Int.add 5 4)

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def extern_const (lit : Unit) : (BitVec 64) :=
   (0xFFFF000012340000 : (BitVec 64))

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 /-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
 def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -17,7 +17,7 @@ instance : Inhabited (RegisterRef RegisterType Bool) where
   default := .Reg B
 instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg R
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := PreSailM RegisterType trivialChoiceSource
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
 def elif (n : Nat) : (BitVec 1) :=
@@ -43,6 +43,6 @@ def monadic_lines (n : Nat) : SailM Unit := do
   else writeReg B b
 
 def initialize_registers (lit : Unit) : SailM Unit := do
-  writeReg R sorry
-  writeReg B sorry
+  writeReg R (← (undefined_nat ()))
+  writeReg B (← (undefined_bool ()))
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def foo (lit : Unit) : (BitVec 16) :=
   let z := (HOr.hOr (0xFFFF : (BitVec 16)) (0xABCD : (BitVec 16)))

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -22,10 +22,10 @@ abbrev RegisterType : Register → Type
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType E) where
   default := .Reg r_A
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := PreSailM RegisterType trivialChoiceSource
 
 def undefined_E (lit : Unit) : SailM E := do
-  sorry
+  (internal_pick [A, B, C])
 
 def match_enum (x : E) : (BitVec 1) :=
   match x with

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def match_option (x : (Option (BitVec 1))) : (BitVec 1) :=
   match x with

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 /-- Type quantifiers: x : Nat, 0 ≤ x ∧ x ≤ 31 -/
 def f_int (x : Nat) : Int :=

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -77,7 +77,7 @@ abbrev RegisterType : Register → Type
 open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
   default := .Reg _PC
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := PreSailM RegisterType trivialChoiceSource
 
 def GPRs : (Vector (RegisterRef RegisterType (BitVec 64)) 31) :=
   #v[Reg R30, Reg R29, Reg R28, Reg R27, Reg R26, Reg R25, Reg R24, Reg R23, Reg R22, Reg R21,
@@ -111,36 +111,36 @@ def monad_test (r : Nat) : SailM (BitVec 1) := do
        else (pure 0#1)
 
 def initialize_registers (lit : Unit) : SailM Unit := do
-  writeReg _PC sorry
-  writeReg R30 sorry
-  writeReg R29 sorry
-  writeReg R28 sorry
-  writeReg R27 sorry
-  writeReg R26 sorry
-  writeReg R25 sorry
-  writeReg R24 sorry
-  writeReg R23 sorry
-  writeReg R22 sorry
-  writeReg R21 sorry
-  writeReg R20 sorry
-  writeReg R19 sorry
-  writeReg R18 sorry
-  writeReg R17 sorry
-  writeReg R16 sorry
-  writeReg R15 sorry
-  writeReg R14 sorry
-  writeReg R13 sorry
-  writeReg R12 sorry
-  writeReg R11 sorry
-  writeReg R10 sorry
-  writeReg R9 sorry
-  writeReg R8 sorry
-  writeReg R7 sorry
-  writeReg R6 sorry
-  writeReg R5 sorry
-  writeReg R4 sorry
-  writeReg R3 sorry
-  writeReg R2 sorry
-  writeReg R1 sorry
-  writeReg R0 sorry
+  writeReg _PC (← (undefined_bitvector 64))
+  writeReg R30 (← (undefined_bitvector 64))
+  writeReg R29 (← (undefined_bitvector 64))
+  writeReg R28 (← (undefined_bitvector 64))
+  writeReg R27 (← (undefined_bitvector 64))
+  writeReg R26 (← (undefined_bitvector 64))
+  writeReg R25 (← (undefined_bitvector 64))
+  writeReg R24 (← (undefined_bitvector 64))
+  writeReg R23 (← (undefined_bitvector 64))
+  writeReg R22 (← (undefined_bitvector 64))
+  writeReg R21 (← (undefined_bitvector 64))
+  writeReg R20 (← (undefined_bitvector 64))
+  writeReg R19 (← (undefined_bitvector 64))
+  writeReg R18 (← (undefined_bitvector 64))
+  writeReg R17 (← (undefined_bitvector 64))
+  writeReg R16 (← (undefined_bitvector 64))
+  writeReg R15 (← (undefined_bitvector 64))
+  writeReg R14 (← (undefined_bitvector 64))
+  writeReg R13 (← (undefined_bitvector 64))
+  writeReg R12 (← (undefined_bitvector 64))
+  writeReg R11 (← (undefined_bitvector 64))
+  writeReg R10 (← (undefined_bitvector 64))
+  writeReg R9 (← (undefined_bitvector 64))
+  writeReg R8 (← (undefined_bitvector 64))
+  writeReg R7 (← (undefined_bitvector 64))
+  writeReg R6 (← (undefined_bitvector 64))
+  writeReg R5 (← (undefined_bitvector 64))
+  writeReg R4 (← (undefined_bitvector 64))
+  writeReg R3 (← (undefined_bitvector 64))
+  writeReg R2 (← (undefined_bitvector 64))
+  writeReg R1 (← (undefined_bitvector 64))
+  writeReg R0 (← (undefined_bitvector 64))
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -31,17 +31,17 @@ instance : Inhabited (RegisterRef RegisterType Int) where
   default := .Reg INT
 instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg NAT
-abbrev SailM := PreSailM RegisterType
+abbrev SailM := PreSailM RegisterType trivialChoiceSource
 
 def test (lit : Unit) : SailM Int := do
   writeReg INT (HAdd.hAdd (← readReg INT) 1)
   readReg INT
 
 def initialize_registers (lit : Unit) : SailM Unit := do
-  writeReg R0 sorry
-  writeReg R1 sorry
-  writeReg INT sorry
-  writeReg BOOL sorry
-  writeReg NAT sorry
-  writeReg BIT sorry
+  writeReg R0 (← (undefined_bitvector 64))
+  writeReg R1 (← (undefined_bitvector 64))
+  writeReg INT (← (undefined_int ()))
+  writeReg BOOL (← (undefined_bool ()))
+  writeReg NAT (← (undefined_nat ()))
+  writeReg BIT (← (undefined_bit ()))
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -19,11 +19,11 @@ structure Mem_write_request
   value : (Option (BitVec (8 * k_n)))
   tag : (Option Bool)
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def undefined_My_struct (lit : Unit) : SailM My_struct := do
-  (pure { field1 := sorry
-          field2 := sorry })
+  (pure { field1 := (← (undefined_int ()))
+          field2 := (← (undefined_bit ())) })
 
 def struct_field2 (s : My_struct) : (BitVec 1) :=
   s.field2

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -11,10 +11,10 @@ open e_test
 structure s_test where
   f : e_test
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def undefined_e_test (lit : Unit) : SailM e_test := do
-  sorry
+  (internal_pick [VAL])
 
 /-- Type quantifiers: arg_ : Nat, 0 ≤ arg_ ∧ arg_ ≤ 0 -/
 def e_test_of_num (arg_ : Nat) : e_test :=

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def foo (y : Unit) : Unit :=
   y

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -2,13 +2,13 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def tuple1 (lit : Unit) : (Int × Int × ((BitVec 2) × Unit)) :=
   (3, 5, ((0b10 : (BitVec 2)), ()))
 
 def tuple2 (lit : Unit) : SailM (Int × Int) := do
-  (pure ((← sorry), (← sorry)))
+  (pure ((← (undefined_int ())), (← (undefined_int ()))))
 
 def initialize_registers (lit : Unit) : Unit :=
   ()

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 /-- Type quantifiers: k_a : Type -/
 def foo (x : k_a) : (k_a × k_a) :=

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -8,7 +8,7 @@ abbrev xlen_bytes : Int := 8
 
 abbrev xlenbits := (BitVec 64)
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 /-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
 def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 /-- Type quantifiers: n : Int -/
 def foo (n : Int) : (BitVec 4) :=

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -2,7 +2,7 @@ import Out.Sail.Sail
 
 open Sail
 
-abbrev SailM := PreSailM (fun x : PEmpty.{0} => nomatch x) trivialChoiceSource
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 /-- Type quantifiers: n : Int -/
 def foo (n : Int) : SailM (Bool × (BitVec 1) × Int × Nat × (BitVec 3)) := do

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -1,0 +1,14 @@
+import Out.Sail.Sail
+
+open Sail
+
+abbrev SailM := PreSailM (fun x : PEmpty.{0} => nomatch x) trivialChoiceSource
+
+/-- Type quantifiers: n : Int -/
+def foo (n : Int) : SailM (Bool × (BitVec 1) × Int × Nat × (BitVec 3)) := do
+  (pure ((← (undefined_bool ())), (← (undefined_bit ())), (← (undefined_int ())), (← (undefined_nat
+        ())), (← (undefined_bitvector 3))))
+
+def initialize_registers (lit : Unit) : Unit :=
+  ()
+

--- a/test/lean/undefined.sail
+++ b/test/lean/undefined.sail
@@ -1,0 +1,5 @@
+
+val foo : int -> (bool, bit, int, nat, bitvector(3))
+function foo (n) = {
+    (undefined_bool(), undefined_bit(), undefined_int(), undefined_nat(), undefined_bitvector(3))
+} 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -26,14 +26,14 @@ inductive my_option (k_a : Type) where
 
 open my_option
 
-abbrev SailM := PreSailM (fun (x : PEmpty.{1}) => nomatch x)
+abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource
 
 def undefined_rectangle (lit : Unit) : SailM rectangle := do
-  (pure { width := sorry
-          height := sorry })
+  (pure { width := (← (undefined_int ()))
+          height := (← (undefined_int ())) })
 
 def undefined_circle (lit : Unit) : SailM circle := do
-  (pure { radius := sorry })
+  (pure { radius := (← (undefined_int ())) })
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : my_option k_a) : Bool :=


### PR DESCRIPTION
Translates
```sail
val foo : int -> (bool, bit, int, nat, bitvector(3))
function foo (n) = {
    (undefined_bool(), undefined_bit(), undefined_int(), undefined_nat(), undefined_bitvector(3))
} 
```
to
```lean
import Out.Sail.Sail

open Sail

abbrev SailM := PreSailM (fun x : PEmpty.{1} => nomatch x) trivialChoiceSource

/-- Type quantifiers: n : Int -/
def foo (n : Int) : SailM (Bool × (BitVec 1) × Int × Nat × (BitVec 3)) := do
  (pure ((← (undefined_bool ())), (← (undefined_bit ())), (← (undefined_int ())), (← (undefined_nat
        ())), (← (undefined_bitvector 3))))

def initialize_registers (lit : Unit) : Unit :=
  ()

```