### PR TITLE
Lean: force all arithmetic operations to be on integers

### DIFF
--- a/lib/arith.sail
+++ b/lib/arith.sail
@@ -51,10 +51,10 @@ $include <flow.sail>
 
 // ***** Addition *****
 
-val add_atom = pure {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", coq: "Z.add", lean: "_lean_add", _: "add_int"} : forall 'n 'm.
+val add_atom = pure {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", coq: "Z.add", lean: "_lean_addi", _: "add_int"} : forall 'n 'm.
   (int('n), int('m)) -> int('n + 'm)
 
-val add_int = pure {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", coq: "Z.add", lean: "_lean_add", _: "add_int"} : (int, int) -> int
+val add_int = pure {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", coq: "Z.add", lean: "_lean_addi", _: "add_int"} : (int, int) -> int
 
 overload operator + = {add_atom, add_int}
 
@@ -85,10 +85,10 @@ overload negate = {negate_atom, negate_int}
 
 // ***** Multiplication *****
 
-val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", coq: "Z.mul", lean: "_lean_mul", _: "mult_int"} : forall 'n 'm.
+val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", coq: "Z.mul", lean: "_lean_muli", _: "mult_int"} : forall 'n 'm.
   (int('n), int('m)) -> int('n * 'm)
 
-val mult_int = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", coq: "Z.mul", lean: "_lean_mul", _: "mult_int"} : (int, int) -> int
+val mult_int = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", coq: "Z.mul", lean: "_lean_muli", _: "mult_int"} : (int, int) -> int
 
 overload operator * = {mult_atom, mult_int}
 
@@ -111,7 +111,7 @@ $endif
 /*!
 We have special support for raising values to the power of two. Any Sail expression `2 ^ x` will be compiled to this builtin.
 */
-val pow2 = pure {lean : "_lean_pow2", _:"pow2"} : forall 'n. int('n) -> int(2 ^ 'n)
+val pow2 = pure {lean : "_lean_pow2i", _:"pow2"} : forall 'n. int('n) -> int(2 ^ 'n)
 
 // ***** Integer shifts *****
 

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -164,10 +164,10 @@ instance : HShiftLeft (BitVec w) Int (BitVec w) where
   hShiftLeft b i :=
     match i with
     | .ofNat n => BitVec.shiftLeft b n
-    | .negSucc n => BitVec.ushiftRight b n
+    | .negSucc n => BitVec.ushiftRight b (n + 1)
 
 instance : HShiftRight (BitVec w) Int (BitVec w) where
-  hShiftRight b i := b <<< (-i)
+  hShiftRight b i := b <<< (- i)
 
 section Loops
 
@@ -596,19 +596,14 @@ instance : HOr (BitVec n) (BitVec m) (BitVec n) where
 instance : HXor (BitVec n) (BitVec m) (BitVec n) where
   hXor x y := x ^^^ y
 
-instance : HPow Nat Int Nat where
-  hPow x n := x ^ n.toNat
+def Int.zpow (m n : Int) : Int := m ^ n.toNat
 
-instance : HPow Int Int Int where
-  hPow x n := x ^ n.toNat
+infixl:65 " +i "   => Int.add
+infixl:65 " -i " => Int.sub
+infixr:80 " ^i "   => Int.pow
+infixl:70 " *i "   => Int.mul
 
-instance : HSub Nat Nat Int where
-  hSub m n := (m : Int) - (n : Int)
-
-instance : HPow Nat Int Int where
-  hPow m z := (m : Int) ^ z
-
-instance : HSub Nat Int Int where
-  hSub m z := (m : Int) - z
-
-infixl:65 " -i " => HSub.hSub (γ := Int)
+macro_rules | `($x +i $y)   => `(binop% Int.add $x $y)
+macro_rules | `($x -i $y)   => `(binop% Int.sub $x $y)
+macro_rules | `($x ^i $y)   => `(rightact% Int.zpow $x $y)
+macro_rules | `($x *i $y)   => `(binop% Int.mul $x $y)

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -530,9 +530,11 @@ let rec doc_implicit_args ?(docs = []) ns ims d_args =
 let op_of_id id =
   match id with
   | Some "_lean_add" -> `Binop "+"
+  | Some "_lean_addi" -> `Binop "+i"
   | Some "_lean_sub" -> `Binop "-"
   | Some "_lean_subi" -> `Binop "-i"
   | Some "_lean_mul" -> `Binop "*"
+  | Some "_lean_muli" -> `Binop "*i"
   | Some "_lean_div" -> `Binop "/"
   | Some "_lean_app" -> `Binop "++"
   | Some "_lean_bvand" -> `Binop "&&&"
@@ -541,6 +543,7 @@ let op_of_id id =
   | Some "_lean_shiftl" -> `Binop "<<<"
   | Some "_lean_shiftr" -> `Binop ">>>"
   | Some "_lean_pow2" -> `Unnop "2 ^"
+  | Some "_lean_pow2i" -> `Unnop "2 ^i"
   | _ -> `NotOp
 
 let unnop_of_id id = match id with Some "_lean_pow2" -> Some "2 ^ " | _ -> None

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -622,14 +622,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -130,7 +130,7 @@ def unif_subrange_bits (x : (BitVec 16)) : (BitVec (17 - 10 + 1)) :=
 
 /-- Type quantifiers: i : Nat, i ≥ 0 -/
 def unif_vector_subrange (i : Nat) (v : (BitVec (8 * i + 8))) : (BitVec 8) :=
-  (Sail.BitVec.extractLsb v ((8 * i) + 7) (8 * i))
+  (Sail.BitVec.extractLsb v ((8 *i i) +i 7) (8 *i i))
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -100,14 +100,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -112,14 +112,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -154,7 +154,7 @@ def foreach_earlyreturneffect (n : Nat) : SailM Bool := do
       if (GT.gt i 5)
       then return (early_return
              (false : Bool))
-      else (pure (cont (← writeReg r ((← readReg r) + 1))))))
+      else (pure (cont (← writeReg r ((← readReg r) +i 1))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -169,7 +169,7 @@ def foreach_earlyreturnpure (n : Nat) : Bool := Id.run do
         if (GT.gt i 5)
         then return (early_return
                (false : Bool))
-        else (cont (res + i))))
+        else (cont (res +i i))))
   (pure (GT.gt res n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -186,7 +186,7 @@ def foreach_inner_earlyreturneffect (n : Nat) : SailM Bool := do
           if (GT.gt i 5)
           then return (early_return
                  (false : Bool))
-          else (pure (cont (← writeReg r ((← readReg r) + 1)))))))
+          else (pure (cont (← writeReg r ((← readReg r) +i 1)))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -205,7 +205,7 @@ def foreach_inner_earlyreturnpure (n : Nat) : Bool := Id.run do
             if (GT.gt i 5)
             then return (early_return
                    (false : Bool))
-            else (cont (res + 1)))))
+            else (cont (res +i 1)))))
   (pure (GT.gt res n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -223,9 +223,9 @@ def foreach_inner_earlyreturneffect_catch (n : Nat) : SailM Bool := do
           if (GT.gt i 5)
           then return (early_return
                  (false : Bool))
-          else (pure (cont (← writeReg r ((← readReg r) + 1))))))
+          else (pure (cont (← writeReg r ((← readReg r) +i 1))))))
       (pure (cont (← do
-            writeReg r ((← readReg r) * 2))))))
+            writeReg r ((← readReg r) *i 2))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -246,8 +246,8 @@ def foreach_inner_earlyreturnpure_catch (n : Nat) : Bool := Id.run do
               if (GT.gt i 5)
               then return (early_return
                      (false : Bool))
