### PR TITLE
CI: Make CI run Sail test suites in parallel

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,107 @@
+name: Upload test coverage
+
+on:
+  workflow_run:
+    workflows: ["Test matrix"]
+    types:
+    - completed
+
+env:
+  OPAMVERBOSE: 1
+
+jobs:
+  build:
+    # GitHub allows matrix variables in more places than env variables
+    strategy:
+      matrix:
+        version: [5.2.1]
+        os: [ubuntu-24.04]
+
+    runs-on: ${{ matrix.os }}
+
+    if: github.event.workflow_run.conclusion != 'skipped'
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: System dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -o Acquire::Retries=3 install build-essential libgmp-dev z3 opam git curl
+
+    - name: Restore cached opam
+      id: cache-opam-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.opam
+        key: ${{ matrix.os }}-${{ matrix.version }}-cov
+
+    - name: Setup opam
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      run: |
+        opam init --yes --no-setup --shell=sh --compiler=${{ matrix.version }}
+
+    - name: Save cached opam
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      id: cache-opam-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.opam
+        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+
+    - name: Install Sail dependencies
+      run: |
+        eval $(opam env)
+        opam pin --yes --no-action add .
+        opam install . --yes --deps-only
+
+    - name: Build Sail with coverage
+      run: |
+        eval $(opam env)
+        dune build --release --instrument-with bisect_ppx
+
+    - name: Download artifacts
+      uses: actions/github-script@v6
+      with:
+        script: |
+          var fs = require('fs');
+          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: ${{ github.event.workflow_run.id }},
+          });
+          var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name.startsWith('test-results-') || artifact.name == 'event.json'
+          });
+          var count = matchArtifacts.length;
+          for (var i = 0; i < count; i++) {
+            var matchArtifact = matchArtifacts[i];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var name = matchArtifact.name;
+            var dest = name + '.zip'
+            fs.writeFileSync('${{ github.workspace }}/' + dest, Buffer.from(download.data));
+            console.log("Downloaded", name, "as", dest);
+          }
+
+    - name: Extract test results
+      run: |
+        find . -maxdepth 1 -name 'test-results-*.zip' -print0 | xargs -0 -I {} -P 1 unzip {}
+
+    - name: Collect coverage
+      run: |
+        eval $(opam env)
+        bisect-ppx-report html --coverage-path=.
+        bisect-ppx-report summary --per-file --coverage-path=. > coverage_summary.txt
+
+    - name: Archive coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage
+        path: |
+          coverage_summary.txt
+          _coverage/*
+          _coverage/src/lib/*

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,4 +1,4 @@
-name: Test coverage
+name: Test matrix
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -12,6 +12,7 @@ jobs:
       matrix:
         version: [5.2.1]
         os: [ubuntu-24.04]
+        suite: [typecheck, exec, sv, prover, other]
 
     runs-on: ${{ matrix.os }}
 
@@ -94,33 +95,21 @@ jobs:
       run: |
         eval $(opam env)
         export SAIL_DIR=$(pwd)
-        etc/ci_coverage_tests.sh
+        etc/ci_coverage_tests.sh ${{ matrix.suite }}
+        bisect-ppx-report merge --coverage-path=test/ test/suite-${{ matrix.suite }}.coverage
 
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-results
+        name: test-results-${{ matrix.suite }}
         path: |
           test/**/tests.xml
+          test/suite-${{ matrix.suite }}.coverage 
 
