### PR TITLE
Lean: increase Lean server stack size

### DIFF
--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -265,7 +265,11 @@ let create_lake_project (ctx : lean_context) executable =
   (* Change the base directory if the option '--lean-output-dir' is set *)
   output_string ctx.lakefile
     ("name = \"" ^ ctx.out_name ^ "\"\ndefaultTargets = [\"" ^ ctx.out_name_camel
-   ^ "\"]\nmoreLeanArgs = [\"--tstack=400000\"]\n\n[[lean_lib]]\nname = \"" ^ ctx.out_name_camel ^ "\""
+   ^ "\"]\n\
+      moreLeanArgs = [\"--tstack=400000\"]\n\
+      moreGlobalServerArgs = [\"--tstack=400000\"]\n\n\
+      [[lean_lib]]\n\
+      name = \"" ^ ctx.out_name_camel ^ "\""
     );
   if executable then (
     output_string ctx.lakefile "\n\n[[lean_exe]]\n";


### PR DESCRIPTION
Allows us to open the RISC-V output in VSCode without causing a stack overflow.