### PR TITLE
Lean: More small fixes for the RISC-V Model

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -2,12 +2,6 @@ import Std.Data.DHashMap
 import Std.Data.HashMap
 namespace Sail
 
-instance : CoeT Int x Nat where
-  coe := x.toNat
-
-instance : CoeT (BitVec n) x (BitVec m) where
-  coe := x.setWidth m
-
 namespace BitVec
 
 def length {w : Nat} (_ : BitVec w) : Nat := w

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -2,6 +2,12 @@ import Std.Data.DHashMap
 import Std.Data.HashMap
 namespace Sail
 
+instance : CoeT Int x Nat where
+  coe := x.toNat
+
+instance : CoeT (BitVec n) x (BitVec m) where
+  coe := x.setWidth m
+
 namespace BitVec
 
 def length {w : Nat} (_ : BitVec w) : Nat := w

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -224,15 +224,16 @@ def assert (p : Bool) (s : String) : PreSailM RegisterType c ue Unit :=
 section ConcurrencyInterface
 
 inductive Access_variety where
-| AV_plain
-| AV_exclusive
-| AV_atomic_rmw
+  | AV_plain
+  | AV_exclusive
+  | AV_atomic_rmw
+deriving DecidableEq
 export Access_variety (AV_plain AV_exclusive AV_atomic_rmw)
 
 inductive Access_strength where
-| AS_normal
-| AS_rel_or_acq
-| AS_acq_rcpc
+  | AS_normal
+  | AS_rel_or_acq
+  | AS_acq_rcpc
 export Access_strength(AS_normal AS_rel_or_acq AS_acq_rcpc)
 
 structure Explicit_access_kind where

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -516,7 +516,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
     let d_of_arg ctx arg =
       let wrap =
         match arg with
-        | E_aux (E_let _, _) | E_aux (E_internal_plet _, _) | E_aux (E_if _, _) -> parens
+        | E_aux (E_let _, _) | E_aux (E_internal_plet _, _) | E_aux (E_if _, _) | E_aux (E_match _, _) -> parens
         | _ -> fun x -> x
       in
       wrap (doc_exp false ctx arg)
@@ -675,7 +675,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
           (braces (space ^^ doc_exp false ctx exp ^^ string " with " ^^ separate (comma ^^ space) args ^^ space))
     | E_match (discr, brs) ->
         let cases = separate_map hardline (doc_match_clause as_monadic ctx) brs in
-        string (match_or_match_bv brs) ^^ doc_exp false (remove_er ctx) discr ^^ string " with" ^^ hardline ^^ cases
+        string (match_or_match_bv brs) ^^ d_of_arg (remove_er ctx) discr ^^ string " with" ^^ hardline ^^ cases
     | E_assign ((LE_aux (le_act, tannot) as le), e) ->
         wrap_with_left_arrow (not as_monadic)
           ( match le_act with
@@ -685,7 +685,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
           )
     | E_if (i, t, e) ->
         let statements_monadic = as_monadic || effectful (effect_of t) || effectful (effect_of e) in
-        nest 2 (string "if" ^^ space ^^ nest 1 (doc_exp false (remove_er ctx) i))
+        nest 2 (string "if" ^^ space ^^ nest 1 (d_of_arg (remove_er ctx) i))
         ^^ hardline
         ^^ nest 2 (string "then" ^^ space ^^ nest 3 (doc_exp statements_monadic ctx t))
         ^^ hardline
@@ -835,9 +835,7 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
   | TD_enum (id, fields, _) ->
       let fields = List.map doc_id_ctor fields in
       let fields = List.map (fun i -> space ^^ pipe ^^ space ^^ i) fields in
-      let derivers =
-        if List.length fields == 0 then [string "DecidableEq"] else [string "Inhabited"; string "DecidableEq"]
-      in
+      let derivers = if List.length fields == 0 then [string "BEq"] else [string "Inhabited"; string "BEq"] in
       let enums_doc = concat fields in
       let id = doc_id_ctor id in
       nest 2
@@ -853,7 +851,7 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       doc_typ_quant_in_comment ctx tq ^^ hardline
       ^^ nest 2
            (flow (break 1) (remove_empties [string "structure"; doc_id_ctor id; rectyp; string "where"])
-           ^^ hardline ^^ fields_doc ^^ hardline ^^ string "deriving DecidableEq"
+           ^^ hardline ^^ fields_doc ^^ hardline ^^ string "deriving BEq"
            )
   | TD_abbrev (id, tq, A_aux (A_typ (Typ_aux (Typ_app (Id_aux (Id "range", _), _), _) as t), _)) ->
       let vars = doc_typ_quant_relevant ctx tq in
@@ -875,7 +873,10 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let rectyp = List.map (fun d -> parens d) rectyp |> separate space in
       let id = doc_id_ctor id in
       doc_typ_quant_in_comment ctx tq ^^ hardline
-      ^^ nest 2 (nest 2 (flow space (remove_empties [string "inductive"; id; rectyp; string "where"])) ^^ pp_tus ^^ hardline ^^ string "deriving DecidableEq")
+      ^^ nest 2
+           (nest 2 (flow space (remove_empties [string "inductive"; id; rectyp; string "where"]))
+           ^^ pp_tus ^^ hardline ^^ string "deriving BEq"
+           )
       ^^ hardline ^^ hardline
       ^^ flow space [string "open"; id]
   | _ -> failwith ("Type definition " ^ string_of_type_def_con full_typdef ^ " not translatable yet.")

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -166,7 +166,7 @@ let rec doc_nexp ctx (Nexp_aux (n, l) as nexp) =
   and uneg (Nexp_aux (n, l) as nexp) =
     match n with Nexp_neg n -> parens (separate space [minus; uneg n]) | _ -> exp nexp
   and exp (Nexp_aux (n, l) as nexp) =
-    match n with Nexp_exp n -> separate space [string "2"; caret; exp n] | _ -> app nexp
+    match n with Nexp_exp n -> separate space [string "pow2"; exp n] | _ -> app nexp
   and app (Nexp_aux (n, l) as nexp) =
     match n with
     | Nexp_if (i, t, e) ->
