### PR TITLE
add Lean library functions for custom_flow test (issue 1122)

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -178,8 +178,6 @@ def toHexUpper (i : Int) : String :=
   | Int.ofNat n => Nat.toHexUpper n
   | Int.negSucc n => "-" ++ Nat.toHexUpper (n+1)
 
-def lteq (x y: Int) : Bool := decide (x <= y)
-
 end Int
 
 def get_slice_int (len n lo : Nat) : BitVec len :=

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -178,6 +178,8 @@ def toHexUpper (i : Int) : String :=
   | Int.ofNat n => Nat.toHexUpper n
   | Int.negSucc n => "-" ++ Nat.toHexUpper (n+1)
 
+def lteq (x y: Int) : Bool := decide (x <= y)
+
 end Int
 
 def get_slice_int (len n lo : Nat) : BitVec len :=

--- a/test/c/custom_flow.sail
+++ b/test/c/custom_flow.sail
@@ -3,7 +3,7 @@ val "print_endline" : string -> unit
 
 val operator <= = {
   coq: "Z.leb",
-  lean: "Int.lteq",
+  lean: "LE.le",
   _: "lteq"
 } : forall 'n 'm. (int('n), int('m)) -> bool('n <= 'm)
 

--- a/test/c/custom_flow.sail
+++ b/test/c/custom_flow.sail
@@ -3,6 +3,7 @@ val "print_endline" : string -> unit
 
 val operator <= = {
   coq: "Z.leb",
+  lean: "Int.lteq",
   _: "lteq"
 } : forall 'n 'm. (int('n), int('m)) -> bool('n <= 'm)
 
@@ -18,6 +19,7 @@ function test1 forall 'n 'm. (n: int('n), m: int('m)) -> unit = {
 
 val and_bool = {
   coq: "andb",
+  lean: "and",
   _: "and_bool"
 } : forall ('p: Bool) ('q: Bool). (bool('p), bool('q)) -> bool('p & 'q)
 

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -30,7 +30,6 @@ skip_selftests = {
     'inc_tests',
     'poly_outcome',
     'string_of_bits',
-    'custom_flow',
     'pointer_assign',
     'concurrency_interface',
     'for_shadow',


### PR DESCRIPTION
Adds the Lean library functions for and_bool and lteq to the custom_flow test (one of the failing tests on issue 1122).