### PR TITLE
Coq: add function to perform register initialisation

### DIFF
--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4693,6 +4693,7 @@ let all_rewriters =
             )
         )
     );
+    ("add_register_init_function", base_rewriter State.add_register_init_function);
     ("add_unspecified_rec", basic_rewriter rewrite_add_unspecified_rec);
     ("toplevel_let_patterns", basic_rewriter rewrite_toplevel_let_patterns);
     ("remove_bitfield_records", basic_rewriter remove_bitfield_records);
@@ -4760,7 +4761,13 @@ let rewrite ctx effect_info env rewriters ast =
          (1, (ctx, ast, effect_info, env))
          rewriters
       )
-  with Type_error.Type_error (l, err) -> raise (Type_error.to_reporting_exn l err)
+  with
+  | Type_error.Type_error (l, err) ->
+      Printexc.print_backtrace stderr;
+      raise (Type_error.to_reporting_exn l err)
+  | e ->
+      Printexc.print_backtrace stderr;
+      raise e
 
 let () =
   let open Interactive in

--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -876,3 +876,27 @@ let add_regstate_defs mwords ctx env ast =
   let defs, ctx = generate_regstate_defs ctx env ast in
   let reg_defs, env = Type_error.check_defs env defs in
   (ctx, env, append_ast_defs ast reg_defs)
+
+(* To suport register initialization without using the above, this
+   produces a new function that assigns registers their initializer.
+   It's intended to be a prover-backend counterpart to the function
+   that the model_init function that the C backend generates.
+
+   If the ast has been sorted, it will also respect register
+   initialisation order.  However, we probably want to ban
+   inter-register dependencies anyway... *)
+let add_register_init_function ctx env ast =
+  let init_exp = function
+    | DEF_aux (DEF_register (DEC_aux (DEC_reg (_typ, id, Some exp), _)), _) ->
+        let loc = gen_loc (exp_loc exp) in
+        Some (mk_exp ~loc (E_assign (mk_lexp ~loc (LE_id id), strip_exp exp)))
+    | _ -> None
+  in
+  let init_exps = List.filter_map init_exp ast.defs in
+  let uninit = mk_exp (E_app (mk_id "initialize_registers", [mk_exp (E_lit (mk_lit L_unit))])) in
+  let id = mk_id "sail_model_init" in
+  let funcl = mk_exp (E_block (init_exps @ [uninit])) |> mk_funcl id (mk_pat P_wild) in
+  let fundef = mk_fundef [funcl] in
+  let val_spec = mk_val_spec (VS_val_spec (mk_typschm (mk_typquant []) (function_typ [unit_typ] unit_typ), id, None)) in
+  let new_defs, env = Type_error.check_defs env [val_spec; fundef] in
+  (append_ast_defs ast new_defs, ctx, env)

--- a/src/sail_coq_backend/sail_plugin_coq.ml
+++ b/src/sail_coq_backend/sail_plugin_coq.ml
@@ -146,13 +146,9 @@ let coq_rewrites =
     ("minimise_recursive_functions", []);
     ("remove_bitfield_records", []);
     ("recheck_defs", []);
-    (* Put prover regstate generation after removing bitfield records,
-          which has to be followed by type checking.
-          This is the old regstate, so it's disabled now, but if we did something
-          like this again, this is where it would go.
-       ("prover_regstate", [Bool_arg true]);*)
     (* ("remove_assert", rewrite_ast_remove_assert); *)
     ("top_sort_defs", []);
+    ("add_register_init_function", []);
     ("const_prop_mutrec", [String_arg "coq"]);
     ("exp_lift_assign", []);
     ("early_return", []);

--- a/test/c/mk_coq_main.sh
+++ b/test/c/mk_coq_main.sh
@@ -27,9 +27,14 @@ else
   else
     REGSTATE='init_regstate'
   fi
+  if grep -q 'sail_model_init.*: unit :=' "_coqbuild_$1/$1.v"; then
+    RUN="main tt"
+  else
+    RUN="Prompt_monad.bind0 (sail_model_init tt) (main tt)"
+  fi
   cat <<EOF >> "$OUT"
 set (outerr := ltac:(
-let result := eval vm_compute in (liftState register_accessors (main tt) (init_state $REGSTATE) default_choice) in
+let result := eval vm_compute in (liftState register_accessors ($RUN) (init_state $REGSTATE) default_choice) in
 match result with
   | [(Value tt,?state,_)] => idtac "OK"; exact (state.(ss_output), "")
   | [(Ex (Failure ?s),?state,_)] => idtac "Fail:" s; exact (state.(ss_output), "Assertion failed: " ++ s)

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -158,11 +158,8 @@ def test_coq(name):
     results.expect_failure("type_if_bits.sail", "existential type not supported by Coq backend yet")
     results.expect_failure("lib_hex_bits_signed.sail","bug: unable to drop the type variable")
     results.expect_failure("for_shadow.sail","bug: remove_e_assign rewrite assumes <= available")
-    results.expect_failure("config.sail","bug: configuration register initialisation missing")
-    results.expect_failure("reg_init_let.sail","bug: configuration register initialisation missing")
-    results.expect_failure("partial_mapping.sail","bug: configuration register initialisation missing")
     results.expect_failure("concurrency_interface_write.sail","Test output not supported in concurrency interface yet")
-    results.expect_failure("ctz.sail","bug: configuration register initialisation missing")
+    results.expect_failure("config_vec_list.sail", "existential type not supported by Coq backend yet")
     for filenames in chunks(os.listdir('.'), parallel()):
         tests = {}
         for filename in filenames:


### PR DESCRIPTION
Adds a new rewrite to produce a sail_model_init function that, like the C backend's model_init, assigns the initialisation expression for each register to the register, then uses initialize_registers to set the rest to undefined.

Hopefully this can also be used by other prover backends.