### PR TITLE
C: Add Gen name constructor to Jib IR

### DIFF
--- a/language/jib.ott
+++ b/language/jib.ott
@@ -77,6 +77,7 @@ chan :: 'Chan_' ::=
   | stderr :: :: stderr
 
 name :: '' ::=
+  | nat0 nat1 nat2        :: :: gen
   | id nat                :: :: name
   | have_exception nat    :: :: have_exception
   | current_exception nat :: :: current_exception
@@ -84,6 +85,10 @@ name :: '' ::=
   | channel chan nat      :: :: channel
   | memory_writes nat     :: :: memory_writes
   | return nat            :: :: return
+
+return_name :: '' ::=
+  | name :: :: return_via
+  |      :: :: return_plain
 
 op :: '' ::=
   | not               :: :: bnot
@@ -284,7 +289,7 @@ def_annot :: '' ::=
 
 cdef :: 'CDEF_' ::=
   {{ aux _ def_annot }}
-  | register id : ctyp = {
+  | register name : ctyp = {
       instr0 ; ... ; instrn
     } :: :: register
   | ctype_def :: :: type
@@ -300,7 +305,7 @@ cdef :: 'CDEF_' ::=
 % return type and passes a pointer to it as an extra argument id for
 % the function to fill in. This is only done via Jib->Jib rewrites
 % used when compiling to C.
-  | function id mid ( id0 , ... , idn ) {
+  | function id return_name ( name0 , ... , namen ) {
       instr0 ; ... ; instrm
     } :: :: fundef
 

--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -70,7 +70,7 @@ and 'a aexp_aux =
   | AE_app of function_id * 'a aval list * 'a
   | AE_typ of 'a aexp * 'a
   | AE_assign of 'a alexp * 'a aexp
-  | AE_let of mut * id * 'a * 'a aexp * 'a aexp * 'a
+  | AE_let of mut * name * 'a * 'a aexp * 'a aexp * 'a
   | AE_block of 'a aexp list * 'a aexp * 'a
   | AE_return of 'a aval * 'a
   | AE_exit of 'a aval * 'a
@@ -80,7 +80,7 @@ and 'a aexp_aux =
   | AE_match of 'a aval * ('a apat * 'a aexp * 'a aexp * uannot) list * 'a
   | AE_try of 'a aexp * ('a apat * 'a aexp * 'a aexp * uannot) list * 'a
   | AE_struct_update of 'a aval * 'a aval Bindings.t * 'a
-  | AE_for of id * 'a aexp * 'a aexp * 'a aexp * order * 'a aexp
+  | AE_for of name * 'a aexp * 'a aexp * 'a aexp * order * 'a aexp
   | AE_loop of loop * 'a aexp * 'a aexp
   | AE_short_circuit of sc_op * 'a aval * 'a aexp
 
@@ -90,18 +90,18 @@ and 'a apat = AP_aux of 'a apat_aux * anf_annot
 
 and 'a apat_aux =
   | AP_tuple of 'a apat list
-  | AP_id of id * 'a
+  | AP_id of name * 'a
   | AP_global of id * 'a
   | AP_app of constructor_id * 'a apat * 'a
   | AP_cons of 'a apat * 'a apat
