### PR TITLE
Lean: fix indentation of then/else blocks

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -871,9 +871,9 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
       let statements_monadic = as_monadic || has_effect t || has_effect e in
       nest 2 (string "if" ^^ space ^^ nest 1 (d_of_arg ctx i))
       ^^ hardline
-      ^^ nest 2 (string "then" ^^ space ^^ nest 3 (doc_exp statements_monadic ctx t))
+      ^^ prefix 2 1 (string "then") (doc_exp statements_monadic ctx t)
       ^^ hardline
-      ^^ nest 2 (string "else" ^^ space ^^ nest 3 (doc_exp statements_monadic ctx e))
+      ^^ prefix 2 1 (string "else") (doc_exp statements_monadic ctx e)
   | E_ref id -> string ".Reg " ^^ doc_id_ctor id
   | E_exit _ -> string "throw Error.Exit"
   | E_throw e -> string "sailThrow " ^^ parens (doc_exp false ctx e)

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -604,8 +604,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -623,9 +624,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -1886,11 +1888,13 @@ def decodeLoadStoreRegister (opc : (BitVec 2)) (Rm : (BitVec 5)) (option_v : (Bi
   let m : reg_index := (BitVec.toNat Rm)
   if (Bool.or (bne option_v (0b011 : (BitVec 3))) (BEq.beq S 1#1))
   then none
-  else if (BEq.beq opc (0b00 : (BitVec 2)))
-       then (some (LoadRegister (t, n, m)))
-       else if (BEq.beq opc (0b01 : (BitVec 2)))
-            then (some (StoreRegister (t, n, m)))
-            else none
+  else
+    if (BEq.beq opc (0b00 : (BitVec 2)))
+    then (some (LoadRegister (t, n, m)))
+    else
+      if (BEq.beq opc (0b01 : (BitVec 2)))
+      then (some (StoreRegister (t, n, m)))
+      else none
 
 def decodeExclusiveOr (sf : (BitVec 1)) (shift : (BitVec 2)) (N : (BitVec 1)) (Rm : (BitVec 5)) (imm6 : (BitVec 6)) (Rn : (BitVec 5)) (Rd : (BitVec 5)) : (Option ast) :=
   let d : reg_index := (BitVec.toNat Rd)
@@ -1898,9 +1902,10 @@ def decodeExclusiveOr (sf : (BitVec 1)) (shift : (BitVec 2)) (N : (BitVec 1)) (R
   let m : reg_index := (BitVec.toNat Rm)
   if (Bool.and (BEq.beq sf 0#1) (BEq.beq (BitVec.access imm6 5) 1#1))
   then none
-  else if (bne imm6 (0b000000 : (BitVec 6)))
-       then none
-       else (some (ExclusiveOr (d, n, m)))
+  else
+    if (bne imm6 (0b000000 : (BitVec 6)))
+    then none
+    else (some (ExclusiveOr (d, n, m)))
 
 def decodeDataMemoryBarrier (CRm : (BitVec 4)) : (Option ast) :=
   if (bne CRm (0xF : (BitVec 4)))
@@ -1990,9 +1995,10 @@ def execute_DataMemoryBarrier (_ : Unit) : SailM Unit := do
 def execute_CompareAndBranch (t : Nat) (offset : (BitVec 64)) : SailM Unit := do
   let operand ← do (rX t)
   if (BEq.beq operand (0x0000000000000000 : (BitVec 64)))
-  then let base ← do (rPC ())
-       let addr := (base + offset)
-       (wPC addr)
+  then
+    let base ← do (rPC ())
+    let addr := (base + offset)
+    (wPC addr)
   else writeReg _PC (BitVec.addInt (← readReg _PC) 4)
 
 def execute (merge_var : ast) : SailM Unit := do
@@ -2007,31 +2013,38 @@ def decode (v__0 : (BitVec 32)) : (Option ast) :=
   if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 31 24) (0xF8 : (BitVec 8)))
        (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 21 21) (0b1 : (BitVec 1)))
          (BEq.beq (Sail.BitVec.extractLsb v__0 11 10) (0b10 : (BitVec 2)))))
-  then let S := (BitVec.access v__0 12)
-       let option_v : (BitVec 3) := (Sail.BitVec.extractLsb v__0 15 13)
-       let opc : (BitVec 2) := (Sail.BitVec.extractLsb v__0 23 22)
-       let Rt : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
-       let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
-       let Rm : (BitVec 5) := (Sail.BitVec.extractLsb v__0 20 16)
-       (decodeLoadStoreRegister opc Rm option_v S Rn Rt)
-  else if (BEq.beq (Sail.BitVec.extractLsb v__0 30 24) (0b1001010 : (BitVec 7)))
-       then let sf := (BitVec.access v__0 31)
-            let N := (BitVec.access v__0 21)
-            let shift : (BitVec 2) := (Sail.BitVec.extractLsb v__0 23 22)
-            let imm6 : (BitVec 6) := (Sail.BitVec.extractLsb v__0 15 10)
-            let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
-            let Rm : (BitVec 5) := (Sail.BitVec.extractLsb v__0 20 16)
-            let Rd : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
-            (decodeExclusiveOr sf shift N Rm imm6 Rn Rd)
-       else if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 31 12) (0xD5033 : (BitVec 20)))
-                 (BEq.beq (Sail.BitVec.extractLsb v__0 7 0) (0xBF : (BitVec 8))))
-            then let CRm : (BitVec 4) := (Sail.BitVec.extractLsb v__0 11 8)
-                 (decodeDataMemoryBarrier CRm)
-            else if (BEq.beq (Sail.BitVec.extractLsb v__0 31 24) (0xB4 : (BitVec 8)))
-                 then let imm19 : (BitVec 19) := (Sail.BitVec.extractLsb v__0 23 5)
-                      let Rt : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
-                      (decodeCompareAndBranch imm19 Rt)
-                 else none
+  then
+    let S := (BitVec.access v__0 12)
+    let option_v : (BitVec 3) := (Sail.BitVec.extractLsb v__0 15 13)
+    let opc : (BitVec 2) := (Sail.BitVec.extractLsb v__0 23 22)
+    let Rt : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
+    let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
+    let Rm : (BitVec 5) := (Sail.BitVec.extractLsb v__0 20 16)
+    (decodeLoadStoreRegister opc Rm option_v S Rn Rt)
+  else
+    if (BEq.beq (Sail.BitVec.extractLsb v__0 30 24) (0b1001010 : (BitVec 7)))
+    then
+      let sf := (BitVec.access v__0 31)
+      let N := (BitVec.access v__0 21)
+      let shift : (BitVec 2) := (Sail.BitVec.extractLsb v__0 23 22)
+      let imm6 : (BitVec 6) := (Sail.BitVec.extractLsb v__0 15 10)
+      let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
+      let Rm : (BitVec 5) := (Sail.BitVec.extractLsb v__0 20 16)
+      let Rd : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
+      (decodeExclusiveOr sf shift N Rm imm6 Rn Rd)
+    else
+      if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 31 12) (0xD5033 : (BitVec 20)))
+           (BEq.beq (Sail.BitVec.extractLsb v__0 7 0) (0xBF : (BitVec 8))))
+      then
+        let CRm : (BitVec 4) := (Sail.BitVec.extractLsb v__0 11 8)
+        (decodeDataMemoryBarrier CRm)
+      else
+        if (BEq.beq (Sail.BitVec.extractLsb v__0 31 24) (0xB4 : (BitVec 8)))
+        then
+          let imm19 : (BitVec 19) := (Sail.BitVec.extractLsb v__0 23 5)
+          let Rt : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
+          (decodeCompareAndBranch imm19 Rt)
+        else none
 
 def iFetch (addr : (BitVec 64)) : SailM (BitVec 32) := do
   let req : (Mem_read_request 4 64 (BitVec 56) (Option TranslationInfo) arm_acc_type) :=

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -82,8 +82,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -101,9 +102,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -94,8 +94,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -113,9 +114,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -430,8 +432,9 @@ def ite_early_return (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
     if x
-    then throw (← do
-             readReg r_A)
+    then
+      throw (← do
+          readReg r_A)
     else readReg r_B ) : SailME _ E )
   readReg r_B
 
