### PR TITLE
Lean: improve handling of arguments

### DIFF
--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -554,13 +554,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/
@@ -1846,11 +1846,11 @@ def wMem (addr : (BitVec 64)) (value : (BitVec 64)) : SailM Unit := do
       value := (some value)
       tag := none }
   match (← (sail_mem_write req)) with
-  | Ok _ => (pure ())
-  | Err _ => throw Error.Exit
+  | .Ok _ => (pure ())
+  | .Err _ => throw Error.Exit
 
-/-- Type quantifiers: x : Nat, x ∈ {32, 64} -/
-def sail_address_announce (x : Nat) (x : (BitVec x)) : Unit :=
+/-- Type quantifiers: x_0 : Nat, x_0 ∈ {32, 64} -/
+def sail_address_announce (x_0 : Nat) (x_1 : (BitVec x_0)) : Unit :=
   ()
 
 def wMem_Addr (addr : (BitVec 64)) : Unit :=
@@ -1878,8 +1878,8 @@ def rMem (addr : (BitVec 64)) : SailM (BitVec 64) := do
       size := 8
       tag := false }
   match (← (sail_mem_read req)) with
-  | Ok (value, _) => (pure value)
-  | Err _ => throw Error.Exit
+  | .Ok (value, _) => (pure value)
+  | .Err _ => throw Error.Exit
 
 /-- Type quantifiers: m : Nat, n : Nat, t : Nat, 0 ≤ t ∧ t ≤ 31, 0 ≤ n ∧ n ≤ 31, 0 ≤ m
   ∧ m ≤ 31 -/
@@ -1919,11 +1919,11 @@ def execute_CompareAndBranch (t : Nat) (offset : (BitVec 64)) : SailM Unit := do
 
 def execute (merge_var : ast) : SailM Unit := do
   match merge_var with
-  | LoadRegister (t, n, m) => (execute_LoadRegister t n m)
-  | StoreRegister (t, n, m) => (execute_StoreRegister t n m)
-  | ExclusiveOr (d, n, m) => (execute_ExclusiveOr d n m)
-  | DataMemoryBarrier arg0 => (execute_DataMemoryBarrier arg0)
-  | CompareAndBranch (t, offset) => (execute_CompareAndBranch t offset)
+  | .LoadRegister (t, n, m) => (execute_LoadRegister t n m)
+  | .StoreRegister (t, n, m) => (execute_StoreRegister t n m)
+  | .ExclusiveOr (d, n, m) => (execute_ExclusiveOr d n m)
+  | .DataMemoryBarrier arg0 => (execute_DataMemoryBarrier arg0)
+  | .CompareAndBranch (t, offset) => (execute_CompareAndBranch t offset)
 
 def decode (v__0 : (BitVec 32)) : (Option ast) :=
   if (Bool.and (Eq (Sail.BitVec.extractLsb v__0 31 24) (0xF8 : (BitVec 8)))
@@ -1964,52 +1964,52 @@ def iFetch (addr : (BitVec 64)) : SailM (BitVec 32) := do
       size := 4
       tag := false }
   match (← (sail_mem_read req)) with
-  | Ok (value, _) => (pure value)
-  | Err _ => throw Error.Exit
+  | .Ok (value, _) => (pure value)
+  | .Err _ => throw Error.Exit
 
 def fetch_and_execute (_ : Unit) : SailM Unit := do
   let machineCode ← do (iFetch (← readReg _PC))
   let instr := (decode machineCode)
   match instr with
-  | some instr => (execute instr)
+  | .some instr => (execute instr)
   | none => assert false "Unsupported Encoding"
 
 /-- Type quantifiers: k_a : Type, k_b : Type -/
 def is_ok (r : (Result k_a k_b)) : Bool :=
   match r with
-  | Ok _ => true
-  | Err _ => false
+  | .Ok _ => true
+  | .Err _ => false
 
 /-- Type quantifiers: k_a : Type, k_b : Type -/
 def is_err (r : (Result k_a k_b)) : Bool :=
   match r with
-  | Ok _ => false
-  | Err _ => true
+  | .Ok _ => false
+  | .Err _ => true
 
 /-- Type quantifiers: k_a : Type, k_b : Type -/
 def ok_option (r : (Result k_a k_b)) : (Option k_a) :=
   match r with