-              else (cont (res + 1))))
-        (cont (res * 2))))
+              else (cont (res +i 1))))
+        (cont (res *i 2))))
   (pure (GT.gt res n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -258,7 +258,7 @@ def while_earlyreturneffect (n : Nat) : SailM Bool := do
       if (GT.gt (← readReg r) 5)
       then return (early_return
              (false : Bool))
-      else (pure (cont (← writeReg r ((← readReg r) + 1))))))
+      else (pure (cont (← writeReg r ((← readReg r) +i 1))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -271,7 +271,7 @@ def while_earlyreturnpure (n : Nat) : Bool := Id.run do
         if (GT.gt res 5)
         then return (early_return
                (false : Bool))
-        else (cont (res + 1))))
+        else (cont (res +i 1))))
   (pure (GT.gt res n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -284,7 +284,7 @@ def while_inner_earlyreturneffect (n : Nat) : SailM Bool := do
           if (GT.gt n 5)
           then return (early_return
                  (false : Bool))
-          else (pure (cont (← writeReg r ((← readReg r) + 1)))))))
+          else (pure (cont (← writeReg r ((← readReg r) +i 1)))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -299,7 +299,7 @@ def while_inner_earlyreturnpure (n : Nat) : Bool := Id.run do
             if (GT.gt n 5)
             then return (early_return
                    (false : Bool))
-            else (cont (res + 1)))))
+            else (cont (res +i 1)))))
   (pure (GT.gt res n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -313,9 +313,9 @@ def while_inner_earlyreturneffect_catch (n : Nat) : SailM Bool := do
           if (GT.gt n 5)
           then return (early_return
                  (false : Bool))
-          else (pure (cont (← writeReg r ((← readReg r) + 1))))))
+          else (pure (cont (← writeReg r ((← readReg r) +i 1))))))
       (pure (cont (← do
-            writeReg r ((← readReg r) * 2))))))
+            writeReg r ((← readReg r) *i 2))))))
   (pure (GT.gt (← readReg r) n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -332,8 +332,8 @@ def while_inner_earlyreturnpure_catch (n : Nat) : Bool := Id.run do
               if (GT.gt n 5)
               then return (early_return
                      (false : Bool))
-              else (cont (res + 1))))
-        (cont (res * 2))))
+              else (cont (res +i 1))))
+        (cont (res *i 2))))
   (pure (GT.gt res n))
 
 def match_early_return (x : E) : SailM E := do

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -96,14 +96,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -98,14 +98,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -175,7 +175,7 @@ def sep_backwards_matches (arg_ : String) : SailM Bool := do
   | _ => throw Error.Exit
 
 def extern_add (_ : Unit) : Int :=