@@ -446,8 +449,9 @@ def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
       writeReg r_A (← readReg r_C)
       let y ← (( do
         if x
-        then throw (← do
-                 readReg r_A)
+        then
+          throw (← do
+              readReg r_A)
         else readReg r_B ) : SailME _ E )
       (pure ())
   (pure loop_vars)
@@ -456,15 +460,16 @@ def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
 /-- Type quantifiers: k_ex2661# : Bool -/
 def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
   if x
-  then let loop_i_lower := 0
-       let loop_i_upper := 10
-       let mut loop_vars := ()
-       for i in [loop_i_lower:loop_i_upper + 1:1] do
-         let () := loop_vars
-         loop_vars ← do
-           throw (← do
-               readReg r_A)
-       (pure loop_vars)
+  then
+    let loop_i_lower := 0
+    let loop_i_upper := 10
+    let mut loop_vars := ()
+    for i in [loop_i_lower:loop_i_upper + 1:1] do
+      let () := loop_vars
+      loop_vars ← do
+        throw (← do
+            readReg r_A)
+    (pure loop_vars)
   else writeReg r_B A
   readReg r_B
 
@@ -476,9 +481,10 @@ def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
     if x
-    then throw (← do
-             (unit_type A)
-             readReg r_A)
+    then
+      throw (← do
+          (unit_type A)
+          readReg r_A)
     else readReg r_B ) : SailME _ E )
   readReg r_B
 

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -78,8 +78,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -97,9 +98,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -80,8 +80,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -99,9 +100,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -130,8 +132,9 @@ def foo (x : (BitVec 8)) : (BitVec 16) :=
 def slice_mask2 {n : _} (i : (BitVec n)) (l : (BitVec n)) (b : Bool) : (BitVec n) :=
   if b
   then i
