### PR TITLE
Lean: put the generated functions in a namepace

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -988,6 +988,7 @@ let pp_ast_lean (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail
   let monad = doc_monad_abbrev defs has_registers in
   let instantiations = doc_instantiations ctx env in
   let types, fundefs = doc_defs ctx defs in
+  let fundefs = string "namespace Functions\n\n" ^^ fundefs ^^ string "end Functions\n\nopen Functions\n\n" in
   let main_function = if !the_main_function_has_been_seen then main_function_stub else empty in
   print o (types ^^ register_refs ^^ monad ^^ instantiations ^^ fundefs ^^ main_function);
   !the_main_function_has_been_seen

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -510,6 +510,8 @@ instance : Arch where
   arch_ak := arm_acc_type
   sys_reg_id := Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -2145,4 +2147,8 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R2 (← (undefined_bitvector 64))
   writeReg R1 (← (undefined_bitvector 64))
   writeReg R0 (← (undefined_bitvector 64))
+
+end Functions
+
+open Functions
 

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -9,9 +9,15 @@ open Sail
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 def foo (_ : Unit) : Bool :=
   true
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -32,6 +32,8 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
   default := .Reg R
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -165,4 +167,8 @@ def _set_cr_type_LT (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R (← (undefined_cr_type ()))
+
+end Functions
+
+open Functions
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -142,4 +144,8 @@ def bitvector_plus_int (x : (BitVec 16)) (i : Int) : (BitVec 16) :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -24,6 +24,8 @@ open E
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -107,4 +109,8 @@ def num_of_E (arg_ : E) : Int :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -30,6 +30,8 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
   default := .Reg dummy
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -108,4 +110,8 @@ def test_assert (b : Bool) : SailM (BitVec 1) := do
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg dummy (← (undefined_bit ()))
+
+end Functions
+
+open Functions
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 def spc_forwards (_ : Unit) : String :=
   " "
 
@@ -194,4 +196,8 @@ def extern_n_leading_spaces (_ : Unit) : Nat :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -95,4 +97,8 @@ def extern_replicate_bits (_ : Unit) : (BitVec 64) :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -100,4 +102,8 @@ def slice_mask2 {n : _} (i : (BitVec n)) (l : (BitVec n)) (b : Bool) : (BitVec n
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -34,6 +34,8 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg R
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -125,4 +127,8 @@ def monadic_lines (n : Nat) : SailM Unit := do
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R (← (undefined_nat ()))
   writeReg B (← (undefined_bool ()))
+
+end Functions
+
+open Functions
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -98,4 +100,8 @@ def baz (_ : Unit) : SailM (BitVec 16) := do
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -30,6 +30,8 @@ instance : Inhabited (RegisterRef RegisterType Int) where
   default := .Reg r
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -146,4 +148,8 @@ def foreachloopuseindex (m : Nat) (n : Nat) : Nat :=
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r (← (undefined_int ()))
+
+end Functions
+
+open Functions
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -24,6 +24,8 @@ open word_width
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -217,4 +219,8 @@ def size_bits3_backwards_matches (arg_ : (BitVec 2)) : Bool :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -39,6 +39,8 @@ instance : Inhabited (RegisterRef RegisterType E) where
   default := .Reg r_A
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -149,4 +151,8 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r_A (← (undefined_E ()))
   writeReg r_B (← (undefined_E ()))
   writeReg r_C (← (undefined_E ()))
+
+end Functions
+
+open Functions
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -130,4 +132,8 @@ def write_CSR2 (v__30 : (BitVec 12)) : SailM Bool := do
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -96,4 +98,8 @@ def option_match (x : (Option Unit)) (y : (BitVec 1)) : (Option (BitVec 1)) :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -19,6 +19,8 @@ open option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -106,4 +108,8 @@ def f_unkn (x : Int) : Int :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -94,6 +94,8 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
   default := .Reg _PC
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -223,4 +225,8 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R2 (← (undefined_bitvector 64))
   writeReg R1 (← (undefined_bitvector 64))
   writeReg R0 (← (undefined_bitvector 64))
+
+end Functions
+
+open Functions
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -48,6 +48,8 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg NAT
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -124,4 +126,8 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg BOOL (← (undefined_bool ()))
   writeReg NAT (← (undefined_nat ()))
   writeReg BIT (← (undefined_bit ()))
+
+end Functions
+
+open Functions
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -36,6 +36,8 @@ structure Mem_write_request
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -133,4 +135,8 @@ def match_struct (value : My_struct) : SailM Int := do
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -28,6 +28,8 @@ structure s_test where
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -110,4 +112,8 @@ def undefined_s_test (_ : Unit) : SailM s_test := do
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -9,9 +9,15 @@ open Sail
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 def foo (y : Unit) : Unit :=
   y
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -9,6 +9,8 @@ open Sail
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 def let0 := (20, 300000000000000000000000)
 
 def y :=
@@ -27,4 +29,8 @@ def tuple2 (_ : Unit) : SailM (Int × Int) := do
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -9,10 +9,16 @@ open Sail
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: k_a : Type -/
 def foo (x : k_a) : (k_a × k_a) :=
   (x, x)
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -27,6 +27,8 @@ abbrev my_bits k_n := (BitVec k_n)
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -92,6 +94,8 @@ def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
 def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
+def xlen := 64
+
 /-- Type quantifiers: k_n : Int, m : Int, m ≥ k_n -/
 def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
   (Sail.BitVec.zeroExtend v m)
@@ -100,6 +104,13 @@ def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
 def EXTS {m : _} (v : (BitVec k_n)) : (BitVec m) :=
   (Sail.BitVec.signExtend v m)
 
+def uses_xlen_term (_ : Unit) : Int :=
+  xlen
+
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/typedef.sail
+++ b/test/lean/typedef.sail
@@ -5,6 +5,8 @@ type xlen       : Int = 64
 type xlen_bytes : Int = 8
 type xlenbits         = bits(xlen)
 
+let xlen = 64
+
 type my_bits('n) = bitvector('n)
 
 val EXTZ : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
@@ -13,3 +15,4 @@ function EXTZ(m, v) = sail_zero_extend(v, m)
 val EXTS : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
 function EXTS(m, v) = sail_sign_extend(v, m)
 
+function uses_xlen_term() -> int = xlen

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -25,6 +25,8 @@ open virtaddr
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: x : Int -/
 def __id (x : Int) : Int :=
   x
@@ -154,4 +156,8 @@ def test_constr (app_0 : virtaddr) : (BitVec 32) :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -9,6 +9,8 @@ open Sail
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 /-- Type quantifiers: n : Int -/
 def foo (n : Int) : SailM (Bool × (BitVec 1) × Int × Nat × (BitVec 3)) := do
   (pure ((← (undefined_bool ())), (← (undefined_bit ())), (← (undefined_int ())), (← (undefined_nat
@@ -20,4 +22,8 @@ def bar (n : Int) : SailM (Vector Int 4) := do
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -33,6 +33,8 @@ open my_option
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 
+namespace Functions
+
 def undefined_rectangle (_ : Unit) : SailM rectangle := do
   (pure { width := (← (undefined_int ()))
           height := (← (undefined_int ())) })
@@ -52,4 +54,8 @@ def use_is_none (opt : my_option k_a) : Bool :=
 
 def initialize_registers (_ : Unit) : Unit :=
   ()
+
+end Functions
+
+open Functions
 


### PR DESCRIPTION
This partially addresses the fact that Sail has a different namespace for types and terms, and as such some models have types with the same names as terms.