### PR TITLE
Coq: always use stdpp by default

### DIFF
--- a/src/sail_coq_backend/sail_plugin_coq.ml
+++ b/src/sail_coq_backend/sail_plugin_coq.ml
@@ -185,13 +185,7 @@ let output_coq opt_dir filename alt_modules alt_modules2 libs ctx env effect_inf
   let generated_line = generated_line filename in
   let types_module = filename ^ "_types" in
   let concurrency_monad_params = Monad_params.find_monad_parameters env in
-  let library_style =
-    let open Pretty_print_coq in
-    match (concurrency_monad_params, !opt_coq_lib_style) with
-    | None, None -> BBV
-    | Some _, None -> Stdpp
-    | _, Some style -> style
-  in
+  let library_style = Option.value ~default:Pretty_print_coq.Stdpp !opt_coq_lib_style in
   let base_imports_lib = match library_style with BBV -> "Sail." | Stdpp -> "SailStdpp." in
   let base_imports_default =
     List.map (( ^ ) base_imports_lib)

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -167,7 +167,7 @@ def test_coq(name):
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 # Generate Coq from Sail
-                step('\'{}\' -coq -coq-lib-style stdpp -coq-record-update -D PRINT_EFFECTS -splice coq-print.splice -undefined_gen -o {} {}'.format(sail, basename, filename))
+                step('\'{}\' -coq -coq-record-update -D PRINT_EFFECTS -splice coq-print.splice -undefined_gen -o {} {}'.format(sail, basename, filename))
 
                 step('mkdir -p _coqbuild_{}'.format(basename))
                 step('mv {}.v _coqbuild_{}'.format(basename, basename))
@@ -175,7 +175,6 @@ def test_coq(name):
                 step('./mk_coq_main.sh {} {}'.format(basename, basename.capitalize()))
                 os.chdir('_coqbuild_{}'.format(basename))
 
-                # TODO: find bbv properly
                 step('coqc {}_types.v'.format(basename))
                 step('coqc {}.v'.format(basename))
                 step('coqtop -require-import {}_types -require-import {} -l main.v -batch | tee /dev/stderr | grep -q OK'.format(basename,basename), expected_status = 1 if basename.startswith('fail') else 0)

--- a/test/coq/run_tests.py
+++ b/test/coq/run_tests.py
@@ -21,9 +21,9 @@ skip_tests = {
   'while_PM', # Not currently in a useful state
 }
 
-def test(name, dir):
-    banner('Testing Coq backend on {}'.format(name))
-    results = Results(name)
+def test(name, dir, lib):
+    banner('Testing Coq backend on {} with {}'.format(name, lib))
+    results = Results('{} on {}'.format(name, lib))
     results.expect_failure('bind_typ_var.sail', 'unsupported existential quantification of a vector length')
     results.expect_failure('execute_decode_hard.sail', 'Complex existential type - probably going to need this for ARM instruction ASTs')
     results.expect_failure('exist1.sail', 'Needs an existential witness')
@@ -52,6 +52,12 @@ def test(name, dir):
     results.expect_failure('ex_list_infer.sail', 'Would need to turn a term with existential type into a dependent pair')
     results.expect_failure('ex_vector_infer.sail', 'Would need to turn a term with existential type into a dependent pair')
     results.expect_failure('float_prelude.sail', 'Would need float types in coq-sail')
+    results.expect_failure('config_bits_types.sail', 'Would need to turn a term with existential type into a dependent pair')
+    results.expect_failure('config_mismatch.sail', 'Uses non-existant configuration entry')
+    if lib == 'bbv':
+        results.expect_failure('sysreg.sail', 'Concurrency interface not currently supported on BBV')
+        results.expect_failure('type_alias.sail', 'Concurrency interface not currently supported on BBV')
+
     for filenames in chunks(os.listdir(dir), parallel()):
         tests = {}
         for filename in filenames:
@@ -62,7 +68,7 @@ def test(name, dir):
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 step('mkdir -p _build_{}'.format(basename))
-                step('\'{}\' --coq --coq-lib-style stdpp --dcoq-undef-axioms --strict-bitvector --coq-output-dir _build_{} -o out {}/{}'.format(sail, basename, dir, filename))
+                step('\'{}\' --coq --coq-lib-style {} --dcoq-undef-axioms --strict-bitvector --coq-output-dir _build_{} -o out {}/{}'.format(sail, lib, basename, dir, filename))
                 os.chdir('_build_{}'.format(basename))
                 step('coqc out_types.v')
                 step('coqc out.v')
@@ -75,8 +81,10 @@ def test(name, dir):
 
 xml = '<testsuites>\n'
 
-xml += test('typecheck tests', '../typecheck/pass')
-xml += test('Coq specific tests', 'pass')
+xml += test('typecheck tests', '../typecheck/pass', 'stdpp')
+xml += test('Coq specific tests', 'pass', 'stdpp')
+xml += test('typecheck tests', '../typecheck/pass', 'bbv')
+xml += test('Coq specific tests', 'pass', 'bbv')
 
 xml += '</testsuites>\n'
 


### PR DESCRIPTION
Also allow the typecheck tests to run with BBV to stop it bitrotting too quickly.