-  else let one : (BitVec n) := (EXTZ (m := n) l)
-       (one + one)
+  else
+    let one : (BitVec n) := (EXTZ (m := n) l)
+    (one + one)
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -84,8 +84,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -103,9 +104,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -135,9 +137,10 @@ def concat_str_dec (str : String) (x : Int) : String :=
 def elif (n : Nat) : (BitVec 1) :=
   if (BEq.beq n 0)
   then 1#1
-  else if (BEq.beq n 1)
-       then 1#1
-       else 0#1
+  else
+    if (BEq.beq n 1)
+    then 1#1
+    else 0#1
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
 def monadic_in_out (n : Nat) : SailM Nat := do
@@ -150,8 +153,9 @@ def monadic_in_out (n : Nat) : SailM Nat := do
 def monadic_lines (n : Nat) : SailM Unit := do
   let b := (BEq.beq n 0)
   if b
-  then writeReg R n
-       writeReg B b
+  then
+    writeReg R n
+    writeReg B b
   else writeReg B b
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -80,8 +80,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -99,9 +100,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -78,8 +78,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -97,9 +98,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -154,11 +156,13 @@ def size_bits_backwards (arg_ : (BitVec 2)) : word_width :=
   let b__0 := arg_
   if (BEq.beq b__0 (0b00 : (BitVec 2)))
   then BYTE
-  else if (BEq.beq b__0 (0b01 : (BitVec 2)))
-       then HALF
-       else if (BEq.beq b__0 (0b10 : (BitVec 2)))
-            then WORD
-            else DOUBLE
+  else
+    if (BEq.beq b__0 (0b01 : (BitVec 2)))
+    then HALF
+    else
+      if (BEq.beq b__0 (0b10 : (BitVec 2)))
+      then WORD
+      else DOUBLE
 
 def size_bits_forwards_matches (arg_ : word_width) : Bool :=
   match arg_ with
@@ -171,13 +175,16 @@ def size_bits_backwards_matches (arg_ : (BitVec 2)) : Bool :=
   let b__0 := arg_
   if (BEq.beq b__0 (0b00 : (BitVec 2)))
   then true
-  else if (BEq.beq b__0 (0b01 : (BitVec 2)))
-       then true
-       else if (BEq.beq b__0 (0b10 : (BitVec 2)))
-            then true
-            else if (BEq.beq b__0 (0b11 : (BitVec 2)))
-                 then true
-                 else false
+  else
+    if (BEq.beq b__0 (0b01 : (BitVec 2)))
+    then true
+    else
+      if (BEq.beq b__0 (0b10 : (BitVec 2)))
+      then true
+      else
+        if (BEq.beq b__0 (0b11 : (BitVec 2)))
+        then true
+        else false
 
 def size_bits2_forwards (arg_ : word_width) : (BitVec 2) :=
   match arg_ with
