### PR TITLE
Lean: add option to mark function as noncomputable

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -16,6 +16,8 @@ type global_context = { effect_info : Effects.side_effect_info }
 
 let the_main_function_has_been_seen = ref false
 
+let opt_noncomputable_functions : IdSet.t ref = ref IdSet.empty
+
 let remove_empties (docs : document list) = List.filter (fun d -> d != empty) docs
 
 type context = {
@@ -837,7 +839,12 @@ let doc_funcl_init global (FCL_aux (FCL_funcl (id, pexp), annot)) =
     else if early_return then decl_val @ [string "Id.run"; string "do"]
     else decl_val
   in
-  (typ_quant_comment, separate space ([string "def"; doc_id_ctor id] @ binders @ [colon] @ decl_val), ctx, fixup_binders)
+  let computability = if IdSet.mem id !opt_noncomputable_functions then string "noncomputable" else empty in
+  ( typ_quant_comment,
+    separate space (remove_empties [computability; string "def"; doc_id_ctor id] @ binders @ [colon] @ decl_val),
+    ctx,
+    fixup_binders
+  )
 
 let doc_funcl_body fixup_binders ctx (FCL_aux (FCL_funcl (id, pexp), annot)) =
   let env = env_of_tannot (snd annot) in

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -66,7 +66,7 @@
 (****************************************************************************)
 
 open Libsail
-
+open Ast_util
 open Interactive.State
 
 let opt_lean_output_dir : string option ref = ref None
@@ -100,6 +100,11 @@ let lean_options =
     ( Flag.create ~prefix:["lean"] ~arg:"file" "import_file",
       Arg.String (fun file -> opt_lean_import_files := file :: !opt_lean_import_files),
       "import this file in the generated model"
+    );
+    ( Flag.create ~prefix:["lean"] ~arg:"func-name" "noncomputable_function",
+      Arg.String
+        Pretty_print_lean.(fun fn -> opt_noncomputable_functions := IdSet.add (mk_id fn) !opt_noncomputable_functions),
+      "do not generate a definition for the type"
     );
   ]
 


### PR DESCRIPTION
Fixes #1055. The riscv-model PR has been updated with it.