### PR TITLE
Fix error check in load_elf().

### DIFF
--- a/lib/elf.c
+++ b/lib/elf.c
@@ -439,7 +439,7 @@ void load_elf(char *filename, bool *is32bit_p, uint64_t *entry) {
         if (buffer == NULL) { goto fail; }
 
         int s = fread(buffer+read, 1, size - read, in);
-        if (s < 0) { goto fail; }
+        if (s < 0 || ferror(in)) { goto fail; }
         read += s;
     }
     fclose(in);


### PR DESCRIPTION
If load_elf is erroneously given the name of a directory as an input stream, fread returns 0 while feof indicates no error, resulting in an infinite loop.  Augmenting the error check with ferror fixes the problem.

Found thanks to a broken test script.