### PR TITLE
Float: Remove unnecessary return when invoke float_round_and_compose

### DIFF
--- a/lib/float/arith_internal.sail
+++ b/lib/float/arith_internal.sail
@@ -168,7 +168,7 @@ function float_add_same_exp_internal (op_0, op_1) = {
     let mantissa_offset = mantissa_sum + sail_shiftleft (one, shift_bitsize);
     let mantissa = sail_shiftleft (mantissa_offset, length (fp_0.exp) - 2);
 
-    return float_round_and_compose (sign, exp, mantissa, fp_rounding_global);
+    float_round_and_compose (sign, exp, mantissa, fp_rounding_global);
   }
 }
 


### PR DESCRIPTION
* The return is unnecessary up to a point, remove it to align the style.

Signed-off-by: Pan Li <pan2.li@intel.com>