### PR TITLE
Lean: generate two files, for types and funcs

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -174,6 +174,7 @@ structure SequentialState (RegisterType : Register → Type) (c : ChoiceSource) 
 
 inductive RegisterRef (RegisterType : Register → Type) : Type → Type where
   | Reg (r : Register) : RegisterRef _ (RegisterType r)
+export RegisterRef (Reg)
 
 abbrev PreSailM (RegisterType : Register → Type) (c : ChoiceSource) (ue: Type) :=
   EStateM (Error ue) (SequentialState RegisterType c)

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -20,6 +20,8 @@ let opt_noncomputable_functions : IdSet.t ref = ref IdSet.empty
 
 let remove_empties (docs : document list) = List.filter (fun d -> d != empty) docs
 
+let opens = ref IdSet.empty
+
 type context = {
   global : global_context;
   env : Type_check.env;
@@ -907,12 +909,13 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let fields = List.map (fun i -> space ^^ pipe ^^ space ^^ i) fields in
       let derivers = if List.length fields == 0 then [string "BEq"] else [string "Inhabited"; string "BEq"] in
       let enums_doc = concat fields in
+      let _ = opens := IdSet.add id !opens in
       let id = doc_id_ctor id in
       nest 2
         (flow (break 1) [string "inductive"; id; string "where"]
         ^^ enums_doc ^^ hardline ^^ string "deriving" ^^ space ^^ separate comma_sp derivers
         )
-      ^^ hardline ^^ hardline ^^ string "open " ^^ id
+      ^^ hardline ^^ hardline
   | TD_record (id, tq, fields, _) ->
       let fields = List.map (doc_typ_id ctx) fields in
       let fields_doc = separate hardline fields in
@@ -941,6 +944,7 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let pp_tus = concat (List.map (fun tu -> hardline ^^ doc_type_union ctx tu) ar) in
       let rectyp = doc_typ_quant_relevant ctx tq in
       let rectyp = List.map (fun d -> parens d) rectyp |> separate space in
+      let _ = opens := IdSet.add id !opens in
       let id = doc_id_ctor id in
       doc_typ_quant_in_comment ctx tq ^^ hardline
       ^^ nest 2
@@ -948,7 +952,6 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
            ^^ pp_tus ^^ hardline ^^ string "deriving BEq"
            )
       ^^ hardline ^^ hardline
-      ^^ flow space [string "open"; id]
   | _ -> failwith ("Type definition " ^ string_of_type_def_con full_typdef ^ " not translatable yet.")
 
 (* Copied from the Coq PP *)
@@ -1008,6 +1011,7 @@ let add_reg_typ typ_map (typ, id, _) =
   Bindings.add typ_id (id, typ) typ_map
 
 let register_enums registers =
