### PR TITLE
Lean: print some implicit arguments

### DIFF
--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -96,13 +96,13 @@ def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
   (Sail.BitVec.zeroExtend v m)
 
 def foo (x : (BitVec 8)) : (BitVec 16) :=
-  (EXTZ x)
+  (EXTZ (m := 16) x)
 
 /-- Type quantifiers: k_ex882# : Bool, n : Nat, n ≥ 0 -/
 def slice_mask2 {n : _} (i : (BitVec n)) (l : (BitVec n)) (b : Bool) : (BitVec n) :=
   if b
   then i
-  else let one : (BitVec n) := (EXTZ l)
+  else let one : (BitVec n) := (EXTZ (m := n) l)
        (one + one)
 
 def initialize_registers (_ : Unit) : Unit :=

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -144,7 +144,7 @@ def zeros (n : Nat) : (BitVec n) :=
 def rX (r : (BitVec 5)) : SailM (BitVec 64) := do
   let b__0 := r
   if (BEq.beq b__0 (0b00000 : (BitVec 5)))
-  then (pure (EXTZ (0x0 : (BitVec 4))))
+  then (pure (EXTZ (m := 64) (0x0 : (BitVec 4))))
   else (pure (vectorAccess (← readReg Xs) (BitVec.toNat r)))
 
 def wX (r : (BitVec 5)) (v : (BitVec 64)) : SailM Unit := do
@@ -154,7 +154,7 @@ def wX (r : (BitVec 5)) (v : (BitVec 64)) : SailM Unit := do
 
 /-- Type quantifiers: width : Nat, width ≥ 0 -/
 def read_mem (addr : (BitVec 64)) (width : Nat) : SailM (BitVec (8 * width)) := do
-  (read_ram 64 width (EXTZ (0x0 : (BitVec 4))) addr)
+  (read_ram 64 width (EXTZ (m := 64) (0x0 : (BitVec 4))) addr)
 
 def undefined_iop (_ : Unit) : SailM iop := do
   (internal_pick [RISCV_ADDI, RISCV_SLTI, RISCV_SLTIU, RISCV_XORI, RISCV_ORI, RISCV_ANDI])
@@ -179,7 +179,7 @@ def num_of_iop (arg_ : iop) : Int :=
   | RISCV_ANDI => 5
 
 def execute_LOAD (imm : (BitVec 12)) (rs1 : (BitVec 5)) (rd : (BitVec 5)) : SailM Unit := do
-  let addr : xlenbits ← do (pure ((← (rX rs1)) + (EXTS imm)))
+  let addr : xlenbits ← do (pure ((← (rX rs1)) + (EXTS (m := 64) imm)))
   let result : xlenbits ← do (read_mem addr 8)
   (wX rd result)
 
@@ -188,7 +188,7 @@ def execute_ITYPE (arg0 : (BitVec 12)) (arg1 : (BitVec 5)) (arg2 : (BitVec 5)) (
   match merge_var with
   | (imm, rs1, rd, RISCV_ADDI) =>
     let rs1_val ← do (rX rs1)
-    let imm_ext : xlenbits := (EXTS imm)
+    let imm_ext : xlenbits := (EXTS (m := 64) imm)
     let result := (rs1_val + imm_ext)
     (wX rd result)
   | _ => throw Error.Exit


### PR DESCRIPTION
This is a bit ugly, because we cannot detect which implicits were written by the programmer and which were filled by Sail, but it solves many issues with `ones` for example.

NB: this PR is stacked on top of #1043 