### PR TITLE
Lean: add coercions and use Lean native binops

### DIFF
--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -91,9 +91,9 @@ val vector_length = pure {
   _: "length"
 } : forall 'n ('a : Type). vector('n, 'a) -> int('n)
 
-val vector_init = pure { 
+val vector_init = pure {
   lean: "vectorInit",
-  _: "vector_init" 
+  _: "vector_init"
 } : forall 'n ('a : Type), 'n >= 0. (implicit('n), 'a) -> vector('n, 'a)
 
 overload length = {bitvector_length, vector_length}
@@ -162,7 +162,7 @@ val bitvector_concat = pure {
   interpreter: "append",
   lem: "concat_vec",
   coq: "concat_vec",
-  lean: "Sail.BitVec.append'",
+  lean: "_lean_app",
    _: "append"
 } : forall 'n 'm.
   (bits('n), bits('m)) -> bits('n + 'm)
@@ -262,7 +262,7 @@ val sub_bits = pure {
 } : forall 'n. (bits('n), bits('n)) -> bits('n)
 
 val not_vec = pure {
-  ocaml: "not_vec", 
+  ocaml: "not_vec",
   lem: "not_vec",
   coq: "not_vec",
   interpreter: "not_vec",
@@ -275,7 +275,7 @@ val and_vec = pure {
   coq: "and_vec",
   ocaml: "and_vec",
   interpreter: "and_vec",
-  lean: "HAnd.hAnd",
+  lean: "_lean_bvand",
   _: "and_bits"
 } : forall 'n. (bits('n), bits('n)) -> bits('n)
 
@@ -286,7 +286,7 @@ val or_vec = pure {
   coq: "or_vec",
   ocaml: "or_vec",
   interpreter: "or_vec",
-  lean: "HOr.hOr",
+  lean: "_lean_bvor",
   _: "or_bits"
 } : forall 'n. (bits('n), bits('n)) -> bits('n)
 
@@ -297,7 +297,7 @@ val xor_vec = pure {
   coq: "xor_vec",
   ocaml: "xor_vec",
   interpreter: "xor_vec",
-  lean: "HXor.hXor",
+  lean: "_lean_bvxor",
   _: "xor_bits"
 } : forall 'n. (bits('n), bits('n)) -> bits('n)
 
@@ -346,12 +346,12 @@ $endif
 overload vector_update_subrange = {update_subrange_bits}
 
 val sail_shiftleft = pure {
-  lean: "HShiftLeft.hShiftLeft",
+  lean: "_lean_shiftl",
   _: "shiftl"} : forall 'n ('ord : Order).
     (bitvector('n, 'ord), int) -> bitvector('n, 'ord)
 
 val sail_shiftright = pure {
-  lean: "HShiftRight.hShiftRight",
+  lean: "_lean_shiftr",
   _: "shiftr"} : forall 'n ('ord : Order).
     (bitvector('n, 'ord), int) -> bitvector('n, 'ord)
 

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -14,6 +14,15 @@ instance : HAdd (BitVec n) (BitVec m) (BitVec n) where
 instance : HSub (BitVec n) (BitVec m) (BitVec n) where
   hSub x y := x - y
 
+instance : HAnd (BitVec n) (BitVec m) (BitVec n) where
+  hAnd x y := x &&& y
+
+instance : HOr (BitVec n) (BitVec m) (BitVec n) where
+  hOr x y := x ||| y
+
+instance : HXor (BitVec n) (BitVec m) (BitVec n) where
+  hXor x y := x ^^^ y
+
 namespace BitVec
 
 def length {w : Nat} (_ : BitVec w) : Nat := w
@@ -462,3 +471,4 @@ instance : HShiftRight (BitVec w) Int (BitVec w) where
   hShiftRight b i := b <<< (-i)
 
 end Sail