+  opens := IdSet.add (mk_id "Register") !opens;
   separate hardline
     [
       string "inductive Register : Type where";
@@ -1039,8 +1043,7 @@ let doc_reg_info env global registers =
   let ctx = context_init env global in
   let type_map = List.fold_left add_reg_typ Bindings.empty registers in
   let type_map = Bindings.bindings type_map in
-  separate hardline
-    [register_enums registers; type_enum ctx registers; string "open RegisterRef"; inhabit_enum ctx type_map; empty]
+  separate hardline [register_enums registers; type_enum ctx registers; inhabit_enum ctx type_map; empty]
 
 let doc_monad_abbrev defs (has_registers : bool) =
   let find_exc_typ defs =
@@ -1114,7 +1117,8 @@ let populate_fun_args defs =
   in
   List.fold_left (fun args d -> add_args args d) Bindings.empty defs
 
-let pp_ast_lean (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail.Type_check.typed_ast) o =
+let pp_ast_lean (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail.Type_check.typed_ast) types_file
+    funcs_file =
   let regs = State.find_registers defs in
   let fun_args = populate_fun_args defs in
   let global = { effect_info; fun_args } in
@@ -1124,7 +1128,9 @@ let pp_ast_lean (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail
   let monad = doc_monad_abbrev defs has_registers in
   let instantiations = doc_instantiations ctx env in
   let types, fundefs = doc_defs ctx defs in
-  let fundefs = string "namespace Functions\n\n" ^^ fundefs ^^ string "end Functions\n\nopen Functions\n\n" in
+  let fundefs = string "namespace Functions\n\n" ^^ fundefs ^^ string "end Functions\n" in
   let main_function = if !the_main_function_has_been_seen then main_function_stub has_registers else empty in
-  print o (types ^^ register_refs ^^ monad ^^ instantiations ^^ fundefs ^^ main_function);
+  let opens = IdSet.fold (fun id doc -> string "open " ^^ doc_id_ctor id ^^ hardline ^^ doc) !opens empty in
+  print types_file (types ^^ register_refs ^^ monad ^^ instantiations);
+  print funcs_file (opens ^^ hardline ^^ fundefs ^^ string "open Functions\n\n" ^^ main_function);
   !the_main_function_has_been_seen

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -180,13 +180,25 @@ type lean_context = {
   out_name : string;
   out_name_camel : string;
   sail_dir : string;
-  main_file : out_channel;
+  types_file : out_channel;
+  funcs_file : out_channel;
   lakefile : out_channel;
 }
 
 let file_to_module (filename : string) =
   let base = Filename.basename filename in
   Filename.chop_extension base
+
+let file_prelude =
+  {|set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+|}
 
 let start_lean_output (out_name : string) default_sail_dir =
   let base_dir = match !opt_lean_output_dir with Some dir -> dir | None -> "." in
@@ -219,23 +231,25 @@ let start_lean_output (out_name : string) default_sail_dir =
       |> ignore
     )
     !opt_lean_import_files;
-  let main_file = open_out (Filename.concat project_dir (out_name_camel ^ ".lean")) in
-  output_string main_file ("import " ^ out_name_camel ^ ".Sail.Sail\n");
-  output_string main_file ("import " ^ out_name_camel ^ ".Sail.BitVec\n\n");
+  let types_file = open_out (Filename.concat lean_src_dir "Defs.lean") in
+  output_string types_file ("import " ^ out_name_camel ^ ".Sail.Sail\n");
+  output_string types_file ("import " ^ out_name_camel ^ ".Sail.BitVec\n\n");
+  output_string types_file file_prelude;
+  let funcs_file = open_out (Filename.concat project_dir (out_name_camel ^ ".lean")) in
+  output_string funcs_file ("import " ^ out_name_camel ^ ".Sail.Sail\n");
+  output_string funcs_file ("import " ^ out_name_camel ^ ".Sail.BitVec\n");
+  output_string funcs_file ("import " ^ out_name_camel ^ ".Defs\n\n");
   List.iter
-    (fun filename -> output_string main_file ("import " ^ out_name_camel ^ "." ^ file_to_module filename ^ "\n\n"))
+    (fun filename -> output_string funcs_file ("import " ^ out_name_camel ^ "." ^ file_to_module filename ^ "\n\n"))
     !opt_lean_import_files;
-  if !opt_lean_noncomputable then output_string main_file "noncomputable section\n\n";
-  output_string main_file "set_option maxHeartbeats 1_000_000_000\n";
-  output_string main_file "set_option maxRecDepth 10_000\n";
-  output_string main_file "set_option linter.unusedVariables false\n";
-  output_string main_file "set_option match.ignoreUnusedAlts true\n\n";
-  output_string main_file "open Sail\n\n";
+  output_string funcs_file file_prelude;
+  if !opt_lean_noncomputable then output_string funcs_file "noncomputable section\n\n";
   let lakefile = open_out (Filename.concat project_dir "lakefile.toml") in
-  { out_name; out_name_camel; sail_dir; main_file; lakefile }
+  { out_name; out_name_camel; sail_dir; types_file; funcs_file; lakefile }
 
 let close_context ctx =
-  close_out ctx.main_file;
+  close_out ctx.types_file;
+  close_out ctx.funcs_file;
   close_out ctx.lakefile
 
 let create_lake_project (ctx : lean_context) executable =
@@ -252,7 +266,7 @@ let create_lake_project (ctx : lean_context) executable =
 
 let output (out_name : string) env effect_info ast default_sail_dir =
   let ctx = start_lean_output out_name default_sail_dir in
-  let executable = Pretty_print_lean.pp_ast_lean env effect_info ast ctx.main_file in
+  let executable = Pretty_print_lean.pp_ast_lean env effect_info ast ctx.types_file ctx.funcs_file in
   create_lake_project ctx executable
 (* Uncomment for debug output of the Sail code after the rewrite passes *)
 (* Pretty_print_sail.output_ast stdout (Type_check.strip_ast ast) *)

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev MAIRType := (BitVec 64)
 
@@ -28,7 +29,7 @@ abbrev S2PIRType := (BitVec 64)
 inductive SecurityState where | SS_NonSecure | SS_Root | SS_Realm | SS_Secure
   deriving Inhabited, BEq
 
-open SecurityState
+
 
 abbrev PARTIDtype := (BitVec 16)
 
@@ -37,7 +38,7 @@ abbrev PMGtype := (BitVec 8)
 inductive PARTIDspaceType where | PIdSpace_Secure | PIdSpace_Root | PIdSpace_Realm | PIdSpace_NonSecure
   deriving Inhabited, BEq
 
-open PARTIDspaceType
+
 
 
 structure MPAMinfo where
@@ -49,37 +50,37 @@ structure MPAMinfo where
 inductive AccessType where | AccessType_IFETCH | AccessType_GPR | AccessType_ASIMD | AccessType_SVE | AccessType_SME | AccessType_IC | AccessType_DC | AccessType_DCZero | AccessType_AT | AccessType_NV2 | AccessType_SPE | AccessType_GCS | AccessType_GPTW | AccessType_TTW
   deriving Inhabited, BEq
 
-open AccessType
+
 
 inductive VARange where | VARange_LOWER | VARange_UPPER
   deriving Inhabited, BEq
 
-open VARange
+
 
 inductive MemAtomicOp where | MemAtomicOp_GCSSS1 | MemAtomicOp_ADD | MemAtomicOp_BIC | MemAtomicOp_EOR | MemAtomicOp_ORR | MemAtomicOp_SMAX | MemAtomicOp_SMIN | MemAtomicOp_UMAX | MemAtomicOp_UMIN | MemAtomicOp_SWP | MemAtomicOp_CAS
   deriving Inhabited, BEq
 
-open MemAtomicOp
+
 
 inductive CacheOp where | CacheOp_Clean | CacheOp_Invalidate | CacheOp_CleanInvalidate
   deriving Inhabited, BEq
 
-open CacheOp
+
 
 inductive CacheOpScope where | CacheOpScope_SetWay | CacheOpScope_PoU | CacheOpScope_PoC | CacheOpScope_PoE | CacheOpScope_PoP | CacheOpScope_PoDP | CacheOpScope_PoPA | CacheOpScope_ALLU | CacheOpScope_ALLUIS
   deriving Inhabited, BEq
 
-open CacheOpScope
+
 
 inductive CacheType where | CacheType_Data | CacheType_Tag | CacheType_Data_Tag | CacheType_Instruction
   deriving Inhabited, BEq
 
-open CacheType
+
 
 inductive CachePASpace where | CPAS_NonSecure | CPAS_Any | CPAS_RealmNonSecure | CPAS_Realm | CPAS_Root | CPAS_SecureNonSecure | CPAS_Secure
   deriving Inhabited, BEq
 
-open CachePASpace
+
 
 
 structure AccessDescriptor where
@@ -121,12 +122,12 @@ structure AccessDescriptor where
 inductive MemType where | MemType_Normal | MemType_Device
   deriving Inhabited, BEq
 
-open MemType
+
 
 inductive DeviceType where | DeviceType_GRE | DeviceType_nGRE | DeviceType_nGnRE | DeviceType_nGnRnE
   deriving Inhabited, BEq
 
-open DeviceType
+
 
 
 structure MemAttrHints where
@@ -138,12 +139,12 @@ structure MemAttrHints where
 inductive Shareability where | Shareability_NSH | Shareability_ISH | Shareability_OSH
   deriving Inhabited, BEq
 
-open Shareability
+
 
 inductive MemTagType where | MemTag_Untagged | MemTag_AllocationTagged | MemTag_CanonicallyTagged
   deriving Inhabited, BEq
 
-open MemTagType
+
 
 
 structure MemoryAttributes where
@@ -160,7 +161,7 @@ structure MemoryAttributes where
 inductive PASpace where | PAS_NonSecure | PAS_Secure | PAS_Root | PAS_Realm
   deriving Inhabited, BEq
 
-open PASpace
+
 
 
 structure FullAddress where
@@ -171,7 +172,7 @@ structure FullAddress where
 inductive GPCF where | GPCF_None | GPCF_AddressSize | GPCF_Walk | GPCF_EABT | GPCF_Fail
   deriving Inhabited, BEq
 
-open GPCF
+
 
 
 structure GPCFRecord where
@@ -182,12 +183,12 @@ structure GPCFRecord where
 inductive Fault where | Fault_None | Fault_AccessFlag | Fault_Alignment | Fault_Background | Fault_Domain | Fault_Permission | Fault_Translation | Fault_AddressSize | Fault_SyncExternal | Fault_SyncExternalOnWalk | Fault_SyncParity | Fault_SyncParityOnWalk | Fault_GPCFOnWalk | Fault_GPCFOnOutput | Fault_AsyncParity | Fault_AsyncExternal | Fault_TagCheck | Fault_Debug | Fault_TLBConflict | Fault_BranchTarget | Fault_HWUpdateAccessFlag | Fault_Lockdown | Fault_Exclusive | Fault_ICacheMaint
   deriving Inhabited, BEq
 
-open Fault
+
 
 inductive ErrorState where | ErrorState_UC | ErrorState_UEU | ErrorState_UEO | ErrorState_UER | ErrorState_CE | ErrorState_Uncategorized | ErrorState_IMPDEF
   deriving Inhabited, BEq
 
-open ErrorState
+
 
 
 structure FaultRecord where
@@ -216,12 +217,12 @@ structure FaultRecord where
 inductive MBReqDomain where | MBReqDomain_Nonshareable | MBReqDomain_InnerShareable | MBReqDomain_OuterShareable | MBReqDomain_FullSystem
   deriving Inhabited, BEq
 
-open MBReqDomain
+
 
 inductive MBReqTypes where | MBReqTypes_Reads | MBReqTypes_Writes | MBReqTypes_All
   deriving Inhabited, BEq
 
-open MBReqTypes
+
 
 
 structure CacheRecord where
@@ -248,12 +249,12 @@ structure CacheRecord where
 inductive Regime where | Regime_EL3 | Regime_EL30 | Regime_EL2 | Regime_EL20 | Regime_EL10
   deriving Inhabited, BEq
 
-open Regime
+
 
 inductive TGx where | TGx_4KB | TGx_16KB | TGx_64KB
   deriving Inhabited, BEq
 
-open TGx
+
 
 
 structure S1TTWParams where
@@ -350,17 +351,17 @@ structure TranslationInfo where
 inductive TLBILevel where | TLBILevel_Any | TLBILevel_Last
   deriving Inhabited, BEq
 
-open TLBILevel
+
 
 inductive TLBIOp where | TLBIOp_DALL | TLBIOp_DASID | TLBIOp_DVA | TLBIOp_IALL | TLBIOp_IASID | TLBIOp_IVA | TLBIOp_ALL | TLBIOp_ASID | TLBIOp_IPAS2 | TLBIPOp_IPAS2 | TLBIOp_VAA | TLBIOp_VA | TLBIPOp_VAA | TLBIPOp_VA | TLBIOp_VMALL | TLBIOp_VMALLS12 | TLBIOp_RIPAS2 | TLBIPOp_RIPAS2 | TLBIOp_RVAA | TLBIOp_RVA | TLBIPOp_RVAA | TLBIPOp_RVA | TLBIOp_RPA | TLBIOp_PAALL
   deriving Inhabited, BEq
 
-open TLBIOp
+
 
 inductive TLBIMemAttr where | TLBI_AllAttr | TLBI_ExcludeXS
   deriving Inhabited, BEq
 
-open TLBIMemAttr
+
 
 
 structure TLBIRecord where
@@ -396,7 +397,7 @@ inductive arm_acc_type where
   | SAcc_GPTW (_ : Unit)
   deriving BEq
 
-open arm_acc_type
+
 
 
 structure TLBIInfo where
@@ -421,7 +422,7 @@ inductive Barrier where
   | Barrier_SB (_ : Unit)
   deriving BEq
 
-open Barrier
+
 
 abbrev boolean := (BitVec 1)
 
@@ -440,7 +441,7 @@ inductive ast where
   | CompareAndBranch (_ : (reg_index × (BitVec 64)))
   deriving BEq
 
-open ast
+
 
 inductive Register : Type where
   | R0
@@ -512,7 +513,6 @@ abbrev RegisterType : Register → Type
   | .R30 => (BitVec 64)
   | ._PC => (BitVec 64)
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
   default := .Reg _PC
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
@@ -528,6 +528,51 @@ instance : Arch where
   barrier := Barrier
   arch_ak := arm_acc_type
   sys_reg_id := Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open ast
+open arm_acc_type
+open VARange
+open TLBIOp
+open TLBIMemAttr
+open TLBILevel
+open TGx
+open Shareability
+open SecurityState
+open Register
+open Regime
+open PASpace
+open PARTIDspaceType
+open MemType
+open MemTagType
+open MemAtomicOp
+open MBReqTypes
+open MBReqDomain
+open GPCF
+open Fault
+open ErrorState
+open DeviceType
+open CacheType
+open CachePASpace
+open CacheOpScope
+open CacheOp
+open Barrier
+open AccessType
 
 namespace Functions
 
@@ -2170,6 +2215,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R0 (← (undefined_bitvector 64))
 
 end Functions
-
 open Functions
 

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -109,6 +127,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -8,7 +8,24 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
 
 namespace Functions
 
@@ -19,6 +36,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev cr_type := (BitVec 8)
 
@@ -29,10 +30,27 @@ open Register
 abbrev RegisterType : Register → Type
   | .R => (BitVec 8)
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
   default := .Reg R
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open Register
 
 namespace Functions
 
@@ -175,6 +193,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R (← (undefined_cr_type ()))
 
 end Functions
-
 open Functions
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -159,6 +177,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,14 +18,32 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive E where | A | B | C
   deriving Inhabited, BEq
 
-open E
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open E
 
 namespace Functions
 
@@ -117,6 +136,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive Register : Type where
   | dummy
@@ -27,10 +28,27 @@ open Register
 abbrev RegisterType : Register → Type
   | .dummy => (BitVec 1)
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
   default := .Reg dummy
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open Register
 
 namespace Functions
 
@@ -118,6 +136,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg dummy (← (undefined_bit ()))
 
 end Functions
-
 open Functions
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -275,6 +293,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -111,6 +129,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -110,6 +128,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -108,6 +126,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive Register : Type where
   | r
@@ -27,10 +28,27 @@ open Register
 abbrev RegisterType : Register → Type
   | .r => Int
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType Int) where
   default := .Reg r
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open Register
 
 namespace Functions
 
