### PR TITLE
Lean: use `Array.zipIdx` instead of `Array.zipWithIndex`

### DIFF
--- a/src/sail_lean_backend/Sail/BitVec.lean
+++ b/src/sail_lean_backend/Sail/BitVec.lean
@@ -145,7 +145,7 @@ open Elab
 open Term
 
 def checkBVPatLengths (lens : Array (Option Nat)) (pss : Array (Array BVPat)) : TermElabM Unit := do
-    for (len, i) in lens.zipWithIndex do
+    for (len, i) in lens.zipIdx do
       let mut patLen := none
       for ps in pss do
         unless ps.size == lens.size do


### PR DESCRIPTION
Fixes the one deprecation warning we get on every build.