### PR TITLE
Lean: add option to ignore redundant match cases

### DIFF
--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -228,7 +228,8 @@ let start_lean_output (out_name : string) default_sail_dir =
   if !opt_lean_noncomputable then output_string main_file "noncomputable section\n\n";
   output_string main_file "set_option maxHeartbeats 1_000_000_000\n";
   output_string main_file "set_option maxRecDepth 10_000\n";
-  output_string main_file "set_option linter.unusedVariables false\n\n";
+  output_string main_file "set_option linter.unusedVariables false\n";
+  output_string main_file "set_option match.ignoreUnusedAlts true\n\n";
   output_string main_file "open Sail\n\n";
   let lakefile = open_out (Filename.concat project_dir "lakefile.toml") in
   { out_name; out_name_camel; sail_dir; main_file; lakefile }

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -4,6 +4,7 @@ import Out.Sail.BitVec
 set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 10_000
 set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
 
 open Sail
 


### PR DESCRIPTION
This solves an issue with the RISC-V model.