### PR TITLE
Add a --warnings-as-error flag.

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -279,6 +279,7 @@ let rec options =
       );
       ("-no_warn", Arg.Clear Reporting.opt_warnings, " do not print warnings");
       ("-all_warnings", Arg.Set Reporting.opt_all_warnings, " print all warning messages");
+      ("-warnings_as_error", Arg.Set Reporting.opt_warnings_as_error, " treat any warnings as an error");
       ("-strict_var", Arg.Set Type_check.opt_strict_var, " require var expressions for variable declarations");
       ("-strict_bitvector", Arg.Set Initial_check.opt_strict_bitvector, " require bitvectors to be indexed by naturals");
       ("-plugin", Arg.String (fun plugin -> load_plugin options plugin), "<file> load a Sail plugin");

--- a/src/lib/reporting.ml
+++ b/src/lib/reporting.ml
@@ -93,6 +93,7 @@
 let opt_warnings = ref true
 let opt_all_warnings = ref false
 let opt_backtrace_length = ref 10
+let opt_warnings_as_error = ref false
 
 type pos_or_loc = Loc of Parse_ast.l | Pos of Lexing.position
 
@@ -247,6 +248,7 @@ let suppress_warnings_for_file f = ignored_files := StringSet.add f !ignored_fil
 let seen_warnings = ref RangeMap.empty
 let once_from_warnings = ref StringSet.empty
 let suppressed_warnings = ref 0
+let shown_warning_cnt = ref 0
 
 let suppressed_warning_info () =
   if !suppressed_warnings > 0 then (
@@ -274,6 +276,7 @@ let warn ?once_from ?(force_show = false) short_str l explanation =
     | _ -> false
   in
   if (!opt_warnings && not already_shown) || force_show then (
+    incr shown_warning_cnt;
     match simp_loc l with
     | Some (p1, p2) when not (StringSet.mem p1.pos_fname !ignored_files) ->
         let shorts = RangeMap.find_opt (p1, p2) !seen_warnings |> Option.value ~default:[] in
@@ -305,6 +308,7 @@ let format_warn ?once_from short_str l explanation =
     | _ -> false
   in
   if !opt_warnings && not already_shown then (
+    incr shown_warning_cnt;
     match simp_loc l with
     | Some (p1, p2) when not (StringSet.mem p1.pos_fname !ignored_files) ->
         let shorts = RangeMap.find_opt (p1, p2) !seen_warnings |> Option.value ~default:[] in
@@ -319,6 +323,15 @@ let format_warn ?once_from short_str l explanation =
   )
 
 let simple_warn str = warn str Parse_ast.Unknown ""
+
+let check_warnings_as_error () =
+  if !opt_warnings_as_error && !shown_warning_cnt > 0 then (
+    prerr_endline
+      (Util.("Error" |> yellow |> clear)
+      ^ ": " ^ string_of_int !shown_warning_cnt ^ " warnings were generated.  Treating as an error."
+      );
+    exit 1
+  )
 
 let get_sail_dir default_sail_dir =
   match Sys.getenv_opt "SAIL_DIR" with

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -59,6 +59,9 @@ val opt_warnings : bool ref
 (** If this is true, we will print all warnings, even if generated with [~once_from]. *)
 val opt_all_warnings : bool ref
 
+(** If this is true, if any warnings are generated, Sail will terminate after all warnings are shown. *)
+val opt_warnings_as_error : bool ref
+
 (** How many backtrace entries to show for unreachable code errors *)
 val opt_backtrace_length : int ref
 
@@ -150,6 +153,9 @@ val simple_warn : string -> unit
 
 (** Will suppress all warnings for a given (Sail) file name. Used by $suppress_warnings directive in process_file.ml *)
 val suppress_warnings_for_file : string -> unit
+
+(** Will stop execution if warnings_as_error is set and any warnings have been generated. *)
+val check_warnings_as_error : unit -> unit
 
 val get_sail_dir : string -> string
 

--- a/src/sail_c_backend/sail_plugin_c.ml
+++ b/src/sail_c_backend/sail_plugin_c.ml
@@ -207,6 +207,8 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
 
   let header_opt, impl = Codegen.compile_ast env effect_info basename ast in
 
+  Reporting.check_warnings_as_error ();
+
   let impl_out = Util.open_output_with_check (out_file ^ ".c") in
   output_string impl_out.channel impl;
   flush impl_out.channel;


### PR DESCRIPTION
If any warnings are generated before an output action of a target, terminate with an error.  This should allow as many warnings to be shown before termination.

This is mainly meant for use as a CI flag.

Trigger it only in the C backend for now.