### PR TITLE
Config: Cache configuration values

### DIFF
--- a/language/jib.ott
+++ b/language/jib.ott
@@ -220,6 +220,7 @@ creturn :: 'CR_' ::=
 
 init :: 'Init_' ::=
   | cval                             :: :: cval
+  | static value                     :: :: static
   | json_key string0 . ... . stringn :: :: json_key
 
 instr :: 'I_' ::=

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -194,6 +194,8 @@
   (%{workspace_root}/lib/sail.tex as lib/sail.tex)
   (%{workspace_root}/lib/json/cJSON.c as lib/json/cJSON.c)
   (%{workspace_root}/lib/json/cJSON.h as lib/json/cJSON.h)
+  (%{workspace_root}/lib/json/sail_config.c as lib/json/sail_config.c)
+  (%{workspace_root}/lib/json/sail_config.h as lib/json/sail_config.h)
   (%{workspace_root}/lib/sail_coverage.h as lib/sail_coverage.h)
   (%{workspace_root}/lib/sail_failure.c as lib/sail_failure.c)
   (%{workspace_root}/lib/sail_failure.h as lib/sail_failure.h)

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -132,6 +132,7 @@ type ctx = {
   letbinds : int list;
   letbind_ids : IdSet.t;
   no_raw : bool;
+  no_static : bool;
   coverage_override : bool;
   def_annot : unit def_annot option;
 }
@@ -181,6 +182,7 @@ let initial_ctx ?for_target env effect_info =
     letbinds = [];
     letbind_ids = IdSet.empty;
     no_raw = false;
+    no_static = false;
     coverage_override = true;
     def_annot = None;
   }
@@ -656,6 +658,21 @@ module Make (C : CONFIG) = struct
        )
     |> if_chain
 
+  let static_load l ctyp f =
+    let loaded, loaded_instr = istatic l CT_bool (VL_bool false) in
+    let s, s_instr = istatic l ctyp VL_undefined in
+    ( [
+        loaded_instr;
+        s_instr;
+        iif l
+          (V_call (Bnot, [V_id (loaded, CT_bool)]))
+          (f s @ [icopy l (CL_id (loaded, CT_bool)) (V_lit (VL_bool true, CT_bool))])
+          [];
+      ],
+      (fun clexp -> icopy l clexp (V_id (s, ctyp))),
+      []
+    )
+
   let compile_config' l ctx key ctyp =
     let key_name = ngensym () in
     let json = ngensym () in
@@ -953,7 +970,11 @@ module Make (C : CONFIG) = struct
     in
 
     let setup, call, cleanup = extract json ctyp in
-    (init @ setup, call, cleanup @ [iclear CT_json json; iclear CT_json_key key_name])
+    if ctx.no_static then (init @ setup, call, cleanup @ [iclear CT_json json; iclear CT_json_key key_name])
+    else
+      static_load l ctyp (fun s ->
+          init @ setup @ [call (CL_id (s, ctyp))] @ cleanup @ [iclear CT_json json; iclear CT_json_key key_name]
+      )
 
   let compile_config l ctx args typ =
     let ctyp = ctyp_of_typ ctx typ in
@@ -1717,7 +1738,9 @@ module Make (C : CONFIG) = struct
     | TD_abstract (id, K_aux (kind, _), inst) -> begin
         let compile_inst ctyp = function
           | TDC_key key ->
