### PR TITLE
Fix interpreter to work with new interface

### DIFF
--- a/src/bin/repl.ml
+++ b/src/bin/repl.ml
@@ -267,9 +267,9 @@ let rec run istate =
       | Break frame ->
           print_endline "Breakpoint";
           { istate with mode = Evaluation frame }
-      | Effect_request (_, state, _, eff) ->
+      | Effect_request (out, state, stack, eff) ->
           let istate =
-            try { istate with mode = Evaluation (!Interpreter.effect_interp state eff) }
+            try { istate with mode = Evaluation (!Interpreter.effect_interp out state stack eff) }
             with Failure str ->
               print_endline str;
               { istate with mode = Normal }
@@ -304,9 +304,9 @@ let rec run_function istate depth =
       | Break frame ->
           print_endline "Breakpoint";
           { istate with mode = Evaluation frame }
-      | Effect_request (_, state, stack, eff) ->
+      | Effect_request (out, state, stack, eff) ->
           let istate =
-            try { istate with mode = Evaluation (!Interpreter.effect_interp state eff) }
+            try { istate with mode = Evaluation (!Interpreter.effect_interp out state stack eff) }
             with Failure str ->
               print_endline str;
               { istate with mode = Normal }
@@ -337,9 +337,9 @@ let rec run_steps istate n =
       | Break frame ->
           print_endline "Breakpoint";
           { istate with mode = Evaluation frame }
-      | Effect_request (_, state, _, eff) ->
+      | Effect_request (out, state, stack, eff) ->
           let istate =
-            try { istate with mode = Evaluation (!Interpreter.effect_interp state eff) }
+            try { istate with mode = Evaluation (!Interpreter.effect_interp out state stack eff) }
             with Failure str ->
               print_endline str;
               { istate with mode = Normal }
@@ -679,7 +679,9 @@ let handle_input' istate input =
                us in evaluation mode. *)
           let exp = Type_check.infer_exp istate.env (Initial_check.exp_of_string ~inline:pos str) in
           let istate = setup_interpreter_state istate in
-          let istate = { istate with mode = Evaluation (eval_frame (Step (lazy "", istate.state, return exp, []))) } in
+          let istate =
+            { istate with mode = Evaluation (eval_frame (Step (lazy "", istate.state, Monad.return exp, []))) }
+          in
           print_program istate;
           istate
       | Empty -> istate
@@ -725,9 +727,11 @@ let handle_input' istate input =
           | Break frame ->
               print_endline "Breakpoint";
               { istate with mode = Evaluation frame }
-          | Effect_request (_, state, _, eff) -> begin
+          | Effect_request (out, state, stack, eff) -> begin
               try
-                let istate = { istate with mode = Evaluation (!Interpreter.effect_interp state eff); state } in
+                let istate =
+                  { istate with mode = Evaluation (!Interpreter.effect_interp out state stack eff); state }
+                in
                 print_program istate;
                 istate
               with Failure str ->

--- a/src/lib/constant_fold.ml
+++ b/src/lib/constant_fold.ml
@@ -181,7 +181,7 @@ let no_fixed = { registers = Bindings.empty; fields = Bindings.empty }
 
 let rw_exp fixed target ok not_ok istate =
   let evaluate e_aux annot =
-    let initial_monad = Interpreter.return (E_aux (e_aux, annot)) in
+    let initial_monad = Interpreter.Monad.return (E_aux (e_aux, annot)) in
     try
       begin
         let v = run (Interpreter.Step (lazy "", istate, initial_monad, [])) in

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -62,7 +62,6 @@ type gstate = {
   primops : (value list -> value) StringMap.t;
   letbinds : Type_check.tannot letbind list;
   fundefs : Type_check.tannot fundef Bindings.t;
-  last_write_ea : (value * value * value) option;
   typecheck_env : Type_check.Env.t;
 }
 
@@ -122,109 +121,90 @@ let fallthrough =
 
 type return_value = Return_ok of value | Return_exception of value
 
