### PR TITLE
Exit with error if --smt-auto finds counterexamples.

### DIFF
--- a/src/lib/smt_exp.ml
+++ b/src/lib/smt_exp.ml
@@ -1074,7 +1074,7 @@ let string_of_smt_def def = Pretty_print_sail.Document.to_string (pp_smt_def def
 
 type counterexample_solver = Cvc5 | Cvc4 | Z3
 
-let counterexample_command = function Cvc5 -> "cvc5 --lang=smt2.6" | Cvc4 -> "cvc4 --lang=smt2.6" | Z3 -> "z3"
+let counterexample_command = function Cvc5 -> "cvc5 --lang=smt2.6" | Cvc4 -> "cvc4 --lang=smt2.6" | Z3 -> "z3 -model"
 
 let counterexample_solver_from_name name =
   match String.lowercase_ascii name with "cvc4" -> Some Cvc4 | "cvc5" -> Some Cvc5 | "z3" -> Some Z3 | _ -> None
@@ -1210,7 +1210,7 @@ module Counterexample (Config : COUNTEREXAMPLE_CONFIG) = struct
       with End_of_file -> ()
     end;
     let solver_output = List.rev !lines |> String.concat "\n" in
-    begin
+    let unsat =
       match parse_sexps solver_output with
       | Some (Atom "sat" :: (List (Atom "model" :: model) | List model) :: _) ->
           let open Value in
@@ -1244,15 +1244,23 @@ module Counterexample (Config : COUNTEREXAMPLE_CONFIG) = struct
             | Result.Error msg ->
                 ksprintf print_endline "Failed to replay counterexample: %s\n  %s" Util.("error" |> red |> clear) msg
             | _ -> ()
-          end
+          end;
+          false
       | Some (Atom "unsat" :: _) ->
           print_endline "Solver could not find counterexample";
           print_endline "Solver output:";
-          print_endline solver_output
+          print_endline solver_output;
+          true
+      | Some (Atom "sat" :: _) ->
+          print_endline (sprintf "Solver found counterexample: %s" Util.("ok" |> green |> clear));
+          print_endline "Solver output:";
+          print_endline solver_output;
+          false
       | _ ->
           print_endline "Unexpected solver output:";
-          print_endline solver_output
-    end;
+          print_endline solver_output;
+          false
+    in
     let _ = Unix.close_process_in in_chan in
-    ()
+    unsat
 end

--- a/src/sail_smt_backend/sail_plugin_smt.ml
+++ b/src/sail_smt_backend/sail_plugin_smt.ml
@@ -165,13 +165,26 @@ let smt_target out_file { ast; effect_info; env; _ } =
   let t = Profile.start () in
   let generated_smt = SMTGen.generate_smt ~properties ~name_file ~smt_includes:!opt_smt_includes ctx cdefs in
   Profile.finish "Generating SMT" t;
-  if !opt_smt_auto then
+  if !opt_smt_auto then (
+    let unsats =
+      List.map
+        (fun ({ loc; file_name; function_id; args; arg_ctyps; arg_smt_names } : SMTGen.generated_smt_info) ->
+          ( Counterexample.check ~loc ~ctx ~env:ctx.tc_env ~ast ~solver:!opt_smt_auto_solver ~file_name ~function_id
+              ~args ~arg_ctyps ~arg_smt_names,
+            function_id
+          )
+        )
+        generated_smt
+    in
     List.iter
-      (fun ({ loc; file_name; function_id; args; arg_ctyps; arg_smt_names } : SMTGen.generated_smt_info) ->
-        Counterexample.check ~loc ~ctx ~env:ctx.tc_env ~ast ~solver:!opt_smt_auto_solver ~file_name ~function_id ~args
-          ~arg_ctyps ~arg_smt_names
+      (fun (u, fid) ->
+        if u = false then (
+          let l, tf = (Ast_util.id_loc fid, Ast_util.string_of_id fid) in
+          raise (Reporting.err_general l ("Property check failure for " ^ tf ^ "."))
+        )
       )
-      generated_smt;
+      unsats
+  );
   ()
 
 let _ = Target.register ~name:"smt" ~options:smt_options ~rewrites:smt_rewrites smt_target


### PR DESCRIPTION
Unexpected output is treated as a counterexample to cause a failure in CI.

While here, pass "-model" Z3 which allows a counterexample to be parsed.  Lightly tested.

Fixes #1210.