+

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -516,6 +516,12 @@ let binop_of_id id =
   | Some "_lean_sub" -> Some "-"
   | Some "_lean_mul" -> Some "*"
   | Some "_lean_div" -> Some "/"
+  | Some "_lean_app" -> Some "++"
+  | Some "_lean_bvand" -> Some "&&&"
+  | Some "_lean_bvor" -> Some "|||"
+  | Some "_lean_bvxor" -> Some "^^^"
+  | Some "_lean_shiftl" -> Some "<<<"
+  | Some "_lean_shiftr" -> Some ">>>"
   | _ -> None
 
 let remove_er ctx = { ctx with early_ret = false }
@@ -654,7 +660,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
         | Some op ->
             let e1 = List.nth d_args 0 in
             let e2 = List.nth d_args 1 in
-            let res = e1 ^^ break 1 ^^ string op ^^ break 1 ^^ e2 in
+            let res = e1 ^^ space ^^ string op ^^ space ^^ e2 in
             wrap_with_pure as_monadic (parens res) |> nest 2
         | None ->
             nest 2

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -100,7 +92,7 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def unif_bitvec_append (x : (BitVec 13)) (y : (BitVec 3)) : (BitVec (4 * 4)) :=
-  (Sail.BitVec.append' x y)
+  (x ++ y)
 
 def unif_bitvec_replicate (x : (BitVec 4)) : (BitVec (2 * 8)) :=
   (BitVec.replicateBits x 4)

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -56,9 +56,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -75,22 +75,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -121,29 +113,25 @@ def bitvector_truncateLSB (x : (BitVec 32)) : (BitVec 16) :=
   (Sail.BitVec.truncateLsb x 16)
 
 def bitvector_append (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 32) :=
-  (Sail.BitVec.append' x y)
+  (x ++ y)
 
 def bitvector_add (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 16) :=
-  (x
-    +
-    y)
+  (x + y)
 
 def bitvector_sub (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 16) :=
-  (x
-    -
-    y)
+  (x - y)
 
 def bitvector_not (x : (BitVec 16)) : (BitVec 16) :=
   (Complement.complement x)
 
 def bitvector_and (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 16) :=
-  (HAnd.hAnd x y)
+  (x &&& y)
 
 def bitvector_or (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 16) :=
-  (HOr.hOr x y)
+  (x ||| y)
 
 def bitvector_xor (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 16) :=
-  (HXor.hXor x y)
+  (x ^^^ y)
 
 def bitvector_unsigned (x : (BitVec 16)) : Nat :=
   (BitVec.toNat x)

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -48,9 +48,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -67,22 +67,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -54,9 +54,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -73,22 +73,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -155,27 +147,19 @@ def sep_backwards_matches (arg_ : String) : SailM Bool := do
   | _ => throw Error.Exit
 
 def extern_add (_ : Unit) : Int :=
-  (5
-    +
-    4)
+  (5 + 4)
 
 def extern_sub (_ : Unit) : Int :=
-  (5
-    -
-    (-4))
+  (5 - (-4))
 
 def extern_sub_nat (_ : Unit) : Nat :=
-  (5
-    -
-    4)
+  (5 - 4)
 
 def extern_negate (_ : Unit) : Int :=
   (Neg.neg 5)
 
 def extern_mult (_ : Unit) : Int :=
-  (5
-    *
-    4)
+  (5 * 4)
 
 def extern__shl8 (_ : Unit) : Int :=
   (Int.shiftl 8 2)

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -103,9 +95,7 @@ def extern_const (_ : Unit) : (BitVec 64) :=
   (0xFFFF000012340000 : (BitVec 64))
 
 def extern_add (_ : Unit) : (BitVec 16) :=
-  ((0xFFFF : (BitVec 16))
-    +
-    (0x1234 : (BitVec 16)))
+  ((0xFFFF : (BitVec 16)) + (0x1234 : (BitVec 16)))
 
 def extern_replicate_bits (_ : Unit) : (BitVec 64) :=
   (BitVec.replicateBits (0x1234 : (BitVec 16)) 4)

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -111,9 +103,7 @@ def slice_mask2 {n : _} (i : (BitVec n)) (l : (BitVec n)) (b : Bool) : (BitVec n
   if b
   then i
   else let one : (BitVec n) := (EXTZ l)
-       (one
-         +
-         one)
+       (one + one)
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -58,9 +58,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -77,22 +77,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -100,12 +92,12 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def foo (_ : Unit) : (BitVec 16) :=
-  let z := (HOr.hOr (0xFFFF : (BitVec 16)) (0xABCD : (BitVec 16)))
-  (HAnd.hAnd (0x0000 : (BitVec 16)) z)
+  let z := ((0xFFFF : (BitVec 16)) ||| (0xABCD : (BitVec 16)))
+  ((0x0000 : (BitVec 16)) &&& z)
 
 def bar (_ : Unit) : (BitVec 16) :=
-  let z : (BitVec 16) := (HOr.hOr (0xFFFF : (BitVec 16)) (0xABCD : (BitVec 16)))
-  (HAnd.hAnd (0x0000 : (BitVec 16)) z)
+  let z : (BitVec 16) := ((0xFFFF : (BitVec 16)) ||| (0xABCD : (BitVec 16)))
+  ((0x0000 : (BitVec 16)) &&& z)
 
 def baz (_ : Unit) : SailM (BitVec 16) := do
   (print_effect "baz")

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -54,9 +54,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -73,22 +73,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -133,9 +125,7 @@ def foreachloopboth (m : Nat) (n : Nat) : SailM Int := do
     foreach_M loop_i_lower loop_i_upper 1 res
       (λ i res => do
         let res : Int := (res + 1)
-        writeReg r ((← readReg r)
-          +
-          res)
+        writeReg r ((← readReg r) + res)
         (pure res))
   (pure (res + 1))
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -48,9 +48,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -67,22 +67,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -63,9 +63,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -82,22 +82,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -43,9 +43,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -62,22 +62,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -118,9 +118,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -137,22 +137,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -72,9 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,22 +91,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -129,9 +121,7 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def test (_ : Unit) : SailM Int := do
-  writeReg INT ((← readReg INT)
-    +
-    1)
+  writeReg INT ((← readReg INT) + 1)
   readReg INT
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -81,9 +81,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -100,22 +100,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -62,9 +62,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -81,22 +81,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -53,9 +53,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -72,22 +72,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -51,9 +51,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -70,22 +70,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -50,9 +50,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 /-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (GE.ge l n)
-  then (HShiftLeft.hShiftLeft (sail_ones n) i)
+  then ((sail_ones n) <<< i)
   else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (HShiftLeft.hShiftLeft ((HShiftLeft.hShiftLeft one l) - one) i)
+       (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -69,22 +69,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m)
-         -
-         1)
+  then ((Int.tdiv (n + 1) m) - 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
-       then ((Int.tdiv (n - 1) m)
-              -
-              1)
+       then ((Int.tdiv (n - 1) m) - 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n
-    -
-    (m
-      *
-      (fdiv_int n m)))
+  (n - (m * (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=


### PR DESCRIPTION
We use the coercion system to cast bitvectors of any length.

```lean
instance : CoeT Int x Nat where
  coe := x.toNat

instance : CoeT (BitVec n) x (BitVec m) where
  coe := x.setWidth m

instance : HAdd (BitVec n) (BitVec m) (BitVec n) where
  hAdd x y := x + y

instance : HSub (BitVec n) (BitVec m) (BitVec n) where
  hSub x y := x - y
```

We also use the native Lean +, -, etc because the elaborator treats them in a special way when infering the types of the result of the operation.

We do this by translating the operations to special function names such as `_lean_add` which are printed in a special way.

This reduces substantially the number of errors in the Risc-V output.