### PR TITLE
C: Add an option to generate C with minimal name mangling

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -68,6 +68,11 @@ metavar value ::=
   {{ lem value }}
   {{ isa value }}
 
+metavar attribute_data ::=
+  {{ phantom }}
+  {{ ocaml attribute_data }}
+  {{ lem attribute_data }}
+
 embed
 {{ ocaml
 
@@ -776,6 +781,11 @@ loop_measure :: '' ::= {{ lem (loop * exp unit) }}
    {{ auxparam 'a }}
    | loop exp :: :: Loop
 
+pragma :: 'Pragma_' ::=
+  {{ com pragma contents }}
+  | string l                                                    :: :: line
+  | string1 = attribute_data1 , ... , stringn = attribute_datan :: :: structured
+
 def :: 'DEF_' ::=
   {{ com top-level definition }}
   {{ aux _ def_annot }} {{ auxparam 'a 'b }}
@@ -813,7 +823,7 @@ def :: 'DEF_' ::=
     {{ com register declaration }}
   | fundef1 .. fundefn                                 :: I :: internal_mutrec
     {{ com internal representation of mutually recursive functions }}
-  | $ string1 string2 l                                :: :: pragma
+  | $ string pragma                                    :: :: pragma
     {{ com compiler directive }}
 
 terminals :: '' ::=

--- a/lib/arith.sail
+++ b/lib/arith.sail
@@ -185,6 +185,8 @@ val _tmod_int_positive = pure {
 
 overload tmod_int = {_tmod_int_positive, _tmod_int}
 
+$c_reserved fdiv_int
+
 function fdiv_int(n: int, m: int) -> int = {
   if n < 0 & m > 0 then {
     tdiv_int(n + 1, m) - 1
@@ -194,6 +196,8 @@ function fdiv_int(n: int, m: int) -> int = {
     tdiv_int(n, m)
   }
 }
+
+$c_reserved fmod_int
 
 function fmod_int(n: int, m: int) -> int = {
   n - (m * fdiv_int(n, m))

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -147,7 +147,7 @@ bool EQUAL(sail_string)(const_sail_string, const_sail_string);
 void concat_str(sail_string *stro, const_sail_string str1, const_sail_string str2);
 bool string_startswith(const_sail_string s, const_sail_string prefix);
 
-                       
+
 /* ***** Sail integers ***** */
 
 typedef int64_t mach_int;
@@ -352,7 +352,7 @@ void vector_subrange_inc_lbits(lbits *rop,
 			       const lbits op,
 			       const sail_int n_mpz,
 			       const sail_int m_mpz);
-                     
+
 void sail_truncate(lbits *rop, const lbits op, const sail_int len);
 void sail_truncateLSB(lbits *rop, const lbits op, const sail_int len);
 

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -1032,7 +1032,7 @@ and map_def_annot f (DEF_aux (aux, annot)) =
     | DEF_loop_measures (id, measures) -> DEF_loop_measures (id, measures)
     | DEF_register ds -> DEF_register (map_register_annot f ds)
     | DEF_internal_mutrec fds -> DEF_internal_mutrec (List.map (map_fundef_annot f) fds)
-    | DEF_pragma (name, arg, l) -> DEF_pragma (name, arg, l)
+    | DEF_pragma (pragma, arg) -> DEF_pragma (pragma, arg)
   in
   DEF_aux (aux, annot)
 
@@ -1058,7 +1058,7 @@ let rec map_def_def_annot f (DEF_aux (aux, annot)) =
     | DEF_loop_measures (id, measures) -> DEF_loop_measures (id, measures)
     | DEF_register ds -> DEF_register ds
     | DEF_internal_mutrec fds -> DEF_internal_mutrec fds
-    | DEF_pragma (name, arg, l) -> DEF_pragma (name, arg, l)
+    | DEF_pragma (pragma, arg) -> DEF_pragma (pragma, arg)
   in
   DEF_aux (aux, f annot)
 

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -1306,9 +1306,14 @@ let rec chunk_def source last_line_span comments chunks (DEF_aux (def, l)) =
       begin
         match def with
         | DEF_fundef fdef -> chunk_fundef comments chunks fdef
-        | DEF_pragma (pragma, arg, _) ->
+        | DEF_pragma (pragma, Pragma_line (arg, _)) ->
             Queue.add (Pragma (pragma, arg)) chunks;
             pragma_span := true
+        | DEF_pragma (pragma, Pragma_structured data) ->
+            let open Parse_ast.Attribute_data in
+            Queue.add
+              (Pragma (pragma, Ast_util.string_of_attribute_data (AD_aux (AD_object data, Parse_ast.Unknown))))
+              chunks
         | DEF_default dts -> chunk_default_typing_spec comments chunks dts
         | DEF_fixity (prec, n, id) ->
             pop_comments comments chunks (id_loc id);

--- a/src/lib/effects.ml
+++ b/src/lib/effects.ml
@@ -392,7 +392,7 @@ let check_side_effects effect_info ast =
   List.iter
     (fun (DEF_aux (aux, _) as def) ->
       match aux with
-      | DEF_pragma ("non_exec", name, _) -> allowed_nonexec := IdSet.add (mk_id name) !allowed_nonexec
+      | DEF_pragma ("non_exec", Pragma_line (name, _)) -> allowed_nonexec := IdSet.add (mk_id name) !allowed_nonexec
       | DEF_let _ ->
           IdSet.iter
             (fun id ->

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -116,7 +116,7 @@ let wrap_module proj parsed_module =
   let module P = Parse_ast in
   let open Project in
   let name, l = module_name proj parsed_module.id in
-  let bracket_pragma p = [Generated [P.DEF_aux (P.DEF_pragma (p, name, 1), to_loc l)]] in
+  let bracket_pragma p = [Generated [P.DEF_aux (P.DEF_pragma (p, P.Pragma_line (name, 1)), to_loc l)]] in
   { parsed_module with files = bracket_pragma "start_module#" @ parsed_module.files @ bracket_pragma "end_module#" }
 
 let filter_modules proj is_included ast =
@@ -127,13 +127,13 @@ let filter_modules proj is_included ast =
     | None -> Reporting.unreachable l __POS__ "Failed to get module id"
   in
   let rec go skipping acc = function
-    | DEF_aux (DEF_pragma ("ended_module#", name, l), def_annot) :: defs ->
+    | DEF_aux (DEF_pragma ("ended_module#", Pragma_line (name, l)), def_annot) :: defs ->
         let mod_id = get_module_id l name in
         begin
           match skipping with Some skip_id when mod_id = skip_id -> go None acc defs | _ -> go skipping acc defs
         end
     | _ :: defs when Option.is_some skipping -> go skipping acc defs
-    | DEF_aux (DEF_pragma ("started_module#", name, l), def_annot) :: defs ->
+    | DEF_aux (DEF_pragma ("started_module#", Pragma_line (name, l)), def_annot) :: defs ->
         let mod_id = get_module_id l name in
         if is_included mod_id then go None acc defs else go (Some mod_id) acc defs
     | def :: defs -> go None (def :: acc) defs

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1989,30 +1989,32 @@ let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : untyped_def list ctx
       if not !opt_abstract_types then raise (Reporting.err_general l abstract_type_error);
       let nc = to_ast_constraint ctx nc in
       ([DEF_aux (DEF_constraint nc, annot)], ctx)
-  | P.DEF_pragma (pragma, arg, ltrim) ->
+  | P.DEF_pragma (pragma, P.Pragma_line (arg, ltrim)) ->
       let l = pragma_arg_loc pragma ltrim l in
       begin
         match pragma with
         | "sail_internal" -> begin
             match Reporting.loc_file l with
             | Some file ->
-                ( [DEF_aux (DEF_pragma ("sail_internal", arg, l), annot)],
+                ( [DEF_aux (DEF_pragma ("sail_internal", Pragma_line (arg, l)), annot)],
                   { ctx with internal_files = StringSet.add file ctx.internal_files }
                 )
-            | None -> ([DEF_aux (DEF_pragma ("sail_internal", arg, l), annot)], ctx)
+            | None -> ([DEF_aux (DEF_pragma ("sail_internal", Pragma_line (arg, l)), annot)], ctx)
           end
         | "target_set" ->
             let args = String.split_on_char ' ' arg |> List.filter (fun s -> String.length s > 0) in
             begin
               match args with
               | set :: targets ->
-                  ( [DEF_aux (DEF_pragma ("target_set", arg, l), annot)],
+                  ( [DEF_aux (DEF_pragma ("target_set", Pragma_line (arg, l)), annot)],
                     { ctx with target_sets = StringMap.add set targets ctx.target_sets }
                   )
               | [] -> raise (Reporting.err_general l "No arguments provided to target set directive")
             end
-        | _ -> ([DEF_aux (DEF_pragma (pragma, arg, l), annot)], ctx)
+        | _ -> ([DEF_aux (DEF_pragma (pragma, Pragma_line (arg, l)), annot)], ctx)
       end
+  | P.DEF_pragma (pragma, P.Pragma_structured data) ->
+      ([DEF_aux (DEF_pragma (pragma, Pragma_structured data), annot)], ctx)
   | P.DEF_internal_mutrec _ ->
       (* Should never occur because of remove_mutrec *)
       raise (Reporting.err_unreachable l __POS__ "Internal mutual block found when processing scattered defs")
@@ -2044,9 +2046,9 @@ let to_ast ctx (P.Defs files) =
     (List.rev defs, ctx)
   in
   let wrap_file file defs =
-    [mk_def (DEF_pragma ("file_start", file, P.Unknown)) ()]
+    [mk_def (DEF_pragma ("file_start", Pragma_line (file, P.Unknown))) ()]
     @ defs
-    @ [mk_def (DEF_pragma ("file_end", file, P.Unknown)) ()]
+    @ [mk_def (DEF_pragma ("file_end", Pragma_line (file, P.Unknown))) ()]
   in
   let defs, ctx =
     List.fold_left

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -1820,8 +1820,9 @@ module Make (C : CONFIG) = struct
     | DEF_overload _ -> ([], ctx)
     (* Only the parser and sail pretty printer care about this. *)
     | DEF_fixity _ -> ([], ctx)
-    | DEF_pragma ("abstract", id_str, _) -> ([CDEF_aux (CDEF_pragma ("abstract", id_str), def_annot)], ctx)
-    | DEF_pragma ("c_in_main", source, _) -> ([CDEF_aux (CDEF_pragma ("c_in_main", source), def_annot)], ctx)
+    | DEF_pragma ("abstract", Pragma_line (id_str, _)) -> ([CDEF_aux (CDEF_pragma ("abstract", id_str), def_annot)], ctx)
+    | DEF_pragma ("c_in_main", Pragma_line (source, _)) ->
+        ([CDEF_aux (CDEF_pragma ("c_in_main", source), def_annot)], ctx)
     (* We just ignore any pragmas we don't want to deal with. *)
     | DEF_pragma _ -> ([], ctx)
     (* Termination measures only needed for Coq, and other theorem prover output *)

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -204,6 +204,8 @@ rule token comments = parse
   | "*/"        { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) "Unbalanced comment") }
   | "$[" (ident+ as i)
     { Attribute i }
+  | "$" (ident+ as i) wsc* "{"
+    { StructuredPragma i }
   | "$" (ident+ as i)
     { let startpos = Lexing.lexeme_start_p lexbuf in
       let arg = pragma comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) false lexbuf in

--- a/src/lib/name_generator.mli
+++ b/src/lib/name_generator.mli
@@ -44,6 +44,12 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
+val parse_override : (string * Ast.attribute_data) list -> ((string * string * string) * string) option
+
+module Overrides : sig
+  include Map.S with type key = string * string * string
+end
+
 module type CONFIG = sig
   type style
 
@@ -61,6 +67,8 @@ module type CONFIG = sig
 
   (** Create the n-th variant of a name. It should be the case that [variant s 0 = s] *)
   val variant : string -> int -> string
+
+  val overrides : string Overrides.t
 end
 
 module Make (Config : CONFIG) () : sig

--- a/src/lib/outcome_rewrites.ml
+++ b/src/lib/outcome_rewrites.ml
@@ -150,7 +150,9 @@ let instantiate target ast =
           | None ->
               [
                 DEF_aux
-                  (DEF_pragma ("abstract", string_of_id id, gen_loc (id_loc id)), mk_def_annot (gen_loc (id_loc id)) ());
+                  ( DEF_pragma ("abstract", Pragma_line (string_of_id id, gen_loc (id_loc id))),
+                    mk_def_annot (gen_loc (id_loc id)) ()
+                  );
                 valspec true;
               ]
           | Some def -> [valspec false; strip_def def]

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -424,6 +424,9 @@ type prec = Infix | InfixL | InfixR
 
 type fixity_token = prec * Big_int.num * string
 
+type pragma = (* pragma contents *)
+  | Pragma_line of string * int | Pragma_structured of (string * attribute_data) list
+
 type def_aux =
   (* Top-level definition *)
   | DEF_type of type_def (* type definition *)
@@ -442,7 +445,7 @@ type def_aux =
   | DEF_measure of id * pat * exp (* separate termination measure declaration *)
   | DEF_loop_measures of id * loop_measure list (* separate termination measure declaration *)
   | DEF_register of dec_spec (* register declaration *)
-  | DEF_pragma of string * string * int
+  | DEF_pragma of string * pragma
   | DEF_private of def
   | DEF_attribute of string * attribute_data option * def
   | DEF_doc of string * def

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -241,6 +241,7 @@ let set_syntax_deprecated l =
 %token <string> OpId
 
 %token <string * string> Pragma
+%token <string> StructuredPragma
 %token <string> Attribute
 
 %token <Parse_ast.fixity_token> Fixity
@@ -1347,10 +1348,12 @@ def_aux:
     { DEF_constraint $2 }
   | Mutual Lcurly fun_def_list Rcurly
     { DEF_internal_mutrec $3 }
+  | pragma = StructuredPragma; kvs = separated_list(Comma, attribute_data_key_value); Rcurly
+    { DEF_pragma (pragma, Pragma_structured kvs) }
   | Pragma
     { let (pragma, arg) = $1 in
       let ltrim = pragma_left_spaces pragma $startpos arg in
-      DEF_pragma (pragma, String.trim arg, ltrim) }
+      DEF_pragma (pragma, Pragma_line (String.trim arg, ltrim)) }
   | TerminationMeasure id pat Eq exp
     { DEF_measure ($2, $3, $5) }
   | TerminationMeasure id loop_measures

--- a/src/lib/pragma.mli
+++ b/src/lib/pragma.mli
@@ -8,7 +8,7 @@
 (*  The ASL derived parts of the ARMv8.3 specification in                   *)
 (*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
 (*                                                                          *)
-(*  Copyright (c) 2013-2025                                                 *)
+(*  Copyright (c) 2013-2021                                                 *)
 (*    Kathyrn Gray                                                          *)
 (*    Shaked Flur                                                           *)
 (*    Stephen Kell                                                          *)
@@ -44,60 +44,9 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-open Ast_util
+(** We want to provide warnings for e.g. a mispelled pragma rather
+    than just silently ignoring them, so we can access a list of all
+    recognised pragmas. *)
+val all : unit -> Util.StringSet.t
 
-let parse_override obj =
-  let open Util.Option_monad in
-  let* id = Option.bind (List.assoc_opt "id" obj) attribute_data_string in
-  let* target = Option.bind (List.assoc_opt "target" obj) attribute_data_string in
-  let* prefix =
-    match List.assoc_opt "prefix" obj with Some (AD_aux (AD_string s, _)) -> Some s | Some _ -> None | None -> Some ""
-  in
-  let* suffix =
-    match List.assoc_opt "prefix" obj with Some (AD_aux (AD_string s, _)) -> Some s | Some _ -> None | None -> Some ""
-  in
-  Some ((prefix, id, suffix), target)
-
-module Overrides = Map.Make (struct
-  type t = string * string * string
-
-  let compare (p1, n1, s1) (p2, n2, s2) = Util.lex_ord_list String.compare [p1; n1; s1] [p2; n2; s2]
-end)
-
-module type CONFIG = sig
-  type style
-
-  val allowed : string -> bool
-  val pretty : style -> string -> string
-  val mangle : style -> string -> string
-  val variant : string -> int -> string
-  val overrides : string Overrides.t
-end
-
-module Make (Config : CONFIG) () = struct
-  let names = Hashtbl.create 1024
-  let generated = Hashtbl.create 1024
-
-  let translate ?(prefix = "") ?(suffix = "") style orig_str =
-    match Overrides.find_opt (prefix, orig_str, suffix) Config.overrides with
-    | Some result -> result
-    | None -> (
-        match Hashtbl.find_opt names (prefix, orig_str, suffix) with
-        | Some result -> result
-        | None ->
-            let str = if Config.allowed orig_str then Config.pretty style orig_str else Config.mangle style orig_str in
-            let str = prefix ^ str ^ suffix in
-            let rec variant_str n =
-              let modified = Config.variant str n in
-              if Hashtbl.mem generated modified then variant_str (n + 1)
-              else (
-                Hashtbl.add generated modified ();
-                Hashtbl.add names (prefix, orig_str, suffix) modified;
-                modified
-              )
-            in
-            variant_str 0
-      )
-
-  let to_string ?(prefix = "") ?(suffix = "") style id = translate ~prefix ~suffix style (string_of_id id)
-end
+val register : string -> unit

--- a/src/lib/property.ml
+++ b/src/lib/property.ml
@@ -52,7 +52,8 @@ open Parser_combinators
 
 let find_properties { defs; _ } =
   let rec find_prop acc = function
-    | DEF_aux (DEF_pragma ((("property" | "counterexample") as prop_type), command, l), _) :: defs -> begin
+    | DEF_aux (DEF_pragma ((("property" | "counterexample") as prop_type), Pragma_line (command, l)), _) :: defs ->
+      begin
         match Util.find_next (function DEF_aux (DEF_val _, _) -> true | _ -> false) defs with
         | _, Some (DEF_aux (DEF_val vs, _), defs) -> find_prop ((prop_type, command, l, vs) :: acc) defs
         | _, _ -> raise (Reporting.err_general l "Property is not attached to any function signature")

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -316,7 +316,7 @@ let rec rewrite_def rewriters (DEF_aux (aux, def_annot)) =
     | DEF_outcome (outcome_spec, defs) -> DEF_outcome (outcome_spec, List.map (rewrite_def rewriters) defs)
     | DEF_internal_mutrec fdefs -> DEF_internal_mutrec (List.map (rewriters.rewrite_fun rewriters) fdefs)
     | DEF_let letbind -> DEF_let (rewriters.rewrite_let rewriters letbind)
-    | DEF_pragma (pragma, arg, l) -> DEF_pragma (pragma, arg, l)
+    | DEF_pragma (pragma, arg) -> DEF_pragma (pragma, arg)
     | DEF_scattered sd -> DEF_scattered (rewrite_scattered rewriters sd)
     | DEF_measure (id, pat, exp) ->
         DEF_measure (id, rewriters.rewrite_pat rewriters pat, rewriters.rewrite_exp rewriters exp)

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5246,19 +5246,19 @@ and check_def : Env.t -> untyped_def -> typed_def list * Env.t =
         ],
         env
       )
-  | DEF_pragma ("project#", arg, l) ->
+  | DEF_pragma ("project#", Pragma_line (arg, l)) ->
       let start_p = match Reporting.simp_loc l with Some (p, _) -> Some p | None -> None in
       let proj_defs = Initial_check.parse_project ?inline:start_p ~contents:arg () in
       let proj = Project.initialize_project_structure ~variables:(ref Util.StringMap.empty) proj_defs in
       typ_print (lazy "set modules");
       ([], Env.set_modules proj env)
-  | DEF_pragma ("start_module#", arg, l) ->
+  | DEF_pragma ("start_module#", Pragma_line (arg, l)) ->
       let mod_id = Env.get_module_id ~at:l env arg in
       typ_print (lazy (Printf.sprintf "module start %d '%s'" (Project.ModId.to_int mod_id) arg));
-      ([DEF_aux (DEF_pragma ("started_module#", arg, l), def_annot)], Env.start_module ~at:l mod_id env)
-  | DEF_pragma ("end_module#", arg, l) ->
-      ([DEF_aux (DEF_pragma ("ended_module#", arg, l), def_annot)], Env.end_module env)
-  | DEF_pragma (pragma, arg, l) -> ([DEF_aux (DEF_pragma (pragma, arg, l), def_annot)], env)
+      ([DEF_aux (DEF_pragma ("started_module#", Pragma_line (arg, l)), def_annot)], Env.start_module ~at:l mod_id env)
+  | DEF_pragma ("end_module#", Pragma_line (arg, l)) ->
+      ([DEF_aux (DEF_pragma ("ended_module#", Pragma_line (arg, l)), def_annot)], Env.end_module env)
+  | DEF_pragma (pragma, cmd) -> ([DEF_aux (DEF_pragma (pragma, cmd), def_annot)], env)
   | DEF_scattered sdef -> check_scattered env def_annot sdef
   | DEF_measure (id, pat, exp) -> ([check_termination_measure_decl env def_annot (id, pat, exp)], env)
   | DEF_loop_measures (id, measures) ->

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -108,6 +108,14 @@ module type CODEGEN_CONFIG = sig
       before executing any instruction semantics. *)
   val no_rts : bool
 
+  (** Do not mangle generated C identifiers, prefer readable names
+      when possible. *)
+  val no_mangle : bool
+
+  val reserved_words : Util.StringSet.t
+
+  val overrides : string Name_generator.Overrides.t
+
   (** If [Some channel], the generated C code will be instrumented to
       track branch coverage information. Information about all the
       possible branches will be written to the provided output

--- a/src/sail_c_backend/keywords.mli
+++ b/src/sail_c_backend/keywords.mli
@@ -25,6 +25,7 @@
 (*    Stephen Kell                                                          *)
 (*    Mark Wassell                                                          *)
 (*    Alastair Reid (Arm Ltd)                                               *)
+(*    Louis-Emile Ploix                                                     *)
 (*                                                                          *)
 (*  All rights reserved.                                                    *)
 (*                                                                          *)
@@ -44,60 +45,11 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-open Ast_util
+open Libsail
 
-let parse_override obj =
-  let open Util.Option_monad in
-  let* id = Option.bind (List.assoc_opt "id" obj) attribute_data_string in
-  let* target = Option.bind (List.assoc_opt "target" obj) attribute_data_string in
-  let* prefix =
-    match List.assoc_opt "prefix" obj with Some (AD_aux (AD_string s, _)) -> Some s | Some _ -> None | None -> Some ""
-  in
-  let* suffix =
-    match List.assoc_opt "prefix" obj with Some (AD_aux (AD_string s, _)) -> Some s | Some _ -> None | None -> Some ""
-  in
-  Some ((prefix, id, suffix), target)
+(** We use some words in the compilation process, so treat them as
+    C reserveds even though they are not. *)
+val c_used_words : Util.StringSet.t
 
-module Overrides = Map.Make (struct
-  type t = string * string * string
-
-  let compare (p1, n1, s1) (p2, n2, s2) = Util.lex_ord_list String.compare [p1; n1; s1] [p2; n2; s2]
-end)
-
-module type CONFIG = sig
-  type style
-
-  val allowed : string -> bool
-  val pretty : style -> string -> string
-  val mangle : style -> string -> string
-  val variant : string -> int -> string
-  val overrides : string Overrides.t
-end
-
-module Make (Config : CONFIG) () = struct
-  let names = Hashtbl.create 1024
-  let generated = Hashtbl.create 1024
-
-  let translate ?(prefix = "") ?(suffix = "") style orig_str =
-    match Overrides.find_opt (prefix, orig_str, suffix) Config.overrides with
-    | Some result -> result
-    | None -> (
-        match Hashtbl.find_opt names (prefix, orig_str, suffix) with
-        | Some result -> result
-        | None ->
-            let str = if Config.allowed orig_str then Config.pretty style orig_str else Config.mangle style orig_str in
-            let str = prefix ^ str ^ suffix in
-            let rec variant_str n =
-              let modified = Config.variant str n in
-              if Hashtbl.mem generated modified then variant_str (n + 1)
-              else (
-                Hashtbl.add generated modified ();
-                Hashtbl.add names (prefix, orig_str, suffix) modified;
-                modified
-              )
-            in
-            variant_str 0
-      )
-
-  let to_string ?(prefix = "") ?(suffix = "") style id = translate ~prefix ~suffix style (string_of_id id)
-end
+(** The set of C reserved keywords *)
+val c_reserved_words : Util.StringSet.t

--- a/src/sail_doc_backend/html_source.ml
+++ b/src/sail_doc_backend/html_source.ml
@@ -93,7 +93,7 @@ let highlights ~filename ~contents =
     | Configuration | TerminationMeasure | Forwards | Backwards | Let_ | Bitfield ->
         mark Highlight.Keyword;
         go ()
-    | Pragma _ | Attribute _ | Fixity _ ->
+    | StructuredPragma _ | Pragma _ | Attribute _ | Fixity _ ->
         mark Highlight.Pragma;
         go ()
     | InternalPLet | InternalReturn | InternalAssume ->

--- a/src/sail_latex_backend/latex.ml
+++ b/src/sail_latex_backend/latex.ml
@@ -515,7 +515,7 @@ let defs { defs; _ } =
         typedefs := Bindings.add id id !typedefs;
         Some (latex_command ~docstring Type id (Pretty_print_sail.doc_def def) (fst annot))
     | DEF_fundef (FD_aux (FD_function (_, _, funcls), annot)) as def -> Some (latex_funcls def funcls)
-    | DEF_pragma ("latex", command, l) -> process_pragma l command
+    | DEF_pragma ("latex", Pragma_line (command, l)) -> process_pragma l command
     | DEF_register (DEC_aux (_, annot) as dec) ->
         let id = id_of_dec_spec dec in
         regdefs := Bindings.add id id !regdefs;

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -940,8 +940,8 @@ let doc_defs ctx defs = doc_defs_rec ctx defs empty empty
 let rec remove_imports (defs : (Libsail.Type_check.tannot, Libsail.Type_check.env) def list) depth =
   match defs with
   | [] -> []
-  | DEF_aux (DEF_pragma ("include_start", _, _), _) :: ds -> remove_imports ds (depth + 1)
-  | DEF_aux (DEF_pragma ("include_end", _, _), _) :: ds -> remove_imports ds (depth - 1)
+  | DEF_aux (DEF_pragma ("include_start", _), _) :: ds -> remove_imports ds (depth + 1)
+  | DEF_aux (DEF_pragma ("include_end", _), _) :: ds -> remove_imports ds (depth - 1)
   | d :: ds -> if depth > 0 then remove_imports ds depth else d :: remove_imports ds depth
 
 let add_reg_typ typ_map (typ, id, _) =

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -1753,16 +1753,16 @@ let find_exc_typ defs =
 let group_defs_by_file top_filename defs =
   let rec group current_filename current_defs groups defs =
     let is_file_start = function
-      | DEF_aux (DEF_pragma ("file_start", f, _), a) ->
+      | DEF_aux (DEF_pragma ("file_start", Pragma_line (f, _)), a) ->
           (* Ignore file markers from generated blocks and spliced files;
              we want to preserve the original input file structure *)
           f <> "" && get_def_attribute "spliced" a = None
       | _ -> false
     in
     match (defs, current_filename) with
-    | (DEF_aux (DEF_pragma ("file_start", f, _), _) as d) :: defs, None when is_file_start d ->
+    | (DEF_aux (DEF_pragma ("file_start", Pragma_line (f, _)), _) as d) :: defs, None when is_file_start d ->
         group (Some f) current_defs groups defs
-    | DEF_aux (DEF_pragma ("file_end", f, _), _) :: defs, Some f' when f' = f ->
+    | DEF_aux (DEF_pragma ("file_end", Pragma_line (f, _)), _) :: defs, Some f' when f' = f ->
         if current_defs = [] then group None [] groups defs
         else group None [] (groups @ [(f', List.rev current_defs)]) defs
     | d :: defs, _ -> group current_filename (d :: current_defs) groups defs

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -608,6 +608,8 @@ module Make (Config : CONFIG) = struct
         let mangle () s = Util.zencode_string s
 
         let variant s = function 0 -> s | n -> s ^ string_of_int n
+
+        let overrides = Name_generator.Overrides.empty
       end)
       ()
 

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -191,6 +191,7 @@ def test_coq(name):
 xml = '<testsuites>\n'
 
 if 'c' in targets:
+    xml += test_c('unoptimized C', '', '--c-no-mangle', False)
     xml += test_c('unoptimized C', '', '', False)
     xml += test_c('unoptimized C', '', '--c-generate-header', False)
     xml += test_c('unoptimized C with C++ compiler', '-xc++', '', False, compiler='c++')

--- a/test/c/xlen_val.sail
+++ b/test/c/xlen_val.sail
@@ -9,6 +9,11 @@ $option -c_include includes/xlen_val.h
 
 type xlen: Int = 64
 
+$c_override {
+  id = xlen_val,
+  target = "zxlen_val"
+}
+
 let xlen_val = sizeof(xlen)
 
 val test = { c: "test" } : int(32) -> int(64)

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -4,6 +4,12 @@ import sys
 import subprocess
 import datetime
 import argparse
+import signal
+
+def signal_handler(sig, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, signal_handler)
 
 parser = argparse.ArgumentParser("run_tests.py")
 parser.add_argument("--hide-error-output", help="Hide error information.", action='store_true')


### PR DESCRIPTION
There are a few additional directives to support this:
```
$c_reserved <name>
```
means that <name> is treated like a reserved identifier (i.e. it will be mangled). Meanwhile
```
$c_override { id = <name>, target = "foo" }
```
will force the generation of the string `"foo"` for `<name>`.

Most of this PR is actually devoted to making this directive work, because I didn't want to implement yet another ad-hoc parser for this attribute.

Now a directive immediately followed by a opening brace is parsed as a 'structured' directive (as opposed to a line directive)
```
$directive { ...
```
which shares the same JSON-like structure as attributes `$[attr <data>]`

This can span multiple lines:
```
$directive {
  foo = "bar",
  baz = "quux"
}
```