@@ -181,6 +199,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r (← (undefined_int ()))
 
 end Functions
-
 open Functions
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,14 +18,32 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive word_width where | BYTE | HALF | WORD | DOUBLE
   deriving Inhabited, BEq
 
-open word_width
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open word_width
+open option
 
 namespace Functions
 
@@ -227,6 +246,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,12 +18,12 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive E where | A | B | C
   deriving Inhabited, BEq
 
-open E
+
 
 inductive Register : Type where
   | r_C
@@ -36,10 +37,28 @@ abbrev RegisterType : Register → Type
   | .r_B => E
   | .r_A => E
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType E) where
   default := .Reg r_A
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open Register
+open E
 
 namespace Functions
 
@@ -166,6 +185,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r_C (← (undefined_E ()))
 
 end Functions
-
 open Functions
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -140,6 +158,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -106,6 +124,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/output
+++ b/test/lean/output
@@ -20,24 +20,23 @@ inductive option (k_a : Type) where
 
 
 
+abbrev cr_type := (BitVec 8)
+
 inductive Register : Type where
-  | B
   | R
   deriving DecidableEq, Hashable
 open Register
 
 abbrev RegisterType : Register → Type
-  | .B => Bool
-  | .R => Nat
+  | .R => (BitVec 8)
 