-    - name: Collect coverage
-      run: |
-        eval $(opam env)
-        bisect-ppx-report html --coverage-path=test/
-        bisect-ppx-report summary --per-file --coverage-path=test/ > coverage_summary.txt
-
-    - name: Archive coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: code-coverage
-        path: |
-          coverage_summary.txt
-          _coverage/*
-          _coverage/src/lib/*
-
+    # Only do this for one job in the test matrix
     - name: Upload event payload
-      if: always()
+      if: matrix.suite == 'typecheck'
       uses: actions/upload-artifact@v4
       with:
         name: event.json

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -2,13 +2,14 @@ name: Publish test results
 
 on:
   workflow_run:
-    workflows: ["Test coverage"]
+    workflows: ["Test matrix"]
     types:
     - completed
 
 jobs:
   publish-test-results:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+
     if: github.event.workflow_run.conclusion != 'skipped'
     steps:
     - name: Download artifacts
@@ -22,7 +23,7 @@ jobs:
              run_id: ${{ github.event.workflow_run.id }},
           });
           var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == 'test-results' || artifact.name == 'event.json'
+            return artifact.name.startsWith('test-results-') || artifact.name == 'event.json'
           });
           var count = matchArtifacts.length;
           for (var i = 0; i < count; i++) {
@@ -38,10 +39,14 @@ jobs:
             fs.writeFileSync('${{ github.workspace }}/' + dest, Buffer.from(download.data));
             console.log("Downloaded", name, "as", dest);
           }
+
     - name: Extract test results
-      run: unzip test-results.zip
+      run: |
+        find . -maxdepth 1 -name 'test-results-*.zip' -print0 | xargs -0 -I {} -P 1 unzip {}
+
     - name: Extract event payload
       run: unzip event.json.zip
+
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:

--- a/etc/ci_coverage_tests.sh
+++ b/etc/ci_coverage_tests.sh
@@ -4,4 +4,25 @@ set -eu
 
 export TEST_PAR=4
 
-test/run_coverage_tests.sh
+returncode=0
+
+if [ "$1" = "typecheck" ]; then
+    test/typecheck/run_tests.py || returncode=1
+elif [ "$1" = "exec" ]; then
+    test/ocaml/run_tests.sh || returncode=1
+    test/c/run_tests.py || returncode=1
+elif [ "$1" = "sv" ]; then
+    test/sv/run_tests.py || returncode=1
+elif [ "$1" = "prover" ]; then
+    test/lem/run_tests.py || returncode=1
+    test/smt/run_tests.py || returncode=1
+    test/lean/run_tests.py || returncode=1
+elif [ "$1" = "other" ]; then
+    test/lexing/run_tests.py || returncode=1
+    test/pattern_completeness/run_tests.py || returncode=1
+    test/sailcov/run_tests.py || returncode=1
+    test/format/run_tests.py || returncode=1
+    test/oneoff/run_tests.py || returncode=1
+fi
+
+exit $returncode

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -82,7 +82,7 @@ def chunks(filenames, cores):
     ys = []
     chunk = []
     for filename in filenames:
-        if re.match('.+\.sail$', filename):
+        if re.match(r'.+\.sail$', filename):
             chunk.append(filename)
         if len(chunk) >= cores:
             ys.append(list(chunk))
@@ -106,7 +106,7 @@ def project_chunks(filenames, cores):
     ys = []
     chunk = []
     for filename in filenames:
-        if re.match('.+\.sail_project$', filename):
+        if re.match(r'.+\.sail_project$', filename):
             chunk.append(filename)
         if len(chunk) >= cores:
             ys.append(list(chunk))

--- a/test/smt/run_tests.py
+++ b/test/smt/run_tests.py
@@ -49,7 +49,7 @@ def test_smt(name, solver, sail_opts):
             if tests[filename] == 0:
                 step('\'{}\' {} -smt {} -o {}'.format(sail, sail_opts, filename, basename))
                 step('timeout 30s {} {}_prop.smt2 1> {}.out'.format(solver, basename, basename))
-                if re.match('.+\.sat\.sail$', filename):
+                if re.match(r'.+\.sat\.sail$', filename):
                     step('grep -q ^sat$ {}.out'.format(basename))
                 else:
                     step('grep -q ^unsat$ {}.out'.format(basename))


### PR DESCRIPTION
Reduces the runtime down to about 10 minutes. Could be faster if the splitting was slightly smarter as we are bottlenecked by the SystemVerilog tests being a single suite.