@@ -190,11 +197,13 @@ def size_bits2_backwards (arg_ : (BitVec 2)) : word_width :=
   let b__0 := arg_
   if (BEq.beq b__0 (0b00 : (BitVec 2)))
   then BYTE
-  else if (BEq.beq b__0 (0b01 : (BitVec 2)))
-       then HALF
-       else if (BEq.beq b__0 (0b10 : (BitVec 2)))
-            then WORD
-            else DOUBLE
+  else
+    if (BEq.beq b__0 (0b01 : (BitVec 2)))
+    then HALF
+    else
+      if (BEq.beq b__0 (0b10 : (BitVec 2)))
+      then WORD
+      else DOUBLE
 
 def size_bits2_forwards_matches (arg_ : word_width) : Bool :=
   match arg_ with
@@ -207,13 +216,16 @@ def size_bits2_backwards_matches (arg_ : (BitVec 2)) : Bool :=
   let b__0 := arg_
   if (BEq.beq b__0 (0b00 : (BitVec 2)))
   then true
-  else if (BEq.beq b__0 (0b01 : (BitVec 2)))
-       then true
-       else if (BEq.beq b__0 (0b10 : (BitVec 2)))
-            then true
-            else if (BEq.beq b__0 (0b11 : (BitVec 2)))
-                 then true
-                 else false
+  else
+    if (BEq.beq b__0 (0b01 : (BitVec 2)))
+    then true
+    else
+      if (BEq.beq b__0 (0b10 : (BitVec 2)))
+      then true
+      else
+        if (BEq.beq b__0 (0b11 : (BitVec 2)))
+        then true
+        else false
 
 def size_bits3_forwards (arg_ : word_width) : (BitVec 2) :=
   match arg_ with
@@ -226,11 +238,13 @@ def size_bits3_backwards (arg_ : (BitVec 2)) : word_width :=
   let b__0 := arg_
   if (BEq.beq b__0 (0b00 : (BitVec 2)))
   then BYTE
-  else if (BEq.beq b__0 (0b01 : (BitVec 2)))
-       then HALF
-       else if (BEq.beq b__0 (0b10 : (BitVec 2)))
-            then WORD
-            else DOUBLE
+  else
+    if (BEq.beq b__0 (0b01 : (BitVec 2)))
+    then HALF
+    else
+      if (BEq.beq b__0 (0b10 : (BitVec 2)))
+      then WORD
+      else DOUBLE
 
 def size_bits3_forwards_matches (arg_ : word_width) : Bool :=
   match arg_ with
@@ -243,13 +257,16 @@ def size_bits3_backwards_matches (arg_ : (BitVec 2)) : Bool :=
   let b__0 := arg_
   if (BEq.beq b__0 (0b00 : (BitVec 2)))
   then true
-  else if (BEq.beq b__0 (0b01 : (BitVec 2)))
-       then true
-       else if (BEq.beq b__0 (0b10 : (BitVec 2)))
-            then true
-            else if (BEq.beq b__0 (0b11 : (BitVec 2)))
-                 then true
-                 else false
+  else
+    if (BEq.beq b__0 (0b01 : (BitVec 2)))
+    then true
+    else
+      if (BEq.beq b__0 (0b10 : (BitVec 2)))
+      then true
+      else
+        if (BEq.beq b__0 (0b11 : (BitVec 2)))
+        then true
+        else false
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -90,8 +90,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -109,9 +110,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -123,23 +125,28 @@ def decode (v__0 : (BitVec 32)) : Bool :=
   if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 31 24) (0xF8 : (BitVec 8)))
        (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 21 21) (0b1 : (BitVec 1)))
          (BEq.beq (Sail.BitVec.extractLsb v__0 11 10) (0b10 : (BitVec 2)))))