-              let setup, call, cleanup = compile_config' l ctx key ctyp in
+              (* The abstract initialisers are ran very early, before the rest of the model,
+                 so we can't rely on Jib static initialisers being set up. *)
+              let setup, call, cleanup = compile_config' l { ctx with no_static = true } key ctyp in
               CTDI_instrs (setup @ [call (CL_id (name id, ctyp))] @ cleanup)
           | TDC_none -> CTDI_none
         in
@@ -2777,6 +2800,44 @@ module Make (C : CONFIG) = struct
     let toplevel_lets_of_defs defs = List.fold_left IdSet.union IdSet.empty (List.map toplevel_lets_of_def defs) in
     toplevel_lets_of_defs ast.defs |> IdSet.elements
 
+  class static_visitor statics =
+    object
+      inherit empty_jib_visitor
+
+      method! vctyp _ = SkipChildren
+      method! vclexp _ = SkipChildren
+      method! vcval _ = SkipChildren
+
+      method! vinstr =
+        function
+        | I_aux (I_init (ctyp, Name (id, _), Init_static VL_undefined), (_, l)) ->
+            statics := (l, ctyp, id, None) :: !statics;
+            ChangeTo (Printf.ksprintf icomment "lifted %s" (string_of_id id))
+        | I_aux (I_init (ctyp, Name (id, _), Init_static vl), (_, l)) ->
+            statics := (l, ctyp, id, Some vl) :: !statics;
+            ChangeTo (Printf.ksprintf icomment "lifted %s" (string_of_id id))
+        | _ -> DoChildren
+    end
+
+  let lift_statics cdefs =
+    List.map
+      (fun cdef ->
+        let statics = ref [] in
+        let cdef = visit_cdef (new static_visitor statics) cdef in
+        List.rev_map
+          (fun (l, ctyp, id, vl_opt) ->
+            match vl_opt with
+            | None -> CDEF_aux (CDEF_register (id, ctyp, []), mk_def_annot l ())
+            | Some vl ->
+                CDEF_aux
+                  (CDEF_register (id, ctyp, [icopy l (CL_id (name id, ctyp)) (V_lit (vl, ctyp))]), mk_def_annot l ())
+          )
+          !statics
+        @ [cdef]
+      )
+      cdefs
+    |> List.concat
+
   let compile_ast ctx ast =
     let module G = Graph.Make (Callgraph.Node) in
     let g = Callgraph.graph_of_ast ast in
@@ -2830,5 +2891,6 @@ module Make (C : CONFIG) = struct
     let cdefs, ctx = specialize_variants ctx [] cdefs in
     let cdefs = make_calls_precise ctx cdefs in
     let cdefs = sort_ctype_defs false cdefs in
+    let cdefs = lift_statics cdefs in
     (cdefs, ctx)
 end

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -88,6 +88,7 @@ type ctx = {
   letbinds : int list;
   letbind_ids : IdSet.t;
   no_raw : bool;
+  no_static : bool;
   coverage_override : bool;
   def_annot : unit def_annot option;
 }

--- a/src/lib/jib_optimize.ml
+++ b/src/lib/jib_optimize.ml
@@ -241,7 +241,7 @@ end
 let remove_functions_to_references = Jib_visitor.visit_instrs (new Remove_functions_to_references.visitor)
 
 let init_subst id subst init =
-  match init with Init_cval cval -> Init_cval (cval_subst id subst cval) | Init_json_key _ -> init
+  match init with Init_cval cval -> Init_cval (cval_subst id subst cval) | Init_static _ | Init_json_key _ -> init
 
 let rec instrs_subst id subst = function
   | I_aux (I_decl (_, id'), _) :: _ as instrs when Name.compare id id' = 0 -> instrs
@@ -546,7 +546,11 @@ let remove_tuples cdefs ctx =
     | CR_one clexp -> CR_one (fix_clexp clexp)
     | CR_multi clexps -> CR_multi (List.map fix_clexp clexps)
   in
-  let fix_init = function Init_cval cval -> Init_cval (fix_cval cval) | Init_json_key parts -> Init_json_key parts in
+  let fix_init = function
+    | Init_cval cval -> Init_cval (fix_cval cval)
+    | Init_static vl -> Init_static vl
+    | Init_json_key parts -> Init_json_key parts
+  in
   let rec fix_instr_aux = function
     | I_funcall (creturn, extern, id, args) -> I_funcall (fix_creturn creturn, extern, id, List.map fix_cval args)
     | I_copy (clexp, cval) -> I_copy (fix_clexp clexp, fix_cval cval)

--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -552,6 +552,7 @@ let rename_variables globals graph root children =
 
   let fold_init = function
     | Init_cval cval -> Init_cval (fold_cval cval)
+    | Init_static vl -> Init_static vl
     | Init_json_key parts -> Init_json_key parts
   in
 

--- a/src/lib/jib_util.ml
+++ b/src/lib/jib_util.ml
@@ -76,6 +76,12 @@ let idecl l ctyp id = I_aux (I_decl (ctyp, id), (instr_number (), l))
 
 let ireset l ctyp id = I_aux (I_reset (ctyp, id), (instr_number (), l))
 
+let generate_static_var, _ = symbol_generator "gen_static"
+
+let istatic l ctyp value =
+  let id = Name (generate_static_var (), -1) in
+  (id, I_aux (I_init (ctyp, id, Init_static value), (instr_number (), l)))
+
 let iinit l ctyp id cval = I_aux (I_init (ctyp, id, Init_cval cval), (instr_number (), l))
 
 let ijson_key l id parts = I_aux (I_init (CT_json_key, id, Init_json_key parts), (instr_number (), l))
@@ -351,6 +357,7 @@ let string_of_creturn = function
 
 let string_of_init = function
   | Init_cval cval -> string_of_cval cval
+  | Init_static vl -> "static " ^ string_of_value vl
   | Init_json_key parts -> Util.string_of_list "." (fun part -> "\"" ^ part ^ "\"") parts
 
 let rec doc_instr (I_aux (aux, _)) =
@@ -694,7 +701,7 @@ let creturn_deps = function
         )
         (NameSet.empty, NameSet.empty) clexps
 
-let init_deps = function Init_cval cval -> cval_deps cval | Init_json_key _ -> NameSet.empty
+let init_deps = function Init_cval cval -> cval_deps cval | Init_static _ | Init_json_key _ -> NameSet.empty
 
 (* Return the direct, read/write dependencies of a single instruction *)
 let instr_deps = function
@@ -776,7 +783,7 @@ let map_creturn_ctyp f = function
   | CR_multi clexps -> CR_multi (List.map (map_clexp_ctyp f) clexps)
 
 let map_init_ctyp f init =
-  match init with Init_cval cval -> Init_cval (map_cval_ctyp f cval) | Init_json_key _ -> init
+  match init with Init_cval cval -> Init_cval (map_cval_ctyp f cval) | Init_static _ | Init_json_key _ -> init
 
 let rec map_instr_ctyp f (I_aux (instr, aux)) =
   let instr =
@@ -1077,7 +1084,9 @@ let rec clexp_ctyp = function
 
 let creturn_ctyp = function CR_one clexp -> clexp_ctyp clexp | CR_multi clexps -> CT_tup (List.map clexp_ctyp clexps)
 
-let init_ctyps = function Init_cval cval -> CTSet.singleton (cval_ctyp cval) | Init_json_key _ -> CTSet.empty
+let init_ctyps = function
+  | Init_cval cval -> CTSet.singleton (cval_ctyp cval)
+  | Init_static _ | Init_json_key _ -> CTSet.empty
 
 let rec instr_ctyps (I_aux (instr, aux)) =
   match instr with

--- a/src/lib/jib_util.mli
+++ b/src/lib/jib_util.mli
@@ -58,6 +58,7 @@ open Jib
 val symbol_generator : string -> (unit -> id) * (unit -> unit)
 
 val idecl : l -> ctyp -> name -> instr
+val istatic : l -> ctyp -> Value2.vl -> name * instr
 val ireset : l -> ctyp -> name -> instr
 val iinit : l -> ctyp -> name -> cval -> instr
 val ijson_key : l -> name -> string list -> instr

--- a/src/lib/jib_visitor.ml
+++ b/src/lib/jib_visitor.ml
@@ -160,7 +160,7 @@ let visit_init vis no_change =
   | Init_cval cval ->
       let cval' = visit_cval vis cval in
       if cval == cval' then no_change else Init_cval cval'
-  | Init_json_key _ -> no_change
+  | Init_static _ | Init_json_key _ -> no_change
 
 let rec visit_instr vis outer_instr =
   let aux vis no_change =

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1390,6 +1390,8 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         match init with
         | Init_cval cval ->
             codegen_instr fid ctx (idecl l ctyp id) ^^ hardline ^^ codegen_conversion l (CL_id (id, ctyp)) cval
+        | Init_static VL_undefined -> ksprintf string "  static %s %s;" (sgen_ctyp ctyp) (sgen_name id)
+        | Init_static vl -> ksprintf string "  static %s %s = %s;" (sgen_ctyp ctyp) (sgen_name id) (sgen_value vl)
         | Init_json_key parts ->
             ksprintf string "  sail_config_key %s = {%s};" (sgen_name id)
               (Util.string_of_list ", " (fun part -> "\"" ^ part ^ "\"") parts)
@@ -2368,16 +2370,23 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       in
 
       let model_main =
-        let extra =
+        let extra_pre =
           List.filter_map
             (function CDEF_aux (CDEF_pragma ("c_in_main", arg), _) -> Some ("  " ^ arg) | _ -> None)
+            cdefs
+        in
+        let extra_post =
+          List.filter_map
+            (function CDEF_aux (CDEF_pragma ("c_in_main_post", arg), _) -> Some ("  " ^ arg) | _ -> None)
             cdefs
         in
         separate hardline
           ( if Config.no_main then []
             else
               List.map string
-                (["int main(int argc, char *argv[])"; "{"] @ extra @ ["  return model_main(argc, argv);"; "}"])
+                (["int main(int argc, char *argv[])"; "{"; "  int retcode;"]
+                @ extra_pre @ ["  retcode = model_main(argc, argv);"] @ extra_post @ ["  return retcode;"; "}"]
+                )
           )
       in
       let end_extern_cpp = separate hardline (List.map string [""; "#ifdef __cplusplus"; "}"; "#endif"]) in

--- a/src/sail_c_backend/keywords.ml
+++ b/src/sail_c_backend/keywords.ml
@@ -47,7 +47,18 @@
 
 open Libsail
 
-let c_used_words = ["main"; "have_exception"; "current_exception"; "throw_location"] |> Util.StringSet.of_list
+let c_used_words =
+  [
+    "main";
+    "have_exception";
+    "current_exception";
+    "throw_location";
+    "model_main";
+    "model_init";
+    "model_fini";
+    "model_pre_exit";
+  ]
+  |> Util.StringSet.of_list
 
 let c_reserved_words =
   [

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -1308,7 +1308,8 @@ module Make (Config : CONFIG) = struct
         | Init_cval cval ->
             let* value = Smt.smt_cval cval in
             wrap (SVS_var (id, ctyp, Some value))
-        | Init_json_key _ -> Reporting.unreachable l __POS__ "Json key found in SV backend"
+        | Init_json_key _ | Init_static _ ->
+            Reporting.unreachable l __POS__ "Unexpected cval initializer found in SV backend"
       )
     | I_return cval ->
         let* value = Smt.smt_cval cval in

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -148,7 +148,7 @@ def step_with_status(string, expected_status=0, cwd=None, name='', stderr_file='
     return status
 
 def step(string, expected_status=0, cwd=None, name='', stderr_file=''):
-    if step_with_status(string, expected_status=expected_status, cwd=cwd, name=name) != expected_status:
+    if step_with_status(string, expected_status=expected_status, cwd=cwd, name=name, stderr_file=stderr_file) != expected_status:
         sys.exit(1)
 
 def banner(string):


### PR DESCRIPTION
Avoid re-fetching configuration values by memoising the values. This avoids the overhead of reparsing and traversing the JSON each time we need a value.