-instance : Inhabited (RegisterRef RegisterType Bool) where
-  default := .Reg B
-instance : Inhabited (RegisterRef RegisterType Nat) where
+open RegisterRef
+instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
   default := .Reg R
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
 
 
-XXXXXXXXX
+
 
 import Out.Sail.Sail
 import Out.Sail.BitVec
@@ -56,7 +55,7 @@ open Register
 
 namespace Functions
 
-/-- Type quantifiers: k_ex805# : Bool, k_ex804# : Bool -/
+/-- Type quantifiers: k_ex700# : Bool, k_ex699# : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (Bool.not (BEq.beq x y))
 
@@ -125,32 +124,74 @@ def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
 def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
-/-- Type quantifiers: n : Nat, 0 ≤ n -/
-def elif (n : Nat) : (BitVec 1) :=
-  if (BEq.beq n 0)
-  then 1#1
-  else if (BEq.beq n 1)
-       then 1#1
-       else 0#1
+def undefined_cr_type (_ : Unit) : SailM (BitVec 8) := do
+  (undefined_bitvector 8)
 
-/-- Type quantifiers: n : Nat, 0 ≤ n -/
-def monadic_in_out (n : Nat) : SailM Nat := do
-  if (← readReg B)
-  then writeReg R n
-  else (pure ())
-  readReg R
+def Mk_cr_type (v : (BitVec 8)) : (BitVec 8) :=
+  v
 
