### PR TITLE
Lean: fix list torture test

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -505,6 +505,9 @@ instance {α α' β : Type u} (x : β × α) [CoeT α x.2 α'] : CoeT (β × α)
 instance {α α' β β' : Type u} (x : α × β) [CoeT α x.1 α'] [CoeT β x.2 β'] : CoeT (α × β) x (α' × β') where
   coe := (x.1, x.2)
 
+instance {α α' : Type u} [∀ x, CoeT α x α'] (xs : List α) : CoeT (List α) xs (List α') where
+  coe := List.map (α := α) (β := α') (fun x => x) xs
+
 instance : HAdd (BitVec n) (BitVec m) (BitVec n) where
   hAdd x y := x + y
 

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -45,7 +45,6 @@ skip_selftests = {
     'spc_mappings',
     'concurrency_interface',
     'for_shadow',
-    'list_torture',
     'string_literal_type',
     'cheri_capreg',
     'loop_exception',


### PR DESCRIPTION
Fixes #1091.

Adds a coercion between lists of coercable types to fix the `list_torture.sail` test.