-(* when changing effect arms remember to also update effect_request type below *)
-type 'a response =
-  | Early_return of value
-  | Exception of value
-  | Assertion_failed of string
-  | Call of id * value list * (return_value -> 'a)
-  | Fail of string
-  | Read_mem of (* read_kind : *) value * (* address : *) value * (* length : *) value * (value -> 'a)
-  | Write_ea of (* write_kind : *) value * (* address : *) value * (* length : *) value * (unit -> 'a)
-  | Excl_res of (bool -> 'a)
-  | Write_mem of
-      (* write_kind : *) value * (* address : *) value * (* length : *) value * (* value : *) value * (bool -> 'a)
-  | Barrier of (* barrier_kind : *) value * (unit -> 'a)
-  | Read_reg of string * (value -> 'a)
-  | Write_reg of string * value * (unit -> 'a)
-  | Get_primop of string * ((value list -> value) -> 'a)
-  | Get_local of string * (value -> 'a)
-  | Put_local of string * value * (unit -> 'a)
-  | Get_global_letbinds of (Type_check.tannot letbind list -> 'a)
+module Monad = struct
+  (* when changing effect arms remember to also update effect_request type below *)
+  type 'a response =
+    | Early_return of value
+    | Exception of value
+    | Assertion_failed of string
+    | Call of id * value list * (return_value -> 'a)
+    | Fail of string
+    | Read_reg of string * (value -> 'a)
+    | Write_reg of string * value * (unit -> 'a)
+    | Get_primop of string * ((value list -> value) -> 'a)
+    | Get_local of string * (value -> 'a)
+    | Put_local of string * value * (unit -> 'a)
+    | Get_global_letbinds of (Type_check.tannot letbind list -> 'a)
 
-and 'a monad = Pure of 'a | Yield of 'a monad response
+  and 'a t = Pure of 'a | Yield of 'a t response
 
-let map_response f = function
-  | Early_return v -> Early_return v
-  | Exception v -> Exception v
-  | Assertion_failed str -> Assertion_failed str
-  | Call (id, vals, cont) -> Call (id, vals, fun v -> f (cont v))
-  | Fail s -> Fail s
-  | Read_mem (rk, addr, len, cont) -> Read_mem (rk, addr, len, fun v -> f (cont v))
-  | Write_ea (wk, addr, len, cont) -> Write_ea (wk, addr, len, fun () -> f (cont ()))
-  | Excl_res cont -> Excl_res (fun b -> f (cont b))
-  | Write_mem (wk, addr, len, v, cont) -> Write_mem (wk, addr, len, v, fun b -> f (cont b))
-  | Barrier (bk, cont) -> Barrier (bk, fun () -> f (cont ()))
-  | Read_reg (name, cont) -> Read_reg (name, fun v -> f (cont v))
-  | Write_reg (name, v, cont) -> Write_reg (name, v, fun () -> f (cont ()))
-  | Get_primop (name, cont) -> Get_primop (name, fun op -> f (cont op))
-  | Get_local (name, cont) -> Get_local (name, fun v -> f (cont v))
-  | Put_local (name, v, cont) -> Put_local (name, v, fun () -> f (cont ()))
-  | Get_global_letbinds cont -> Get_global_letbinds (fun lbs -> f (cont lbs))
+  let map_response f = function
+    | Early_return v -> Early_return v
+    | Exception v -> Exception v
+    | Assertion_failed str -> Assertion_failed str
+    | Call (id, vals, cont) -> Call (id, vals, fun v -> f (cont v))
+    | Fail s -> Fail s
+    | Read_reg (name, cont) -> Read_reg (name, fun v -> f (cont v))
+    | Write_reg (name, v, cont) -> Write_reg (name, v, fun () -> f (cont ()))
+    | Get_primop (name, cont) -> Get_primop (name, fun op -> f (cont op))
+    | Get_local (name, cont) -> Get_local (name, fun v -> f (cont v))
+    | Put_local (name, v, cont) -> Put_local (name, v, fun () -> f (cont ()))
+    | Get_global_letbinds cont -> Get_global_letbinds (fun lbs -> f (cont lbs))
 
-let rec liftM f = function Pure x -> Pure (f x) | Yield g -> Yield (map_response (liftM f) g)
+  let rec liftM f = function Pure x -> Pure (f x) | Yield g -> Yield (map_response (liftM f) g)
 
-let return x = Pure x
+  let ( let+ ) = liftM
 
-let rec bind m f = match m with Pure x -> f x | Yield m -> Yield (map_response (fun m -> bind m f) m)
+  let return x = Pure x
 
-let ( >>= ) m f = bind m f
+  let rec bind m f = match m with Pure x -> f x | Yield m -> Yield (map_response (fun m -> bind m f) m)
 
-let ( >> ) m1 m2 = bind m1 (function () -> m2)
+  let ( >>= ) m f = bind m f
 
-type ('a, 'b) either = Left of 'a | Right of 'b
+  let ( let* ) = bind
 
-(* Support for interpreting exceptions *)
+  let ( >> ) m1 m2 = bind m1 (function () -> m2)
 
-let catch m =
-  match m with
-  | Pure x -> Pure (Right x)
-  | Yield (Exception v) -> Pure (Left v)
-  | Yield resp -> Yield (map_response (fun m -> liftM (fun r -> Right r) m) resp)
+  (* Support for interpreting exceptions *)
 
-let throw v = Yield (Exception v)
+  let catch m =
+    match m with
+    | Pure x -> Pure (Ok x)
+    | Yield (Exception v) -> Pure (Error v)
+    | Yield resp -> Yield (map_response (fun m -> liftM (fun r -> Ok r) m) resp)
 
-let call (f : id) (args : value list) : return_value monad = Yield (Call (f, args, fun v -> Pure v))
+  let throw v = Yield (Exception v)
 
-let read_mem rk addr len : value monad = Yield (Read_mem (rk, addr, len, fun v -> Pure v))
+  let call f args = Yield (Call (f, args, fun v -> Pure v))
 
-let write_ea wk addr len : unit monad = Yield (Write_ea (wk, addr, len, fun () -> Pure ()))
+  let read_reg name = Yield (Read_reg (name, fun v -> Pure v))
 
-let excl_res () : bool monad = Yield (Excl_res (fun b -> Pure b))
+  let write_reg name v = Yield (Write_reg (name, v, fun () -> Pure ()))
 
-let write_mem wk addr len v : bool monad = Yield (Write_mem (wk, addr, len, v, fun b -> Pure b))
+  let fail s = Yield (Fail s)
 
-let barrier bk : unit monad = Yield (Barrier (bk, fun () -> Pure ()))
+  let get_primop name = Yield (Get_primop (name, fun op -> Pure op))
 
-let read_reg name : value monad = Yield (Read_reg (name, fun v -> Pure v))
+  let get_local name = Yield (Get_local (name, fun v -> Pure v))
 
-let write_reg name v : unit monad = Yield (Write_reg (name, v, fun () -> Pure ()))
+  let put_local name v = Yield (Put_local (name, v, fun () -> Pure ()))
 
-let fail s = Yield (Fail s)
+  let get_global_letbinds () = Yield (Get_global_letbinds (fun lbs -> Pure lbs))
 
-let get_primop name : (value list -> value) monad = Yield (Get_primop (name, fun op -> Pure op))
+  let early_return v = Yield (Early_return v)
 
-let get_local name : value monad = Yield (Get_local (name, fun v -> Pure v))
+  let assertion_failed msg = Yield (Assertion_failed msg)
 
-let put_local name v : unit monad = Yield (Put_local (name, v, fun () -> Pure ()))
+  let expect_ok ~error = function Ok v -> Pure v | Error e -> Yield (Fail (error e))
 
-let get_global_letbinds () : Type_check.tannot letbind list monad = Yield (Get_global_letbinds (fun lbs -> Pure lbs))
+  let expect_some ~none = function Some v -> Pure v | None -> Yield (Fail none)
+end
 
-let early_return v = Yield (Early_return v)
-
-let assertion_failed msg = Yield (Assertion_failed msg)
-
-let liftM2 f m1 m2 =
-  m1 >>= fun x ->
-  m2 >>= fun y -> return (f x y)
+open Monad
 
 let letbind_pat_ids (LB_aux (LB_val (pat, _), _)) = pat_ids pat
 
 let subst id value exp = Ast_util.subst id (exp_of_value value) exp
-
-let local_variable id lstate gstate =
-  try Bindings.find id lstate.locals |> exp_of_value
-  with Not_found -> failwith ("Could not find local variable " ^ string_of_id id)
 
 (**************************************************************************)
 (* 2. Expression Evaluation                                               *)
@@ -280,6 +260,31 @@ let complete_bindings =
           (value_zeros [V_int len]) ((v1, n1, m1) :: partial_values)
     | Partial_binding [] -> Reporting.unreachable Parse_ast.Unknown __POS__ "Empty partial binding set"
     )
+
+let rec split_list_exact acc ns xs =
+  match (ns, xs) with
+  | [], [] -> Some []
+  | [], _ -> None
+  | n :: ns, _ when Big_int.equal n Big_int.zero -> (
+      match split_list_exact [] ns xs with Some split -> Some (List.rev acc :: split) | None -> None
+    )
+  | n :: ns, x :: xs -> split_list_exact (x :: acc) (Big_int.pred n :: ns) xs
+  | _, [] -> None
+
+let lexp_vector_concat_widths env lexps =
+  let open Type_check in
+  let get_length lexp =
+    let l = lexp_loc lexp in
+    let typ = typ_of_lexp lexp in
+    match destruct_vector env typ with
+    | Some (nexp, _) -> Option.to_result ~none:l (solve_unique env nexp)
+    | None -> (
+        match destruct_bitvector env typ with
+        | Some nexp -> Option.to_result ~none:l (solve_unique env nexp)
+        | None -> Error l
+      )
+  in
+  Util.result_all (List.map get_length lexps)
 
 let rec step (E_aux (e_aux, annot) as orig_exp) =
   let wrap e_aux' = return (E_aux (e_aux', annot)) in
@@ -340,62 +345,30 @@ let rec step (E_aux (e_aux, annot) as orig_exp) =
       (* FIXME: Currently not general enough *)
       wrap (E_app (mk_id "vector_update_subrange_dec", [vec; n; m; x]))
   (* otherwise left-to-right evaluation order for function applications *)
-  | E_app (id, exps) ->
+  | E_app (id, exps) -> (
+      let open Type_check in
       let evaluated, unevaluated = Util.take_drop is_value exps in
-      begin
-        let open Type_check in
-        match unevaluated with
-        | exp :: exps -> step exp >>= fun exp' -> wrap (E_app (id, evaluated @ (exp' :: exps)))
-        | [] when Env.is_union_constructor id (env_of_annot annot) ->
-            return (exp_of_value (V_ctor (string_of_id id, List.map value_of_exp evaluated)))
-        | [] when is_interpreter_extern id (env_of_annot annot) -> begin
-            let extern = get_interpreter_extern id (env_of_annot annot) in
-            match extern with
-            | "reg_deref" ->
-                let regname = List.hd evaluated |> value_of_exp |> coerce_ref in
-                read_reg regname >>= fun v -> return (exp_of_value v)
-            | "read_mem" -> begin
-                match evaluated with
-                | [rk; addrsize; addr; len] ->
-                    read_mem (value_of_exp rk) (value_of_exp addr) (value_of_exp len) >>= fun v ->
-                    return (exp_of_value v)
-                | _ -> fail "Wrong number of parameters to read_mem intrinsic"
-              end
-            | "write_mem_ea" -> begin
-                match evaluated with
-                | [wk; addrsize; addr; len] ->
-                    write_ea (value_of_exp wk) (value_of_exp addr) (value_of_exp len) >> wrap unit_exp
-                | _ -> fail "Wrong number of parameters to write_ea intrinsic"
-              end
-            | "excl_res" -> begin
-                match evaluated with
-                | [_] -> excl_res () >>= fun b -> return (exp_of_value (V_bool b))
-                | _ -> fail "Wrong number of parameters to excl_res intrinsic"
-              end
-            | "write_mem" -> begin
-                match evaluated with
-                | [wk; addrsize; addr; len; v] ->
-                    write_mem (value_of_exp wk) (value_of_exp addr) (value_of_exp len) (value_of_exp v) >>= fun b ->
-                    return (exp_of_value (V_bool b))
-                | _ -> fail "Wrong number of parameters to write_memv intrinsic"
-              end
-            | "barrier" -> begin
-                match evaluated with
-                | [bk] -> barrier (value_of_exp bk) >> wrap unit_exp
-                | _ -> fail "Wrong number of parameters to barrier intrinsic"
-              end
-            | _ -> (
-                get_primop extern >>= fun op ->
-                try return (exp_of_value (op (List.map value_of_exp evaluated)))
-                with _ as exc -> fail ("Exception calling primop '" ^ extern ^ "': " ^ Printexc.to_string exc)
-              )
-          end
-        | [] -> (
-            call id (List.map value_of_exp evaluated) >>= function
-            | Return_ok v -> return (exp_of_value v)
-            | Return_exception v -> wrap (E_throw (exp_of_value v))
+      match unevaluated with
+      | exp :: exps -> step exp >>= fun exp' -> wrap (E_app (id, evaluated @ (exp' :: exps)))
+      | [] when Env.is_union_constructor id (env_of_annot annot) ->
+          return (exp_of_value (V_ctor (string_of_id id, List.map value_of_exp evaluated)))
+      | [] when is_interpreter_extern id (env_of_annot annot) -> (
+          let extern = get_interpreter_extern id (env_of_annot annot) in
+          if extern = "reg_deref" then (
+            let regname = List.hd evaluated |> value_of_exp |> coerce_ref in
+            read_reg regname >>= fun v -> return (exp_of_value v)
           )
-      end
+          else
+            get_primop extern >>= fun op ->
+            try return (exp_of_value (op (List.map value_of_exp evaluated)))
+            with _ as exc -> fail ("Exception calling primop '" ^ extern ^ "': " ^ Printexc.to_string exc)
+        )
+      | [] -> (
+          call id (List.map value_of_exp evaluated) >>= function
+          | Return_ok v -> return (exp_of_value v)
+          | Return_exception v -> wrap (E_throw (exp_of_value v))
+        )
+    )
   | E_app_infix (x, id, y) when is_value x && is_value y -> (
       call id [value_of_exp x; value_of_exp y] >>= function
       | Return_ok v -> return (exp_of_value v)
@@ -532,19 +505,41 @@ let rec step (E_aux (e_aux, annot) as orig_exp) =
   | E_assign (LE_aux (LE_deref reference, annot), exp) ->
       let name = coerce_ref (value_of_exp reference) in
       write_reg name (value_of_exp exp) >> wrap unit_exp
-  | E_assign (LE_aux (LE_tuple lexps, annot), exp) -> fail "Tuple assignment"
+  | E_assign (LE_aux (LE_tuple lexps, annot), exp) ->
+      if is_value exp then (
+        match value_of_exp exp with
+        | V_tuple vs when List.compare_lengths lexps vs = 0 ->
+            E_block (List.map2 (fun lexp v -> E_aux (E_assign (lexp, exp_of_value v), annot)) lexps vs) |> wrap
+        | _ -> fail "Type error in tuple assignment"
+      )
+      else
+        let* exp' = step exp in
+        wrap (E_assign (LE_aux (LE_tuple lexps, annot), exp'))
   | E_assign (LE_aux (LE_vector_concat lexps, annot), exp) ->
-      fail "Vector concat assignment"
-      (*
-     let values = coerce_tuple (value_of_exp exp) in
-     wrap (E_block (List.map2 (fun lexp v -> E_aux (E_assign (lexp, exp_of_value v), (Parse_ast.Unknown, None))) lexps values))
-      *)
+      let env = Type_check.env_of_annot annot in
+      if is_value exp then (
+        let* widths =
+          expect_ok (lexp_vector_concat_widths env lexps) ~error:(fun _ ->
+              "Non-constant width in vector concatenation assignment"
+          )
+        in
+        let vs = coerce_gv (value_of_exp exp) in
+        let* split =
+          expect_some (split_list_exact [] widths vs) ~none:"Type error in vector concatenation assignment"
+        in
+        assert (List.compare_lengths lexps split = 0);
+        E_block (List.map2 (fun lexp vs -> E_aux (E_assign (lexp, exp_of_value (V_vector vs)), annot)) lexps split)
+        |> wrap
+      )
+      else
+        let* exp' = step exp in
+        wrap (E_assign (LE_aux (LE_vector_concat lexps, annot), exp'))
   | E_try (exp, pexps) when is_value exp -> return exp
   | E_try (exp, pexps) -> begin
       catch (step exp) >>= fun exp' ->
       match exp' with
-      | Left exn -> wrap (E_match (exp_of_value exn, pexps @ [fallthrough]))
-      | Right exp' -> wrap (E_try (exp', pexps))
+      | Error exn -> wrap (E_match (exp_of_value exn, pexps @ [fallthrough]))
+      | Ok exp' -> wrap (E_try (exp', pexps))
     end
   | E_for (id, exp_from, exp_to, exp_step, ord, body) when is_value exp_from && is_value exp_to && is_value exp_step ->
       let v_from = value_of_exp exp_from in
@@ -735,35 +730,25 @@ type frame =
   | Step of
       string Lazy.t
       * state
-      * Type_check.tannot exp monad
-      * (string Lazy.t * lstate * (return_value -> Type_check.tannot exp monad)) list
+      * Type_check.tannot exp Monad.t
+      * (string Lazy.t * lstate * (return_value -> Type_check.tannot exp Monad.t)) list
   | Break of frame
   | Effect_request of
       string Lazy.t
       * state
-      * (string Lazy.t * lstate * (return_value -> Type_check.tannot exp monad)) list
+      * (string Lazy.t * lstate * (return_value -> Type_check.tannot exp Monad.t)) list
       * effect_request
   | Fail of
       string Lazy.t
       * state
-      * Type_check.tannot exp monad
-      * (string Lazy.t * lstate * (return_value -> Type_check.tannot exp monad)) list
+      * Type_check.tannot exp Monad.t
+      * (string Lazy.t * lstate * (return_value -> Type_check.tannot exp Monad.t)) list
       * string
 
-(* when changing effect_request remember to also update response type above *)
 and effect_request =
-  | Read_mem of (* read_kind : *) value * (* address : *) value * (* length : *) value * (value -> state -> frame)
-  | Write_ea of (* write_kind : *) value * (* address : *) value * (* length : *) value * (unit -> state -> frame)
-  | Excl_res of (bool -> state -> frame)
-  | Write_mem of
-      (* write_kind : *) value
-      * (* address : *) value
-      * (* length : *) value
-      * (* value : *) value
-      * (bool -> state -> frame)
-  | Barrier of (* barrier_kind : *) value * (unit -> state -> frame)
   | Read_reg of string * (value -> state -> frame)
   | Write_reg of string * value * (unit -> state -> frame)
+  | Outcome of id * value list * (return_value -> Type_check.tannot exp Monad.t)
 
 let rec eval_frame' = function
   | Done (state, v) -> Done (state, v)
@@ -785,6 +770,9 @@ let rec eval_frame' = function
             let body = exp_of_fundef (Bindings.find id gstate.fundefs) arg in
             Break (Step (lazy "", (initial_lstate, gstate), return body, (out, lstate, cont) :: stack))
           with Not_found -> Step (out, state, fail ("Fundef not found: " ^ string_of_id id), stack)
+        end
+      | Yield (Call (id, vals, cont)), _ when Type_check.Env.is_outcome id gstate.typecheck_env -> begin
+          Effect_request (out, state, stack, Outcome (id, vals, cont))
         end
       | Yield (Call (id, vals, cont)), _ -> begin
           let arg = if List.length vals != 1 then tuple_value vals else List.hd vals in
@@ -814,32 +802,6 @@ let rec eval_frame' = function
           let state' = ({ locals = Bindings.add (mk_id name) v lstate.locals }, gstate) in
           eval_frame' (Step (out, state', cont (), stack))
       | Yield (Get_global_letbinds cont), _ -> eval_frame' (Step (out, state, cont gstate.letbinds, stack))
-      | Yield (Read_mem (rk, addr, len, cont)), _ ->
-          Effect_request
-            ( out,
-              state,
-              stack,
-              Read_mem (rk, addr, len, fun result state' -> eval_frame' (Step (out, state', cont result, stack)))
-            )
-      | Yield (Write_ea (wk, addr, len, cont)), _ ->
-          Effect_request
-            ( out,
-              state,
-              stack,
-              Write_ea (wk, addr, len, fun () state' -> eval_frame' (Step (out, state', cont (), stack)))
-            )
-      | Yield (Excl_res cont), _ ->
-          Effect_request (out, state, stack, Excl_res (fun b state' -> eval_frame' (Step (out, state', cont b, stack))))
-      | Yield (Write_mem (wk, addr, len, v, cont)), _ ->
-          Effect_request
-            ( out,
-              state,
-              stack,
-              Write_mem (wk, addr, len, v, fun b state' -> eval_frame' (Step (out, state', cont b, stack)))
-            )
-      | Yield (Barrier (bk, cont)), _ ->
-          Effect_request
-            (out, state, stack, Barrier (bk, fun () state' -> eval_frame' (Step (out, state', cont (), stack))))
       | Yield (Early_return v), [] -> Done (state, v)
       | Yield (Early_return v), head :: stack' ->
           Step (stack_string head, (stack_state head, gstate), stack_cont head (Return_ok v), stack')
@@ -852,40 +814,9 @@ let rec eval_frame' = function
 let eval_frame frame =
   try eval_frame' frame with Type_error.Type_error (l, err) -> raise (Type_error.to_reporting_exn l err)
 
-let default_effect_interp state eff =
+let default_effect_interp out state stack eff =
   let lstate, gstate = state in
   match eff with
-  | Read_mem (rk, addr, len, cont) ->
-      (* all read-kinds treated the same in single-threaded interpreter *)
-      let addr' = coerce_bv addr in
-      let len' = coerce_int len in
-      let result = mk_vector (Sail_lib.read_ram (List.length addr', len', [], addr')) in
-      cont result state
-  | Write_ea (wk, addr, len, cont) ->
-      (* just store the values for the next Write_memv *)
-      let state' = (lstate, { gstate with last_write_ea = Some (wk, addr, len) }) in
-      cont () state'
-  | Excl_res cont ->
-      (* always succeeds in single-threaded interpreter *)
-      cont true state
-  | Write_mem (wk, addr, len, v, cont) -> begin
-      match gstate.last_write_ea with
-      | Some (wk', addr', len') ->
-          let state' = (lstate, { gstate with last_write_ea = None }) in
-          (* all write-kinds treated the same in single-threaded interpreter *)
-          let addr' = coerce_bv addr in
-          let len' = coerce_int len in
-          let v' = coerce_bv v in
-          if Big_int.mul len' (Big_int.of_int 8) = Big_int.of_int (List.length v') then (
-            let b = Sail_lib.write_ram (List.length addr', len', [], addr', v') in
-            cont b state'
-          )
-          else failwith "Write_memv with length mismatch to preceding Write_ea"
-      | None -> failwith "Write_memv without preceding Write_ea"
-    end
-  | Barrier (bk, cont) ->
-      (* no-op in single-threaded interpreter *)
-      cont () state
   | Read_reg (name, cont) ->
       if gstate.allow_registers then (
         try cont (Bindings.find (mk_id name) gstate.registers) state
@@ -901,10 +832,16 @@ let default_effect_interp state eff =
         )
         else failwith ("Write of nonexistent register: " ^ name)
       else failwith ("Register write disallowed by allow_registers setting: " ^ name)
+  | Outcome (id, vals, cont) -> (
+      let arg = if List.length vals != 1 then tuple_value vals else List.hd vals in
+      match Bindings.find_opt id gstate.fundefs with
+      | Some fundef ->
+          let body = exp_of_fundef fundef arg in
+          Step (lazy "", (initial_lstate, gstate), return body, (out, lstate, cont) :: stack)
+      | None -> failwith ("Outcome implementation not found: " ^ string_of_id id)
+    )
 
 let effect_interp = ref default_effect_interp
-
-let set_effect_interp interp = effect_interp := interp
 
 let rec run_frame frame =
   match frame with
@@ -912,7 +849,7 @@ let rec run_frame frame =
   | Fail (_, _, _, _, msg) -> failwith ("run_frame got Fail: " ^ msg)
   | Step (_, _, _, _) -> run_frame (eval_frame frame)
   | Break frame -> run_frame (eval_frame frame)
-  | Effect_request (_, state, _, eff) -> run_frame (!effect_interp state eff)
+  | Effect_request (out, state, stack, eff) -> run_frame (!effect_interp out state stack eff)
 
 let eval_exp state exp = run_frame (Step (lazy "", state, return exp, []))
 
@@ -923,7 +860,6 @@ let initial_gstate primops defs env =
     primops;
     letbinds = defs_letbinds defs;
     fundefs = Bindings.empty;
-    last_write_ea = None;
     typecheck_env = env;
   }
 
@@ -954,45 +890,3 @@ let initial_state ?(registers = true) ?(undef_registers = true) ast env primops 
   let gstate = List.fold_left add_function gstate ast.defs in
   let gstate = { (initialize_registers registers undef_registers gstate ast.defs) with allow_registers = registers } in
   (initial_lstate, gstate)
-
-type value_result = Value_success of value | Value_error of exn
-
-let decode_instruction state bv =
-  try
-    let env = (snd state).typecheck_env in
-    let untyped = mk_exp (E_app (mk_id "decode", [mk_exp (E_vector (List.map mk_lit_exp bv))])) in
-    let typed =
-      Type_check.check_exp env untyped
-        (app_typ (mk_id "option") [A_aux (A_typ (mk_typ (Typ_id (mk_id "ast"))), Parse_ast.Unknown)])
-    in
-    let evaled = eval_exp state typed in
-    match evaled with
-    | V_ctor ("Some", [v]) -> Value_success v
-    | V_ctor ("None", _) -> failwith "decode returned None"
-    | _ -> failwith "decode returned wrong value type"
-  with _ as exn -> Value_error exn
-
-let annot_exp_effect e_aux l env typ = E_aux (e_aux, (l, Type_check.mk_tannot env typ))
-let annot_exp e_aux l env typ = annot_exp_effect e_aux l env typ
-let id_typ id = mk_typ (Typ_id (mk_id id))
-
-let analyse_instruction state ast =
-  let env = (snd state).typecheck_env in
-  let unk = Parse_ast.Unknown in
-  let typed =
-    annot_exp
-      (E_app (mk_id "initial_analysis", [annot_exp (E_internal_value ast) unk env (id_typ "ast")]))
-      unk env
-      (tuple_typ
-         [id_typ "regfps"; id_typ "regfps"; id_typ "regfps"; id_typ "niafps"; id_typ "diafp"; id_typ "instruction_kind"]
-      )
-  in
-  Step (lazy (Document.to_string (Printer.doc_exp (Type_check.strip_exp typed))), state, return typed, [])
-
-let execute_instruction state ast =
-  let env = (snd state).typecheck_env in
-  let unk = Parse_ast.Unknown in
-  let typed =
-    annot_exp (E_app (mk_id "execute", [annot_exp (E_internal_value ast) unk env (id_typ "ast")])) unk env unit_typ
-  in
-  Step (lazy (Document.to_string (Printer.doc_exp (Type_check.strip_exp typed))), state, return typed, [])

--- a/src/lib/interpreter.mli
+++ b/src/lib/interpreter.mli
@@ -1,0 +1,126 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Ast
+open Ast_util
+open Ast_defs
+open Type_check
+open Value
+
+type gstate = {
+  registers : value Bindings.t;
+  allow_registers : bool; (* For some uses we want to forbid touching any registers. *)
+  primops : (value list -> value) StringMap.t;
+  letbinds : tannot letbind list;
+  fundefs : tannot fundef Bindings.t;
+  typecheck_env : Env.t;
+}
+
+type lstate = { locals : value Bindings.t }
+
+type state = lstate * gstate
+
+type return_value = Return_ok of value | Return_exception of value
+
+module Monad : sig
+  type 'a t
+
+  val return : 'a -> 'a t
+
+  val ( let+ ) : ('a -> 'b) -> 'a t -> 'b t
+
+  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+
+  val ( >> ) : unit t -> 'a t -> 'a t
+
+  val catch : 'a t -> ('a, value) Result.t t
+  val throw : value -> 'a t
+
+  val call : id -> value list -> return_value t
+end
+
+type frame =
+  | Done of state * value
+  | Step of
+      string Lazy.t * state * tannot exp Monad.t * (string Lazy.t * lstate * (return_value -> tannot exp Monad.t)) list
+  | Break of frame
+  | Effect_request of
+      string Lazy.t * state * (string Lazy.t * lstate * (return_value -> tannot exp Monad.t)) list * effect_request
+  | Fail of
+      string Lazy.t
+      * state
+      * tannot exp Monad.t
+      * (string Lazy.t * lstate * (return_value -> tannot exp Monad.t)) list
+      * string
+
+and effect_request =
+  | Read_reg of string * (value -> state -> frame)
+  | Write_reg of string * value * (unit -> state -> frame)
+  | Outcome of id * value list * (return_value -> tannot exp Monad.t)
+
+val stack_string : string Lazy.t * lstate * (return_value -> tannot exp Monad.t) -> string Lazy.t
+
+val eval_frame : frame -> frame
+
+val default_effect_interp :
+  string Lazy.t ->
+  state ->
+  (string Lazy.t * lstate * (return_value -> tannot exp Monad.t)) list ->
+  effect_request ->
+  frame
+
+val effect_interp :
+  (string Lazy.t ->
+  state ->
+  (string Lazy.t * lstate * (return_value -> tannot exp Monad.t)) list ->
+  effect_request ->
+  frame
+  )
+  ref
+
+val initial_state :
+  ?registers:bool -> ?undef_registers:bool -> typed_ast -> env -> (value list -> value) StringMap.t -> state

--- a/src/lib/smt_exp.ml
+++ b/src/lib/smt_exp.ml
@@ -1194,7 +1194,7 @@ module Counterexample (Config : COUNTEREXAMPLE_CONFIG) = struct
     | Interpreter.Step (lazy_str, _, _, _) -> run (Interpreter.eval_frame frame)
     | Interpreter.Break frame -> run (Interpreter.eval_frame frame)
     | Interpreter.Fail (_, _, _, _, msg) -> Result.Error msg
-    | Interpreter.Effect_request (out, state, stack, eff) -> run (Interpreter.default_effect_interp state eff)
+    | Interpreter.Effect_request (out, state, stack, eff) -> run (Interpreter.default_effect_interp out state stack eff)
 
   let check ~loc ~ctx ~env ~ast ~solver ~file_name ~function_id ~args ~arg_ctyps ~arg_smt_names =
     let open Printf in
@@ -1233,7 +1233,7 @@ module Counterexample (Config : COUNTEREXAMPLE_CONFIG) = struct
                 annot
               )
           in
-          let result = run (Step (lazy "", istate, return call, [])) in
+          let result = run (Step (lazy "", istate, Monad.return call, [])) in
           begin
             match result with
             | Result.Ok (V_bool false) | Result.Ok V_unit ->

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1452,6 +1452,10 @@ let typ_of_pat (P_aux (_, (l, tannot))) = typ_of_annot (l, tannot)
 
 let env_of_pat (P_aux (_, (l, tannot))) = env_of_annot (l, tannot)
 
+let typ_of_lexp (LE_aux (_, (l, tannot))) = typ_of_annot (l, tannot)
+
+let env_of_lexp (LE_aux (_, (l, tannot))) = env_of_annot (l, tannot)
+
 let typ_of_pexp (Pat_aux (_, (l, tannot))) = typ_of_annot (l, tannot)
 
 let env_of_pexp (Pat_aux (_, (l, tannot))) = env_of_annot (l, tannot)

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -181,6 +181,8 @@ module Env : sig
 
   val get_toplevel_lets : t -> IdSet.t
 
+  val is_outcome : id -> t -> bool
+
   val get_outcome_instantiation : t -> (Ast.l * typ_arg) KBindings.t
 
   (** Check if id is a constructor, then if it is return a (n, m, id, type_union) triple where the values represent its
@@ -387,6 +389,9 @@ val env_of_pat : tannot pat -> Env.t
 
 val typ_of_pexp : tannot pexp -> typ
 val env_of_pexp : tannot pexp -> Env.t
+
+val typ_of_lexp : tannot lexp -> typ
+val env_of_lexp : tannot lexp -> Env.t
 
 val typ_of_mpat : tannot mpat -> typ
 val env_of_mpat : tannot mpat -> Env.t

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1250,6 +1250,8 @@ and add_mapping id (typq, typ1, typ2) env =
   |> add_val_spec ~ignore_duplicate:true forwards_matches_id (typq, forwards_matches_typ)
   |> add_val_spec ~ignore_duplicate:true backwards_matches_id (typq, backwards_matches_typ)
 
+let is_outcome id env = Bindings.mem id env.global.outcomes
+
 let get_outcome_instantiation env = env.global.outcome_instantiation
 
 let add_outcome_variable l kid arg env =

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -105,6 +105,7 @@ val get_val_spec : id -> t -> typquant * typ
 val get_val_specs : t -> (typquant * typ) Bindings.t
 val get_val_spec_orig : id -> t -> typquant * typ
 
+val is_outcome : id -> t -> bool
 val add_outcome : id -> typquant * typ * kinded_id list * id list * t -> t -> t
 val get_outcome : l -> id -> t -> typquant * typ * kinded_id list * id list * t
 val get_outcome_instantiation : t -> (Ast.l * typ_arg) KBindings.t

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -237,6 +237,13 @@ let rec option_all = function
   | None :: _ -> None
   | Some x :: xs -> begin match option_all xs with None -> None | Some xs -> Some (x :: xs) end
 
+let rec result_all = function
+  | [] -> Ok []
+  | Error e :: _ -> Error e
+  | Ok x :: xs -> (
+      match result_all xs with Error e -> Error e | Ok xs -> Ok (x :: xs)
+    )
+
 let rec map_all (f : 'a -> 'b option) (l : 'a list) : 'b list option =
   match l with
   | [] -> Some []

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -119,6 +119,8 @@ val option_these : 'a option list -> 'a list
     result is None is None. [option_all []] is [Some []] *)
 val option_all : 'a option list -> 'a list option
 
+val result_all : ('a, 'e) Result.t list -> ('a list, 'e) Result.t
+
 (** {2 List Functions} *)
 
 val list_empty : 'a list -> bool


### PR DESCRIPTION
Notably, effect_request type simplified to:
```
and effect_request =
  | Read_reg of string * (value -> state -> frame)
  | Write_reg of string * value * (unit -> state -> frame)
  | Outcome of id * value list * (return_value -> tannot exp Monad.t)
```