-/-- Type quantifiers: n : Nat, 0 ≤ n -/
-def monadic_lines (n : Nat) : SailM Unit := do
-  let b := (BEq.beq n 0)
-  if b
-  then writeReg R n
-       writeReg B b
-  else writeReg B b
+def _get_cr_type_bits (v : (BitVec 8)) : (BitVec 8) :=
+  (Sail.BitVec.extractLsb v (8 - 1) 0)
+
+def _update_cr_type_bits (v : (BitVec 8)) (x : (BitVec 8)) : (BitVec 8) :=
+  (Sail.BitVec.updateSubrange v (8 - 1) 0 x)
+
+def _set_cr_type_bits (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec 8)) : SailM Unit := do
+  let r ← do (reg_deref r_ref)
+  writeRegRef r_ref (_update_cr_type_bits r v)
+
+def _get_cr_type_CR0 (v : (BitVec 8)) : (BitVec 4) :=
+  (Sail.BitVec.extractLsb v 7 4)
+
+def _update_cr_type_CR0 (v : (BitVec 8)) (x : (BitVec 4)) : (BitVec 8) :=
+  (Sail.BitVec.updateSubrange v 7 4 x)
+
+def _set_cr_type_CR0 (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec 4)) : SailM Unit := do
+  let r ← do (reg_deref r_ref)
+  writeRegRef r_ref (_update_cr_type_CR0 r v)
+
+def _get_cr_type_CR1 (v : (BitVec 8)) : (BitVec 2) :=
+  (Sail.BitVec.extractLsb v 3 2)
+
+def _update_cr_type_CR1 (v : (BitVec 8)) (x : (BitVec 2)) : (BitVec 8) :=
+  (Sail.BitVec.updateSubrange v 3 2 x)
+
+def _set_cr_type_CR1 (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec 2)) : SailM Unit := do
+  let r ← do (reg_deref r_ref)
+  writeRegRef r_ref (_update_cr_type_CR1 r v)
+
+def _get_cr_type_CR3 (v : (BitVec 8)) : (BitVec 2) :=
+  (Sail.BitVec.extractLsb v 1 0)
+
+def _update_cr_type_CR3 (v : (BitVec 8)) (x : (BitVec 2)) : (BitVec 8) :=
+  (Sail.BitVec.updateSubrange v 1 0 x)
+
+def _set_cr_type_CR3 (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec 2)) : SailM Unit := do
+  let r ← do (reg_deref r_ref)
+  writeRegRef r_ref (_update_cr_type_CR3 r v)
+
+def _get_cr_type_GT (v : (BitVec 8)) : (BitVec 1) :=
+  (Sail.BitVec.extractLsb v 6 6)
+
+def _update_cr_type_GT (v : (BitVec 8)) (x : (BitVec 1)) : (BitVec 8) :=
+  (Sail.BitVec.updateSubrange v 6 6 x)
+
+def _set_cr_type_GT (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec 1)) : SailM Unit := do
+  let r ← do (reg_deref r_ref)
+  writeRegRef r_ref (_update_cr_type_GT r v)
+
+def _get_cr_type_LT (v : (BitVec 8)) : (BitVec 1) :=
+  (Sail.BitVec.extractLsb v 7 7)
+
+def _update_cr_type_LT (v : (BitVec 8)) (x : (BitVec 1)) : (BitVec 8) :=
+  (Sail.BitVec.updateSubrange v 7 7 x)
+
+def _set_cr_type_LT (r_ref : (RegisterRef RegisterType (BitVec 8))) (v : (BitVec 1)) : SailM Unit := do
+  let r ← do (reg_deref r_ref)
+  writeRegRef r_ref (_update_cr_type_LT r v)
 
 def initialize_registers (_ : Unit) : SailM Unit := do