-  | Ok x => (some x)
-  | Err _ => none
+  | .Ok x => (some x)
+  | .Err _ => none
 
 /-- Type quantifiers: k_a : Type, k_b : Type -/
 def err_option (r : (Result k_a k_b)) : (Option k_b) :=
   match r with
-  | Ok _ => none
-  | Err err => (some err)
+  | .Ok _ => none
+  | .Err err => (some err)
 
 /-- Type quantifiers: k_a : Type, k_b : Type -/
 def unwrap_or (r : (Result k_a k_b)) (y : k_a) : k_a :=
   match r with
-  | Ok x => x
-  | Err _ => y
+  | .Ok x => x
+  | .Err _ => y
 
 /-- Type quantifiers: k_n : Nat, k_n > 0 -/
-def sail_instr_announce (x : (BitVec k_n)) : Unit :=
+def sail_instr_announce (x_0 : (BitVec k_n)) : Unit :=
   ()
 
-/-- Type quantifiers: x : Nat, x ∈ {32, 64} -/
-def sail_branch_announce (x : Nat) (x : (BitVec x)) : Unit :=
+/-- Type quantifiers: x_0 : Nat, x_0 ∈ {32, 64} -/
+def sail_branch_announce (x_0 : Nat) (x_1 : (BitVec x_0)) : Unit :=
   ()
 
 def sail_reset_registers (_ : Unit) : Unit :=
@@ -2019,11 +2019,11 @@ def sail_synchronize_registers (_ : Unit) : Unit :=
   ()
 
 /-- Type quantifiers: k_a : Type -/
-def sail_mark_register (x : (RegisterRef RegisterType k_a)) (x : String) : Unit :=
+def sail_mark_register (x_0 : (RegisterRef RegisterType k_a)) (x_1 : String) : Unit :=
   ()
 
 /-- Type quantifiers: k_a : Type, k_b : Type -/
-def sail_mark_register_pair (x : (RegisterRef RegisterType k_a)) (x : (RegisterRef RegisterType k_b)) (x : String) : Unit :=
+def sail_mark_register_pair (x_0 : (RegisterRef RegisterType k_a)) (x_1 : (RegisterRef RegisterType k_b)) (x_2 : String) : Unit :=
   ()
 
 /-- Type quantifiers: k_a : Type -/
@@ -2078,7 +2078,7 @@ def undefined_Explicit_access_kind (_ : Unit) : SailM Explicit_access_kind := do
   : Type, k_n > 0 ∧ k_vasize > 0 -/
 def mem_read_request_is_exclusive (request : Mem_read_request k_n k_vasize k_pa k_translation_summary k_arch_ak) : Bool :=
   match request.access_kind with
-  | AK_explicit eak =>
+  | .AK_explicit eak =>
     match eak.variety with
     | AV_exclusive => true
     | _ => false
