### PR TITLE
Lean: join2 uses big endian

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -60,7 +60,7 @@ def toFormatted {w : Nat} (x : BitVec w) : String :=
     s!"0b{BitVec.toBin x}"
 
 def join1 (xs : List (BitVec 1)) : BitVec xs.length :=
-  (BitVec.ofBoolListLE (xs.map fun x => x[0])).cast (by simp)
+  (BitVec.ofBoolListBE (xs.map fun x => x[0])).cast (by simp)
 
 instance : Coe (BitVec (1 * n)) (BitVec n) where
   coe x := x.cast (by simp)

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -23,7 +23,6 @@ sail = get_sail()
 # Not all self-tests are supported.
 skip_selftests = {
     'list_rec_functions2',
-    'bv_literal',
     'pow2_var',
     'large_bitvector',
     'exn_hello_world',


### PR DESCRIPTION
This fixes the bv_literal test case.