-  (5 + 4)
+  (5 +i 4)
 
 def extern_sub (_ : Unit) : Int :=
   (5 -i (-4))
@@ -187,7 +187,7 @@ def extern_negate (_ : Unit) : Int :=
   (Neg.neg 5)
 
 def extern_mult (_ : Unit) : Int :=
-  (5 * 4)
+  (5 *i 4)
 
 def extern__shl8 (_ : Unit) : Int :=
   (Int.shiftl 8 2)

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -102,14 +102,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -98,14 +98,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -132,13 +132,13 @@ def foreach_loop (m : Nat) (n : Nat) : Nat :=
   let res : Nat := 0
   let loop_i_lower := m
   let loop_i_upper := n
-  foreach_ loop_i_lower loop_i_upper 1 res (λ i res => (res + 1))
+  foreach_ loop_i_lower loop_i_upper 1 res (λ i res => (res +i 1))
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
 def foreach_loopmon (m : Nat) (n : Nat) : SailM Nat := do
   let loop_i_lower := n
   let loop_i_upper := m
-  foreach_M loop_i_lower loop_i_upper 1 () (λ i _ => do writeReg r ((← readReg r) + 1))
+  foreach_M loop_i_lower loop_i_upper 1 () (λ i _ => do writeReg r ((← readReg r) +i 1))
   readReg r
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
@@ -149,10 +149,10 @@ def foreach_loopboth (m : Nat) (n : Nat) : SailM Nat := do
     let loop_i_upper := m
     foreach_M loop_i_lower loop_i_upper 1 res
       (λ i res => do
-        let res : Nat := (res + 1)
-        writeReg r ((← readReg r) + res)
+        let res : Nat := (res +i 1)
+        writeReg r ((← readReg r) +i res)
         (pure res))
-  (pure (res + 1))
+  (pure (res +i 1))
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
 def foreach_loopmultiplevar (m : Nat) (n : Nat) : Nat :=
@@ -163,8 +163,8 @@ def foreach_loopmultiplevar (m : Nat) (n : Nat) : Nat :=
     let loop_i_upper := n
     foreach_ loop_i_lower loop_i_upper 1 (mult, res)
       (λ i (mult, res) =>
-        let res : Nat := (res + 1)
-        let mult : Nat := (res * mult)
+        let res : Nat := (res +i 1)
+        let mult : Nat := (res *i mult)
         (mult, res))
   mult
 
@@ -173,17 +173,17 @@ def foreach_loopuseindex (m : Nat) (n : Nat) : Nat :=
   let res : Nat := 0
   let loop_i_lower := m
   let loop_i_upper := n
