### PR TITLE
Lean: mark `not` as a reserved keyword

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -50,6 +50,7 @@ let rec fix_id name =
   (* Lean keywords to avoid, to expand as needed *)
   | "rec" -> name ^ "'"
   | "def" -> name ^ "'"
+  | "not" -> name ^ "'"
   | "main" ->
       the_main_function_has_been_seen := true;
       "sail_main"


### PR DESCRIPTION
This fixes 32 occurrences of `ambiguous, possible interpretations` in the RISC-V spec.