-  writeReg R (← (undefined_nat ()))
-  writeReg B (← (undefined_bool ()))
+  writeReg R (← (undefined_cr_type ()))
 
 end Functions
 open Functions

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,9 +18,26 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -116,6 +134,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev reg_index := Nat
 
@@ -91,10 +92,27 @@ abbrev RegisterType : Register → Type
   | .R30 => (BitVec 64)
   | ._PC => (BitVec 64)
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
   default := .Reg _PC
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open Register
 
 namespace Functions
 
@@ -231,6 +249,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg R0 (← (undefined_bitvector 64))
 
 end Functions
-
 open Functions
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive Register : Type where
   | BIT
@@ -37,7 +38,6 @@ abbrev RegisterType : Register → Type
   | .R1 => (BitVec 64)
   | .R0 => (BitVec 64)
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
   default := .Reg BIT
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
@@ -49,6 +49,24 @@ instance : Inhabited (RegisterRef RegisterType Int) where
 instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg NAT
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open Register
 
 namespace Functions
 
@@ -134,6 +152,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg BIT (← (undefined_bit ()))
 
 end Functions
-
 open Functions
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev xlen : Int := 64
 
@@ -30,7 +31,7 @@ abbrev regbits := (BitVec 5)
 inductive iop where | RISCV_ADDI | RISCV_SLTI | RISCV_SLTIU | RISCV_XORI | RISCV_ORI | RISCV_ANDI
   deriving Inhabited, BEq
 