@@ -250,7 +250,7 @@ and doc_typ ctx (Typ_aux (t, _) as typ) =
   | Typ_app (Id_aux (Id "result", _), [A_aux (A_typ typ1, _); A_aux (A_typ typ2, _)]) ->
       parens (separate space [string "Result"; doc_typ ctx typ1; doc_typ ctx typ2])
   | Typ_var kid -> doc_kid ctx kid
-  | Typ_app (id, args) -> doc_id_ctor id ^^ space ^^ separate_map space (doc_typ_arg ctx `Only_relevant) args
+  | Typ_app (id, args) -> parens (doc_id_ctor id ^^ space ^^ separate_map space (doc_typ_arg ctx `Only_relevant) args)
   | Typ_exist (_, _, typ) -> doc_typ ctx typ
   | _ -> failwith ("Type " ^ string_of_typ_con typ ^ " " ^ string_of_typ typ ^ " not translatable yet.")
 
@@ -474,8 +474,9 @@ let rebind_cast_pattern_vars pat typ exp =
   in
   List.fold_left add_lb exp lbs
 
-let wrap_with_pure (needs_return : bool) (d : document) =
-  if needs_return then parens (nest 2 (flow space [string "pure"; d])) else d
+let wrap_with_pure (needs_return : bool) ?(with_parens = false) (d : document) =
+  if needs_return then let d = if with_parens then parens d else d in
+    parens (nest 2 (flow space [string "pure"; d])) else d
 
 let wrap_with_left_arrow (needs_return : bool) (d : document) =
   if needs_return then parens (nest 2 (flow space [string "←"; d])) else d
@@ -591,7 +592,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
             in
             let effects = effectful (effect_of body) in
             let early_return = has_early_return body in
-            let combinator, catch, as_monadic =
+            let combinator, catch, body_as_monadic =
               match (as_monadic && effects, early_return) with
               | true, true -> ("foreach_ME", string "catchEarlyReturn", true)
               | true, false -> ("foreach_M", empty, true)
@@ -609,10 +610,11 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
             let body_lambda = if effects then body_lambda ^^ string " do" else body_lambda in
             (* TODO: this should probably be construct_dep_pairs, but we would need
                to change it to use the updated context. *)
-            let body_pp = doc_exp as_monadic body_ctxt body in
+            let body_pp = doc_exp body_as_monadic body_ctxt body in
             let loop_head = flow (break 1) [string combinator; from_exp_pp; to_exp_pp; step_exp_pp; vartuple_pp] in
             let full_loop = (prefix 2 1) loop_head (parens (prefix 2 1 (group body_lambda) body_pp)) in
-            if early_return then flow (break 1) [catch; parens full_loop] else full_loop
+            let full_loop = if early_return then flow (break 1) [catch; parens full_loop] else full_loop in
+            wrap_with_pure ( as_monadic && not (early_return || body_as_monadic)) ~with_parens:true full_loop
         | _ -> raise (Reporting.err_unreachable l __POS__ "Unexpected number of arguments for loop combinator")
       end
     | E_app (f, args) ->
@@ -635,7 +637,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
           match typ_of full_exp with
           | Typ_aux (Typ_app (Id_aux (Id "bitvector", _), [A_aux (A_nexp m, _)]), _)
           | Typ_aux (Typ_app (Id_aux (Id "bits", _), [A_aux (A_nexp m, _)]), _) ->
-              nest 2 (flow space [string "BitVec.join1"; brackets (separate_map comma_sp (d_of_arg ctx) vals)])
+              nest 2 (parens (flow space [string "BitVec.join1"; brackets (separate_map comma_sp (d_of_arg ctx) vals)]))
           | _ -> string "#v" ^^ wrap_with_pure as_monadic (brackets (nest 2 (separate_map comma_sp (d_of_arg ctx) vals)))
         in
         pp
