### PR TITLE
Lean: Two fixes for the RISCV duopod

### DIFF
--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -205,6 +205,7 @@ val bitvector_update = pure {
   interpreter: "update",
   lem: "update_vec_dec",
   coq: "update_vec_dec",
+  lean: "vectorUpdate",
   _: "vector_update"
 } : forall 'n 'm, 0 <= 'm < 'n. (bits('n), int('m), bit) -> bits('n)
 $else
@@ -222,6 +223,7 @@ val plain_vector_update = pure {
   interpreter: "update",
   lem: "update_list_dec",
   coq: "vec_update_dec",
+  lean: "vectorUpdate",
   _: "vector_update"
 } : forall 'n 'm ('a : Type), 0 <= 'm < 'n. (vector('n, dec, 'a), int('m), 'a) -> vector('n, dec, 'a)
 

--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -365,7 +365,9 @@ val slice = pure "slice_inc" : forall 'n 'm 'o, 0 <= 'o < 'm & 'o + 'n <= 'm.
   (bits('m), int('o), int('n)) -> bits('n)
 $endif
 
-val replicate_bits = pure "replicate_bits" : forall 'n 'm, 'm >= 0. (bits('n), int('m)) -> bits('n * 'm)
+val replicate_bits = pure {
+  lean: "BitVec.replicateBits",
+  _: "replicate_bits" } : forall 'n 'm, 'm >= 0. (bits('n), int('m)) -> bits('n * 'm)
 
 val slice_mask : forall 'n, 'n >= 0. (implicit('n), int, int) -> bits('n)
 function slice_mask(n,i,l) =

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -85,7 +85,7 @@ def undefined_bitvector (n : Nat) : PreSailM RegisterType c (BitVec n) :=
 def internal_pick {α : Type} : List α → PreSailM RegisterType c α
   | [] => .error .Unreachable
   | (a :: as) => do
-    let idx ← choose <| Primitive.fin (as.length)
+    let idx ← choose <| .fin (as.length)
     pure <| (a :: as).get idx
 
 def writeReg (r : Register) (v : RegisterType r) : PreSailM RegisterType c PUnit :=
@@ -107,6 +107,8 @@ def reg_deref (reg_ref : @RegisterRef Register RegisterType α) : PreSailM Regis
   readRegRef reg_ref
 
 def vectorAccess [Inhabited α] (v : Vector α m) (n : Nat) := v[n]!
+
+def vectorUpdate (v : Vector α m) (n : Nat) (a : α) := v.set! n a
 
 def assert (p : Bool) (s : String) : PreSailM RegisterType c Unit :=
   if p then pure () else throw (Assertion s)

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -140,6 +140,8 @@ def updateSubrange' {w : Nat} (x : BitVec w) (start len : Nat) (y : BitVec len) 
 def updateSubrange {w : Nat} (x : BitVec w) (hi lo : Nat) (y : BitVec (hi - lo + 1)) : BitVec w :=
   updateSubrange' x lo _ y
 
+def replicateBits {w : Nat} (x : BitVec w) (i : Nat) := BitVec.replicate i x
+
 def access {w : Nat} (x : BitVec w) (i : Nat) : BitVec 1 :=
   BitVec.ofBool x[i]!
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -77,6 +77,9 @@ def extern_gt_int (_ : Unit) : Bool :=
 def extern_eq_anything (_ : Unit) : Bool :=
   (BEq.beq true true)
 
+def extern_vector_update (_ : Unit) : (Vector Int 5) :=
+  (vectorUpdate #v[23, 23, 23, 23, 23] 2 42)
+
 def initialize_registers (_ : Unit) : Unit :=
   ()
 

--- a/test/lean/extern.sail
+++ b/test/lean/extern.sail
@@ -105,3 +105,8 @@ function extern_gt_int() -> bool = {
 function extern_eq_anything() -> bool = {
   return eq_anything(true, true)
 }
+
+function extern_vector_update() -> vector(5, dec, int) = {
+  vector_update([23, 23, 23, 23, 23], 2, 42)
+}
+

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -10,6 +10,9 @@ def extern_const (_ : Unit) : (BitVec 64) :=
 def extern_add (_ : Unit) : (BitVec 16) :=
   (HAdd.hAdd (0xFFFF : (BitVec 16)) (0x1234 : (BitVec 16)))
 
+def extern_replicate_bits (_ : Unit) : (BitVec 64) :=
+  (BitVec.replicateBits (0x1234 : (BitVec 16)) 4)
+
 def initialize_registers (_ : Unit) : Unit :=
   ()
 

--- a/test/lean/extern_bitvec.sail
+++ b/test/lean/extern_bitvec.sail
@@ -10,3 +10,7 @@ function extern_add() -> bitvector(16) = {
   return 0xFFFF + 0x1234
 }
 
+function extern_replicate_bits() -> bitvector(64) = {
+  return replicate_bits(0x1234, 4)
+}
+


### PR DESCRIPTION
Annotates `replicate_bits` and `vector_update`.