-open iop
+
 
 
 inductive ast where
@@ -38,7 +39,7 @@ inductive ast where
   | LOAD (_ : ((BitVec 12) × regbits × regbits))
   deriving BEq
 
-open ast
+
 
 inductive Register : Type where
   | Xs
@@ -52,12 +53,31 @@ abbrev RegisterType : Register → Type
   | .nextPC => (BitVec 64)
   | .PC => (BitVec 64)
 
-open RegisterRef
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
   default := .Reg PC
 instance : Inhabited (RegisterRef RegisterType (Vector (BitVec 64) 32)) where
   default := .Reg Xs
 abbrev SailM := PreSailM RegisterType trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open iop
+open ast
+open Register
 
 namespace Functions
 
@@ -222,6 +242,5 @@ def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg Xs (← (undefined_vector 32 (← (undefined_bitvector 64))))
 
 end Functions
-
 open Functions
 

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -136,11 +136,15 @@ def test_lean(subdir: str, skip_list = None, runnable: bool = False):
                     step('lake build', cwd=f'{basename}/out', name=filename)
 
                 if not runnable:
-                    status = step_with_status(f'diff {basename}/out/Out.lean {basename}.expected.lean', name=filename)
+                    output = f"{basename}/output"
+                    step(f'cat {basename}/out/Out/Defs.lean > {output}')
+                    step(f'echo >> {output}; echo "XXXXXXXXX" >> {output}; echo >> {output}')
+                    step(f'cat {basename}/out/Out.lean >> {output}')
+                    status = step_with_status(f'diff {output} {basename}.expected.lean', name=filename)
                     if status != 0:
                         if update_expected:
                             print(f'Overriding file {basename}.expected.lean')