-  then let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
-       let Rm : (BitVec 5) := (Sail.BitVec.extractLsb v__0 20 16)
-       if (BEq.beq Rm Rn)
-       then true
-       else false
-  else if (BEq.beq (Sail.BitVec.extractLsb v__0 30 24) (0b1001010 : (BitVec 7)))
-       then let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
-            let Rd : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
-            if (BEq.beq Rn Rd)
-            then true
-            else false
-       else if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 31 12) (0xD5033 : (BitVec 20)))
-                 (BEq.beq (Sail.BitVec.extractLsb v__0 7 0) (0xBF : (BitVec 8))))
-            then true
-            else if (BEq.beq (Sail.BitVec.extractLsb v__0 31 24) (0xB4 : (BitVec 8)))
-                 then false
-                 else true
+  then
+    let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
+    let Rm : (BitVec 5) := (Sail.BitVec.extractLsb v__0 20 16)
+    if (BEq.beq Rm Rn)
+    then true
+    else false
+  else
+    if (BEq.beq (Sail.BitVec.extractLsb v__0 30 24) (0b1001010 : (BitVec 7)))
+    then
+      let Rn : (BitVec 5) := (Sail.BitVec.extractLsb v__0 9 5)
+      let Rd : (BitVec 5) := (Sail.BitVec.extractLsb v__0 4 0)
+      if (BEq.beq Rn Rd)
+      then true
+      else false
+    else
+      if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 31 12) (0xD5033 : (BitVec 20)))
+           (BEq.beq (Sail.BitVec.extractLsb v__0 7 0) (0xBF : (BitVec 8))))
+      then true
+      else
+        if (BEq.beq (Sail.BitVec.extractLsb v__0 31 24) (0xB4 : (BitVec 8)))
+        then false
+        else true
 
 def xlen := 32
 
@@ -148,20 +155,23 @@ def write_CSR (v__26 : (BitVec 12)) : SailM Bool := do
        (let index : (BitVec 5) := (Sail.BitVec.extractLsb v__26 4 0)
        ((BitVec.toNat index) ≥b 3) : Bool))
   then (pure true)
-  else if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__26 11 5) (0b1011100 : (BitVec 7)))
-            (let index : (BitVec 5) := (Sail.BitVec.extractLsb v__26 4 0)
-            (Bool.and (BEq.beq xlen 32) (((BitVec.toNat index) ≥b 3) : Bool))))
-       then (pure true)
-       else assert false "Pattern match failure at match_bv.sail:36.0-38.1"
-            throw Error.Exit
+  else
+    if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__26 11 5) (0b1011100 : (BitVec 7)))
+         (let index : (BitVec 5) := (Sail.BitVec.extractLsb v__26 4 0)
+         (Bool.and (BEq.beq xlen 32) (((BitVec.toNat index) ≥b 3) : Bool))))
+    then (pure true)
+    else
+      assert false "Pattern match failure at match_bv.sail:36.0-38.1"
+      throw Error.Exit
 
 def write_CSR2 (v__30 : (BitVec 12)) : SailM Bool := do
   if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__30 11 5) (0b1011100 : (BitVec 7)))
        (let index : (BitVec 5) := (Sail.BitVec.extractLsb v__30 4 0)
        (Bool.and (BEq.beq xlen 32) (((BitVec.toNat index) ≥b 3) : Bool))))
   then (pure true)
