### PR TITLE
Assertion reachability check should include incoming assert_reachable signal. fixes #1208

### DIFF
--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -1985,7 +1985,7 @@ module Make (Config : CONFIG) = struct
                 muxers;
               let* this_pathcond =
                 let* pi = mapM Smt.smt_cval (get_pi n) in
-                return (Smt_exp.simp SimpSet.empty (smt_conj pi))
+                return (Smt_exp.simp SimpSet.empty (smt_conj (Var (Name (mk_id "assert_reachable#", -1)) :: pi)))
               in
               let* block = svir_cfnode spec_info ctx this_pathcond cfnode in
               List.iter add_comb_statement block;


### PR DESCRIPTION
I believe this fixes issue #1208 

I tried it on the test case that I provided, and found that the generated code looks correct now, and sure enough there is no assertion failure when I run the code.

I have also generated the riscv code with this fix included, it generates without issue.

I have another change, which I would like to merge soon too, which generates properties that a formal tool can verify for all of these assertions. With that and the fix from this PR in place, I go from having most of the 5,124 properties failing, to only having 30 failures, which suggests this is an improvement. Those failures are likely related to things I've not wired up properly.

@Alasdair would you be able to have a look at this soon?
Thanks! :)