### PR TITLE
Lean: implement and annotate count_leading_zeros and count_trailing_zeros

### DIFF
--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -99,8 +99,15 @@ val vector_init = pure {
 
 overload length = {bitvector_length, vector_length}
 
-val count_leading_zeros = pure "count_leading_zeros" : forall 'N , 'N >= 1. bits('N) -> {'n, 0 <= 'n <= 'N . atom('n)}
-val count_trailing_zeros = pure "count_trailing_zeros" : forall 'N , 'N >= 1. bits('N) -> {'n, 0 <= 'n <= 'N . atom('n)}
+val count_leading_zeros = pure {
+  lean: "BitVec.countLeadingZeros",
+  _: "count_leading_zeros"
+} : forall 'N , 'N >= 1. bits('N) -> {'n, 0 <= 'n <= 'N . atom('n)}
+
+val count_trailing_zeros = pure {
+  lean: "BitVec.countTrailingZeros",
+  _: "count_trailing_zeros"
+} : forall 'N , 'N >= 1. bits('N) -> {'n, 0 <= 'n <= 'N . atom('n)}
 
 $ifndef PRINT_EFFECTS
 

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -44,6 +44,18 @@ def addInt {w : Nat} (x : BitVec w) (i : Int) : BitVec w :=
 def subInt (x : BitVec w) (i : Int) : BitVec w :=
   x - BitVec.ofInt w i
 
+def countLeadingZeros (x : BitVec w) : Nat :=
+  if h : w = 0 || BitVec.msb x then
+    0
+  else
+    1 + countLeadingZeros (x.extractLsb' 0 (w - 1))
+  decreasing_by
+    simp only [Bool.or_eq_true, decide_eq_true_eq, not_or, Bool.not_eq_true] at h
+    omega
+
+def countTrailingZeros (x : BitVec w) : Nat :=
+  countLeadingZeros (x.reverse)
+
 def append' (x : BitVec n) (y : BitVec m) {mn}
     (hmn : mn = n + m := by (conv => rhs; simp); try rfl) : BitVec mn :=
   (x.append y).cast hmn.symm

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -45,7 +45,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex705# : Bool, k_ex704# : Bool -/
+/-- Type quantifiers: k_ex729# : Bool, k_ex728# : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (Bool.not (BEq.beq x y))
 
@@ -130,6 +130,12 @@ def extern_slice (x : (BitVec 16)) : (BitVec 4) :=
 
 def extern_vector_length (x : (Vector Int 3)) : Int :=
   (Vector.length x)
+
+def extern_count_leading_zeros (_ : Unit) : Int :=
+  (BitVec.countLeadingZeros (0x00FF0FF0 : (BitVec 32)))
+
+def extern_count_trailing_zeros (_ : Unit) : Int :=
+  (BitVec.countTrailingZeros (0x00FF0FF0 : (BitVec 32)))
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/extern_bitvec.sail
+++ b/test/lean/extern_bitvec.sail
@@ -22,3 +22,11 @@ function extern_vector_length(x : vector(3, int)) -> int = {
   return length(x)
 }
 
+function extern_count_leading_zeros() -> int = {
+  return count_leading_zeros(0x00FF0FF0)
+}
+
+function extern_count_trailing_zeros() -> int = {
+  return count_trailing_zeros(0x00FF0FF0)
+}
+


### PR DESCRIPTION
Fixes a current error in the RISC-V output.