@@ -2088,7 +2088,7 @@ def mem_read_request_is_exclusive (request : Mem_read_request k_n k_vasize k_pa 
   : Type, k_n > 0 ∧ k_vasize > 0 -/
 def mem_read_request_is_ifetch (request : Mem_read_request k_n k_vasize k_pa k_translation_summary k_arch_ak) : Bool :=
   match request.access_kind with
-  | AK_ifetch () => true
+  | .AK_ifetch () => true
   | _ => false
 
 def __monomorphize_reads : Bool := false
@@ -2099,7 +2099,7 @@ def __monomorphize_writes : Bool := false
   : Type, k_n > 0 ∧ k_vasize > 0 -/
 def mem_write_request_is_exclusive (request : Mem_write_request k_n k_vasize k_pa k_translation_summary k_arch_ak) : Bool :=
   match request.access_kind with
-  | AK_explicit eak =>
+  | .AK_explicit eak =>
     match eak.variety with
     | AV_exclusive => true
     | _ => false

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -76,13 +76,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -68,13 +68,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -74,13 +74,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -21,7 +21,7 @@ def spc_forwards (_ : Unit) : String :=
 def spc_forwards_matches (_ : Unit) : Bool :=
   true
 
-def spc_backwards (x : String) : Unit :=
+def spc_backwards (x_0 : String) : Unit :=
   ()
 
 def spc_backwards_matches (s : String) : Bool :=
@@ -34,7 +34,7 @@ def opt_spc_forwards (_ : Unit) : String :=
 def opt_spc_forwards_matches (_ : Unit) : Bool :=
   true
 
-def opt_spc_backwards (x : String) : Unit :=
+def opt_spc_backwards (x_0 : String) : Unit :=
   ()
 
 def opt_spc_backwards_matches (s : String) : Bool :=
@@ -46,7 +46,7 @@ def def_spc_forwards (_ : Unit) : String :=
 def def_spc_forwards_matches (_ : Unit) : Bool :=
   true
 
-def def_spc_backwards (x : String) : Unit :=
+def def_spc_backwards (x_0 : String) : Unit :=
   ()
 
 def def_spc_backwards_matches (s : String) : Bool :=

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -78,13 +78,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -74,13 +74,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -68,13 +68,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -83,13 +83,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/
@@ -111,7 +111,7 @@ def match_enum (x : E) : (BitVec 1) :=
 
 def match_option (x : (Option (BitVec 1))) : (BitVec 1) :=
   match x with
-  | some x => x
+  | .some x => x
   | none => 0#1
 
 /-- Type quantifiers: y : Int, x : Int -/

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/
@@ -82,12 +82,12 @@ def concat_str_dec (str : String) (x : Int) : String :=
 
 def match_option (x : (Option (BitVec 1))) : (BitVec 1) :=
   match x with
-  | some x => x
+  | .some x => x
   | none => 0#1
 
 def option_match (x : (Option Unit)) (y : (BitVec 1)) : (Option (BitVec 1)) :=
   match x with
-  | some () => (some y)
+  | .some () => (some y)
   | none => none
 
 def initialize_registers (_ : Unit) : Unit :=

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -63,13 +63,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -138,13 +138,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -92,13 +92,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -80,13 +80,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -72,13 +72,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -71,13 +71,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -13,6 +13,12 @@ inductive option (k_a : Type) where
 
 open option
 
+
+inductive virtaddr where
+  | virtaddr (_ : (BitVec 32))
+
+open virtaddr
+
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
 /-- Type quantifiers: x : Int -/
@@ -63,13 +69,13 @@ def fmod_int (n : Int) (m : Int) : Int :=
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => false
+  | .some _ => false
   | none => true
 
 /-- Type quantifiers: k_a : Type -/
 def is_some (opt : (Option k_a)) : Bool :=
   match opt with
-  | some _ => true
+  | .some _ => true
   | none => false
 
 /-- Type quantifiers: k_n : Int -/
@@ -80,13 +86,67 @@ def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
 def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
-/-- Type quantifiers: n : Int -/
-def foo (n : Int) : (BitVec 4) :=
+/-- Type quantifiers: n : Nat, n > 0 -/
+def foo (n : Nat) : (BitVec 4) :=
   (0xF : (BitVec 4))
+
+/-- Type quantifiers: n : Nat, n > 0 -/
+def foo2 (n : Nat) : (BitVec n) :=
+  (BitVec.zero n)
 
 /-- Type quantifiers: k_n : Int -/
 def bar (x : (BitVec k_n)) : (BitVec k_n) :=
   x
+
+def two_tuples (tuple_0 : (String × String)) (tuple_1 : (String × String)) : String :=
+  let (x, y) := tuple_0
+  let (z, t) := tuple_1
+  y
+
+/-- Type quantifiers: tuple_0.2 : Nat, tuple_0.2 ≥ 0 -/
+def two_tuples_atom (tuple_0 : (String × Nat)) (tuple_1 : (String × String)) : (BitVec tuple_0.2) :=
+  let (x, y) := tuple_0
+  let (z, t) := tuple_1
+  (BitVec.zero y)
+
+def tuple_of_tuple (tuple_0 : (String × String)) : String :=
+  let (s1, s2) := tuple_0
+  s1
+
+def use_tuple_of_tuple (s : String) : String :=
+  (tuple_of_tuple (s, s))
+
+/-- Type quantifiers: k_nn : Nat, k_nn > 0 -/
+def hex_bits_signed2_forwards (bv : (BitVec k_nn)) : (Nat × String) :=
+  let len := (Sail.BitVec.length bv)
+  let s :=
+    if (Eq (BitVec.access bv (HSub.hSub len 1)) 1#1)
+    then "stub1"
+    else "stub2"
+  ((Sail.BitVec.length bv), s)
+
+/-- Type quantifiers: k_nn : Nat, k_nn > 0 -/
+def hex_bits_signed2_forwards_matches (bv : (BitVec k_nn)) : Bool :=
+  true
+
+/-- Type quantifiers: tuple_0.1 : Nat, tuple_0.1 > 0 -/
+def hex_bits_signed2_backwards (tuple_0 : (Nat × String)) : (BitVec tuple_0.1) :=
+  let (notn, str) := tuple_0
+  if (Eq str "-")
+  then (BitVec.zero notn)
+  else let parsed := (BitVec.zero notn)
+       if (Eq (BitVec.access parsed (HSub.hSub notn 1)) 0#1)
+       then parsed
+       else (BitVec.zero notn)
+
+/-- Type quantifiers: tuple_0.1 : Nat, tuple_0.1 > 0 -/
+def hex_bits_signed2_backwards_matches (tuple_0 : (Nat × String)) : Bool :=
+  let (n, str) := tuple_0
+  true
+
+def test_constr (app_0 : virtaddr) : (BitVec 32) :=
+  let .virtaddr addr := app_0
+  addr
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/typquant.sail
+++ b/test/lean/typquant.sail
@@ -2,10 +2,16 @@ default Order dec
 
 $include <prelude.sail>
 
-val foo : forall 'n. int('n) -> bits(4)
+val foo : forall 'n, 'n > 0. int('n) -> bits(4)
 
 function foo(n) = {
   0xF
+}
+
+val foo2 : forall 'n, 'n > 0. int('n) -> bits('n)
+
+function foo2(n) = {
+  sail_zeros(n)
 }
 
 val bar : forall 'n. bits('n) -> bits('n)
@@ -13,3 +19,51 @@ val bar : forall 'n. bits('n) -> bits('n)
 function bar(x) = {
   x
 }
+
+val two_tuples : ((string, string), (string, string)) -> string
+function two_tuples((x, y), (z, t)) = y
+
+val two_tuples_atom : forall 'n, 'n >= 0. ((string, int('n)), (string, string)) -> bits('n)
+function two_tuples_atom((x, y), (z, t)) = sail_zeros(y)
+
+val tuple_of_tuple : ((string, string)) -> string
+function tuple_of_tuple(s1, s2) = s1
+
+function use_tuple_of_tuple(s : string) -> string = {
+  // tutuple(s, s);
+  tuple_of_tuple((s, s))
+}
+
+
+val hex_bits_signed2 : forall 'nn, 'nn > 0. bits('nn) <-> (int('nn), string)
+
+function hex_bits_signed2_forwards(bv) = {
+  let len = length(bv);
+  let s = if bv[len - 1] == bitone then {
+    "stub1"
+  } else {
+    "stub2"
+  };
+  (length(bv), s)
+}
+
+function hex_bits_signed2_forwards_matches(bv) = true
+
+function hex_bits_signed2_backwards(notn, str) = {
+  if str == "-" then {
+    sail_zeros(notn)
+  } else {
+    let parsed = sail_zeros(notn);
+    if parsed[notn - 1] == bitzero then {
+      parsed
+    } else {
+      sail_zeros(notn)
+    }
+  }
+}
+
+function hex_bits_signed2_backwards_matches(n, str) = true
+
+ newtype virtaddr = virtaddr : bits(32)
+
+function test_constr (virtaddr(addr) : virtaddr) -> bits(32) = addr

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -39,8 +39,8 @@ def undefined_circle (_ : Unit) : SailM circle := do
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : my_option k_a) : Bool :=
   match opt with
-  | MySome _ => false
-  | MyNone () => true
+  | .MySome _ => false
+  | .MyNone () => true
 
 /-- Type quantifiers: k_a : Type -/
 def use_is_none (opt : my_option k_a) : Bool :=


### PR DESCRIPTION
1. We handle irrefutable patterns in argument positions by adding an equivalent let in the prelude of the function.
2. We handle `atom` types deep inside the type of the arguments. We translate the pattern in the argument as above as a variable, and we replace the sail type variable by `tuple.2.1` in the return type. This path and the variable bound in the let binding in the prelude are definitionally equal.
3. As a side fix, we use more unique names for the autogenerated variable names by numbering them, which should avoid some spurious shadowing.