-  foreach_ loop_i_lower loop_i_upper 1 res (λ i res => (res + i))
+  foreach_ loop_i_lower loop_i_upper 1 res (λ i res => (res +i i))
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
 def while_loop (m : Nat) (n : Nat) : Nat :=
   let res : Nat := 0
-  while_ (λ res => (LT.lt res n)) res (λ res => ((res + 1) : Nat))
+  while_ (λ res => (LT.lt res n)) res (λ res => ((res +i 1) : Nat))
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
 def while_loopmon (m : Nat) (n : Nat) : SailM Nat := do
   while_M (λ _ => do (pure (LT.lt (← readReg r) n))) ()
-    (λ _ => do writeReg r ((← readReg r) + 1))
+    (λ _ => do writeReg r ((← readReg r) +i 1))
   readReg r
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
@@ -192,10 +192,10 @@ def while_loopboth (m : Nat) (n : Nat) : SailM Nat := do
   let res : Nat ← do
     while_M (λ res => do (pure (LT.lt res n))) res
       (λ res => do
-        let res : Nat := (res + 1)
-        writeReg r ((← readReg r) + res)
+        let res : Nat := (res +i 1)
+        writeReg r ((← readReg r) +i res)
         (pure res))
-  (pure (res + 1))
+  (pure (res +i 1))
 
 /-- Type quantifiers: n : Nat, m : Nat, 0 ≤ m, 0 ≤ n -/
 def while_loopmultiplevar (m : Nat) (n : Nat) : Nat :=
@@ -204,8 +204,8 @@ def while_loopmultiplevar (m : Nat) (n : Nat) : Nat :=
   let (mult, res) :=
     while_ (λ (mult, res) => (LT.lt res n)) (mult, res)
       (λ (mult, res) =>
-        (let res : Nat := (res + 1)
-        let mult : Nat := (res * mult)
+        (let res : Nat := (res +i 1)
+        let mult : Nat := (res *i mult)
         (mult, res) : (Nat × Nat)))
   mult
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -96,14 +96,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -108,14 +108,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -154,13 +154,13 @@ def match_option (x : (Option (BitVec 1))) : (BitVec 1) :=
 /-- Type quantifiers: y : Int, x : Int -/
 def match_pair_pat (x : Int) (y : Int) : Int :=
   match (x, y) with
-  | (a, b) => (a + b)
+  | (a, b) => (a +i b)
 
 /-- Type quantifiers: arg1 : Int, arg0 : Int -/
 def match_pair (arg0 : Int) (arg1 : Int) : Int :=
   let x := (arg0, arg1)
   match x with
-  | (a, b) => (a + b)
+  | (a, b) => (a +i b)
 
 def match_reg (x : E) : SailM E := do
   match x with
@@ -172,9 +172,9 @@ def match_reg (x : E) : SailM E := do
 def match_let (x : E) (y : Int) : SailM Int := do
   match x with
   | A =>
-    let x := (y + y)
-    let z ← do (pure ((y + y) + (← (undefined_int ()))))
-    (pure (z + x))
+    let x := (y +i y)
+    let z ← do (pure ((y +i y) +i (← (undefined_int ()))))
+    (pure (z +i x))
   | B => (pure 42)
   | C => (pure 23)
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -90,14 +90,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -162,14 +162,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -116,14 +116,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=
@@ -146,7 +146,7 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def test (_ : Unit) : SailM Int := do
-  writeReg INT ((← readReg INT) + 1)
+  writeReg INT ((← readReg INT) +i 1)
   readReg INT
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -127,14 +127,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -109,14 +109,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -101,14 +101,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -98,14 +98,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -98,14 +98,14 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 /-- Type quantifiers: m : Int, n : Int -/
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (LT.lt n 0) (GT.gt m 0))
-  then ((Int.tdiv (n + 1) m) -i 1)
+  then ((Int.tdiv (n +i 1) m) -i 1)
   else if (Bool.and (GT.gt n 0) (LT.lt m 0))
        then ((Int.tdiv (n -i 1) m) -i 1)
        else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
-  (n -i (m * (fdiv_int n m)))
+  (n -i (m *i (fdiv_int n m)))
 
 /-- Type quantifiers: k_a : Type -/
 def is_none (opt : (Option k_a)) : Bool :=


### PR DESCRIPTION
This attempts to solve #1075 by just doing all of the operations in `Int` instead of `Nat.