-                            step(f'cp {basename}/out/Out.lean {basename}.expected.lean')
+                            step(f'cp {output} {basename}.expected.lean')
                         else:
                             sys.exit(1)
                 else:

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 
 structure My_struct where
@@ -39,6 +40,23 @@ structure Mem_write_request
   deriving BEq
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -145,6 +163,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,12 +18,12 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 inductive e_test where | VAL
   deriving Inhabited, BEq
 
-open e_test
+
 
 
 structure s_test where
@@ -30,6 +31,24 @@ structure s_test where
   deriving BEq
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
+open e_test
 
 namespace Functions
 
@@ -121,6 +140,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -8,7 +8,24 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
 
 namespace Functions
 
@@ -19,6 +36,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -8,7 +8,24 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
 
 namespace Functions
 
@@ -32,6 +49,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -8,7 +8,24 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
 
 namespace Functions
 
@@ -20,6 +37,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,7 +18,7 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 abbrev xlen : Int := 64
 
@@ -28,6 +29,23 @@ abbrev xlenbits := (BitVec 64)
 abbrev my_bits k_n := (BitVec k_n)
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open option
 
 namespace Functions
 
@@ -117,6 +135,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -8,6 +8,7 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev bits k_n := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
@@ -17,16 +18,34 @@ inductive option (k_a : Type) where
   | None (_ : Unit)
   deriving BEq
 
-open option
+
 
 
 inductive virtaddr where
   | virtaddr (_ : (BitVec 32))
   deriving BEq
 
-open virtaddr
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open virtaddr
+open option
 
 namespace Functions
 
@@ -165,6 +184,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -8,7 +8,24 @@ set_option match.ignoreUnusedAlts true
 
 open Sail
 
+
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
 
 namespace Functions
 
@@ -25,6 +42,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -9,6 +9,7 @@ set_option match.ignoreUnusedAlts true
 open Sail
 
 
+
 structure rectangle where
   width : Int
   height : Int
@@ -25,7 +26,7 @@ inductive shape where
   | Circle (_ : circle)
   deriving BEq
 
-open shape
+
 
 /-- Type quantifiers: k_a : Type -/
 
@@ -34,9 +35,27 @@ inductive my_option (k_a : Type) where
   | MyNone (_ : Unit)
   deriving BEq
 
-open my_option
+
 
 abbrev SailM := PreSailM PEmpty.elim trivialChoiceSource Unit
+
+
+XXXXXXXXX
+
+import Out.Sail.Sail
+import Out.Sail.BitVec
+import Out.Defs
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 10_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+
+
+open shape
+open my_option
 
 namespace Functions
 
@@ -61,6 +80,5 @@ def initialize_registers (_ : Unit) : Unit :=
   ()
 
 end Functions
-
 open Functions
 


### PR DESCRIPTION
This allows the handwritten support to use the types defined in the model. In turn, this allows to prove termination of functions by well founded induction by defining a `SizeOf` instance on the type of RISC-V extensions.

There is a slight difficulty, which is that we need to reopen all the types in the module with the functions to be able to access their fields.