-  | AP_as of 'a apat * id * 'a
+  | AP_as of 'a apat * name * 'a
   | AP_struct of (id * 'a apat) list * 'a
   | AP_nil of 'a
   | AP_wild of 'a
 
 and 'a aval =
   | AV_lit of lit * 'a
-  | AV_id of id * 'a lvar
+  | AV_id of name * 'a lvar
   | AV_abstract of id * 'a
   | AV_ref of id * 'a lvar
   | AV_tuple of 'a aval list
@@ -110,7 +110,7 @@ and 'a aval =
   | AV_record of 'a aval Bindings.t * 'a
   | AV_cval of cval * 'a
 
-and 'a alexp = AL_id of id * 'a | AL_addr of id * 'a | AL_field of 'a alexp * id
+and 'a alexp = AL_id of name * 'a | AL_addr of name * 'a | AL_field of 'a alexp * id
 
 let aexp_loc (AE_aux (_, { loc = l; _ })) = l
 
@@ -118,16 +118,16 @@ let aexp_loc (AE_aux (_, { loc = l; _ })) = l
 
 let rec apat_bindings (AP_aux (apat_aux, _)) =
   match apat_aux with
-  | AP_tuple apats -> List.fold_left IdSet.union IdSet.empty (List.map apat_bindings apats)
-  | AP_id (id, _) -> IdSet.singleton id
-  | AP_global (id, _) -> IdSet.empty
+  | AP_tuple apats -> List.fold_left NameSet.union NameSet.empty (List.map apat_bindings apats)
+  | AP_id (id, _) -> NameSet.singleton id
+  | AP_global (id, _) -> NameSet.empty
   | AP_app (_, apat, _) -> apat_bindings apat
-  | AP_cons (apat1, apat2) -> IdSet.union (apat_bindings apat1) (apat_bindings apat2)
-  | AP_as (apat, id, _) -> IdSet.add id (apat_bindings apat)
-  | AP_nil _ -> IdSet.empty
-  | AP_wild _ -> IdSet.empty
+  | AP_cons (apat1, apat2) -> NameSet.union (apat_bindings apat1) (apat_bindings apat2)
+  | AP_as (apat, id, _) -> NameSet.add id (apat_bindings apat)
+  | AP_nil _ -> NameSet.empty
+  | AP_wild _ -> NameSet.empty
   | AP_struct (afpats, _) ->
-      List.fold_left IdSet.union IdSet.empty (List.map (fun (_, apat) -> apat_bindings apat) afpats)
+      List.fold_left NameSet.union NameSet.empty (List.map (fun (_, apat) -> apat_bindings apat) afpats)
 
 (** This function returns the types of all bound variables in a pattern. It ignores AP_global, apat_globals is used for
     that. *)
@@ -140,28 +140,29 @@ let rec apat_types (AP_aux (apat_aux, { env; _ })) =
     | Some _, Some _ -> assert false
   in
   match apat_aux with
-  | AP_tuple apats -> List.fold_left (Bindings.merge merge) Bindings.empty (List.map apat_types apats)
-  | AP_id (id, typ) when not (is_enum_member id env) -> Bindings.singleton id typ
-  | AP_id _ -> Bindings.empty
-  | AP_global (id, _) -> Bindings.empty
+  | AP_tuple apats -> List.fold_left (NameMap.merge merge) NameMap.empty (List.map apat_types apats)
+  | AP_id (id, typ) -> (
+      match id with Name (id, _) when is_enum_member id env -> NameMap.empty | _ -> NameMap.singleton id typ
+    )
+  | AP_global (id, _) -> NameMap.empty
   | AP_app (_, apat, _) -> apat_types apat
-  | AP_cons (apat1, apat2) -> (Bindings.merge merge) (apat_types apat1) (apat_types apat2)
-  | AP_as (apat, id, typ) -> Bindings.add id typ (apat_types apat)
-  | AP_nil _ -> Bindings.empty
-  | AP_wild _ -> Bindings.empty
+  | AP_cons (apat1, apat2) -> (NameMap.merge merge) (apat_types apat1) (apat_types apat2)
+  | AP_as (apat, id, typ) -> NameMap.add id typ (apat_types apat)
+  | AP_nil _ -> NameMap.empty
+  | AP_wild _ -> NameMap.empty
   | AP_struct (afpats, _) ->
-      List.fold_left (Bindings.merge merge) Bindings.empty (List.map (fun (_, apat) -> apat_types apat) afpats)
+      List.fold_left (NameMap.merge merge) NameMap.empty (List.map (fun (_, apat) -> apat_types apat) afpats)
 
 let rec apat_rename from_id to_id (AP_aux (apat_aux, annot)) =
   let apat_aux =
     match apat_aux with
     | AP_tuple apats -> AP_tuple (List.map (apat_rename from_id to_id) apats)
-    | AP_id (id, typ) when Id.compare id from_id = 0 -> AP_id (to_id, typ)
+    | AP_id (id, typ) when Name.compare id from_id = 0 -> AP_id (to_id, typ)
     | AP_id (id, typ) -> AP_id (id, typ)
     | AP_global (id, typ) -> AP_global (id, typ)
     | AP_app (ctor, apat, typ) -> AP_app (ctor, apat_rename from_id to_id apat, typ)
     | AP_cons (apat1, apat2) -> AP_cons (apat_rename from_id to_id apat1, apat_rename from_id to_id apat2)
-    | AP_as (apat, id, typ) when Id.compare id from_id = 0 -> AP_as (apat, to_id, typ)
+    | AP_as (apat, id, typ) when Name.compare id from_id = 0 -> AP_as (apat, to_id, typ)
     | AP_as (apat, id, typ) -> AP_as (apat, id, typ)
     | AP_nil typ -> AP_nil typ
     | AP_wild typ -> AP_wild typ
@@ -203,22 +204,21 @@ let aexp_typ (AE_aux (aux, _)) =
 
 let rec aval_rename from_id to_id = function
   | AV_lit (lit, typ) -> AV_lit (lit, typ)
-  | AV_id (id, lvar) when Id.compare id from_id = 0 -> AV_id (to_id, lvar)
+  | AV_id (id, lvar) when Name.compare id from_id = 0 -> AV_id (to_id, lvar)
   | AV_id (id, lvar) -> AV_id (id, lvar)
-  | AV_ref (id, lvar) when Id.compare id from_id = 0 -> AV_ref (to_id, lvar)
-  | AV_ref (id, lvar) -> AV_ref (id, lvar)
+  | AV_ref (register_id, lvar) -> AV_ref (register_id, lvar)
   | AV_abstract (id, typ) ->
       AV_abstract (id, typ) (* This id is an abstract type variable, so we don't rename it here *)
   | AV_tuple avals -> AV_tuple (List.map (aval_rename from_id to_id) avals)
   | AV_list (avals, typ) -> AV_list (List.map (aval_rename from_id to_id) avals, typ)
   | AV_vector (avals, typ) -> AV_vector (List.map (aval_rename from_id to_id) avals, typ)
   | AV_record (avals, typ) -> AV_record (Bindings.map (aval_rename from_id to_id) avals, typ)
-  | AV_cval (cval, typ) -> AV_cval (cval_rename (name from_id) (name to_id) cval, typ)
+  | AV_cval (cval, typ) -> AV_cval (cval_rename from_id to_id cval, typ)
 
 let rec alexp_rename from_id to_id = function
-  | AL_id (id, typ) when Id.compare from_id id = 0 -> AL_id (to_id, typ)
+  | AL_id (id, typ) when Name.compare from_id id = 0 -> AL_id (to_id, typ)
   | AL_id (id, typ) -> AL_id (id, typ)
-  | AL_addr (id, typ) when Id.compare from_id id = 0 -> AL_addr (to_id, typ)
+  | AL_addr (id, typ) when Name.compare from_id id = 0 -> AL_addr (to_id, typ)
   | AL_addr (id, typ) -> AL_id (id, typ)
   | AL_field (alexp, field_id) -> AL_field (alexp_rename from_id to_id alexp, field_id)
 
@@ -230,7 +230,7 @@ let rec aexp_rename from_id to_id (AE_aux (aexp, annot)) =
     | AE_app (id, avals, typ) -> AE_app (id, List.map (aval_rename from_id to_id) avals, typ)
     | AE_typ (aexp, typ) -> AE_typ (recur aexp, typ)
     | AE_assign (alexp, aexp) -> AE_assign (alexp_rename from_id to_id alexp, aexp_rename from_id to_id aexp)
-    | AE_let (mut, id, typ1, aexp1, aexp2, typ2) when Id.compare from_id id = 0 ->
+    | AE_let (mut, id, typ1, aexp1, aexp2, typ2) when Name.compare from_id id = 0 ->
         AE_let (mut, id, typ1, recur aexp1, aexp2, typ2)
     | AE_let (mut, id, typ1, aexp1, aexp2, typ2) -> AE_let (mut, id, typ1, recur aexp1, recur aexp2, typ2)
     | AE_block (aexps, aexp, typ) -> AE_block (List.map recur aexps, recur aexp, typ)
@@ -246,7 +246,7 @@ let rec aexp_rename from_id to_id (AE_aux (aexp, annot)) =
         AE_try (aexp_rename from_id to_id aexp, List.map (apexp_rename from_id to_id) apexps, typ)
     | AE_struct_update (aval, avals, typ) ->
         AE_struct_update (aval_rename from_id to_id aval, Bindings.map (aval_rename from_id to_id) avals, typ)
-    | AE_for (id, aexp1, aexp2, aexp3, order, aexp4) when Id.compare from_id to_id = 0 ->
+    | AE_for (id, aexp1, aexp2, aexp3, order, aexp4) when Name.compare from_id id = 0 ->
         AE_for (id, aexp1, aexp2, aexp3, order, aexp4)
     | AE_for (id, aexp1, aexp2, aexp3, order, aexp4) ->
         AE_for (id, recur aexp1, recur aexp2, recur aexp3, order, recur aexp4)
@@ -256,7 +256,7 @@ let rec aexp_rename from_id to_id (AE_aux (aexp, annot)) =
   AE_aux (aexp, annot)
 
 and apexp_rename from_id to_id (apat, aexp1, aexp2, uannot) =
-  if IdSet.mem from_id (apat_bindings apat) then (apat, aexp1, aexp2, uannot)
+  if NameSet.mem from_id (apat_bindings apat) then (apat, aexp1, aexp2, uannot)
   else (apat, aexp_rename from_id to_id aexp1, aexp_rename from_id to_id aexp2, uannot)
 
 let rec fold_aexp f (AE_aux (aexp, annot)) =
@@ -309,22 +309,17 @@ let rec is_pure_aexp effect_info (AE_aux (aexp, { uannot; _ })) =
 let is_pure_case effect_info (_, guard, body, _) = is_pure_aexp effect_info guard && is_pure_aexp effect_info body
 
 let aexp_bindings aexp =
-  let ids = ref IdSet.empty in
+  let ids = ref NameSet.empty in
   let collect_lets = function
     | AE_aux (AE_let (_, id, _, _, _, _), _) as aexp ->
-        ids := IdSet.add id !ids;
+        ids := NameSet.add id !ids;
         aexp
     | aexp -> aexp
   in
   ignore (fold_aexp collect_lets aexp);
   !ids
 
-let shadow_counter = ref 0
-
-let new_shadow id =
-  let shadow_id = append_id id ("shadow#" ^ string_of_int !shadow_counter) in
-  incr shadow_counter;
-  shadow_id
+let new_shadow = symbol_generator ()
 
 let rec no_shadow ids (AE_aux (aexp, annot)) =
   let aexp =
@@ -333,13 +328,13 @@ let rec no_shadow ids (AE_aux (aexp, annot)) =
     | AE_app (id, avals, typ) -> AE_app (id, avals, typ)
     | AE_typ (aexp, typ) -> AE_typ (no_shadow ids aexp, typ)
     | AE_assign (alexp, aexp) -> AE_assign (alexp, no_shadow ids aexp)
-    | AE_let (mut, id, typ1, aexp1, aexp2, typ2) when IdSet.mem id ids ->
-        let shadow_id = new_shadow id in
+    | AE_let (mut, id, typ1, aexp1, aexp2, typ2) when NameSet.mem id ids ->
+        let shadow_id = new_shadow () in
         let aexp1 = no_shadow ids aexp1 in
-        let ids = IdSet.add shadow_id ids in
+        let ids = NameSet.add shadow_id ids in
         AE_let (mut, shadow_id, typ1, aexp1, no_shadow ids (aexp_rename id shadow_id aexp2), typ2)
     | AE_let (mut, id, typ1, aexp1, aexp2, typ2) ->
-        AE_let (mut, id, typ1, no_shadow (IdSet.add id ids) aexp1, no_shadow (IdSet.add id ids) aexp2, typ2)
+        AE_let (mut, id, typ1, no_shadow (NameSet.add id ids) aexp1, no_shadow (NameSet.add id ids) aexp2, typ2)
     | AE_block (aexps, aexp, typ) -> AE_block (List.map (no_shadow ids) aexps, no_shadow ids aexp, typ)
     | AE_return (aval, typ) -> AE_return (aval, typ)
     | AE_exit (aval, typ) -> AE_exit (aval, typ)
@@ -349,15 +344,15 @@ let rec no_shadow ids (AE_aux (aexp, annot)) =
     | AE_match (aval, apexps, typ) -> AE_match (aval, List.map (no_shadow_apexp ids) apexps, typ)
     | AE_try (aexp, apexps, typ) -> AE_try (no_shadow ids aexp, List.map (no_shadow_apexp ids) apexps, typ)
     | AE_struct_update (aval, avals, typ) -> AE_struct_update (aval, avals, typ)
-    | AE_for (id, aexp1, aexp2, aexp3, order, aexp4) when IdSet.mem id ids ->
-        let shadow_id = new_shadow id in
+    | AE_for (id, aexp1, aexp2, aexp3, order, aexp4) when NameSet.mem id ids ->
+        let shadow_id = new_shadow () in
         let aexp1 = no_shadow ids aexp1 in
         let aexp2 = no_shadow ids aexp2 in
         let aexp3 = no_shadow ids aexp3 in
-        let ids = IdSet.add shadow_id ids in
+        let ids = NameSet.add shadow_id ids in
         AE_for (shadow_id, aexp1, aexp2, aexp3, order, no_shadow ids (aexp_rename id shadow_id aexp4))
     | AE_for (id, aexp1, aexp2, aexp3, order, aexp4) ->
-        let ids = IdSet.add id ids in
+        let ids = NameSet.add id ids in
         AE_for (id, no_shadow ids aexp1, no_shadow ids aexp2, no_shadow ids aexp3, order, no_shadow ids aexp4)
     | AE_loop (loop, aexp1, aexp2) -> AE_loop (loop, no_shadow ids aexp1, no_shadow ids aexp2)
     | AE_short_circuit (op, aval, aexp) -> AE_short_circuit (op, aval, no_shadow ids aexp)
@@ -365,13 +360,13 @@ let rec no_shadow ids (AE_aux (aexp, annot)) =
   AE_aux (aexp, annot)
 
 and no_shadow_apexp ids (apat, aexp1, aexp2, uannot) =
-  let shadows = IdSet.inter (apat_bindings apat) ids in
-  let shadows = List.map (fun id -> (id, new_shadow id)) (IdSet.elements shadows) in
+  let shadows = NameSet.inter (apat_bindings apat) ids in
+  let shadows = List.map (fun id -> (id, new_shadow ())) (NameSet.elements shadows) in
   let rename aexp = List.fold_left (fun aexp (from_id, to_id) -> aexp_rename from_id to_id aexp) aexp shadows in
   let rename_apat apat = List.fold_left (fun apat (from_id, to_id) -> apat_rename from_id to_id apat) apat shadows in
-  let ids = IdSet.union (apat_bindings apat) (IdSet.union ids (IdSet.of_list (List.map snd shadows))) in
+  let ids = NameSet.union (apat_bindings apat) (NameSet.union ids (NameSet.of_list (List.map snd shadows))) in
   let new_guard = no_shadow ids (rename aexp1) in
-  (rename_apat apat, new_guard, no_shadow (IdSet.union ids (aexp_bindings new_guard)) (rename aexp2), uannot)
+  (rename_apat apat, new_guard, no_shadow (NameSet.union ids (aexp_bindings new_guard)) (rename aexp2), uannot)
 
 (* Map over all the avals in an aexp. *)
 let rec map_aval f (AE_aux (aexp, annot)) =
@@ -462,6 +457,8 @@ let pp_order = function Ord_aux (Ord_inc, _) -> string "inc" | Ord_aux (Ord_dec,
 
 let pp_id id = string (string_of_id id)
 
+let pp_name id = string (string_of_name id)
+
 let pp_function_id = function
   | Sail_function id -> pp_id id
   | Newtype_wrapper id -> string "newtype" ^^ space ^^ pp_id id
@@ -473,8 +470,8 @@ let pp_constructor_id = function
   | Newtype_wrapper id -> string "newtype" ^^ space ^^ pp_id id
 
 let rec pp_alexp = function
-  | AL_id (id, typ) -> pp_annot typ (pp_id id)
-  | AL_addr (id, typ) -> string "*" ^^ parens (pp_annot typ (pp_id id))
+  | AL_id (id, typ) -> pp_annot typ (pp_name id)
+  | AL_addr (id, typ) -> string "*" ^^ parens (pp_annot typ (pp_name id))
   | AL_field (alexp, field) -> pp_alexp alexp ^^ dot ^^ pp_id field
 
 let pp_anf_uannot uannot =
@@ -499,14 +496,14 @@ let rec pp_aexp (AE_aux (aexp, annot)) =
         begin
           match binding with
           | AE_aux (AE_let _, _) ->
-              (pp_annot typ (separate space [keyword; pp_annot id_typ (pp_id id); string "="])
+              (pp_annot typ (separate space [keyword; pp_annot id_typ (pp_name id); string "="])
               ^^ hardline
               ^^ nest 2 (pp_aexp binding)
               )
               ^^ hardline ^^ string "in" ^^ space ^^ pp_aexp body
           | _ ->
               pp_annot typ
-                (separate space [keyword; pp_annot id_typ (pp_id id); string "="; pp_aexp binding; string "in"])
+                (separate space [keyword; pp_annot id_typ (pp_name id); string "="; pp_aexp binding; string "in"])
               ^^ hardline ^^ pp_aexp body
         end
   | AE_if (cond, then_aexp, else_aexp, typ) ->
@@ -525,7 +522,7 @@ let rec pp_aexp (AE_aux (aexp, annot)) =
              (parens
                 (separate (break 1)
                    [
-                     pp_id id;
+                     pp_name id;
                      string "from " ^^ pp_aexp aexp1;
                      string "to " ^^ pp_aexp aexp2;
                      string "by " ^^ pp_aexp aexp3;
@@ -550,13 +547,13 @@ and pp_apat (AP_aux (apat_aux, annot)) =
   ^^
   match apat_aux with
   | AP_wild _ -> string "_"
-  | AP_id (id, typ) -> pp_annot typ (pp_id id)
+  | AP_id (id, typ) -> pp_annot typ (pp_name id)
   | AP_global (id, _) -> pp_id id
   | AP_tuple apats -> parens (separate_map (comma ^^ space) pp_apat apats)
   | AP_app (ctor, apat, typ) -> pp_annot typ (pp_constructor_id ctor ^^ parens (pp_apat apat))
   | AP_nil _ -> string "[||]"
   | AP_cons (hd_apat, tl_apat) -> pp_apat hd_apat ^^ string " :: " ^^ pp_apat tl_apat
-  | AP_as (apat, id, _) -> pp_apat apat ^^ string " as " ^^ pp_id id
+  | AP_as (apat, id, _) -> pp_apat apat ^^ string " as " ^^ pp_name id
   | AP_struct (afpats, _) ->
       separate space
         [
@@ -578,7 +575,7 @@ and pp_block = function
 
 and pp_aval = function
   | AV_lit (lit, typ) -> pp_annot typ (string (string_of_lit lit))
-  | AV_id (id, lvar) -> pp_lvar lvar (pp_id id)
+  | AV_id (id, lvar) -> pp_lvar lvar (pp_name id)
   | AV_abstract (id, typ) -> string "sizeof" ^^ parens (pp_annot typ (pp_id id))
   | AV_tuple avals -> parens (separate_map (comma ^^ space) pp_aval avals)
   | AV_ref (id, lvar) -> string "ref" ^^ space ^^ pp_lvar lvar (pp_id id)
@@ -600,7 +597,7 @@ let ae_lit lit typ = AE_val (AV_lit (lit, typ))
 
 let is_dead_aexp (AE_aux (_, { env; _ })) = prove __POS__ env nc_false
 
-let gensym, reset_anf_counter = symbol_generator "ga"
+let gensym = symbol_generator ()
 
 let rec split_block l = function
   | [exp] -> ([], exp)
@@ -613,7 +610,7 @@ let rec anf_pat ?(global = false) (P_aux (p_aux, (l, tannot)) as pat) =
   let mk_apat aux = AP_aux (aux, { loc = l; env = env_of_tannot tannot; uannot = untyped_annot tannot }) in
   match p_aux with
   | P_id id when global -> mk_apat (AP_global (id, typ_of_pat pat))
-  | P_id id -> mk_apat (AP_id (id, typ_of_pat pat))
+  | P_id id -> mk_apat (AP_id (name id, typ_of_pat pat))
   | P_wild -> mk_apat (AP_wild (typ_of_pat pat))
   | P_tuple pats -> mk_apat (AP_tuple (List.map (fun pat -> anf_pat ~global pat) pats))
   | P_app (id, [subpat]) -> (
@@ -635,7 +632,7 @@ let rec anf_pat ?(global = false) (P_aux (p_aux, (l, tannot)) as pat) =
         pats
         (mk_apat (AP_nil (typ_of_pat pat)))
   | P_lit (L_aux (L_unit, _)) -> mk_apat (AP_wild (typ_of_pat pat))
-  | P_as (pat, id) -> mk_apat (AP_as (anf_pat ~global pat, id, typ_of_pat pat))
+  | P_as (pat, id) -> mk_apat (AP_as (anf_pat ~global pat, name id, typ_of_pat pat))
   | P_struct (fpats, FP_no_wild) ->
       mk_apat (AP_struct (List.map (fun (field, pat) -> (field, anf_pat ~global pat)) fpats, typ_of_pat pat))
   | _ -> Reporting.unreachable l __POS__ ("Could not convert pattern to ANF: " ^ string_of_pat pat) [@coverage off]
@@ -655,7 +652,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
 
   let rec anf_lexp env (LE_aux (aux, (l, _)) as lexp) =
     match aux with
-    | LE_id id | LE_typ (_, id) -> ((fun x -> x), AL_id (id, lvar_typ ~loc:l (Env.lookup_id id env)))
+    | LE_id id | LE_typ (_, id) -> ((fun x -> x), AL_id (name id, lvar_typ ~loc:l (Env.lookup_id id env)))
     | LE_field (lexp, field_id) ->
         let wrap, alexp = anf_lexp env lexp in
         (wrap, AL_field (alexp, field_id))
@@ -718,7 +715,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
       mk_aexp (AE_loop (loop_typ, acond, aexp))
   | E_for (id, exp1, exp2, exp3, order, body) ->
       let aexp1, aexp2, aexp3, abody = (anf exp1, anf exp2, anf exp3, anf body) in
-      mk_aexp (AE_for (id, aexp1, aexp2, aexp3, order, abody))
+      mk_aexp (AE_for (name id, aexp1, aexp2, aexp3, order, abody))
   | E_if (cond, then_exp, else_exp) ->
       let cond_val, wrap = to_aval (anf cond) in
       let then_aexp = anf then_exp in
@@ -796,7 +793,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
   | E_id id ->
       let lvar = Env.lookup_id id (env_of exp) in
       begin
-        match lvar with _ -> mk_aexp (AE_val (AV_id (id, lvar)))
+        match lvar with _ -> mk_aexp (AE_val (AV_id (name id, lvar)))
       end
   | E_ref id ->
       let lvar = Env.lookup_id id (env_of exp) in
@@ -837,7 +834,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
       let mut = match binder with E_var _ -> Mutable | E_let _ -> Immutable | _ -> assert false in
       let env = env_of body in
       let lvar = Env.lookup_id id env in
-      mk_aexp (AE_let (mut, id, lvar_typ ~loc:l lvar, anf binding, anf body, typ_of exp))
+      mk_aexp (AE_let (mut, name id, lvar_typ ~loc:l lvar, anf binding, anf body, typ_of exp))
   | E_var (lexp, _, _) ->
       Reporting.unreachable l __POS__
         ("Encountered complex l-expression " ^ string_of_lexp lexp ^ " when converting to ANF") [@coverage off]

--- a/src/lib/anf.mli
+++ b/src/lib/anf.mli
@@ -70,6 +70,7 @@
 open Ast
 open Ast_util
 open Jib
+open Jib_util
 open Type_check
 
 type function_id = Sail_function of id | Newtype_wrapper of id | Pure_extern of id | Extern of id
@@ -87,7 +88,7 @@ and 'a aexp_aux =
   | AE_app of function_id * 'a aval list * 'a
   | AE_typ of 'a aexp * 'a
   | AE_assign of 'a alexp * 'a aexp
-  | AE_let of mut * id * 'a * 'a aexp * 'a aexp * 'a
+  | AE_let of mut * name * 'a * 'a aexp * 'a aexp * 'a
   | AE_block of 'a aexp list * 'a aexp * 'a
   | AE_return of 'a aval * 'a
   | AE_exit of 'a aval * 'a
@@ -97,7 +98,7 @@ and 'a aexp_aux =
   | AE_match of 'a aval * ('a apat * 'a aexp * 'a aexp * uannot) list * 'a
   | AE_try of 'a aexp * ('a apat * 'a aexp * 'a aexp * uannot) list * 'a
   | AE_struct_update of 'a aval * 'a aval Bindings.t * 'a
-  | AE_for of id * 'a aexp * 'a aexp * 'a aexp * order * 'a aexp
+  | AE_for of name * 'a aexp * 'a aexp * 'a aexp * order * 'a aexp
   | AE_loop of loop * 'a aexp * 'a aexp
   | AE_short_circuit of sc_op * 'a aval * 'a aexp
       (** A short circuting operator (either [and] or [or]) must have only its first argument reduced to a trivial value
@@ -109,11 +110,11 @@ and 'a apat = AP_aux of 'a apat_aux * anf_annot
 
 and 'a apat_aux =
   | AP_tuple of 'a apat list
-  | AP_id of id * 'a
+  | AP_id of name * 'a
   | AP_global of id * 'a
   | AP_app of constructor_id * 'a apat * 'a
   | AP_cons of 'a apat * 'a apat
-  | AP_as of 'a apat * id * 'a
+  | AP_as of 'a apat * name * 'a
   | AP_struct of (id * 'a apat) list * 'a
   | AP_nil of 'a
   | AP_wild of 'a
@@ -122,7 +123,7 @@ and 'a apat_aux =
     fragments must be side-effect free expressions. *)
 and 'a aval =
   | AV_lit of lit * 'a
-  | AV_id of id * 'a lvar
+  | AV_id of name * 'a lvar
   | AV_abstract of id * 'a
   | AV_ref of id * 'a lvar
   | AV_tuple of 'a aval list
@@ -131,11 +132,7 @@ and 'a aval =
   | AV_record of 'a aval Bindings.t * 'a
   | AV_cval of cval * 'a
 
-and 'a alexp = AL_id of id * 'a | AL_addr of id * 'a | AL_field of 'a alexp * id
-
-(** When the ANF translation has to introduce new bindings it uses a counter to ensure uniqueness. This function resets
-    that counter. *)
-val reset_anf_counter : unit -> unit
+and 'a alexp = AL_id of name * 'a | AL_addr of name * 'a | AL_field of 'a alexp * id
 
 (** Get the location from an [aexp]'s annotation *)
 val aexp_loc : 'a aexp -> Parse_ast.l
@@ -155,17 +152,17 @@ val map_functions : (anf_annot -> function_id -> 'a aval list -> 'a -> 'a aexp_a
     function to their containing expression, and so on recursively in a bottom-up order. *)
 val fold_aexp : ('a aexp -> 'a aexp) -> 'a aexp -> 'a aexp
 
-val aexp_bindings : 'a aexp -> IdSet.t
+val aexp_bindings : 'a aexp -> NameSet.t
 
 val is_pure_aexp : Effects.side_effect_info -> 'a aexp -> bool
 
 val is_pure_case : Effects.side_effect_info -> 'a apat * 'a aexp * 'a aexp * uannot -> bool
 
 (** Remove all variable shadowing in an ANF expression *)
-val no_shadow : IdSet.t -> 'a aexp -> 'a aexp
+val no_shadow : NameSet.t -> 'a aexp -> 'a aexp
 
 val apat_globals : 'a apat -> (id * 'a) list
-val apat_types : 'a apat -> 'a Bindings.t
+val apat_types : 'a apat -> 'a NameMap.t
 
 (** Returns true if an ANF expression is dead due to flow typing implying it is unreachable. Note: This function calls
     SMT. *)

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -61,8 +61,7 @@ let opt_memo_cache = ref false
 
 let optimize_aarch64_fast_struct = ref false
 
-let gensym, _ = symbol_generator "gs"
-let ngensym () = name (gensym ())
+let ngensym = symbol_generator ()
 
 (**************************************************************************)
 (* 4. Conversion to low-level AST                                         *)
@@ -116,10 +115,10 @@ type ctx = {
   local_env : Env.t;
   tc_env : Env.t;
   effect_info : Effects.side_effect_info;
-  locals : (mut * ctyp) Bindings.t;
+  locals : (mut * ctyp) NameMap.t;
   registers : ctyp Bindings.t;
   letbinds : int list;
-  letbind_ids : IdSet.t;
+  letbind_ids : NameSet.t;
   no_raw : bool;
   no_static : bool;
   coverage_override : bool;
@@ -178,10 +177,10 @@ let initial_ctx ?for_target env effect_info =
     local_env = env;
     tc_env = env;
     effect_info;
-    locals = Bindings.empty;
+    locals = NameMap.empty;
     registers = Bindings.empty;
     letbinds = [];
-    letbind_ids = IdSet.empty;
+    letbind_ids = NameSet.empty;
     no_raw = false;
     no_static = false;
     coverage_override = true;
@@ -389,10 +388,14 @@ module Make (C : CONFIG) = struct
   let unit_cval = V_lit (VL_unit, CT_unit)
 
   let get_variable_ctyp id ctx =
-    match Bindings.find_opt id ctx.locals with
+    match NameMap.find_opt id ctx.locals with
     | Some binding -> Some binding
     | None -> (
-        match Bindings.find_opt id ctx.registers with Some ctyp -> Some (Mutable, ctyp) | None -> None
+        match id with
+        | Name (id, _) -> (
+            match Bindings.find_opt id ctx.registers with Some ctyp -> Some (Mutable, ctyp) | None -> None
+          )
+        | _ -> None
       )
 
   let rec compile_aval l ctx = function
@@ -404,11 +407,11 @@ module Make (C : CONFIG) = struct
           ([iinit l ctyp' gs cval], V_id (gs, ctyp'), [iclear ctyp' gs])
         )
         else ([], cval, [])
-    | AV_id (id, Enum typ) -> ([], V_member (id, ctyp_of_typ ctx typ), [])
+    | AV_id (Name (id, _), Enum typ) -> ([], V_member (id, ctyp_of_typ ctx typ), [])
     | AV_id (id, typ) -> begin
         match get_variable_ctyp id ctx with
-        | Some (_, ctyp) -> ([], V_id (name id, ctyp), [])
-        | None -> ([], V_id (name id, ctyp_of_typ ctx (lvar_typ typ)), [])
+        | Some (_, ctyp) -> ([], V_id (id, ctyp), [])
+        | None -> ([], V_id (id, ctyp_of_typ ctx (lvar_typ typ)), [])
       end
     | AV_abstract (id, typ) -> ([], V_call (Get_abstract, [V_id (name id, ctyp_of_typ ctx typ)]), [])
     | AV_ref (id, typ) -> ([], V_lit (VL_ref (string_of_id id), CT_ref (ctyp_of_typ ctx (lvar_typ typ))), [])
@@ -1047,24 +1050,20 @@ module Make (C : CONFIG) = struct
     | AP_global (pid, typ) ->
         let global_ctyp = ctyp_of_typ ctx typ in
         ([], [icopy l (CL_id (name pid, global_ctyp)) cval], [], ctx)
-    | AP_id (pid, _) when is_ct_enum ctyp -> begin
+    | AP_id (Name (pid, _), _) when is_ct_enum ctyp -> begin
         match Env.lookup_id pid ctx.tc_env with
         | Unbound _ -> ([], [idecl l ctyp (name pid); icopy l (CL_id (name pid, ctyp)) cval], [], ctx)
         | _ -> ([on_failure l (V_call (Neq, [V_member (pid, ctyp); cval]))], [], [], ctx)
       end
     | AP_id (pid, typ) ->
         let id_ctyp = ctyp_of_typ ctx typ in
-        let ctx = { ctx with locals = Bindings.add pid (Immutable, id_ctyp) ctx.locals } in
-        ([], [idecl l id_ctyp (name pid); icopy l (CL_id (name pid, id_ctyp)) cval], [iclear id_ctyp (name pid)], ctx)
+        let ctx = { ctx with locals = NameMap.add pid (Immutable, id_ctyp) ctx.locals } in
+        ([], [idecl l id_ctyp pid; icopy l (CL_id (pid, id_ctyp)) cval], [iclear id_ctyp pid], ctx)
     | AP_as (apat, id, typ) ->
         let id_ctyp = ctyp_of_typ ctx typ in
         let pre, instrs, cleanup, ctx = compile_match ctx apat cval on_failure in
-        let ctx = { ctx with locals = Bindings.add id (Immutable, id_ctyp) ctx.locals } in
-        ( pre,
-          instrs @ [idecl l id_ctyp (name id); icopy l (CL_id (name id, id_ctyp)) cval],
-          iclear id_ctyp (name id) :: cleanup,
-          ctx
-        )
+        let ctx = { ctx with locals = NameMap.add id (Immutable, id_ctyp) ctx.locals } in
+        (pre, instrs @ [idecl l id_ctyp id; icopy l (CL_id (id, id_ctyp)) cval], iclear id_ctyp id :: cleanup, ctx)
     | AP_struct (afpats, _) ->
         let _, field_ctyp = struct_fields l ctx ctyp in
         let fold (pre, instrs, cleanup, ctx) (field, apat) =
@@ -1139,10 +1138,10 @@ module Make (C : CONFIG) = struct
     match alexp with
     | AL_id (id, typ) ->
         let ctyp = match get_variable_ctyp id ctx with Some (_, ctyp) -> ctyp | None -> ctyp_of_typ ctx typ in
-        CL_id (name id, ctyp)
+        CL_id (id, ctyp)
     | AL_addr (id, typ) ->
         let ctyp = match get_variable_ctyp id ctx with Some (_, ctyp) -> ctyp | None -> ctyp_of_typ ctx typ in
-        CL_addr (CL_id (name id, ctyp))
+        CL_addr (CL_id (id, ctyp))
     | AL_field (alexp, field_id) ->
         let clexp = compile_alexp ctx alexp in
         let _, field_ctyp = struct_fields (id_loc field_id) ctx (clexp_ctyp clexp) in
@@ -1176,11 +1175,11 @@ module Make (C : CONFIG) = struct
         let binding_ctyp = ctyp_of_typ { ctx with local_env = body_env } binding_typ in
         let setup, call, cleanup = compile_aexp ctx binding in
         let letb_setup, letb_cleanup =
-          ( [idecl l binding_ctyp (name id); iblock1 (setup @ [call (CL_id (name id, binding_ctyp))] @ cleanup)],
-            [iclear binding_ctyp (name id)]
+          ( [idecl l binding_ctyp id; iblock1 (setup @ [call (CL_id (id, binding_ctyp))] @ cleanup)],
+            [iclear binding_ctyp id]
           )
         in
-        let ctx = { ctx with locals = Bindings.add id (mut, binding_ctyp) ctx.locals } in
+        let ctx = { ctx with locals = NameMap.add id (mut, binding_ctyp) ctx.locals } in
         let setup, call, cleanup = compile_aexp ctx body in
         (letb_setup @ setup, call, cleanup @ letb_cleanup)
     | AE_app (Sail_function id, vs, _) ->
@@ -1500,12 +1499,12 @@ module Make (C : CONFIG) = struct
     (* This is a faster assignment rule for updating fields of a
        struct. *)
     | AE_assign (AL_id (id, assign_typ), AE_aux (AE_struct_update (AV_id (rid, _), fields, typ), _))
-      when Id.compare id rid = 0 ->
+      when Name.compare id rid = 0 ->
         let ctyp = ctyp_of_typ ctx typ in
         let _, field_ctyp = struct_fields l ctx ctyp in
         let compile_fields (field_id, aval) =
           let field_setup, cval, field_cleanup = compile_aval l ctx aval in
-          field_setup @ [icopy l (CL_field (CL_id (name id, ctyp), field_id, field_ctyp field_id)) cval] @ field_cleanup
+          field_setup @ [icopy l (CL_field (CL_id (id, ctyp), field_id, field_ctyp field_id)) cval] @ field_cleanup
         in
         (List.concat (List.map compile_fields (Bindings.bindings fields)), (fun clexp -> icopy l clexp unit_cval), [])
     | AE_assign (alexp, aexp) ->
@@ -1604,11 +1603,10 @@ module Make (C : CONFIG) = struct
           body
         )
       when Option.is_some C.unroll_loops ->
-        let ctx = { ctx with locals = Bindings.add loop_var (Immutable, CT_fint 64) ctx.locals } in
+        let ctx = { ctx with locals = NameMap.add loop_var (Immutable, CT_fint 64) ctx.locals } in
 
         let is_inc = match ord with Ord_inc -> true | Ord_dec -> false in
 
-        let loop_var = name loop_var in
         let body_setup, body_call, body_cleanup = compile_aexp ctx body in
         let body_gs = ngensym () in
 
@@ -1634,7 +1632,7 @@ module Make (C : CONFIG) = struct
         )
     | AE_for (loop_var, loop_from, loop_to, loop_step, Ord_aux (ord, _), body) ->
         (* We assume that all loop indices are safe to put in a CT_fint. *)
-        let ctx = { ctx with locals = Bindings.add loop_var (Immutable, CT_fint 64) ctx.locals } in
+        let ctx = { ctx with locals = NameMap.add loop_var (Immutable, CT_fint 64) ctx.locals } in
 
         let is_inc = match ord with Ord_inc -> true | Ord_dec -> false in
 
@@ -1653,8 +1651,6 @@ module Make (C : CONFIG) = struct
         let loop_end_label = label "for_end_" in
         let body_setup, body_call, body_cleanup = compile_aexp ctx body in
         let body_gs = ngensym () in
-
-        let loop_var = name loop_var in
 
         let loop_body prefix continue =
           prefix
@@ -1878,19 +1874,19 @@ module Make (C : CONFIG) = struct
 
   let rec compile_arg_pat ctx label (P_aux (p_aux, (l, _)) as pat) ctyp =
     match p_aux with
-    | P_id id -> (id, ([], []))
+    | P_id id -> (name id, ([], []))
     | P_wild ->
-        let gs = gensym () in
+        let gs = ngensym () in
         (gs, ([], []))
     | P_tuple [] | P_lit (L_aux (L_unit, _)) ->
-        let gs = gensym () in
+        let gs = ngensym () in
         (gs, ([], []))
     | P_var (pat, _) -> compile_arg_pat ctx label pat ctyp
     | P_typ (_, pat) -> compile_arg_pat ctx label pat ctyp
     | _ ->
         let apat = anf_pat pat in
-        let gs = gensym () in
-        let pre_destructure, destructure, cleanup, _ = compile_match ctx apat (V_id (name gs, ctyp)) label in
+        let gs = ngensym () in
+        let pre_destructure, destructure, cleanup, _ = compile_match ctx apat (V_id (gs, ctyp)) label in
         (gs, (pre_destructure @ destructure, cleanup))
 
   let rec compile_arg_pats ctx label (P_aux (p_aux, (l, _)) as pat) ctyps =
@@ -1901,14 +1897,14 @@ module Make (C : CONFIG) = struct
     | _ when List.length ctyps = 1 -> ([], [compile_arg_pat ctx label pat (List.nth ctyps 0)], [])
     | _ ->
         let arg_id, (destructure, cleanup) = compile_arg_pat ctx label pat (CT_tup ctyps) in
-        let new_ids = List.map (fun ctyp -> (gensym (), ctyp)) ctyps in
+        let new_ids = List.map (fun ctyp -> (ngensym (), ctyp)) ctyps in
         ( destructure
-          @ [idecl l (CT_tup ctyps) (name arg_id)]
+          @ [idecl l (CT_tup ctyps) arg_id]
           @ List.mapi
-              (fun i (id, ctyp) -> icopy l (CL_tuple (CL_id (name arg_id, CT_tup ctyps), i)) (V_id (name id, ctyp)))
+              (fun i (id, ctyp) -> icopy l (CL_tuple (CL_id (arg_id, CT_tup ctyps), i)) (V_id (id, ctyp)))
               new_ids,
           List.map (fun (id, _) -> (id, ([], []))) new_ids,
-          [iclear (CT_tup ctyps) (name arg_id)] @ cleanup
+          [iclear (CT_tup ctyps) arg_id] @ cleanup
         )
 
   let combine_destructure_cleanup xs = (List.concat (List.map fst xs), List.concat (List.rev (List.map snd xs)))
@@ -2038,12 +2034,12 @@ module Make (C : CONFIG) = struct
     let ctx =
       (* We need the primop analyzer to be aware of the function argument types, so put them in ctx *)
       List.fold_left2
-        (fun ctx (id, _) ctyp -> { ctx with locals = Bindings.add id (Immutable, ctyp) ctx.locals })
+        (fun ctx (id, _) ctyp -> { ctx with locals = NameMap.add id (Immutable, ctyp) ctx.locals })
         ctx compiled_args arg_ctyps
     in
 
-    let known_ids = IdSet.union ctx.letbind_ids (pat_ids pat) in
-    let guard_bindings = ref IdSet.empty in
+    let known_ids = IdSet.fold (fun id -> NameSet.add (name id)) (pat_ids pat) ctx.letbind_ids in
+    let guard_bindings = ref NameSet.empty in
     let guard_instrs =
       match guard with
       | Some guard ->
@@ -2066,7 +2062,7 @@ module Make (C : CONFIG) = struct
     in
 
     (* Optimize and compile the expression to ANF. *)
-    let aexp = C.optimize_anf ctx (no_shadow (IdSet.union known_ids !guard_bindings) (anf exp)) in
+    let aexp = C.optimize_anf ctx (no_shadow (NameSet.union known_ids !guard_bindings) (anf exp)) in
 
     if Option.is_some debug_attr then (
       prerr_endline Util.("ANF for " ^ string_of_id id ^ ":" |> yellow |> bold |> clear);
@@ -2109,14 +2105,14 @@ module Make (C : CONFIG) = struct
           let id = append_id id "_infallible" in
           ( [
               CDEF_aux (CDEF_val (id, params, arg_ctyps, ret_ctyp, None), def_annot);
-              CDEF_aux (CDEF_fundef (id, None, compiled_args, instrs), def_annot);
+              CDEF_aux (CDEF_fundef (id, Return_plain, compiled_args, instrs), def_annot);
             ],
             { orig_ctx with valspecs = Bindings.add id (None, arg_ctyps, ret_ctyp, empty_uannot) orig_ctx.valspecs }
           )
       | None -> ([], orig_ctx)
     in
 
-    ([CDEF_aux (CDEF_fundef (id, None, compiled_args, instrs), def_annot)] @ mapping_infallible, return_ctx)
+    ([CDEF_aux (CDEF_fundef (id, Return_plain, compiled_args, instrs), def_annot)] @ mapping_infallible, return_ctx)
 
   (** Compile a Sail toplevel definition into an IR definition **)
   let rec compile_def n total ctx (DEF_aux (aux, _) as def) =
@@ -2160,7 +2156,7 @@ module Make (C : CONFIG) = struct
     match aux with
     | DEF_register (DEC_aux (DEC_reg (typ, id, None), _)) ->
         let ctyp = ctyp_of_typ ctx typ in
-        ( [CDEF_aux (CDEF_register (id, ctyp, []), def_annot)],
+        ( [CDEF_aux (CDEF_register (name id, ctyp, []), def_annot)],
           { ctx with registers = Bindings.add id ctyp ctx.registers }
         )
     | DEF_register (DEC_aux (DEC_reg (typ, id, Some exp), _)) ->
@@ -2169,7 +2165,7 @@ module Make (C : CONFIG) = struct
         let setup, call, cleanup = compile_aexp ctx aexp in
         let instrs = setup @ [call (CL_id (name id, ctyp))] @ cleanup in
         let instrs = unique_names instrs in
-        ( [CDEF_aux (CDEF_register (id, ctyp, instrs), def_annot)],
+        ( [CDEF_aux (CDEF_register (name id, ctyp, instrs), def_annot)],
           { ctx with registers = Bindings.add id ctyp ctx.registers }
         )
     | DEF_val (VS_aux (VS_val_spec (_, id, ext), _)) ->
@@ -2226,7 +2222,11 @@ module Make (C : CONFIG) = struct
         in
         let instrs = unique_names instrs in
         ( [CDEF_aux (CDEF_let (n, bindings, instrs), def_annot)],
-          { ctx with letbinds = n :: ctx.letbinds; letbind_ids = IdSet.union (pat_ids pat) ctx.letbind_ids }
+          {
+            ctx with
+            letbinds = n :: ctx.letbinds;
+            letbind_ids = IdSet.fold (fun id -> NameSet.add (name id)) (pat_ids pat) ctx.letbind_ids;
+          }
         )
     (* Only DEF_default that matters is default Order, but all order
        polymorphism is specialised by this point. *)
@@ -2762,12 +2762,12 @@ module Make (C : CONFIG) = struct
 
       method! vinstr =
         function
-        | I_aux (I_init (ctyp, Name (id, _), Init_static VL_undefined), (_, l)) ->
+        | I_aux (I_init (ctyp, id, Init_static VL_undefined), (_, l)) ->
             statics := (l, ctyp, id, None) :: !statics;
-            ChangeTo (Printf.ksprintf icomment "lifted %s" (string_of_id id))
-        | I_aux (I_init (ctyp, Name (id, _), Init_static vl), (_, l)) ->
+            ChangeTo (Printf.ksprintf icomment "lifted %s" (string_of_name id))
+        | I_aux (I_init (ctyp, id, Init_static vl), (_, l)) ->
             statics := (l, ctyp, id, Some vl) :: !statics;
-            ChangeTo (Printf.ksprintf icomment "lifted %s" (string_of_id id))
+            ChangeTo (Printf.ksprintf icomment "lifted %s" (string_of_name id))
         | _ -> DoChildren
     end
 
@@ -2781,7 +2781,7 @@ module Make (C : CONFIG) = struct
             let annot = mk_def_annot l () |> add_def_attribute l "early_init" None in
             match vl_opt with
             | None -> CDEF_aux (CDEF_register (id, ctyp, []), annot)
-            | Some vl -> CDEF_aux (CDEF_register (id, ctyp, [icopy l (CL_id (name id, ctyp)) (V_lit (vl, ctyp))]), annot)
+            | Some vl -> CDEF_aux (CDEF_register (id, ctyp, [icopy l (CL_id (id, ctyp)) (V_lit (vl, ctyp))]), annot)
           )
           !statics
         @ [cdef]

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -51,6 +51,7 @@ open Ast
 open Ast_defs
 open Ast_util
 open Jib
+open Jib_util
 open Type_check
 
 (** This forces all integer struct fields to be represented as int64_t. Specifically intended for the various TLB
@@ -78,10 +79,10 @@ type ctx = {
   local_env : Env.t;
   tc_env : Env.t;
   effect_info : Effects.side_effect_info;
-  locals : (mut * ctyp) Bindings.t;
+  locals : (mut * ctyp) NameMap.t;
   registers : ctyp Bindings.t;
   letbinds : int list;
-  letbind_ids : IdSet.t;
+  letbind_ids : NameSet.t;
   no_raw : bool;
   no_static : bool;
   coverage_override : bool;

--- a/src/lib/jib_optimize.ml
+++ b/src/lib/jib_optimize.ml
@@ -250,7 +250,7 @@ module Remove_undefined = struct
   open Jib_util
   open Jib_visitor
 
-  let gensym, _ = symbol_generator "gz"
+  let gensym = symbol_generator ()
 
   let rec create_value l = function
     | CT_unit -> ([], V_lit (VL_unit, CT_unit))
@@ -268,7 +268,7 @@ module Remove_undefined = struct
         in
         (setup, V_tuple values)
     | ctyp ->
-        let gs = name (gensym ()) in
+        let gs = gensym () in
         ([idecl l ctyp gs], V_id (gs, ctyp))
 
   class visitor : jib_visitor =
@@ -294,7 +294,7 @@ module Remove_functions_to_references = struct
   open Jib_util
   open Jib_visitor
 
-  let gensym, _ = symbol_generator "gref"
+  let gensym = symbol_generator ()
 
   class visitor : jib_visitor =
     object
@@ -306,7 +306,7 @@ module Remove_functions_to_references = struct
       method! vinstr =
         function
         | I_aux (I_funcall (CR_one (CL_addr (CL_id (id, CT_ref reg_ctyp))), ext, f, args), (n, l)) ->
-            let gs = name (gensym ()) in
+            let gs = gensym () in
             ChangeTo
               (iblock
                  [
@@ -379,14 +379,7 @@ let rec find_function fid = function
   | cdef :: cdefs -> find_function fid cdefs
   | [] -> None
 
-let ssa_name i = function
-  | Name (id, _) -> Name (id, i)
-  | Have_exception _ -> Have_exception i
-  | Current_exception _ -> Current_exception i
-  | Throw_location _ -> Throw_location i
-  | Return _ -> Return i
-  | Channel (chan, _) -> Channel (chan, i)
-  | Memory_writes _ -> Memory_writes i
+let ssa_name = Jib_ssa.ssa_name
 
 let inline cdefs should_inline instrs =
   let inlines = ref (-1) in
@@ -432,7 +425,7 @@ let inline cdefs should_inline instrs =
     | I_aux (I_funcall (CR_one clexp, false, function_id, args), aux) as instr when should_inline (fst function_id) ->
       begin
         match find_function (fst function_id) cdefs with
-        | Some (None, ids, body) ->
+        | Some (Return_plain, ids, body) ->
             incr inlines;
             incr label_count;
             let inline_label = label "end_inline_" in
@@ -442,14 +435,14 @@ let inline cdefs should_inline instrs =
                is undone by fix_substs which removes the -2 SSA
                numbers. *)
             let args = List.map (cval_map_id (ssa_name (-2))) args in
-            let body = List.fold_right2 instrs_subst (List.map name ids) args body in
+            let body = List.fold_right2 instrs_subst ids args body in
             let body = List.map (map_instr fix_substs) body in
             let body = List.map (map_instr fix_labels) body in
             let body = List.map (map_instr (replace_end inline_label)) body in
             let body = List.map (map_instr (replace_return clexp)) body in
             I_aux (I_block (body @ [ilabel inline_label]), aux)
-        | Some (Some _, ids, body) ->
-            (* Some _ is only introduced by C backend, so we don't
+        | Some (Return_via _, ids, body) ->
+            (* Return_via _ is only introduced by C backend, so we don't
                expect it at this point. *)
             raise (Reporting.err_general (snd aux) "Unexpected return method in IR")
         | None -> instr
@@ -660,7 +653,7 @@ let remove_tuples cdefs ctx =
         Bindings.map
           (fun (extern, ctyps, ctyp, uannot) -> (extern, List.map fix_tuples ctyps, fix_tuples ctyp, uannot))
           ctx.valspecs;
-      locals = Bindings.map (fun (mut, ctyp) -> (mut, fix_tuples ctyp)) ctx.locals;
+      locals = NameMap.map (fun (mut, ctyp) -> (mut, fix_tuples ctyp)) ctx.locals;
     }
   in
   let to_struct = function

--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -55,6 +55,7 @@ module IntMap = Map.Make (struct
 end)
 
 let ssa_name i = function
+  | Gen (v1, v2, _) -> Gen (v1, v2, i)
   | Name (id, _) -> Name (id, i)
   | Have_exception _ -> Have_exception i
   | Current_exception _ -> Current_exception i
@@ -64,6 +65,7 @@ let ssa_name i = function
   | Return _ -> Return i
 
 let unssa_name = function
+  | Gen (v1, v2, n) -> (Gen (v1, v2, -1), n)
   | Name (id, n) -> (Name (id, -1), n)
   | Have_exception n -> (Have_exception (-1), n)
   | Current_exception n -> (Current_exception (-1), n)

--- a/src/lib/jib_util.ml
+++ b/src/lib/jib_util.ml
@@ -52,15 +52,18 @@ open Value2
 open PPrint
 module Document = Pretty_print_sail.Document
 
-let symbol_generator str =
+let generators = ref 0
+
+let symbol_generator () =
+  let gen_no = !generators in
+  incr generators;
   let counter = ref 0 in
   let gensym () =
-    let id = mk_id (str ^ "#" ^ string_of_int !counter) in
+    let id = Gen (gen_no, !counter, -1) in
     incr counter;
     id
   in
-  let reset () = counter := 0 in
-  (gensym, reset)
+  gensym
 
 (* Define wrappers for creating bytecode instructions. Each function
    uses a counter to assign each instruction a unique identifier. *)
@@ -76,10 +79,10 @@ let idecl l ctyp id = I_aux (I_decl (ctyp, id), (instr_number (), l))
 
 let ireset l ctyp id = I_aux (I_reset (ctyp, id), (instr_number (), l))
 
-let generate_static_var, _ = symbol_generator "gen_static"
+let generate_static_var = symbol_generator ()
 
 let istatic l ctyp value =
-  let id = Name (generate_static_var (), -1) in
+  let id = generate_static_var () in
   (id, I_aux (I_init (ctyp, id, Init_static value), (instr_number (), l)))
 
 let iinit l ctyp id cval = I_aux (I_init (ctyp, id, Init_cval cval), (instr_number (), l))
@@ -102,7 +105,7 @@ let ireturn ?loc:(l = Parse_ast.Unknown) cval = I_aux (I_return cval, (instr_num
 
 let iend l = I_aux (I_end (Return (-1)), (instr_number (), l))
 
-let iend_id l id = I_aux (I_end (Name (id, -1)), (instr_number (), l))
+let iend_name l name = I_aux (I_end name, (instr_number (), l))
 
 let iblock ?loc:(l = Parse_ast.Unknown) instrs = I_aux (I_block instrs, (instr_number (), l))
 
@@ -132,9 +135,16 @@ module Name = struct
   type t = name
   let compare id1 id2 =
     match (id1, id2) with
+    | Gen (x1, x2, n), Gen (y1, y2, m) ->
+        let c1 = Int.compare x1 y1 in
+        if c1 = 0 then (
+          let c2 = Int.compare x2 y2 in
+          if c2 = 0 then Int.compare n m else c2
+        )
+        else c1
     | Name (x, n), Name (y, m) ->
         let c1 = Id.compare x y in
-        if c1 = 0 then compare n m else c1
+        if c1 = 0 then Int.compare n m else c1
     | Have_exception n, Have_exception m -> compare n m
     | Current_exception n, Current_exception m -> compare n m
     | Return n, Return m -> compare n m
@@ -146,6 +156,8 @@ module Name = struct
         | Chan_stdout, Chan_stderr -> 1
         | Chan_stderr, Chan_stdout -> -1
       end
+    | Gen _, _ -> 1
+    | _, Gen _ -> -1
     | Name _, _ -> 1
     | _, Name _ -> -1
     | Have_exception _, _ -> 1
@@ -206,6 +218,7 @@ let instrs_rename from_name to_name = visit_instrs (new rename_visitor from_name
 let string_of_name ?deref_current_exception:(dce = false) ?(zencode = true) =
   let ssa_num n = if n = -1 then "" else "/" ^ string_of_int n in
   function
+  | Gen (v1, v2, n) -> "%" ^ string_of_int v1 ^ "." ^ string_of_int v2 ^ ssa_num n
   | Name (id, n) -> (if zencode then Util.zencode_string (string_of_id id) else string_of_id id) ^ ssa_num n
   | Have_exception n -> "have_exception" ^ ssa_num n
   | Return n -> "return" ^ ssa_num n

--- a/src/lib/jib_util.mli
+++ b/src/lib/jib_util.mli
@@ -52,9 +52,8 @@ open Jib
 
 (** {1 Instruction construction functions, and Jib names} *)
 
-(** Create a generator that produces fresh names, paired with a function that resets the generator (allowing it to
-    regenerate the same name). *)
-val symbol_generator : string -> (unit -> id) * (unit -> unit)
+(** Create a generator that produces fresh names. *)
+val symbol_generator : unit -> unit -> name
 
 val idecl : l -> ctyp -> name -> instr
 val istatic : l -> ctyp -> Value2.vl -> name * instr
@@ -69,7 +68,7 @@ val icopy : l -> clexp -> cval -> instr
 val iclear : ?loc:l -> ctyp -> name -> instr
 val ireturn : ?loc:l -> cval -> instr
 val iend : l -> instr
-val iend_id : l -> id -> instr
+val iend_name : l -> name -> instr
 val iblock : ?loc:l -> instr list -> instr
 val itry_block : l -> instr list -> instr
 val ithrow : l -> cval -> instr

--- a/src/lib/jib_visitor.ml
+++ b/src/lib/jib_visitor.ml
@@ -277,7 +277,7 @@ let visit_cdef vis outer_cdef =
   let aux vis (CDEF_aux (aux, def_annot) as no_change) =
     match aux with
     | CDEF_register (id, ctyp, instrs) ->
-        let id' = visit_id vis id in
+        let id' = visit_name vis id in
         let ctyp' = visit_ctyp vis ctyp in
         let instrs' = visit_instrs vis instrs in
         if id == id' && ctyp == ctyp' && instrs == instrs' then no_change
@@ -298,8 +298,14 @@ let visit_cdef vis outer_cdef =
         else CDEF_aux (CDEF_val (id', tyvars, ctyps', ctyp', extern), def_annot)
     | CDEF_fundef (id, ret_id, params, instrs) ->
         let id' = visit_id vis id in
-        let ret_id' = map_no_copy_opt (visit_id vis) ret_id in
-        let params' = map_no_copy (visit_id vis) params in
+        let ret_id' =
+          match ret_id with
+          | Return_via name ->
+              let name' = visit_name vis name in
+              if name == name' then ret_id else Return_via name'
+          | Return_plain -> ret_id
+        in
+        let params' = map_no_copy (visit_name vis) params in
         let instrs' = visit_instrs vis instrs in
         if id == id' && ret_id == ret_id' && params == params' && instrs == instrs' then no_change
         else CDEF_aux (CDEF_fundef (id', ret_id', params', instrs'), def_annot)

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4291,18 +4291,17 @@ let opt_unroll_loops = ref false
 let opt_unroll_loops_max_iter = ref 0
 
 (** The loop unrolling pass replaces :
-    {[
+    {v
        foreach k in 0 to 3 by 1 increasing:
          f(k, foo, bar) + k
-    ]}
-   with
-    {[
+    v}
+    with
+    {v
        f(0, foo, bar) + 0;
        f(1, foo, bar) + 1;
        f(2, foo, bar) + 2;
        f(3, foo, bar) + 3;
-    }]
-*)
+    v} *)
 let rewrite_unroll_constant_loops _type_env defs =
   (* This pass replaces expressions like
          f(k, foo, bar) + k

--- a/src/lib/smt_exp.ml
+++ b/src/lib/smt_exp.ml
@@ -1180,7 +1180,7 @@ module Counterexample (Config : COUNTEREXAMPLE_CONFIG) = struct
 
   let rec find_arg l ctx id ctyp arg_smt_names = function
     | List [Atom "define-fun"; Atom str; List []; _; value] :: _
-      when Util.assoc_compare_opt Id.compare id arg_smt_names = Some (Some str) ->
+      when Util.assoc_compare_opt Name.compare id arg_smt_names = Some (Some str) ->
         (id, value_of_sexpr l ctx value ctyp)
     | _ :: sexps -> find_arg l ctx id ctyp arg_smt_names sexps
     | [] -> (id, V_unit)
@@ -1217,7 +1217,9 @@ module Counterexample (Config : COUNTEREXAMPLE_CONFIG) = struct
           let open Interpreter in
           print_endline (sprintf "Solver found counterexample: %s" Util.("ok" |> green |> clear));
           let counterexample = build_counterexample loc ctx args arg_ctyps arg_smt_names model in
-          List.iter (fun (id, v) -> print_endline ("  " ^ string_of_id id ^ " -> " ^ string_of_value v)) counterexample;
+          List.iter
+            (fun (id, v) -> print_endline ("  " ^ string_of_name id ^ " -> " ^ string_of_value v))
+            counterexample;
           let istate = initial_state ast env !primops in
           let annot = (Parse_ast.Unknown, Type_check.mk_tannot env bool_typ) in
           let call =

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -78,8 +78,7 @@ let optimize_alias = ref false
 let optimize_fixed_int = ref false
 let optimize_fixed_bits = ref false
 
-let gensym, _ = symbol_generator "cb"
-let ngensym () = name (gensym ())
+let ngensym = symbol_generator ()
 
 let c_error ?loc:(l = Parse_ast.Unknown) message = raise (Reporting.err_general l ("\nC backend: " ^ message))
 
@@ -333,8 +332,8 @@ end) : CONFIG = struct
             if is_stack_ctyp ctx ctyp && not (never_optimize ctyp) then begin
               try
                 (* We need to check that id's type hasn't changed due to flow typing *)
-                let _, ctyp' = Bindings.find id ctx.locals in
-                if ctyp_equal ctyp ctyp' then AV_cval (V_id (name id, ctyp), typ)
+                let _, ctyp' = NameMap.find id ctx.locals in
+                if ctyp_equal ctyp ctyp' then AV_cval (V_id (id, ctyp), typ)
                 else
                   (* id's type changed due to flow typing, so it's
                      really still heap allocated! *)
@@ -342,12 +341,12 @@ end) : CONFIG = struct
               with
               (* Hack: Assuming global letbindings don't change from flow typing... *)
               | Not_found ->
-                AV_cval (V_id (name id, ctyp), typ)
+                AV_cval (V_id (id, ctyp), typ)
             end
             else v
         | Register typ ->
             let ctyp = convert_typ ctx typ in
-            if is_stack_ctyp ctx ctyp && not (never_optimize ctyp) then AV_cval (V_id (name id, ctyp), typ) else v
+            if is_stack_ctyp ctx ctyp && not (never_optimize ctyp) then AV_cval (V_id (id, ctyp), typ) else v
         | _ -> v
       end
     | AV_vector (v, typ) when is_bitvector v && List.length v <= 64 ->
@@ -369,7 +368,7 @@ end) : CONFIG = struct
           let aexp1 = analyze_functions ctx f aexp1 in
           (* Use aexp2's environment because it will contain constraints for id *)
           let ctyp1 = convert_typ { ctx with local_env = env2 } typ1 in
-          let ctx = { ctx with locals = Bindings.add id (mut, ctyp1) ctx.locals } in
+          let ctx = { ctx with locals = NameMap.add id (mut, ctyp1) ctx.locals } in
           AE_let (mut, id, typ1, aexp1, analyze_functions ctx f aexp2, typ2)
       | AE_block (aexps, aexp, typ) ->
           AE_block (List.map (analyze_functions ctx f) aexps, analyze_functions ctx f aexp, typ)
@@ -382,16 +381,16 @@ end) : CONFIG = struct
           let aexp2 = analyze_functions ctx f aexp2 in
           let aexp3 = analyze_functions ctx f aexp3 in
           (* Currently we assume that loop indexes are always safe to put into an int64 *)
-          let ctx = { ctx with locals = Bindings.add id (Immutable, CT_fint 64) ctx.locals } in
+          let ctx = { ctx with locals = NameMap.add id (Immutable, CT_fint 64) ctx.locals } in
           let aexp4 = analyze_functions ctx f aexp4 in
           AE_for (id, aexp1, aexp2, aexp3, order, aexp4)
       | AE_match (aval, cases, typ) ->
           let analyze_case ((AP_aux (_, { env; _ }) as pat), aexp1, aexp2, uannot) =
-            let pat_bindings = Bindings.bindings (apat_types pat) in
+            let pat_bindings = NameMap.bindings (apat_types pat) in
             let ctx = { ctx with local_env = env } in
             let ctx =
               List.fold_left
-                (fun ctx (id, typ) -> { ctx with locals = Bindings.add id (Immutable, convert_typ ctx typ) ctx.locals })
+                (fun ctx (id, typ) -> { ctx with locals = NameMap.add id (Immutable, convert_typ ctx typ) ctx.locals })
                 ctx pat_bindings
             in
             (pat, analyze_functions ctx f aexp1, analyze_functions ctx f aexp2, uannot)
@@ -593,22 +592,18 @@ let fix_early_stack_return ret ret_ctyp instrs =
 let rec insert_heap_returns ctx ret_ctyps = function
   | (CDEF_aux (CDEF_val (id, _, _, ret_ctyp, _), _) as cdef) :: cdefs ->
       cdef :: insert_heap_returns ctx (Bindings.add id ret_ctyp ret_ctyps) cdefs
-  | CDEF_aux (CDEF_fundef (id, None, args, body), def_annot) :: cdefs ->
-      let gs = gensym () in
+  | CDEF_aux (CDEF_fundef (id, Return_plain, args, body), def_annot) :: cdefs ->
+      let gs = ngensym () in
       begin
         match Bindings.find_opt id ret_ctyps with
         | None -> raise (Reporting.err_general (id_loc id) ("Cannot find return type for function " ^ string_of_id id))
         | Some ret_ctyp when not (is_stack_ctyp ctx ret_ctyp) ->
-            CDEF_aux (CDEF_fundef (id, Some gs, args, fix_early_heap_return (name gs) body), def_annot)
+            CDEF_aux (CDEF_fundef (id, Return_via gs, args, fix_early_heap_return gs body), def_annot)
             :: insert_heap_returns ctx ret_ctyps cdefs
         | Some ret_ctyp ->
             CDEF_aux
               ( CDEF_fundef
-                  ( id,
-                    None,
-                    args,
-                    fix_early_stack_return (name gs) ret_ctyp (idecl (id_loc id) ret_ctyp (name gs) :: body)
-                  ),
+                  (id, Return_plain, args, fix_early_stack_return gs ret_ctyp (idecl (id_loc id) ret_ctyp gs :: body)),
                 def_annot
               )
             :: insert_heap_returns ctx ret_ctyps cdefs
@@ -999,6 +994,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
   let sgen_name =
     let ssa_num n = if n = -1 then "" else "/" ^ string_of_int n in
     function
+    | Gen (v1, v2, n) -> NameGen.to_string () (mk_id (sprintf "%d.%d" v1 v2)) ^ ssa_num n
     | Name (id, n) -> NameGen.to_string () id ^ ssa_num n
     | Have_exception n -> "have_exception" ^ ssa_num n
     | Return n -> "return" ^ ssa_num n
@@ -1254,7 +1250,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     | CL_id (Memory_writes _, _) -> "memory_writes"
     | CL_id (Channel _, _) -> Reporting.unreachable l __POS__ "CL_id Channel should not appear in C backend"
     | CL_id (Return _, _) -> Reporting.unreachable l __POS__ "CL_id Return should have been removed"
-    | CL_id (Name (id, _), _) -> "&" ^ sgen_id id
+    | CL_id (name, _) -> "&" ^ sgen_name name
     | CL_field (clexp, field, _) -> "&((" ^ sgen_clexp l clexp ^ ")->" ^ sgen_id field ^ ")"
     | CL_tuple (clexp, n) -> sprintf "&((%s)->%s)" (sgen_clexp l clexp) (sgen_tuple_id n)
     | CL_addr clexp -> "(*(" ^ sgen_clexp l clexp ^ "))"
@@ -1268,7 +1264,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     | CL_id (Memory_writes _, _) -> "memory_writes"
     | CL_id (Channel _, _) -> Reporting.unreachable l __POS__ "CL_id Channel should not appear in C backend"
     | CL_id (Return _, _) -> Reporting.unreachable l __POS__ "CL_id Return should have been removed"
-    | CL_id (Name (id, _), _) -> sgen_id id
+    | CL_id (name, _) -> sgen_name name
     | CL_field (clexp, field, _) -> sgen_clexp_pure l clexp ^ "." ^ sgen_id field
     | CL_tuple (clexp, n) -> sgen_clexp_pure l clexp ^ "." ^ sgen_tuple_id n
     | CL_addr clexp -> "(*(" ^ sgen_clexp_pure l clexp ^ "))"
@@ -2129,14 +2125,14 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     | CDEF_register (id, ctyp, _) ->
         [
           HeaderOnly
-            (string (Printf.sprintf "// register %s" (string_of_id id))
+            (string (Printf.sprintf "// register %s" (string_of_name id))
             ^^ hardline
-            ^^ string (Printf.sprintf "extern %s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_id id))
+            ^^ string (Printf.sprintf "extern %s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_name id))
             );
           Impl
-            (string (Printf.sprintf "// register %s" (string_of_id id))
+            (string (Printf.sprintf "// register %s" (string_of_name id))
             ^^ hardline
-            ^^ string (Printf.sprintf "%s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_id id))
+            ^^ string (Printf.sprintf "%s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_name id))
             );
         ]
     | CDEF_val (id, _, arg_ctyps, ret_ctyp, _) ->
@@ -2172,7 +2168,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         if List.length arg_ctyps <> List.length args then
           c_error ~loc:(id_loc id)
             ("function arguments "
-            ^ Util.string_of_list ", " string_of_id args
+            ^ Util.string_of_list ", " string_of_name args
             ^ " matched against type "
             ^ Util.string_of_list ", " string_of_ctyp arg_ctyps
             )
@@ -2182,23 +2178,23 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         let args =
           Util.string_of_list ", "
             (fun x -> x)
-            (List.map2 (fun ctyp arg -> sgen_const_ctyp ctyp ^ " " ^ sgen_id arg) arg_ctyps args)
+            (List.map2 (fun ctyp arg -> sgen_const_ctyp ctyp ^ " " ^ sgen_name arg) arg_ctyps args)
         in
         let function_header =
           match ret_arg with
-          | None ->
+          | Return_plain ->
               assert (is_stack_ctyp ctx ret_ctyp);
               (if !opt_static then string "static " else empty)
               ^^ string (sgen_ctyp ret_ctyp)
               ^^ space ^^ codegen_function_id id
               ^^ parens (string (extra_params ()) ^^ string args)
               ^^ hardline
-          | Some gs ->
+          | Return_via gs ->
               assert (not (is_stack_ctyp ctx ret_ctyp));
               (if !opt_static then string "static " else empty)
               ^^ string "void" ^^ space ^^ codegen_function_id id
               ^^ parens
-                   (string (extra_params ()) ^^ string (sgen_ctyp ret_ctyp ^ " *" ^ sgen_id gs ^ ", ") ^^ string args)
+                   (string (extra_params ()) ^^ string (sgen_ctyp ret_ctyp ^ " *" ^ sgen_name gs ^ ", ") ^^ string args)
               ^^ hardline
         in
         [
@@ -2423,9 +2419,9 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       let register_init_clear (id, ctyp, instrs) =
         if is_stack_ctyp ctx ctyp then (List.map (sgen_instr (mk_id "reg") ctx) instrs, [])
         else
-          ( [Printf.sprintf "  CREATE(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_id id)]
+          ( [Printf.sprintf "  CREATE(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_name id)]
             @ List.map (sgen_instr (mk_id "reg") ctx) instrs,
-            [Printf.sprintf "  KILL(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_id id)]
+            [Printf.sprintf "  KILL(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_name id)]
           )
       in
 

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -84,13 +84,14 @@ module Make_optimizer (S : Sequence) = struct
     type t = Jib.name
     let equal x y = Name.compare x y = 0
     let hash = function
-      | Name (Id_aux (aux, _), n) -> Hashtbl.hash (0, (aux, n))
-      | Have_exception n -> Hashtbl.hash (1, n)
-      | Current_exception n -> Hashtbl.hash (2, n)
-      | Throw_location n -> Hashtbl.hash (3, n)
-      | Return n -> Hashtbl.hash (4, n)
-      | Channel (chan, n) -> Hashtbl.hash (5, (chan, n))
-      | Memory_writes n -> Hashtbl.hash (6, n)
+      | Gen (v1, v2, n) -> Hashtbl.hash (0, (v1, v2, n))
+      | Name (Id_aux (aux, _), n) -> Hashtbl.hash (1, (aux, n))
+      | Have_exception n -> Hashtbl.hash (2, n)
+      | Current_exception n -> Hashtbl.hash (3, n)
+      | Throw_location n -> Hashtbl.hash (4, n)
+      | Return n -> Hashtbl.hash (5, n)
+      | Channel (chan, n) -> Hashtbl.hash (6, (chan, n))
+      | Memory_writes n -> Hashtbl.hash (7, n)
   end
 
   module NameHashtbl = Hashtbl.Make (NameHash)
@@ -203,7 +204,7 @@ module type CONFIG = sig
   val max_unknown_integer_width : int
   val max_unknown_bitvector_width : int
   val max_unknown_generic_vector_length : int
-  val register_map : id list CTMap.t
+  val register_map : name list CTMap.t
   val ignore_overflow : bool
 end
 
@@ -221,14 +222,14 @@ module Make (Config : CONFIG) = struct
         let max_unknown_generic_vector_length = Config.max_unknown_generic_vector_length
         let union_ctyp_classify _ _ = true
         let register_ref reg_name =
-          let id = mk_id reg_name in
+          let id = name (mk_id reg_name) in
           let rmap =
-            CTMap.filter (fun ctyp regs -> List.exists (fun reg -> Id.compare reg id = 0) regs) Config.register_map
+            CTMap.filter (fun ctyp regs -> List.exists (fun reg -> Name.compare reg id = 0) regs) Config.register_map
           in
           assert (CTMap.cardinal rmap = 1);
           match CTMap.min_binding_opt rmap with
           | Some (ctyp, regs) -> begin
-              match Util.list_index (fun reg -> Id.compare reg id = 0) regs with
+              match Util.list_index (fun reg -> Name.compare reg id = 0) regs with
               | Some i -> Smt_gen.bvint (required_width (Big_int.of_int (List.length regs))) (Big_int.of_int i)
               | None -> assert false
             end
@@ -622,9 +623,9 @@ module Make (Config : CONFIG) = struct
 
   let generate_reg_decs inits cdefs =
     let rec go acc = function
-      | CDEF_aux (CDEF_register (id, ctyp, _), _) :: cdefs when not (NameMap.mem (Name (id, 0)) inits) ->
+      | CDEF_aux (CDEF_register (id, ctyp, _), _) :: cdefs when not (NameMap.mem (Jib_ssa.ssa_name 0 id) inits) ->
           let* smt_typ = smt_ctyp ctyp in
-          go (Declare_const (Name (id, 0), smt_typ) :: acc) cdefs
+          go (Declare_const (Jib_ssa.ssa_name 0 id, smt_typ) :: acc) cdefs
       | _ :: cdefs -> go acc cdefs
       | [] -> return (List.rev acc)
     in
@@ -840,16 +841,16 @@ module Make (Config : CONFIG) = struct
     loc : Ast.l;
     file_name : string;
     function_id : id;
-    args : id list;
+    args : name list;
     arg_ctyps : ctyp list;
-    arg_smt_names : (id * string option) list;
+    arg_smt_names : (name * string option) list;
   }
 
   let smt_cdef props lets name_file ctx all_cdefs smt_includes (CDEF_aux (aux, def_annot)) =
     match aux with
     | CDEF_val (function_id, _, arg_ctyps, ret_ctyp, _) when Bindings.mem function_id props -> begin
         match find_function [] function_id all_cdefs with
-        | intervening_lets, Some (None, args, instrs, function_def_annot) ->
+        | intervening_lets, Some (Return_plain, args, instrs, function_def_annot) ->
             let function_id_string = string_of_id function_id in
             let debug_attr = get_def_attribute "jib_debug" function_def_annot in
             let prop_type, prop_args, pragma_l, vs = Bindings.find function_id props in
@@ -862,7 +863,7 @@ module Make (Config : CONFIG) = struct
               List.map2
                 (fun id ctyp ->
                   let l = unique pragma_l in
-                  idecl l ctyp (name id)
+                  idecl l ctyp id
                 )
                 args arg_ctyps
             in
@@ -924,7 +925,7 @@ module Make (Config : CONFIG) = struct
             let arg_smt_names =
               List.map
                 (function
-                  | I_aux (I_decl (_, Name (id, _)), (_, Unique (n, _))) -> (id, List.assoc_opt n arg_names)
+                  | I_aux (I_decl (_, name), (_, Unique (n, _))) -> (name, List.assoc_opt n arg_names)
                   | _ -> assert false
                   )
                 arg_decls
@@ -972,8 +973,10 @@ module Make (Config : CONFIG) = struct
                     let try_reg r =
                       let next_label = label "next_reg_write_" in
                       [
-                        ijump l (V_call (Neq, [V_lit (VL_ref (string_of_id r), reg_ctyp); V_id (id, ctyp)])) next_label;
-                        ifuncall l (CL_id (name r, reg_ctyp)) function_id args;
+                        ijump l
+                          (V_call (Neq, [V_lit (VL_ref (string_of_name ~zencode:false r), reg_ctyp); V_id (id, ctyp)]))
+                          next_label;
+                        ifuncall l (CL_id (r, reg_ctyp)) function_id args;
                         igoto end_label;
                         ilabel next_label;
                       ]
@@ -1003,8 +1006,10 @@ module Make (Config : CONFIG) = struct
                           let try_reg r =
                             let next_label = label "next_reg_deref_" in
                             [
-                              ijump l (V_call (Neq, [V_lit (VL_ref (string_of_id r), reg_ctyp); reg_ref])) next_label;
-                              icopy l clexp (V_id (name r, reg_ctyp));
+                              ijump l
+                                (V_call (Neq, [V_lit (VL_ref (string_of_name ~zencode:false r), reg_ctyp); reg_ref]))
+                                next_label;
+                              icopy l clexp (V_id (r, reg_ctyp));
                               igoto end_label;
                               ilabel next_label;
                             ]
@@ -1031,8 +1036,10 @@ module Make (Config : CONFIG) = struct
                     let try_reg r =
                       let next_label = label "next_reg_write_" in
                       [
-                        ijump l (V_call (Neq, [V_lit (VL_ref (string_of_id r), reg_ctyp); V_id (id, ctyp)])) next_label;
-                        icopy l (CL_id (name r, reg_ctyp)) cval;
+                        ijump l
+                          (V_call (Neq, [V_lit (VL_ref (string_of_name ~zencode:false r), reg_ctyp); V_id (id, ctyp)]))
+                          next_label;
+                        icopy l (CL_id (r, reg_ctyp)) cval;
                         igoto end_label;
                         ilabel next_label;
                       ]
@@ -1235,7 +1242,7 @@ end) : Jib_compile.CONFIG = struct
           let aexp1 = analyze ctx aexp1 in
           (* Use aexp2's environment because it will contain constraints for id *)
           let ctyp1 = convert_typ { ctx with local_env = env2 } typ1 in
-          let ctx = { ctx with locals = Bindings.add id (mut, ctyp1) ctx.locals } in
+          let ctx = { ctx with locals = NameMap.add id (mut, ctyp1) ctx.locals } in
           (AE_let (mut, id, typ1, aexp1, analyze ctx aexp2, typ2), annot)
       | AE_block (aexps, aexp, typ) -> (AE_block (List.map (analyze ctx) aexps, analyze ctx aexp, typ), annot)
       | AE_if (aval, aexp1, aexp2, typ) ->
@@ -1253,16 +1260,16 @@ end) : Jib_compile.CONFIG = struct
           let aexp2 = analyze ctx aexp2 in
           let aexp3 = analyze ctx aexp3 in
           (* Currently we assume that loop indexes are always safe to put into an int64 *)
-          let ctx = { ctx with locals = Bindings.add id (Immutable, CT_fint 64) ctx.locals } in
+          let ctx = { ctx with locals = NameMap.add id (Immutable, CT_fint 64) ctx.locals } in
           let aexp4 = analyze ctx aexp4 in
           (AE_for (id, aexp1, aexp2, aexp3, order, aexp4), annot)
       | AE_match (aval, cases, typ) ->
           let analyze_case ((AP_aux (_, { env; _ }) as pat), aexp1, aexp2, uannot) =
-            let pat_bindings = Bindings.bindings (apat_types pat) in
+            let pat_bindings = NameMap.bindings (apat_types pat) in
             let ctx = { ctx with local_env = env } in
             let ctx =
               List.fold_left
-                (fun ctx (id, typ) -> { ctx with locals = Bindings.add id (Immutable, convert_typ ctx typ) ctx.locals })
+                (fun ctx (id, typ) -> { ctx with locals = NameMap.add id (Immutable, convert_typ ctx typ) ctx.locals })
                 ctx pat_bindings
             in
             let uannot =

--- a/src/sail_smt_backend/jib_smt.mli
+++ b/src/sail_smt_backend/jib_smt.mli
@@ -58,7 +58,7 @@ module type CONFIG = sig
   val max_unknown_integer_width : int
   val max_unknown_bitvector_width : int
   val max_unknown_generic_vector_length : int
-  val register_map : id list CTMap.t
+  val register_map : name list CTMap.t
   val ignore_overflow : bool
 end
 
@@ -67,9 +67,9 @@ module Make (Config : CONFIG) : sig
     loc : Ast.l;
     file_name : string;
     function_id : id;
-    args : id list;
+    args : name list;
     arg_ctyps : ctyp list;
-    arg_smt_names : (id * string option) list;
+    arg_smt_names : (name * string option) list;
   }
 
   (** Generate SMT for all the $property and $counterexample pragmas provided, and write the generated SMT to
@@ -88,4 +88,4 @@ val compile :
   Type_check.Env.t ->
   Effects.side_effect_info ->
   Type_check.typed_ast ->
-  cdef list * Jib_compile.ctx * id list CTMap.t
+  cdef list * Jib_compile.ctx * name list CTMap.t

--- a/src/sail_sv_backend/generate_primop2.ml
+++ b/src/sail_sv_backend/generate_primop2.ml
@@ -128,7 +128,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some (CT_fvector (len, elem_ctyp));
-            params = [(mk_id "arr", arr_ctyp); (mk_id "i", CT_fbits ix_width); (mk_id "x", elem_ctyp)];
+            params = [(arr, arr_ctyp); (i, CT_fbits ix_width); (x, elem_ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -315,7 +315,7 @@ module Make
           {
             function_name = SVN_string function_name;
             return_type = Some CT_string;
-            params = [(mk_id "b", CT_fbits width)];
+            params = [(b, CT_fbits width)];
             body = mk_statement (SVS_block (List.map mk_statement (vars @ body)));
           }
     )
@@ -352,7 +352,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some CT_string;
-            params = [(mk_id "i", ctyp)];
+            params = [(i, ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -382,7 +382,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some CT_string;
-            params = [(mk_id "i", ctyp)];
+            params = [(i, ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -411,7 +411,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some CT_string;
-            params = [(mk_id "i", ctyp)];
+            params = [(i, ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -431,7 +431,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some CT_bool;
-            params = [(mk_id "xs", CT_list ctyp)];
+            params = [(xs, CT_list ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -455,7 +455,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some ctyp;
-            params = [(mk_id "xs", CT_list ctyp)];
+            params = [(xs, CT_list ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -475,7 +475,7 @@ module Make
           {
             function_name = SVN_string name;
             return_type = Some (CT_list ctyp);
-            params = [(mk_id "xs", CT_list ctyp)];
+            params = [(xs, CT_list ctyp)];
             body =
               mk_statement
                 (SVS_block
@@ -530,7 +530,7 @@ module Make
              {
                function_name = SVN_string name;
                return_type = Some CT_bool;
-               params = [(mk_id "xs", CT_list ctyp1); (mk_id "ys", CT_list ctyp2)];
+               params = [(xs, CT_list ctyp1); (ys, CT_list ctyp2)];
                body =
                  mk_statement
                    (SVS_block

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -63,8 +63,7 @@ open Sv_ir
 module IntSet = Util.IntSet
 module IntMap = Util.IntMap
 
-let gensym, _ = symbol_generator "sv"
-let ngensym () = name (gensym ())
+let ngensym = symbol_generator ()
 
 let sv_type_of_string = Initial_check.parse_from_string (Sv_type_parser.sv_type Sv_type_lexer.token)
 
@@ -223,8 +222,8 @@ let check_attribute name attr_object f =
    transitive function calls. It is constructed by the footprint
    visitor below as it scans the body of the function. *)
 type direct_footprint = {
-  mutable reads : IdSet.t;
-  mutable writes : IdSet.t;
+  mutable reads : NameSet.t;
+  mutable writes : NameSet.t;
   mutable throws : bool;
   mutable stdout : bool;
   mutable stderr : bool;
@@ -237,8 +236,8 @@ type direct_footprint = {
 
 let empty_direct_footprint () : direct_footprint =
   {
-    reads = IdSet.empty;
-    writes = IdSet.empty;
+    reads = NameSet.empty;
+    writes = NameSet.empty;
     throws = false;
     stdout = false;
     stderr = false;
@@ -257,12 +256,12 @@ class footprint_visitor ctx registers (footprint : direct_footprint) : jib_visit
 
     method! vcval =
       function
-      | V_id (Name (id, _), local_ctyp) ->
+      | V_id (id, local_ctyp) ->
           begin
-            match Bindings.find_opt id registers with
+            match NameMap.find_opt id registers with
             | Some ctyp ->
                 assert (ctyp_equal local_ctyp ctyp);
-                footprint.reads <- IdSet.add id footprint.reads
+                footprint.reads <- NameSet.add id footprint.reads
             | None -> ()
           end;
           SkipChildren
@@ -313,12 +312,12 @@ class footprint_visitor ctx registers (footprint : direct_footprint) : jib_visit
       | CL_id (Have_exception _, _) ->
           footprint.throws <- true;
           SkipChildren
-      | CL_id (Name (id, _), local_ctyp) ->
+      | CL_id (id, local_ctyp) ->
           begin
-            match Bindings.find_opt id registers with
+            match NameMap.find_opt id registers with
             | Some ctyp ->
                 assert (ctyp_equal local_ctyp ctyp);
-                footprint.writes <- IdSet.add id footprint.writes
+                footprint.writes <- NameSet.add id footprint.writes
             | None -> ()
           end;
           SkipChildren
@@ -326,11 +325,11 @@ class footprint_visitor ctx registers (footprint : direct_footprint) : jib_visit
   end
 
 type footprint = {
-  direct_reads : IdSet.t;
-  direct_writes : IdSet.t;
+  direct_reads : NameSet.t;
+  direct_writes : NameSet.t;
   direct_throws : bool;
-  all_reads : IdSet.t;
-  all_writes : IdSet.t;
+  all_reads : NameSet.t;
+  all_writes : NameSet.t;
   throws : bool;
   need_stdout : bool;
   need_stderr : bool;
@@ -342,11 +341,11 @@ type footprint = {
 
 let pure_footprint =
   {
-    direct_reads = IdSet.empty;
-    direct_writes = IdSet.empty;
+    direct_reads = NameSet.empty;
+    direct_writes = NameSet.empty;
     direct_throws = false;
-    all_reads = IdSet.empty;
-    all_writes = IdSet.empty;
+    all_reads = NameSet.empty;
+    all_writes = NameSet.empty;
     throws = false;
     need_stdout = false;
     need_stderr = false;
@@ -358,11 +357,11 @@ let pure_footprint =
 
 type spec_info = {
   (* A map from register types to all the registers with that type *)
-  register_ctyp_map : IdSet.t CTMap.t;
+  register_ctyp_map : NameSet.t CTMap.t;
   (* A map from register names to types *)
-  registers : ctyp Bindings.t;
+  registers : ctyp NameMap.t;
   (* A list of registers with initial values *)
-  initialized_registers : Ast.id list;
+  initialized_registers : name list;
   (* A list of constructor functions *)
   constructors : IdSet.t;
   (* Global letbindings *)
@@ -385,14 +384,14 @@ let collect_spec_info ctx cdefs =
         | CDEF_aux (CDEF_register (id, ctyp, setup), _) ->
             let setup_id = match setup with [] -> [] | _ -> [id] in
             ( CTMap.update ctyp
-                (function Some ids -> Some (IdSet.add id ids) | None -> Some (IdSet.singleton id))
+                (function Some ids -> Some (NameSet.add id ids) | None -> Some (NameSet.singleton id))
                 ctyp_map,
-              Bindings.add id ctyp regs,
+              NameMap.add id ctyp regs,
               setup_id @ inits
             )
         | _ -> (ctyp_map, regs, inits)
       )
-      (CTMap.empty, Bindings.empty, []) cdefs
+      (CTMap.empty, NameMap.empty, []) cdefs
   in
   let initialized_registers = List.rev initialized_registers in
   let constructors =
@@ -426,9 +425,9 @@ let collect_spec_info ctx cdefs =
             let _ = visit_cdef (new footprint_visitor ctx registers direct_footprint) cdef in
             CTSet.iter
               (fun ctyp ->
-                IdSet.iter
-                  (fun reg -> direct_footprint.writes <- IdSet.add reg direct_footprint.writes)
-                  (Option.value ~default:IdSet.empty (CTMap.find_opt ctyp register_ctyp_map))
+                NameSet.iter
+                  (fun reg -> direct_footprint.writes <- NameSet.add reg direct_footprint.writes)
+                  (Option.value ~default:NameSet.empty (CTMap.find_opt ctyp register_ctyp_map))
               )
               direct_footprint.references;
             Bindings.add f
@@ -436,8 +435,8 @@ let collect_spec_info ctx cdefs =
                 direct_reads = direct_footprint.reads;
                 direct_writes = direct_footprint.writes;
                 direct_throws = direct_footprint.throws;
-                all_reads = IdSet.empty;
-                all_writes = IdSet.empty;
+                all_reads = NameSet.empty;
+                all_writes = NameSet.empty;
                 throws = false;
                 need_stdout = direct_footprint.stdout;
                 need_stderr = direct_footprint.stderr;
@@ -473,8 +472,8 @@ let collect_spec_info ctx cdefs =
                      ) callee ->
                   match Bindings.find_opt callee footprints with
                   | Some footprint ->
-                      ( IdSet.union all_reads footprint.direct_reads,
-                        IdSet.union all_writes footprint.direct_writes,
+                      ( NameSet.union all_reads footprint.direct_reads,
+                        NameSet.union all_writes footprint.direct_writes,
                         throws || footprint.direct_throws,
                         need_stdout || footprint.need_stdout,
                         need_stderr || footprint.need_stderr,
@@ -549,6 +548,25 @@ let collect_spec_info ctx cdefs =
     callgraph = cfg;
     exception_ctyp;
   }
+
+let natural_name_compare variable_locations n1 n2 =
+  let open Lexing in
+  let name_compare id1 id2 ssa_num1 ssa_num2 =
+    let c = natural_id_compare id1 id2 in
+    if c <> 0 then c else Int.compare ssa_num1 ssa_num2
+  in
+  match (n1, n2) with
+  | Name (id1, ssa_num1), Name (id2, ssa_num2) -> (
+      let get_pos id = Option.bind (Bindings.find_opt id variable_locations) Reporting.simp_loc in
+      match (get_pos id1, get_pos id2) with
+      | Some (p1, _), Some (p2, _) ->
+          let c = Int.compare p1.pos_cnum p2.pos_cnum in
+          if c <> 0 then c else name_compare id1 id2 ssa_num1 ssa_num2
+      | _ -> name_compare id1 id2 ssa_num1 ssa_num2
+    )
+  | _ -> Name.compare n1 n2
+
+let natural_sort_names names = List.stable_sort (natural_name_compare Bindings.empty) names
 
 module type CONFIG = sig
   val max_unknown_integer_width : int
@@ -740,17 +758,20 @@ module Make (Config : CONFIG) = struct
   let mapM = Smt_gen.mapM
   let fmap = Smt_gen.fmap
 
-  let pp_name =
-    let ssa_num n = if n = -1 then empty else string ("_" ^ string_of_int n) in
+  let pp_name_string =
+    let ssa_num n = if n = -1 then "" else "_" ^ string_of_int n in
     function
-    | Name (id, n) -> pp_id id ^^ ssa_num n
-    | Have_exception n -> string "sail_have_exception" ^^ ssa_num n
-    | Current_exception n -> string "sail_current_exception" ^^ ssa_num n
-    | Throw_location n -> string "sail_throw_location" ^^ ssa_num n
-    | Channel (Chan_stdout, n) -> string "sail_stdout" ^^ ssa_num n
-    | Channel (Chan_stderr, n) -> string "sail_stderr" ^^ ssa_num n
-    | Memory_writes n -> string "sail_writes" ^^ ssa_num n
-    | Return n -> string "sail_return" ^^ ssa_num n
+    | Gen (v1, v2, n) -> pp_id_string (mk_id (sprintf "%d.%d" v1 v2)) ^ ssa_num n
+    | Name (id, n) -> pp_id_string id ^ ssa_num n
+    | Have_exception n -> "sail_have_exception" ^ ssa_num n
+    | Current_exception n -> "sail_current_exception" ^ ssa_num n
+    | Throw_location n -> "sail_throw_location" ^ ssa_num n
+    | Channel (Chan_stdout, n) -> "sail_stdout" ^ ssa_num n
+    | Channel (Chan_stderr, n) -> "sail_stderr" ^ ssa_num n
+    | Memory_writes n -> "sail_writes" ^ ssa_num n
+    | Return n -> "sail_return" ^ ssa_num n
+
+  let pp_name name = string (pp_name_string name)
 
   let wrap_type ctyp doc =
     match sv_ctyp ctyp with
@@ -1585,13 +1606,11 @@ module Make (Config : CONFIG) = struct
       method! vinstr (I_aux (aux, iannot) as no_change) =
         match aux with
         | I_copy (CL_addr (CL_id (id, CT_ref reg_ctyp)), cval) -> begin
-            let regs = Option.value ~default:IdSet.empty (CTMap.find_opt reg_ctyp spec_info.register_ctyp_map) in
+            let regs = Option.value ~default:NameSet.empty (CTMap.find_opt reg_ctyp spec_info.register_ctyp_map) in
 
             let encoded = "sail_reg_assign_" ^ Util.zencode_string (string_of_ctyp reg_ctyp) in
-            let reads = List.map (fun id -> V_id (Name (id, -1), reg_ctyp)) (natural_sort_ids (IdSet.elements regs)) in
-            let writes =
-              List.map (fun id -> CL_id (Name (id, -1), reg_ctyp)) (natural_sort_ids (IdSet.elements regs))
-            in
+            let reads = List.map (fun id -> V_id (id, reg_ctyp)) (natural_sort_names (NameSet.elements regs)) in
+            let writes = List.map (fun id -> CL_id (id, reg_ctyp)) (natural_sort_names (NameSet.elements regs)) in
             ChangeTo
               (I_aux
                  ( I_funcall (CR_multi writes, true, (mk_id encoded, []), V_id (id, CT_ref reg_ctyp) :: cval :: reads),
@@ -1604,13 +1623,13 @@ module Make (Config : CONFIG) = struct
             | Some footprint ->
                 let reads =
                   List.map
-                    (fun id -> V_id (Name (id, -1), Bindings.find id spec_info.registers))
-                    (natural_sort_ids (IdSet.elements (IdSet.union footprint.all_writes footprint.all_reads)))
+                    (fun id -> V_id (id, NameMap.find id spec_info.registers))
+                    (natural_sort_names (NameSet.elements (NameSet.union footprint.all_writes footprint.all_reads)))
                 in
                 let writes =
                   List.map
-                    (fun id -> CL_id (Name (id, -1), Bindings.find id spec_info.registers))
-                    (natural_sort_ids (IdSet.elements footprint.all_writes))
+                    (fun id -> CL_id (id, NameMap.find id spec_info.registers))
+                    (natural_sort_names (NameSet.elements footprint.all_writes))
                 in
                 let throws =
                   if footprint.throws || footprint.exits then
@@ -1679,13 +1698,11 @@ module Make (Config : CONFIG) = struct
                         match cval_ctyp cval with
                         | CT_ref reg_ctyp ->
                             let regs =
-                              Option.value ~default:IdSet.empty (CTMap.find_opt reg_ctyp spec_info.register_ctyp_map)
+                              Option.value ~default:NameSet.empty (CTMap.find_opt reg_ctyp spec_info.register_ctyp_map)
                             in
                             let encoded = "sail_reg_deref_" ^ Util.zencode_string (string_of_ctyp reg_ctyp) in
                             let reads =
-                              List.map
-                                (fun id -> V_id (Name (id, -1), reg_ctyp))
-                                (natural_sort_ids (IdSet.elements regs))
+                              List.map (fun id -> V_id (id, reg_ctyp)) (natural_sort_names (NameSet.elements regs))
                             in
                             ChangeTo (I_aux (I_funcall (CR_one clexp, true, (mk_id encoded, []), cval :: reads), iannot))
                         | _ -> Reporting.unreachable (snd iannot) __POS__ "Invalid type for reg_deref argument"
@@ -1713,9 +1730,7 @@ module Make (Config : CONFIG) = struct
       method! vstatement (SVS_aux (aux, l) as no_change) =
         match aux with
         | SVS_var (name, ctyp, exp_opt) ->
-            begin
-              match name with Name (id, _) -> decls := Bindings.add id ctyp !decls | _ -> ()
-            end;
+            decls := NameMap.add (fst (Jib_ssa.unssa_name name)) ctyp !decls;
             begin
               match exp_opt with
               | Some exp -> ChangeTo (SVS_aux (SVS_assign (SVP_id name, exp), l))
@@ -1851,23 +1866,6 @@ module Make (Config : CONFIG) = struct
       (fun pred -> match get_vertex cfg pred with Some ((_, CF_block (_, T_exit _)), _, _) -> true | _ -> false)
       preds
 
-  let natural_name_compare variable_locations n1 n2 =
-    let open Lexing in
-    let name_compare id1 id2 ssa_num1 ssa_num2 =
-      let c = natural_id_compare id1 id2 in
-      if c <> 0 then c else Int.compare ssa_num1 ssa_num2
-    in
-    match (n1, n2) with
-    | Name (id1, ssa_num1), Name (id2, ssa_num2) -> (
-        let get_pos id = Option.bind (Bindings.find_opt id variable_locations) Reporting.simp_loc in
-        match (get_pos id1, get_pos id2) with
-        | Some (p1, _), Some (p2, _) ->
-            let c = Int.compare p1.pos_cnum p2.pos_cnum in
-            if c <> 0 then c else name_compare id1 id2 ssa_num1 ssa_num2
-        | _ -> name_compare id1 id2 ssa_num1 ssa_num2
-      )
-    | _ -> Name.compare n1 n2
-
   let svir_module ?debug_attr ?(footprint = pure_footprint) ?(return_vars = [Jib_util.return]) spec_info ctx name params
       param_ctyps ret_ctyps body =
     let footprint, is_recursive =
@@ -1884,7 +1882,7 @@ module Make (Config : CONFIG) = struct
     in
 
     let always_comb = Queue.create () in
-    let declvars = ref Bindings.empty in
+    let declvars = ref NameMap.empty in
     let ssa_vars = ref NameMap.empty in
 
     (* Add a statement to the always_comb block *)
@@ -1896,7 +1894,7 @@ module Make (Config : CONFIG) = struct
     let open Jib_ssa in
     let _, end_node, cfg =
       ssa
-        ~globals:(NameSet.diff spec_info.global_lets (NameSet.of_list (List.map Jib_util.name params)))
+        ~globals:(NameSet.diff spec_info.global_lets (NameSet.of_list params))
         ?debug_prefix:(Option.map (fun _ -> string_of_sv_name name) debug_attr)
         (visit_instrs (new thread_registers ctx spec_info) body)
     in
@@ -2037,16 +2035,19 @@ module Make (Config : CONFIG) = struct
 
     (* Create the input and output ports *)
     let input_ports : sv_module_port list =
-      List.map2 (fun id ctyp -> { name = Name (id, 0); external_name = string_of_id id; typ = ctyp }) params param_ctyps
+      List.map2
+        (fun name ctyp -> { name = Jib_ssa.ssa_name 0 name; external_name = string_of_name name; typ = ctyp })
+        params param_ctyps
       @ List.map
           (fun id ->
             {
-              name = Name (id, 0);
-              external_name = string_of_id (prepend_id "in_" id);
-              typ = Bindings.find id spec_info.registers;
+              name = Jib_ssa.ssa_name 0 id;
+              external_name =
+                (match id with Name (id, _) -> string_of_id (prepend_id "in_" id) | _ -> string_of_name id);
+              typ = NameMap.find id spec_info.registers;
             }
           )
-          (natural_sort_ids (IdSet.elements (IdSet.union footprint.all_writes footprint.all_reads)))
+          (natural_sort_names (NameSet.elements (NameSet.union footprint.all_writes footprint.all_reads)))
       @ ( if footprint.need_stdout then
             [{ name = Channel (Chan_stdout, 0); external_name = "in_stdout"; typ = CT_string }]
           else []
@@ -2084,12 +2085,13 @@ module Make (Config : CONFIG) = struct
       @ List.map
           (fun id ->
             {
-              name = output_register (Name (id, -1));
-              external_name = string_of_id (prepend_id "out_" id);
-              typ = Bindings.find id spec_info.registers;
+              name = output_register id;
+              external_name =
+                (match id with Name (id, _) -> string_of_id (prepend_id "out_" id) | _ -> string_of_name id);
+              typ = NameMap.find id spec_info.registers;
             }
           )
-          (natural_sort_ids (IdSet.elements footprint.all_writes))
+          (natural_sort_names (NameSet.elements footprint.all_writes))
       @ ( if footprint.throws || footprint.exits then
             [
               { name = get_final_name (Have_exception (-1)); external_name = "have_exception"; typ = CT_bool };
@@ -2129,24 +2131,22 @@ module Make (Config : CONFIG) = struct
       (fun name nums ->
         let get_ctyp = function
           | Return _ -> Some (List.hd ret_ctyps)
-          | Name (id, _) -> begin
-              match Bindings.find_opt id spec_info.registers with
-              | Some ctyp -> Some ctyp
-              | None -> (
-                  match Bindings.find_opt id !declvars with
-                  | Some ctyp -> Some ctyp
-                  | None -> (
-                      match Util.list_index (fun p -> Id.compare p id = 0) params with
-                      | Some i -> Some (List.nth param_ctyps i)
-                      | None -> None
-                    )
-                )
-            end
           | Channel _ -> Some CT_string
           | Memory_writes _ -> Some CT_memory_writes
           | Have_exception _ -> Some CT_bool
           | Throw_location _ -> Some CT_string
           | Current_exception _ -> Some spec_info.exception_ctyp
+          | name -> (
+              match NameMap.find_opt name !declvars with
+              | Some ctyp -> Some ctyp
+              | None -> (
+                  match Util.list_index (fun p -> Name.compare p name = 0) params with
+                  | Some i -> Some (List.nth param_ctyps i)
+                  | None -> (
+                      match NameMap.find_opt name spec_info.registers with Some ctyp -> Some ctyp | None -> None
+                    )
+                )
+            )
         in
         match get_ctyp name with
         | Some ctyp ->
@@ -2175,6 +2175,8 @@ module Make (Config : CONFIG) = struct
     in
     { name; recursive = is_recursive; input_ports; output_ports; defs = List.map mk_def defs }
 
+  type register_info = { name : name; reset : name; inp : name; out : name; ctyp : ctyp }
+
   let toplevel_module spec_info ctx id fn_ctyps =
     if not (Bindings.mem id fn_ctyps && Bindings.mem id spec_info.footprints) then
       raise
@@ -2198,19 +2200,43 @@ module Make (Config : CONFIG) = struct
     let prefix = Attr.get_string ~default:"SAIL START\\n" "prefix" attr in
     let suffix = Attr.get_string ~default:"SAIL END\\n" "suffix" attr in
 
+    let register_ports =
+      List.rev_map
+        (fun (reg, ctyp) ->
+          match reg with
+          | Name (id, -1) ->
+              {
+                name = reg;
+                reset = Name (prepend_id "reset_" id, -1);
+                inp = Name (prepend_id "in_" id, -1);
+                out = Name (prepend_id "out_" id, -1);
+                ctyp;
+              }
+          | _ -> { name = reg; reset = ngensym (); inp = ngensym (); out = ngensym (); ctyp }
+        )
+        (NameMap.bindings spec_info.registers)
+    in
+
+    let sorted_register_ports =
+      List.stable_sort (fun r1 r2 -> natural_name_compare Bindings.empty r1.name r2.name) register_ports
+    in
+
+    let find_register_port reg = List.find (fun reg_info -> Name.compare reg_info.name reg = 0) register_ports in
+
     let register_resets, register_inputs, register_outputs =
-      Bindings.fold
-        (fun reg ctyp (resets, ins, outs) ->
-          ( mk_port (Name (prepend_id "reset_" reg, -1)) ctyp :: resets,
-            SVD_var (Name (prepend_id "in_" reg, -1), ctyp) :: ins,
-            SVD_var (Name (prepend_id "out_" reg, -1), ctyp) :: outs
+      List.fold_left
+        (fun (resets, ins, outs) reg_info ->
+          ( mk_port reg_info.reset reg_info.ctyp :: resets,
+            SVD_var (reg_info.inp, reg_info.ctyp) :: ins,
+            SVD_var (reg_info.out, reg_info.ctyp) :: outs
           )
         )
-        spec_info.registers ([], [], [])
+        ([], [], []) register_ports
     in
+
     let exposed_registers =
-      Bindings.fold
-        (fun reg ctyp ports -> if StringSet.mem (string_of_id reg) exposed then (reg, ctyp) :: ports else ports)
+      NameMap.fold
+        (fun reg ctyp ports -> if StringSet.mem (string_of_name reg) exposed then (reg, ctyp) :: ports else ports)
         spec_info.registers []
     in
     let memory_writes =
@@ -2235,15 +2261,18 @@ module Make (Config : CONFIG) = struct
     in
     let arg_ports = List.mapi (fun n ctyp -> mk_port (arg_name n) ctyp) arg_ctyps in
     let instantiate_main =
+      let reads_or_writes = NameSet.union footprint.all_writes footprint.all_reads in
       SVD_instantiate
         {
           module_name = SVN_id id;
           instance_name = string_of_id (prepend_id "inst_" id);
           input_connections =
             (args
-            @ List.map
-                (fun reg -> Var (Name (prepend_id "in_" reg, -1)))
-                (natural_sort_ids (IdSet.elements (IdSet.union footprint.all_writes footprint.all_reads)))
+            @ Util.option_these
+                (List.map
+                   (fun reg -> if NameSet.mem reg.name reads_or_writes then Some (Var reg.inp) else None)
+                   sorted_register_ports
+                )
             @ (if footprint.need_stdout then [String_lit ""] else [])
             @ (if footprint.need_stderr then [String_lit ""] else [])
             @ (if footprint.writes_mem then [Var (Name (mk_id "empty_memory_writes", -1))] else [])
@@ -2251,9 +2280,11 @@ module Make (Config : CONFIG) = struct
             );
           output_connections =
             ([SVP_id Jib_util.return]
-            @ List.map
-                (fun reg -> SVP_id (Name (prepend_id "out_" reg, -1)))
-                (natural_sort_ids (IdSet.elements footprint.all_writes))
+            @ Util.option_these
+                (List.map
+                   (fun reg -> if NameSet.mem reg.name footprint.all_writes then Some (SVP_id reg.out) else None)
+                   sorted_register_ports
+                )
             @ ( if footprint.throws || footprint.exits then
                   [SVP_id (Have_exception (-1)); SVP_id (Current_exception (-1))]
                 else []
@@ -2295,27 +2326,32 @@ module Make (Config : CONFIG) = struct
             else []
           )
         @ List.map
-            (fun (reg, _) ->
-              mk_statement (SVS_continuous_assign (SVP_id (Name (reg, -1)), Var (Name (prepend_id "out_" reg, -1))))
-            )
+            (function
+              | Name (reg, _), _ ->
+                  mk_statement (SVS_continuous_assign (SVP_id (Name (reg, -1)), Var (Name (prepend_id "out_" reg, -1))))
+              | _ -> assert false
+              )
             exposed_registers
         @ [mk_statement (svs_raw "sail_flush_writes(out_memory_writes)" ~inputs:[Name (mk_id "out_memory_writes", -1)])]
       in
       if clk then (
         let reset_regs, inout_regs =
-          Bindings.fold
+          NameMap.fold
             (fun reg ctyp (resets, inouts) ->
-              ( mk_statement
-                  (SVS_continuous_assign
-                     (SVP_id (Name (prepend_id "in_" reg, -1)), Var (Name (prepend_id "reset_" reg, -1)))
+              match reg with
+              | Name (reg, _) ->
+                  ( mk_statement
+                      (SVS_continuous_assign
+                         (SVP_id (Name (prepend_id "in_" reg, -1)), Var (Name (prepend_id "reset_" reg, -1)))
+                      )
+                    :: resets,
+                    mk_statement
+                      (SVS_continuous_assign
+                         (SVP_id (Name (prepend_id "in_" reg, -1)), Var (Name (prepend_id "out_" reg, -1)))
+                      )
+                    :: inouts
                   )
-                :: resets,
-                mk_statement
-                  (SVS_continuous_assign
-                     (SVP_id (Name (prepend_id "in_" reg, -1)), Var (Name (prepend_id "out_" reg, -1)))
-                  )
-                :: inouts
-              )
+              | _ -> assert false
             )
             spec_info.registers ([], [])
         in
@@ -2326,13 +2362,16 @@ module Make (Config : CONFIG) = struct
       )
       else (
         let unchanged_registers =
-          Bindings.fold
+          NameMap.fold
             (fun reg _ unchanged ->
-              if not (IdSet.mem reg footprint.all_writes) then
-                mk_statement
-                  (SVS_assign (SVP_id (Name (prepend_id "out_" reg, -1)), Var (Name (prepend_id "in_" reg, -1))))
-                :: unchanged
-              else unchanged
+              match reg with
+              | Name (id, _) ->
+                  if not (NameSet.mem reg footprint.all_writes) then
+                    mk_statement
+                      (SVS_assign (SVP_id (Name (prepend_id "out_" id, -1)), Var (Name (prepend_id "in_" id, -1))))
+                    :: unchanged
+                  else unchanged
+              | _ -> assert false
             )
             spec_info.registers []
         in
@@ -2341,16 +2380,16 @@ module Make (Config : CONFIG) = struct
       )
     in
     let initialize_registers =
-      let reset_target reg = prepend_id (if clk then "reset_" else "in_") reg in
       List.mapi
         (fun i reg ->
-          let name = sprintf "sail_setup_reg_%s" (pp_id_string reg) in
+          let reg_info = find_register_port reg in
+          let name = sprintf "sail_setup_reg_%s" (pp_name_string reg) in
           SVD_instantiate
             {
               module_name = SVN_string name;
               instance_name = sprintf "reg_init_%d" i;
               input_connections = [];
-              output_connections = [SVP_id (Name (reset_target reg, -1))];
+              output_connections = [SVP_id (if clk then reg_info.reset else reg_info.inp)];
             }
         )
         spec_info.initialized_registers
@@ -2372,7 +2411,11 @@ module Make (Config : CONFIG) = struct
             [mk_port (name (mk_id "clk")) CT_bit; mk_port (name (mk_id "reset")) CT_bit] @ arg_ports @ register_resets
           else arg_ports
         );
-      output_ports = output_ports @ List.map (fun (reg, ctyp) -> mk_port (Name (reg, -1)) ctyp) exposed_registers;
+      output_ports =
+        output_ports
+        @ List.map
+            (fun (reg, ctyp) -> match reg with Name (reg, _) -> mk_port (Name (reg, -1)) ctyp | _ -> assert false)
+            exposed_registers;
       defs = List.map mk_def defs;
     }
 
@@ -2420,7 +2463,7 @@ module Make (Config : CONFIG) = struct
           end
       | None -> (string "void", empty)
     in
-    let param_docs = List.map (fun (param, ctyp) -> wrap_type ctyp (pp_id param)) f.params in
+    let param_docs = List.map (fun (param, ctyp) -> wrap_type ctyp (pp_name param)) f.params in
     let block_terminator last = if last then semi else semi ^^ hardline in
     let pp_body = function
       | SVS_aux (SVS_block statements, _) ->
@@ -2568,12 +2611,12 @@ module Make (Config : CONFIG) = struct
 
   let sv_register_references spec_info =
     let rmap = spec_info.register_ctyp_map in
-    let reg_ref id = "SAIL_REG_" ^ Util.zencode_upper_string (string_of_id id) in
+    let reg_ref id = "SAIL_REG_" ^ Util.zencode_upper_string (pp_name_string id) in
     let check reg = parens (separate space [char 'r'; string "=="; string (reg_ref reg)]) in
     let reg_ref_enums =
       List.map
         (fun (ctyp, regs) ->
-          let regs = natural_sort_ids (IdSet.elements regs) in
+          let regs = natural_sort_names (NameSet.elements regs) in
           separate space [string "typedef"; string "enum"; lbrace]
           ^^ nest 4 (hardline ^^ separate_map (comma ^^ hardline) (fun r -> string (reg_ref r)) regs)
           ^^ hardline ^^ rbrace ^^ space
@@ -2586,7 +2629,7 @@ module Make (Config : CONFIG) = struct
     let reg_ref_functions =
       List.map
         (fun (ctyp, regs) ->
-          let regs = natural_sort_ids (IdSet.elements regs) in
+          let regs = natural_sort_names (NameSet.elements regs) in
           let encoded = Util.zencode_string (string_of_ctyp ctyp) in
           let sv_ty, index_ty = sv_ctyp ctyp in
           let sv_ty, typedef =
@@ -2597,27 +2640,27 @@ module Make (Config : CONFIG) = struct
             | None -> (string sv_ty, empty)
           in
           let port ~input ty v = separate space [string (if input then "input" else "output"); ty; v] in
+          let reg_ports =
+            List.map
+              (function
+                | Name (id, -1) -> (Name (id, -1), pp_id (prepend_id "in_" id), pp_id (prepend_id "out_" id))
+                | reg ->
+                    let inp = ngensym () in
+                    let out = ngensym () in
+                    (reg, pp_name inp, pp_name out)
+                )
+              regs
+          in
           let assign_module =
             let ports =
               port ~input:true (string ("sail_reg_" ^ encoded)) (char 'r')
               :: port ~input:true sv_ty (char 'v')
-              :: List.map (fun r -> port ~input:true sv_ty (pp_id (prepend_id "in_" r))) regs
-              @ List.map (fun r -> port ~input:false sv_ty (pp_id (prepend_id "out_" r))) regs
+              :: List.map (fun (_, i, _) -> port ~input:true sv_ty i) reg_ports
+              @ List.map (fun (_, _, o) -> port ~input:false sv_ty o) reg_ports
             in
-            let assignment reg =
-              separate space
-                [
-                  pp_id (prepend_id "out_" reg);
-                  equals;
-                  check reg;
-                  char '?';
-                  char 'v';
-                  colon;
-                  pp_id (prepend_id "in_" reg);
-                ]
-            in
+            let assignment (reg, inp, out) = separate space [out; equals; check reg; char '?'; char 'v'; colon; inp] in
             let comb =
-              nest 4 (string "begin" ^^ hardline ^^ separate_map (semi ^^ hardline) assignment regs ^^ semi)
+              nest 4 (string "begin" ^^ hardline ^^ separate_map (semi ^^ hardline) assignment reg_ports ^^ semi)
               ^^ hardline ^^ string "end" ^^ semi
             in
             string "module" ^^ space
@@ -2630,16 +2673,16 @@ module Make (Config : CONFIG) = struct
           let deref_module =
             let ports =
               port ~input:true (string ("sail_reg_" ^ encoded)) (char 'r')
-              :: List.map (fun r -> port ~input:true sv_ty (pp_id (prepend_id "in_" r))) regs
+              :: List.map (fun (_, i, _) -> port ~input:true sv_ty i) reg_ports
               @ [port ~input:false sv_ty (char 'v')]
             in
             let cases =
               List.map
-                (fun reg ->
-                  let assign = separate space [char 'v'; equals; pp_id (prepend_id "in_" reg)] in
+                (fun (reg, i, _) ->
+                  let assign = separate space [char 'v'; equals; i] in
                   (check reg, assign)
                 )
-                regs
+                reg_ports
             in
             let ifstmt =
               match cases with
@@ -2763,9 +2806,9 @@ module Make (Config : CONFIG) = struct
             in
             let setup_module =
               svir_setup_module spec_info ctx
-                (SVN_string (sprintf "sail_setup_reg_%s" (pp_id_string id)))
-                (name id) ctyp
-                (setup @ [iend_id def_annot.loc id])
+                (SVN_string (sprintf "sail_setup_reg_%s" (pp_name_string id)))
+                id ctyp
+                (setup @ [iend_name def_annot.loc id])
             in
             ([SVD_aux (SVD_module setup_module, def_annot.loc)], fn_ctyps)
       end
@@ -2774,8 +2817,8 @@ module Make (Config : CONFIG) = struct
   let sv_cdef spec_info ctx fn_ctyps setup_calls (CDEF_aux (aux, _)) =
     match aux with
     | CDEF_register (id, ctyp, setup) ->
-        let binding_doc = wrap_type ctyp (pp_id id) ^^ semi ^^ twice hardline in
-        let name = sprintf "sail_setup_reg_%s" (pp_id_string id) in
+        let binding_doc = wrap_type ctyp (pp_name id) ^^ semi ^^ twice hardline in
+        let name = sprintf "sail_setup_reg_%s" (pp_name_string id) in
         ( {
             empty_cdef_doc with
             inside_module_prefix = binding_doc;
@@ -2830,7 +2873,7 @@ module Make (Config : CONFIG) = struct
         | Some (param_ctyps, ret_ctyp) -> begin
             let main_args =
               List.map2
-                (fun param param_ctyp -> match param_ctyp with CT_unit -> string "SAIL_UNIT" | _ -> pp_id param)
+                (fun param param_ctyp -> match param_ctyp with CT_unit -> string "SAIL_UNIT" | _ -> pp_name param)
                 params param_ctyps
             in
             let non_unit =
@@ -2843,7 +2886,7 @@ module Make (Config : CONFIG) = struct
             in
             let module_main_in =
               List.map
-                (fun (param, param_ctyp) -> string "input" ^^ space ^^ wrap_type param_ctyp (pp_id param))
+                (fun (param, param_ctyp) -> string "input" ^^ space ^^ wrap_type param_ctyp (pp_name param))
                 non_unit
             in
             match ret_ctyp with

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -347,8 +347,8 @@ end
 
 let register_types cdefs =
   List.fold_left
-    (fun acc cdef -> match cdef with CDEF_aux (CDEF_register (id, ctyp, _), _) -> Bindings.add id ctyp acc | _ -> acc)
-    Bindings.empty cdefs
+    (fun acc cdef -> match cdef with CDEF_aux (CDEF_register (id, ctyp, _), _) -> NameMap.add id ctyp acc | _ -> acc)
+    NameMap.empty cdefs
 
 let jib_of_ast make_call_precise env ast effect_info =
   let open Jib_compile in

--- a/src/sail_sv_backend/sv_ir.ml
+++ b/src/sail_sv_backend/sv_ir.ml
@@ -88,7 +88,7 @@ type sv_module = {
 and sv_function = {
   function_name : sv_name;
   return_type : Jib.ctyp option;
-  params : (Ast.id * Jib.ctyp) list;
+  params : (Jib.name * Jib.ctyp) list;
   body : sv_statement;
 }
 

--- a/src/sail_sv_backend/sv_ir.mli
+++ b/src/sail_sv_backend/sv_ir.mli
@@ -84,7 +84,7 @@ type sv_module = {
 and sv_function = {
   function_name : sv_name;
   return_type : Jib.ctyp option;
-  params : (Ast.id * Jib.ctyp) list;
+  params : (Jib.name * Jib.ctyp) list;
   body : sv_statement;
 }
 

--- a/src/sail_sv_backend/sv_optimize.ml
+++ b/src/sail_sv_backend/sv_optimize.ml
@@ -411,7 +411,7 @@ module RemoveUnusedVariables = struct
             let frame =
               match aux with
               | SVD_fundef f ->
-                  let paramset = List.fold_left (fun set (id, _) -> NameSet.add (name id) set) NameSet.empty f.params in
+                  let paramset = List.fold_left (fun set (id, _) -> NameSet.add id set) NameSet.empty f.params in
                   Function paramset
               | SVD_module m ->
                   let portset =
@@ -618,7 +618,7 @@ module RemoveUnusedVariables = struct
     match aux with
     | SVD_type _ | SVD_null | SVD_dpi_function _ -> ()
     | SVD_fundef { params; body; _ } ->
-        let paramset = List.fold_left (fun set (id, _) -> NameSet.add (name id) set) NameSet.empty params in
+        let paramset = List.fold_left (fun set (id, _) -> NameSet.add id set) NameSet.empty params in
         push (Function paramset) stack;
         statement_uses stack uses body;
         pop stack


### PR DESCRIPTION
Previously generated names (mostly created during the ANF transform) were represented as strings of the form "prefix#N" where N was a generated number. Now we have a constructor which can represent these names as an `int * int` pair. The first number is the symbol generator number (which replaces the prefix) and the second is `N`.

This improves the performance of some rewrites as it makes `Name.compare` much cheaper on average.