### PR TITLE
Lean: make `Access_variant` and co inhabited

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -251,13 +251,16 @@ inductive Access_variety where
   | AV_plain
   | AV_exclusive
   | AV_atomic_rmw
-deriving DecidableEq
+  deriving Inhabited, DecidableEq
+
 export Access_variety (AV_plain AV_exclusive AV_atomic_rmw)
 
 inductive Access_strength where
   | AS_normal
   | AS_rel_or_acq
   | AS_acq_rcpc
+  deriving Inhabited, DecidableEq
+
 export Access_strength(AS_normal AS_rel_or_acq AS_acq_rcpc)
 
 structure Explicit_access_kind where
@@ -269,6 +272,8 @@ inductive Access_kind (arch : Type) where
   | AK_ifetch (_ : Unit)
   | AK_ttw (_ : Unit)
   | AK_arch (_ : arch)
+  deriving Inhabited
+
 export Access_kind(AK_explicit AK_ifetch AK_ttw AK_arch)
 
 inductive Result (α : Type) (β : Type) where
@@ -284,6 +289,7 @@ structure Mem_read_request
   translation : ts
   size : Int
   tag : Bool
+  deriving Inhabited
 
 structure Mem_write_request
   (n : Nat) (vasize : Nat) (pa : Type) (ts : Type) (arch_ak : Type) where
@@ -294,6 +300,7 @@ structure Mem_write_request
   size : Int
   value : (Option (BitVec (8 * n)))
   tag : (Option Bool)
+  deriving Inhabited
 
 end ConcurrencyInterface
 


### PR DESCRIPTION
Should fix the current error in the RISC-V which has been caused by #1168 in conjunction to `Access_variant` not having an `Inhabited` instance.