### PR TITLE
Lean: add instances for subtracting or expontiating Nat with Int

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -547,4 +547,10 @@ instance : HPow Int Int Int where
 instance : HSub Nat Nat Int where
   hSub m n := (m : Int) - (n : Int)
 
-infixl:65 " -i "   => HSub.hSub (γ := Int)
+instance : HPow Nat Int Int where
+  hPow m z := (m : Int) ^ z
+
+instance : HSub Nat Int Int where
+  hSub m z := (m : Int) - z
+
+infixl:65 " -i " => HSub.hSub (γ := Int)


### PR DESCRIPTION
Small oversight in #1080 was that it causes heterogeneous powers and subtraction on the outside. Added instances for those, they should get rid of all of the "faild to synthesize" errors on RISCV.