-  else assert false "Pattern match failure at match_bv.sail:41.0-43.1"
-       throw Error.Exit
+  else
+    assert false "Pattern match failure at match_bv.sail:41.0-43.1"
+    throw Error.Exit
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -72,8 +72,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -91,9 +92,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -144,8 +144,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -163,9 +164,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -216,9 +218,10 @@ def wPC (pc : (BitVec 64)) : SailM Unit := do
 def monad_test (r : Nat) : SailM (BitVec 1) := do
   if (BEq.beq (← (rX r)) (0x0000000000000000 : (BitVec 64)))
   then (pure 1#1)
-  else if (BEq.beq (← (rX r)) (0x0000000000000001 : (BitVec 64)))
-       then (pure 1#1)
-       else (pure 0#1)
+  else
+    if (BEq.beq (← (rX r)) (0x0000000000000001 : (BitVec 64)))
+    then (pure 1#1)
+    else (pure 0#1)
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg _PC (← (undefined_bitvector 64))

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -98,8 +98,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -117,9 +118,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -109,8 +109,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -128,9 +129,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -228,19 +230,22 @@ def execute (merge_var : ast) : SailM Unit := do
 def decode (v__0 : (BitVec 32)) : (Option ast) :=
   if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 14 12) (0b000 : (BitVec 3)))
        (BEq.beq (Sail.BitVec.extractLsb v__0 6 0) (0b0010011 : (BitVec 7))))
-  then let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
-       let rs1 : regbits := (Sail.BitVec.extractLsb v__0 19 15)
-       let rd : regbits := (Sail.BitVec.extractLsb v__0 11 7)
-       let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
-       (some (ITYPE (imm, rs1, rd, RISCV_ADDI)))
-  else if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 14 12) (0b011 : (BitVec 3)))
-            (BEq.beq (Sail.BitVec.extractLsb v__0 6 0) (0b0000011 : (BitVec 7))))
-       then let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
-            let rs1 : regbits := (Sail.BitVec.extractLsb v__0 19 15)
-            let rd : regbits := (Sail.BitVec.extractLsb v__0 11 7)
-            let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
-            (some (LOAD (imm, rs1, rd)))
-       else none
+  then
+    let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
+    let rs1 : regbits := (Sail.BitVec.extractLsb v__0 19 15)
+    let rd : regbits := (Sail.BitVec.extractLsb v__0 11 7)
+    let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
+    (some (ITYPE (imm, rs1, rd, RISCV_ADDI)))
+  else
+    if (Bool.and (BEq.beq (Sail.BitVec.extractLsb v__0 14 12) (0b011 : (BitVec 3)))
+         (BEq.beq (Sail.BitVec.extractLsb v__0 6 0) (0b0000011 : (BitVec 7))))
+    then
+      let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
+      let rs1 : regbits := (Sail.BitVec.extractLsb v__0 19 15)
+      let rd : regbits := (Sail.BitVec.extractLsb v__0 11 7)
+      let imm : (BitVec 12) := (Sail.BitVec.extractLsb v__0 31 20)
+      (some (LOAD (imm, rs1, rd)))
+    else none
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg PC (← (undefined_bitvector 64))

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -91,8 +91,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -110,9 +111,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -83,8 +83,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -102,9 +103,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -80,8 +80,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -99,9 +100,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -80,8 +80,9 @@ def sail_ones (n : Nat) : (BitVec n) :=
 def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
   if (l ≥b n)
   then ((sail_ones n) <<< i)
-  else let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
-       (((one <<< l) - one) <<< i)
+  else
+    let one : (BitVec n) := (sail_mask n (0b1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i)
 
 /-- Type quantifiers: n : Int, m : Int -/
 def _shl_int_general (m : Int) (n : Int) : Int :=
@@ -99,9 +100,10 @@ def _shr_int_general (m : Int) (n : Int) : Int :=
 def fdiv_int (n : Int) (m : Int) : Int :=
   if (Bool.and (n <b 0) (m >b 0))
   then ((Int.tdiv (n +i 1) m) -i 1)
-  else if (Bool.and (n >b 0) (m <b 0))
-       then ((Int.tdiv (n -i 1) m) -i 1)
-       else (Int.tdiv n m)
+  else
+    if (Bool.and (n >b 0) (m <b 0))
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m)
 
 /-- Type quantifiers: m : Int, n : Int -/
 def fmod_int (n : Int) (m : Int) : Int :=
@@ -175,10 +177,11 @@ def hex_bits_signed2_backwards (tuple_0 : (Nat × String)) : (BitVec tuple_0.1) 
   let (notn, str) := tuple_0
   if (BEq.beq str "-")
   then (BitVec.zero notn)
-  else let parsed := (BitVec.zero notn)
-       if (BEq.beq (BitVec.access parsed (notn -i 1)) 0#1)
-       then parsed
-       else (BitVec.zero notn)
+  else
+    let parsed := (BitVec.zero notn)
+    if (BEq.beq (BitVec.access parsed (notn -i 1)) 0#1)
+    then parsed
+    else (BitVec.zero notn)
 
 /-- Type quantifiers: tuple_0.1 : Nat, tuple_0.1 > 0 -/
 def hex_bits_signed2_backwards_matches (tuple_0 : (Nat × String)) : Bool :=


### PR DESCRIPTION
Before we would put the block just after the `else` as in 
```
if cond
else let x := ...
     let ...
```
now we add a new line when the result does not fit on one line:
```
if cond
else 
  let x := ...
  let ...
```
In addition to producing correct code, this should also reduce a bit the amount of white space in very deep functions.