### PR TITLE
Tag snapshots with linguist-generated gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+snapshots/** linguist-generated


### PR DESCRIPTION
This fixes github's language detection for the repository