### PR TITLE
Lean: add effectless print dummies to `Sail.lean`

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -299,6 +299,18 @@ end ConcurrencyInterface
 
 end PreSailTypes
 
+def print_int : String → Int → Unit := fun _ _ => ()
+
+def prerr_int : String → Int → Unit := fun _ _ => ()
+
+def print_endline : String → Unit := fun _  => ()
+
+def prerr_endline : String → Unit := fun _ => ()
+
+def print : String → Unit := fun _ => ()
+
+def prerr : String → Unit := fun _ => ()
+
 end Sail
 
 namespace PreSail

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -59,7 +59,7 @@ open Register
 
 namespace Functions
 
-/-- Type quantifiers: k_ex1861# : Bool, k_ex1860# : Bool -/
+/-- Type quantifiers: k_ex1941# : Bool, k_ex1940# : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (Bool.not (BEq.beq x y))
 
@@ -242,6 +242,16 @@ def while_loopmultiplevar (m : Nat) (n : Nat) : Nat := Id.run do
         (mult, res) : (Nat × Nat))
     (pure loop_vars) ) : Id (Nat × Nat) )
   (pure mult)
+
+def while_print (_ : Unit) : Unit := Id.run do
+  let i : Int := 0
+  let i ← (( do
+    let mut loop_vars := i
+    while (λ i => (i <b 10)) loop_vars do
+      let i := loop_vars
+      loop_vars := ((i +i 1) : Int)
+    (pure loop_vars) ) : Id Int )
+  (pure (print_int "i = " i))
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r (← (undefined_nat ()))

--- a/test/lean/loop.sail
+++ b/test/lean/loop.sail
@@ -80,3 +80,13 @@ function while_loopmultiplevar(m : nat, n : nat) -> nat = {
   };
   mult
 }
+
+val while_print : unit -> unit
+function while_print() = {
+  var i : int = 0;
+  while i < 10 do {
+    i = i + 1
+  };
+  print_int("i = ", i)
+}
+


### PR DESCRIPTION
It seems like there's edge cases where we really want pure functions to contain `print` commands.