@@ -676,8 +678,8 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
     | E_assign ((LE_aux (le_act, tannot) as le), e) ->
         wrap_with_left_arrow (not as_monadic)
           ( match le_act with
-          | LE_id id | LE_typ (_, id) -> string "writeReg " ^^ doc_id_ctor id ^^ space ^^ doc_exp false ctx e
-          | LE_deref e' -> string "writeRegRef " ^^ doc_exp false ctx e' ^^ space ^^ doc_exp false ctx e
+          | LE_id id | LE_typ (_, id) -> string "writeReg " ^^ doc_id_ctor id ^^ space ^^ d_of_arg ctx e
+          | LE_deref e' -> string "writeRegRef " ^^ d_of_arg ctx e' ^^ space ^^ d_of_arg ctx e
           | _ -> failwith ("assign " ^ string_of_lexp le ^ "not implemented yet")
           )
     | E_if (i, t, e) ->

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -514,13 +514,12 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
   else (
     let env = env_of_tannot annot in
     let d_of_arg ctx arg =
-      let arg_monadic = effectful (effect_of arg) in
       let wrap =
         match arg with
         | E_aux (E_let _, _) | E_aux (E_internal_plet _, _) | E_aux (E_if _, _) -> parens
         | _ -> fun x -> x
       in
-      wrap_with_left_arrow arg_monadic (wrap (doc_exp arg_monadic ctx arg))
+      wrap (doc_exp false ctx arg)
     in
     let d_of_field (FE_aux (FE_fexp (field, e), _) as fexp) =
       let field_monadic = effectful (effect_of e) in

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -853,7 +853,7 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       doc_typ_quant_in_comment ctx tq ^^ hardline
       ^^ nest 2
            (flow (break 1) (remove_empties [string "structure"; doc_id_ctor id; rectyp; string "where"])
-           ^^ hardline ^^ fields_doc
+           ^^ hardline ^^ fields_doc ^^ hardline ^^ string "deriving DecidableEq"
            )
   | TD_abbrev (id, tq, A_aux (A_typ (Typ_aux (Typ_app (Id_aux (Id "range", _), _), _) as t), _)) ->
       let vars = doc_typ_quant_relevant ctx tq in
@@ -875,7 +875,7 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let rectyp = List.map (fun d -> parens d) rectyp |> separate space in
       let id = doc_id_ctor id in
       doc_typ_quant_in_comment ctx tq ^^ hardline
-      ^^ nest 2 (nest 2 (flow space (remove_empties [string "inductive"; id; rectyp; string "where"])) ^^ pp_tus)
+      ^^ nest 2 (nest 2 (flow space (remove_empties [string "inductive"; id; rectyp; string "where"])) ^^ pp_tus ^^ hardline ^^ string "deriving DecidableEq")
       ^^ hardline ^^ hardline
       ^^ flow space [string "open"; id]
   | _ -> failwith ("Type definition " ^ string_of_type_def_con full_typdef ^ " not translatable yet.")

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -165,8 +165,7 @@ let rec doc_nexp ctx (Nexp_aux (n, l) as nexp) =
     match n with Nexp_times (n1, n2) -> separate space [mul n1; star; uneg n2] | _ -> uneg nexp
   and uneg (Nexp_aux (n, l) as nexp) =
     match n with Nexp_neg n -> parens (separate space [minus; uneg n]) | _ -> exp nexp
-  and exp (Nexp_aux (n, l) as nexp) =
-    match n with Nexp_exp n -> separate space [string "pow2"; exp n] | _ -> app nexp
+  and exp (Nexp_aux (n, l) as nexp) = match n with Nexp_exp n -> separate space [string "pow2"; exp n] | _ -> app nexp
   and app (Nexp_aux (n, l) as nexp) =
     match n with
     | Nexp_if (i, t, e) ->
@@ -475,8 +474,11 @@ let rebind_cast_pattern_vars pat typ exp =
   List.fold_left add_lb exp lbs
 
 let wrap_with_pure (needs_return : bool) ?(with_parens = false) (d : document) =
-  if needs_return then let d = if with_parens then parens d else d in
-    parens (nest 2 (flow space [string "pure"; d])) else d
+  if needs_return then (
+    let d = if with_parens then parens d else d in
+    parens (nest 2 (flow space [string "pure"; d]))
+  )
+  else d
 
 let wrap_with_left_arrow (needs_return : bool) (d : document) =
   if needs_return then parens (nest 2 (flow space [string "←"; d])) else d
@@ -614,7 +616,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
             let loop_head = flow (break 1) [string combinator; from_exp_pp; to_exp_pp; step_exp_pp; vartuple_pp] in
             let full_loop = (prefix 2 1) loop_head (parens (prefix 2 1 (group body_lambda) body_pp)) in
             let full_loop = if early_return then flow (break 1) [catch; parens full_loop] else full_loop in
-            wrap_with_pure ( as_monadic && not (early_return || body_as_monadic)) ~with_parens:true full_loop
+            wrap_with_pure (as_monadic && not (early_return || body_as_monadic)) ~with_parens:true full_loop
         | _ -> raise (Reporting.err_unreachable l __POS__ "Unexpected number of arguments for loop combinator")
       end
     | E_app (f, args) ->

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -1844,7 +1844,7 @@ def decodeCompareAndBranch (imm19 : (BitVec 19)) (Rt : (BitVec 5)) : (Option ast
   (some (CompareAndBranch (t, offset)))
 
 def wMem (addr : (BitVec 64)) (value : (BitVec 64)) : SailM Unit := do
-  let req : Mem_write_request 8 64 (BitVec 56) (Option TranslationInfo) arm_acc_type :=
+  let req : (Mem_write_request 8 64 (BitVec 56) (Option TranslationInfo) arm_acc_type) :=
     { access_kind := (AK_explicit
         { variety := AV_plain
           strength := AS_normal })
@@ -1868,7 +1868,7 @@ def wMem_Addr (addr : (BitVec 64)) : Unit :=
 /-- Type quantifiers: m : Nat, n : Nat, t : Nat, 0 ≤ t ∧ t ≤ 31, 0 ≤ n ∧ n ≤ 31, 0 ≤ m
   ∧ m ≤ 31 -/
 def execute_StoreRegister (t : Nat) (n : Nat) (m : Nat) : SailM Unit := do
-  writeReg _PC (BitVec.addInt (← readReg _PC) 4)
+  writeReg _PC (← (pure (BitVec.addInt (← readReg _PC) 4)))
   let base_addr ← do (rX n)
   let offset ← do (rX m)
   let addr := (HAdd.hAdd base_addr offset)
@@ -1877,7 +1877,7 @@ def execute_StoreRegister (t : Nat) (n : Nat) (m : Nat) : SailM Unit := do
   (wMem addr data)
 
 def rMem (addr : (BitVec 64)) : SailM (BitVec 64) := do
-  let req : Mem_read_request 8 64 (BitVec 56) (Option TranslationInfo) arm_acc_type :=
+  let req : (Mem_read_request 8 64 (BitVec 56) (Option TranslationInfo) arm_acc_type) :=
     { access_kind := (AK_explicit
         { variety := AV_plain
           strength := AS_normal })
@@ -1893,7 +1893,7 @@ def rMem (addr : (BitVec 64)) : SailM (BitVec 64) := do
 /-- Type quantifiers: m : Nat, n : Nat, t : Nat, 0 ≤ t ∧ t ≤ 31, 0 ≤ n ∧ n ≤ 31, 0 ≤ m
   ∧ m ≤ 31 -/
 def execute_LoadRegister (t : Nat) (n : Nat) (m : Nat) : SailM Unit := do
-  writeReg _PC (BitVec.addInt (← readReg _PC) 4)
+  writeReg _PC (← (pure (BitVec.addInt (← readReg _PC) 4)))
   let base_addr ← do (rX n)
   let offset ← do (rX m)
   let addr := (HAdd.hAdd base_addr offset)
@@ -1924,7 +1924,7 @@ def execute_CompareAndBranch (t : Nat) (offset : (BitVec 64)) : SailM Unit := do
   then let base ← do (rPC ())
        let addr := (HAdd.hAdd base offset)
        (wPC addr)
-  else writeReg _PC (BitVec.addInt (← readReg _PC) 4)
+  else writeReg _PC (← (pure (BitVec.addInt (← readReg _PC) 4)))
 
 def execute (merge_var : ast) : SailM Unit := do
   match merge_var with
@@ -1965,7 +1965,7 @@ def decode (v__0 : (BitVec 32)) : (Option ast) :=
                  else none
 
 def iFetch (addr : (BitVec 64)) : SailM (BitVec 32) := do
-  let req : Mem_read_request 4 64 (BitVec 56) (Option TranslationInfo) arm_acc_type :=
+  let req : (Mem_read_request 4 64 (BitVec 56) (Option TranslationInfo) arm_acc_type) :=
     { access_kind := (AK_ifetch ())
       va := (some addr)
       pa := (Sail.BitVec.truncate addr 56)
@@ -2085,7 +2085,7 @@ def undefined_Explicit_access_kind (_ : Unit) : SailM Explicit_access_kind := do
 
 /-- Type quantifiers: k_n : Nat, k_vasize : Nat, k_pa : Type, k_translation_summary : Type, k_arch_ak
   : Type, k_n > 0 ∧ k_vasize > 0 -/
-def mem_read_request_is_exclusive (request : Mem_read_request k_n k_vasize k_pa k_translation_summary k_arch_ak) : Bool :=
+def mem_read_request_is_exclusive (request : (Mem_read_request k_n k_vasize k_pa k_translation_summary k_arch_ak)) : Bool :=
   match request.access_kind with
   | .AK_explicit eak =>
     match eak.variety with
@@ -2095,7 +2095,7 @@ def mem_read_request_is_exclusive (request : Mem_read_request k_n k_vasize k_pa 
 
 /-- Type quantifiers: k_n : Nat, k_vasize : Nat, k_pa : Type, k_translation_summary : Type, k_arch_ak
   : Type, k_n > 0 ∧ k_vasize > 0 -/
-def mem_read_request_is_ifetch (request : Mem_read_request k_n k_vasize k_pa k_translation_summary k_arch_ak) : Bool :=
+def mem_read_request_is_ifetch (request : (Mem_read_request k_n k_vasize k_pa k_translation_summary k_arch_ak)) : Bool :=
   match request.access_kind with
   | .AK_ifetch () => true
   | _ => false
@@ -2106,7 +2106,7 @@ def __monomorphize_writes : Bool := false
 
 /-- Type quantifiers: k_n : Nat, k_vasize : Nat, k_pa : Type, k_translation_summary : Type, k_arch_ak
   : Type, k_n > 0 ∧ k_vasize > 0 -/
-def mem_write_request_is_exclusive (request : Mem_write_request k_n k_vasize k_pa k_translation_summary k_arch_ak) : Bool :=
+def mem_write_request_is_exclusive (request : (Mem_write_request k_n k_vasize k_pa k_translation_summary k_arch_ak)) : Bool :=
   match request.access_kind with
   | .AK_explicit eak =>
     match eak.variety with

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
@@ -25,7 +25,7 @@ abbrev S1PIRType := (BitVec 64)
 abbrev S2PIRType := (BitVec 64)
 
 inductive SecurityState where | SS_NonSecure | SS_Root | SS_Realm | SS_Secure
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open SecurityState
 
@@ -34,7 +34,7 @@ abbrev PARTIDtype := (BitVec 16)
 abbrev PMGtype := (BitVec 8)
 
 inductive PARTIDspaceType where | PIdSpace_Secure | PIdSpace_Root | PIdSpace_Realm | PIdSpace_NonSecure
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open PARTIDspaceType
 
@@ -43,40 +43,40 @@ structure MPAMinfo where
   mpam_sp : PARTIDspaceType
   partid : PARTIDtype
   pmg : PMGtype
-  deriving DecidableEq
+  deriving BEq
 
 inductive AccessType where | AccessType_IFETCH | AccessType_GPR | AccessType_ASIMD | AccessType_SVE | AccessType_SME | AccessType_IC | AccessType_DC | AccessType_DCZero | AccessType_AT | AccessType_NV2 | AccessType_SPE | AccessType_GCS | AccessType_GPTW | AccessType_TTW
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open AccessType
 
 inductive VARange where | VARange_LOWER | VARange_UPPER
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open VARange
 
 inductive MemAtomicOp where | MemAtomicOp_GCSSS1 | MemAtomicOp_ADD | MemAtomicOp_BIC | MemAtomicOp_EOR | MemAtomicOp_ORR | MemAtomicOp_SMAX | MemAtomicOp_SMIN | MemAtomicOp_UMAX | MemAtomicOp_UMIN | MemAtomicOp_SWP | MemAtomicOp_CAS
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open MemAtomicOp
 
 inductive CacheOp where | CacheOp_Clean | CacheOp_Invalidate | CacheOp_CleanInvalidate
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open CacheOp
 
 inductive CacheOpScope where | CacheOpScope_SetWay | CacheOpScope_PoU | CacheOpScope_PoC | CacheOpScope_PoE | CacheOpScope_PoP | CacheOpScope_PoDP | CacheOpScope_PoPA | CacheOpScope_ALLU | CacheOpScope_ALLUIS
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open CacheOpScope
 
 inductive CacheType where | CacheType_Data | CacheType_Tag | CacheType_Data_Tag | CacheType_Instruction
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open CacheType
 
 inductive CachePASpace where | CPAS_NonSecure | CPAS_Any | CPAS_RealmNonSecure | CPAS_Realm | CPAS_Root | CPAS_SecureNonSecure | CPAS_Secure
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open CachePASpace
 
@@ -115,15 +115,15 @@ structure AccessDescriptor where
   tagchecked : Bool
   tagaccess : Bool
   mpam : MPAMinfo
-  deriving DecidableEq
+  deriving BEq
 
 inductive MemType where | MemType_Normal | MemType_Device
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open MemType
 
 inductive DeviceType where | DeviceType_GRE | DeviceType_nGRE | DeviceType_nGnRE | DeviceType_nGnRnE
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open DeviceType
 
@@ -132,15 +132,15 @@ structure MemAttrHints where
   attrs : (BitVec 2)
   hints : (BitVec 2)
   transient : Bool
-  deriving DecidableEq
+  deriving BEq
 
 inductive Shareability where | Shareability_NSH | Shareability_ISH | Shareability_OSH
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open Shareability
 
 inductive MemTagType where | MemTag_Untagged | MemTag_AllocationTagged | MemTag_CanonicallyTagged
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open MemTagType
 
@@ -154,10 +154,10 @@ structure MemoryAttributes where
   tags : MemTagType
   notagaccess : Bool
   xs : (BitVec 1)
-  deriving DecidableEq
+  deriving BEq
 
 inductive PASpace where | PAS_NonSecure | PAS_Secure | PAS_Root | PAS_Realm
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open PASpace
 
@@ -165,10 +165,10 @@ open PASpace
 structure FullAddress where
   paspace : PASpace
   address : (BitVec 56)
-  deriving DecidableEq
+  deriving BEq
 
 inductive GPCF where | GPCF_None | GPCF_AddressSize | GPCF_Walk | GPCF_EABT | GPCF_Fail
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open GPCF
 
@@ -176,15 +176,15 @@ open GPCF
 structure GPCFRecord where
   gpf : GPCF
   level : Int
-  deriving DecidableEq
+  deriving BEq
 
 inductive Fault where | Fault_None | Fault_AccessFlag | Fault_Alignment | Fault_Background | Fault_Domain | Fault_Permission | Fault_Translation | Fault_AddressSize | Fault_SyncExternal | Fault_SyncExternalOnWalk | Fault_SyncParity | Fault_SyncParityOnWalk | Fault_GPCFOnWalk | Fault_GPCFOnOutput | Fault_AsyncParity | Fault_AsyncExternal | Fault_TagCheck | Fault_Debug | Fault_TLBConflict | Fault_BranchTarget | Fault_HWUpdateAccessFlag | Fault_Lockdown | Fault_Exclusive | Fault_ICacheMaint
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open Fault
 
 inductive ErrorState where | ErrorState_UC | ErrorState_UEU | ErrorState_UEO | ErrorState_UER | ErrorState_CE | ErrorState_Uncategorized | ErrorState_IMPDEF
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open ErrorState
 
@@ -210,15 +210,15 @@ structure FaultRecord where
   domain : (BitVec 4)
   merrorstate : ErrorState
   debugmoe : (BitVec 4)
-  deriving DecidableEq
+  deriving BEq
 
 inductive MBReqDomain where | MBReqDomain_Nonshareable | MBReqDomain_InnerShareable | MBReqDomain_OuterShareable | MBReqDomain_FullSystem
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open MBReqDomain
 
 inductive MBReqTypes where | MBReqTypes_Reads | MBReqTypes_Writes | MBReqTypes_All
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open MBReqTypes
 
@@ -242,15 +242,15 @@ structure CacheRecord where
   asid : (BitVec 16)
   security : SecurityState
   cpas : CachePASpace
-  deriving DecidableEq
+  deriving BEq
 
 inductive Regime where | Regime_EL3 | Regime_EL30 | Regime_EL2 | Regime_EL20 | Regime_EL10
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open Regime
 
 inductive TGx where | TGx_4KB | TGx_16KB | TGx_64KB
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open TGx
 
@@ -296,7 +296,7 @@ structure S1TTWParams where
   dc : (BitVec 1)
   sif : (BitVec 1)
   mair : MAIRType
-  deriving DecidableEq
+  deriving BEq
 
 
 structure S2TTWParams where
@@ -331,7 +331,7 @@ structure S2TTWParams where
   ee : (BitVec 1)
   ptw : (BitVec 1)
   vm : (BitVec 1)
-  deriving DecidableEq
+  deriving BEq
 
 
 structure TranslationInfo where
@@ -344,20 +344,20 @@ structure TranslationInfo where
   s1params : (Option S1TTWParams)
   s2params : (Option S2TTWParams)
   memattrs : MemoryAttributes
-  deriving DecidableEq
+  deriving BEq
 
 inductive TLBILevel where | TLBILevel_Any | TLBILevel_Last
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open TLBILevel
 
 inductive TLBIOp where | TLBIOp_DALL | TLBIOp_DASID | TLBIOp_DVA | TLBIOp_IALL | TLBIOp_IASID | TLBIOp_IVA | TLBIOp_ALL | TLBIOp_ASID | TLBIOp_IPAS2 | TLBIPOp_IPAS2 | TLBIOp_VAA | TLBIOp_VA | TLBIPOp_VAA | TLBIPOp_VA | TLBIOp_VMALL | TLBIOp_VMALLS12 | TLBIOp_RIPAS2 | TLBIPOp_RIPAS2 | TLBIOp_RVAA | TLBIOp_RVA | TLBIPOp_RVAA | TLBIPOp_RVA | TLBIOp_RPA | TLBIOp_PAALL
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open TLBIOp
 
 inductive TLBIMemAttr where | TLBI_AllAttr | TLBI_ExcludeXS
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open TLBIMemAttr
 
@@ -378,7 +378,7 @@ structure TLBIRecord where
   d128 : Bool
   ttl : (BitVec 4)
   tg : (BitVec 2)
-  deriving DecidableEq
+  deriving BEq
 
 
 inductive arm_acc_type where
@@ -393,7 +393,7 @@ inductive arm_acc_type where
   | SAcc_SPE (_ : Unit)
   | SAcc_GCS (_ : Unit)
   | SAcc_GPTW (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open arm_acc_type
 
@@ -401,14 +401,14 @@ open arm_acc_type
 structure TLBIInfo where
   rec' : TLBIRecord
   shareability : Shareability
-  deriving DecidableEq
+  deriving BEq
 
 
 structure DxB where
   domain : MBReqDomain
   types : MBReqTypes
   nXS : Bool
-  deriving DecidableEq
+  deriving BEq
 
 
 inductive Barrier where
@@ -418,7 +418,7 @@ inductive Barrier where
   | Barrier_SSBB (_ : Unit)
   | Barrier_PSSBB (_ : Unit)
   | Barrier_SB (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open Barrier
 
@@ -437,7 +437,7 @@ inductive ast where
   | ExclusiveOr (_ : (reg_index × reg_index × reg_index))
   | DataMemoryBarrier (_ : Unit)
   | CompareAndBranch (_ : (reg_index × (BitVec 64)))
-  deriving DecidableEq
+  deriving BEq
 
 open ast
 

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 
@@ -42,6 +43,7 @@ structure MPAMinfo where
   mpam_sp : PARTIDspaceType
   partid : PARTIDtype
   pmg : PMGtype
+  deriving DecidableEq
 
 inductive AccessType where | AccessType_IFETCH | AccessType_GPR | AccessType_ASIMD | AccessType_SVE | AccessType_SME | AccessType_IC | AccessType_DC | AccessType_DCZero | AccessType_AT | AccessType_NV2 | AccessType_SPE | AccessType_GCS | AccessType_GPTW | AccessType_TTW
   deriving Inhabited, DecidableEq
@@ -113,6 +115,7 @@ structure AccessDescriptor where
   tagchecked : Bool
   tagaccess : Bool
   mpam : MPAMinfo
+  deriving DecidableEq
 
 inductive MemType where | MemType_Normal | MemType_Device
   deriving Inhabited, DecidableEq
@@ -129,6 +132,7 @@ structure MemAttrHints where
   attrs : (BitVec 2)
   hints : (BitVec 2)
   transient : Bool
+  deriving DecidableEq
 
 inductive Shareability where | Shareability_NSH | Shareability_ISH | Shareability_OSH
   deriving Inhabited, DecidableEq
@@ -150,6 +154,7 @@ structure MemoryAttributes where
   tags : MemTagType
   notagaccess : Bool
   xs : (BitVec 1)
+  deriving DecidableEq
 
 inductive PASpace where | PAS_NonSecure | PAS_Secure | PAS_Root | PAS_Realm
   deriving Inhabited, DecidableEq
@@ -160,6 +165,7 @@ open PASpace
 structure FullAddress where
   paspace : PASpace
   address : (BitVec 56)
+  deriving DecidableEq
 
 inductive GPCF where | GPCF_None | GPCF_AddressSize | GPCF_Walk | GPCF_EABT | GPCF_Fail
   deriving Inhabited, DecidableEq
@@ -170,6 +176,7 @@ open GPCF
 structure GPCFRecord where
   gpf : GPCF
   level : Int
+  deriving DecidableEq
 
 inductive Fault where | Fault_None | Fault_AccessFlag | Fault_Alignment | Fault_Background | Fault_Domain | Fault_Permission | Fault_Translation | Fault_AddressSize | Fault_SyncExternal | Fault_SyncExternalOnWalk | Fault_SyncParity | Fault_SyncParityOnWalk | Fault_GPCFOnWalk | Fault_GPCFOnOutput | Fault_AsyncParity | Fault_AsyncExternal | Fault_TagCheck | Fault_Debug | Fault_TLBConflict | Fault_BranchTarget | Fault_HWUpdateAccessFlag | Fault_Lockdown | Fault_Exclusive | Fault_ICacheMaint
   deriving Inhabited, DecidableEq
@@ -203,6 +210,7 @@ structure FaultRecord where
   domain : (BitVec 4)
   merrorstate : ErrorState
   debugmoe : (BitVec 4)
+  deriving DecidableEq
 
 inductive MBReqDomain where | MBReqDomain_Nonshareable | MBReqDomain_InnerShareable | MBReqDomain_OuterShareable | MBReqDomain_FullSystem
   deriving Inhabited, DecidableEq
@@ -234,6 +242,7 @@ structure CacheRecord where
   asid : (BitVec 16)
   security : SecurityState
   cpas : CachePASpace
+  deriving DecidableEq
 
 inductive Regime where | Regime_EL3 | Regime_EL30 | Regime_EL2 | Regime_EL20 | Regime_EL10
   deriving Inhabited, DecidableEq
@@ -287,6 +296,7 @@ structure S1TTWParams where
   dc : (BitVec 1)
   sif : (BitVec 1)
   mair : MAIRType
+  deriving DecidableEq
 
 
 structure S2TTWParams where
@@ -321,6 +331,7 @@ structure S2TTWParams where
   ee : (BitVec 1)
   ptw : (BitVec 1)
   vm : (BitVec 1)
+  deriving DecidableEq
 
 
 structure TranslationInfo where
@@ -333,6 +344,7 @@ structure TranslationInfo where
   s1params : (Option S1TTWParams)
   s2params : (Option S2TTWParams)
   memattrs : MemoryAttributes
+  deriving DecidableEq
 
 inductive TLBILevel where | TLBILevel_Any | TLBILevel_Last
   deriving Inhabited, DecidableEq
@@ -366,6 +378,7 @@ structure TLBIRecord where
   d128 : Bool
   ttl : (BitVec 4)
   tg : (BitVec 2)
+  deriving DecidableEq
 
 
 inductive arm_acc_type where
@@ -380,6 +393,7 @@ inductive arm_acc_type where
   | SAcc_SPE (_ : Unit)
   | SAcc_GCS (_ : Unit)
   | SAcc_GPTW (_ : Unit)
+  deriving DecidableEq
 
 open arm_acc_type
 
@@ -387,12 +401,14 @@ open arm_acc_type
 structure TLBIInfo where
   rec' : TLBIRecord
   shareability : Shareability
+  deriving DecidableEq
 
 
 structure DxB where
   domain : MBReqDomain
   types : MBReqTypes
   nXS : Bool
+  deriving DecidableEq
 
 
 inductive Barrier where
@@ -402,6 +418,7 @@ inductive Barrier where
   | Barrier_SSBB (_ : Unit)
   | Barrier_PSSBB (_ : Unit)
   | Barrier_SB (_ : Unit)
+  deriving DecidableEq
 
 open Barrier
 
@@ -420,6 +437,7 @@ inductive ast where
   | ExclusiveOr (_ : (reg_index × reg_index × reg_index))
   | DataMemoryBarrier (_ : Unit)
   | CompareAndBranch (_ : (reg_index × (BitVec 64)))
+  deriving DecidableEq
 
 open ast
 

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -1868,7 +1868,7 @@ def wMem_Addr (addr : (BitVec 64)) : Unit :=
 /-- Type quantifiers: m : Nat, n : Nat, t : Nat, 0 ≤ t ∧ t ≤ 31, 0 ≤ n ∧ n ≤ 31, 0 ≤ m
   ∧ m ≤ 31 -/
 def execute_StoreRegister (t : Nat) (n : Nat) (m : Nat) : SailM Unit := do
-  writeReg _PC (← (pure (BitVec.addInt (← readReg _PC) 4)))
+  writeReg _PC (BitVec.addInt (← readReg _PC) 4)
   let base_addr ← do (rX n)
   let offset ← do (rX m)
   let addr := (HAdd.hAdd base_addr offset)
@@ -1893,7 +1893,7 @@ def rMem (addr : (BitVec 64)) : SailM (BitVec 64) := do
 /-- Type quantifiers: m : Nat, n : Nat, t : Nat, 0 ≤ t ∧ t ≤ 31, 0 ≤ n ∧ n ≤ 31, 0 ≤ m
   ∧ m ≤ 31 -/
 def execute_LoadRegister (t : Nat) (n : Nat) (m : Nat) : SailM Unit := do
-  writeReg _PC (← (pure (BitVec.addInt (← readReg _PC) 4)))
+  writeReg _PC (BitVec.addInt (← readReg _PC) 4)
   let base_addr ← do (rX n)
   let offset ← do (rX m)
   let addr := (HAdd.hAdd base_addr offset)
@@ -1924,7 +1924,7 @@ def execute_CompareAndBranch (t : Nat) (offset : (BitVec 64)) : SailM Unit := do
   then let base ← do (rPC ())
        let addr := (HAdd.hAdd base offset)
        (wPC addr)
-  else writeReg _PC (← (pure (BitVec.addInt (← readReg _PC) 4)))
+  else writeReg _PC (BitVec.addInt (← readReg _PC) 4)
 
 def execute (merge_var : ast) : SailM Unit := do
   match merge_var with

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -147,7 +147,7 @@ def bitvector_plus_int (x : (BitVec 16)) (i : Int) : (BitVec 16) :=
   (BitVec.addInt x i)
 
 def bitvector_literal (x : (BitVec 1)) (y : (BitVec 1)) : (BitVec 2) :=
-  BitVec.join1 [x, y]
+  (BitVec.join1 [x, y])
 
 /-- Type quantifiers: y : Int, x : Int -/
 def vector_literal (x : Int) (y : Int) : (Vector Int 2) :=

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -14,12 +14,12 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
 inductive E where | A | B | C
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open E
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -112,7 +112,8 @@ def foreachloop (m : Nat) (n : Nat) : Int :=
 def foreachloopmon (m : Nat) (n : Nat) : SailM Int := do
   let loop_i_lower := n
   let loop_i_upper := m
-  foreach_M loop_i_lower loop_i_upper 1 () (λ i _ => do writeReg r (HAdd.hAdd (← readReg r) 1))
+  foreach_M loop_i_lower loop_i_upper 1 ()
+    (λ i _ => do writeReg r (← (pure (HAdd.hAdd (← readReg r) 1))))
   readReg r
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
@@ -124,7 +125,7 @@ def foreachloopboth (m : Nat) (n : Nat) : SailM Int := do
     foreach_M loop_i_lower loop_i_upper 1 res
       (λ i res => do
         let res : Int := (HAdd.hAdd res 1)
-        writeReg r (HAdd.hAdd (← readReg r) res)
+        writeReg r (← (pure (HAdd.hAdd (← readReg r) res)))
         (pure res))
   (pure (HAdd.hAdd res 1))
 
@@ -158,7 +159,7 @@ def earlyreturneffect (n : Nat) : SailM Bool := do
     (λ i _ => do
       if (GT.gt i 5)
       then (pure (early_return (false : Bool)))
-      else (pure (cont ((← writeReg r (HAdd.hAdd (← readReg r) 1)))))))
+      else (pure (cont ((← writeReg r (← (pure (HAdd.hAdd (← readReg r) 1)))))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -112,8 +112,7 @@ def foreachloop (m : Nat) (n : Nat) : Int :=
 def foreachloopmon (m : Nat) (n : Nat) : SailM Int := do
   let loop_i_lower := n
   let loop_i_upper := m
-  foreach_M loop_i_lower loop_i_upper 1 ()
-    (λ i _ => do writeReg r (← (pure (HAdd.hAdd (← readReg r) 1))))
+  foreach_M loop_i_lower loop_i_upper 1 () (λ i _ => do writeReg r (HAdd.hAdd (← readReg r) 1))
   readReg r
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
@@ -125,7 +124,7 @@ def foreachloopboth (m : Nat) (n : Nat) : SailM Int := do
     foreach_M loop_i_lower loop_i_upper 1 res
       (λ i res => do
         let res : Int := (HAdd.hAdd res 1)
-        writeReg r (← (pure (HAdd.hAdd (← readReg r) res)))
+        writeReg r (HAdd.hAdd (← readReg r) res)
         (pure res))
   (pure (HAdd.hAdd res 1))
 
@@ -159,7 +158,7 @@ def earlyreturneffect (n : Nat) : SailM Bool := do
     (λ i _ => do
       if (GT.gt i 5)
       then (pure (early_return (false : Bool)))
-      else (pure (cont ((← writeReg r (← (pure (HAdd.hAdd (← readReg r) 1)))))))))
+      else (pure (cont ((← writeReg r (HAdd.hAdd (← readReg r) 1)))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -14,12 +14,12 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
 inductive word_width where | BYTE | HALF | WORD | DOUBLE
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open word_width
 

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -14,12 +14,12 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
 inductive E where | A | B | C
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open E
 

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -120,7 +120,7 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def test (_ : Unit) : SailM Int := do
-  writeReg INT (HAdd.hAdd (← readReg INT) 1)
+  writeReg INT (← (pure (HAdd.hAdd (← readReg INT) 1)))
   readReg INT
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -120,7 +120,7 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def test (_ : Unit) : SailM Int := do
-  writeReg INT (← (pure (HAdd.hAdd (← readReg INT) 1)))
+  writeReg INT (HAdd.hAdd (← readReg INT) 1)
   readReg INT
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -147,7 +147,7 @@ def rX (r : (BitVec 5)) : SailM (BitVec 64) := do
 
 def wX (r : (BitVec 5)) (v : (BitVec 64)) : SailM Unit := do
   if (bne r (0b00000 : (BitVec 5)))
-  then writeReg Xs (← (pure (vectorUpdate (← readReg Xs) (BitVec.toNat r) v)))
+  then writeReg Xs (vectorUpdate (← readReg Xs) (BitVec.toNat r) v)
   else (pure ())
 
 /-- Type quantifiers: width : Nat, width ≥ 0 -/

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 
@@ -34,6 +35,7 @@ open iop
 inductive ast where
   | ITYPE (_ : ((BitVec 12) × regbits × regbits × iop))
   | LOAD (_ : ((BitVec 12) × regbits × regbits))
+  deriving DecidableEq
 
 open ast
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
@@ -27,7 +27,7 @@ abbrev xlenbits := (BitVec 64)
 abbrev regbits := (BitVec 5)
 
 inductive iop where | RISCV_ADDI | RISCV_SLTI | RISCV_SLTIU | RISCV_XORI | RISCV_ORI | RISCV_ANDI
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open iop
 
@@ -35,7 +35,7 @@ open iop
 inductive ast where
   | ITYPE (_ : ((BitVec 12) × regbits × regbits × iop))
   | LOAD (_ : ((BitVec 12) × regbits × regbits))
-  deriving DecidableEq
+  deriving BEq
 
 open ast
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -147,7 +147,7 @@ def rX (r : (BitVec 5)) : SailM (BitVec 64) := do
 
 def wX (r : (BitVec 5)) (v : (BitVec 64)) : SailM Unit := do
   if (bne r (0b00000 : (BitVec 5)))
-  then writeReg Xs (vectorUpdate (← readReg Xs) (BitVec.toNat r) v)
+  then writeReg Xs (← (pure (vectorUpdate (← readReg Xs) (BitVec.toNat r) v)))
   else (pure ())
 
 /-- Type quantifiers: width : Nat, width ≥ 0 -/

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
@@ -22,7 +22,7 @@ open option
 structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
-  deriving DecidableEq
+  deriving BEq
 
 /-- Type quantifiers: k_n : Int, k_vasize : Int, k_pa : Type, k_ts : Type, k_arch_ak : Type, k_n > 0
   ∧ k_vasize ≥ 0 -/
@@ -35,7 +35,7 @@ structure Mem_write_request
   size : Int
   value : (Option (BitVec (8 * k_n)))
   tag : (Option Bool)
-  deriving DecidableEq
+  deriving BEq
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 
@@ -21,6 +22,7 @@ open option
 structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
+  deriving DecidableEq
 
 /-- Type quantifiers: k_n : Int, k_vasize : Int, k_pa : Type, k_ts : Type, k_arch_ak : Type, k_n > 0
   ∧ k_vasize ≥ 0 -/
@@ -33,6 +35,7 @@ structure Mem_write_request
   size : Int
   value : (Option (BitVec (8 * k_n)))
   tag : (Option Bool)
+  deriving DecidableEq
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 
@@ -25,6 +26,7 @@ open e_test
 
 structure s_test where
   f : e_test
+  deriving DecidableEq
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -14,19 +14,19 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
 inductive e_test where | VAL
-  deriving Inhabited, DecidableEq
+  deriving Inhabited, BEq
 
 open e_test
 
 
 structure s_test where
   f : e_test
-  deriving DecidableEq
+  deriving BEq
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
 

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -14,6 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -14,7 +14,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -14,12 +14,14 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
+  deriving DecidableEq
 
 open option
 
 
 inductive virtaddr where
   | virtaddr (_ : (BitVec 32))
+  deriving DecidableEq
 
 open virtaddr
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -14,14 +14,14 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open option
 
 
 inductive virtaddr where
   | virtaddr (_ : (BitVec 32))
-  deriving DecidableEq
+  deriving BEq
 
 open virtaddr
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -11,18 +11,18 @@ open Sail
 structure rectangle where
   width : Int
   height : Int
-  deriving DecidableEq
+  deriving BEq
 
 
 structure circle where
   radius : Int
-  deriving DecidableEq
+  deriving BEq
 
 
 inductive shape where
   | Rectangle (_ : rectangle)
   | Circle (_ : circle)
-  deriving DecidableEq
+  deriving BEq
 
 open shape
 
@@ -31,7 +31,7 @@ open shape
 inductive my_option (k_a : Type) where
   | MySome (_ : k_a)
   | MyNone (_ : Unit)
-  deriving DecidableEq
+  deriving BEq
 
 open my_option
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -11,15 +11,18 @@ open Sail
 structure rectangle where
   width : Int
   height : Int
+  deriving DecidableEq
 
 
 structure circle where
   radius : Int
+  deriving DecidableEq
 
 
 inductive shape where
   | Rectangle (_ : rectangle)
   | Circle (_ : circle)
+  deriving DecidableEq
 
 open shape
 
@@ -28,6 +31,7 @@ open shape
 inductive my_option (k_a : Type) where
   | MySome (_ : k_a)
   | MyNone (_ : Unit)
+  deriving DecidableEq
 
 open my_option
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -43,13 +43,13 @@ def undefined_circle (_ : Unit) : SailM circle := do
   (pure { radius := (← (undefined_int ())) })
 
 /-- Type quantifiers: k_a : Type -/
-def is_none (opt : my_option k_a) : Bool :=
+def is_none (opt : (my_option k_a)) : Bool :=
   match opt with
   | .MySome _ => false
   | .MyNone () => true
 
 /-- Type quantifiers: k_a : Type -/
-def use_is_none (opt : my_option k_a) : Bool :=
+def use_is_none (opt : (my_option k_a)) : Bool :=
   (is_none opt)
 
 def initialize_registers (_ : Unit) : Unit :=


### PR DESCRIPTION
note: BEq is used instead of DecidableEq because RISC-V's ast type is too large for DecidableEq 