### PR TITLE
Resurrect the aarch64_small model somewhat

### DIFF
--- a/aarch64_small/armV8.h.sail
+++ b/aarch64_small/armV8.h.sail
@@ -11,7 +11,7 @@
 /*  SPDX-License-Identifier: BSD-2-Clause                                 */
 /*========================================================================*/
 
-type boolean = bit
+type boolean = bool
 type integer = int
 type uinteger = nat /* ARM ARM does not have nat/uint type */
 type reg_size = bits(5)

--- a/aarch64_small/armV8.sail
+++ b/aarch64_small/armV8.sail
@@ -141,7 +141,7 @@ function clause execute (TMTest()) = {
 /* TABORT - dummy decoding */
 val decodeTMAbort : bits(6) -> option(ast) effect pure 
 function decodeTMAbort ([R] @ (imm5 : bits(5))) = {
-  Some(TMAbort(R,imm5));
+  Some(TMAbort(cast_bit_bool(R),imm5));
 }
 
 /* transactional memory, not part of the official spec */
@@ -149,7 +149,7 @@ function clause execute (TMAbort(retry,reason)) = {
   if 0b00000000 <_u TxNestingLevel then {
     status : bits(64) = Zeros();
     status[4..0] = reason; /* REASON */
-    status[8] = retry; /* RTRY */
+    status[8] = cast_bool_bit(retry); /* RTRY */
     status[9] = b1; /* ABRT */
     TMAbortEffect->bits() = status; /* fake effect */
   };
@@ -308,7 +308,7 @@ function clause decodeSystem (0b1101010100@0b0@0b00@(op1 : bits(3))@0b0100@(CRm 
 
 function clause execute ( MoveSystemImmediate(operand,field) ) = {
   match field {
-    PSTATEField_SP  => PSTATE_SP = operand[0],
+    PSTATEField_SP  => PSTATE_SP() = [operand[0]],
     PSTATEField_DAIFSet  => {
       PSTATE_D() = (PSTATE_D() | [operand[3]]);
       PSTATE_A() = (PSTATE_A() | [operand[2]]);
@@ -316,10 +316,10 @@ function clause execute ( MoveSystemImmediate(operand,field) ) = {
       PSTATE_F() = (PSTATE_F() | [operand[0]]);
     },
     PSTATEField_DAIFClr  => {
-      PSTATE_D = (PSTATE_D() & [NOT'(operand[3])]);
-      PSTATE_A = (PSTATE_A() & [NOT'(operand[2])]);
-      PSTATE_I = (PSTATE_I() & [NOT'(operand[1])]);
-      PSTATE_F = (PSTATE_F() & [NOT'(operand[0])]);
+      PSTATE_D() = (PSTATE_D() & [NOT'(operand[3])]);
+      PSTATE_A() = (PSTATE_A() & [NOT'(operand[2])]);
+      PSTATE_I() = (PSTATE_I() & [NOT'(operand[1])]);
+      PSTATE_F() = (PSTATE_F() & [NOT'(operand[0])]);
     }
   }
 }
@@ -564,7 +564,7 @@ scattered function decodeImplementationDefined
 
 /* instructions to signal to Sail that test begins/ends */
 function clause decodeImplementationDefined (0b1101010100@0b0@0b01@0b011@0b1@[_]@0b11@0b0000@0b000@0b0000@[isEnd]) = {
-  Some(ImplementationDefinedTestBeginEnd(isEnd));
+  Some(ImplementationDefinedTestBeginEnd(isEnd == b1));
 }
 
 function clause execute ( ImplementationDefinedTestBeginEnd(isEnd) ) = {
@@ -916,9 +916,9 @@ function clause execute ( LoadStoreAcqExc((n,t,t2,s,acctype,excl,pair,memop,elsi
           /* to the same physical locations after address translation. */
           /* ARM: wMem(address, dbytes, acctype) = data;
           status = ExclusiveMonitorsStatus(); */
-          status = flush_write_buffer_exclusive(
+          status = cast_bool_bit(flush_write_buffer_exclusive(
             wMem_exclusive(empty_write_buffer, address, dbytes, acctype, data)
-          );
+          ));
         };
         /* ARM: the following code was moved up, see note there
         wX(s) = (bits(32)) (ZeroExtend([status]));
@@ -1103,7 +1103,7 @@ function clause execute ( LoadStorePairNonTemp((wback,postindex,n,t,t2,acctype,m
 */
 }
 
-function sharedDecodeLoadImmediate (opc : bits(2),size : bits(2), Rn : bits(5), Rt : bits(5), wback : bit ,postindex : bit, scale : range(0,3), offset : bits(64), acctype : AccType,prefetchAllowed : bool) -> option(ast)
+function sharedDecodeLoadImmediate (opc : bits(2),size : bits(2), Rn : bits(5), Rt : bits(5), wback : bool ,postindex : bool, scale : range(0,3), offset : bits(64), acctype : AccType,prefetchAllowed : bool) -> option(ast)
           = {
   n : reg_index = UInt_reg(Rn);
   t : reg_index = UInt_reg(Rt);
@@ -1280,7 +1280,7 @@ function sharedDecodeLoadRegister(Rn:bits(5), Rt:bits(5), Rm:bits(5), opc : bits
   m : reg_index = UInt_reg(Rm);
   acctype : AccType = AccType_NORMAL;
   memop : MemOp = MemOp_LOAD; /* ARM: uninitialized */
-  _signed : boolean = b0; /* ARM: uninitialized */
+  _signed : boolean = false; /* ARM: uninitialized */
   regsize : { 'R, RegisterSize('R). int('R) }/* int('R) */ = 64; /* ARM: uninitialized */
 
   if opc[1] == b0 then {
@@ -1476,7 +1476,7 @@ function decodeLoadStoreRegisterUnsignedImmediate ((size:bits(2))@0b111@0b0@0b01
   sharedDecodeLoadImmediate (opc,size,Rn,Rt,wback,postindex,scale,offset,AccType_NORMAL,true);
 }
 
-function sharedDecodeLoadStorePair (L:boolean,opc : bits(2),imm7:bits(7),Rn:bits(5),Rt:bits(5),Rt2:bits(5),wback:boolean,postindex:boolean) -> option(ast) = {
+function sharedDecodeLoadStorePair (L:bit,opc : bits(2),imm7:bits(7),Rn:bits(5),Rt:bits(5),Rt2:bits(5),wback:boolean,postindex:boolean) -> option(ast) = {
   n : (reg_index) = UInt_reg(Rn);
   t : (reg_index) = UInt_reg(Rt);
   t2 : (reg_index) = UInt_reg(Rt2);

--- a/aarch64_small/armV8_A64_lib.sail
+++ b/aarch64_small/armV8_A64_lib.sail
@@ -40,12 +40,12 @@ function AArch64_TakeReset(cold_reset) = {
   /* Enter the highest implemented Exception level in AArch64 state */
   PSTATE_nRW = 0b0;
   if HaveEL(EL3) then {
-    PSTATE_EL = EL3;
+    PSTATE_EL() = EL3;
     SCR_EL3->NS() = 0b0; /* Secure state */
   } else if HaveEL(EL2) then
-    PSTATE_EL = EL2
+    PSTATE_EL() = EL2
   else
-    PSTATE_EL = EL1;
+    PSTATE_EL() = EL1;
 
   /* Reset the system registers and other system components */
   AArch64_ResetControlRegisters(cold_reset);
@@ -598,7 +598,7 @@ function rELR'() -> bits(64) = {
 /* FIXME: this reads the whole register. Do we want that? */
 val SCTLR : bits(2) -> SCTLR_type effect {escape, rreg}
 function SCTLR (regime) = {
-   if      regime == EL1 then SCTLR_EL1
+   if      regime == EL1 then SCTLR_EL1_type_to_SCTLR_type(SCTLR_EL1)
    else if regime == EL2 then SCTLR_EL2
    else if regime == EL3 then SCTLR_EL3
    else Unreachable("SCTLR_type unreachable") /* ARM: Unreachable() */
@@ -858,7 +858,7 @@ function ShiftReg(N,_reg, stype, amount) = {
 function Prefetch(address : bits(64), prfop : bits(5)) -> unit = {
   hint : PrefetchHint = Prefetch_READ;
   target : uinteger = 0;
-  stream : boolean = b0;
+  stream : boolean = false;
 
   returnv : bool = false;
   match prfop[4..3] {
@@ -946,7 +946,7 @@ function AArch64_AlignmentFault(acctype : AccType, iswrite : boolean, secondstag
   ipaddress : bits(48) = UNKNOWN_BITS();
   level : uinteger = UNKNOWN;
   extflag : bit = UNKNOWN_BIT;
-  s2fs1walk : boolean = UNKNOWN_BIT;
+  s2fs1walk : boolean = undefined;
 
   AArch64_CreateFaultRecord(Fault_Alignment, ipaddress, level, acctype, iswrite,
                             extflag, secondstage, s2fs1walk);
@@ -958,7 +958,7 @@ function AArch64_NoFault() -> FaultRecord = {
   ipaddress : bits(48) = UNKNOWN_BITS();
   level : uinteger = UNKNOWN;
   acctype : AccType = AccType_NORMAL;
-  iswrite : boolean = UNKNOWN_BIT;
+  iswrite : boolean = undefined;
   extflag : bit = UNKNOWN_BIT;
   secondstage : boolean = false;
   s2fs1walk : boolean = false;

--- a/aarch64_small/armV8_common_lib.sail
+++ b/aarch64_small/armV8_common_lib.sail
@@ -209,7 +209,7 @@ function CountLeadingZeroBits(x) =
   }
 /** FUNCTION:bits(N) Extend(bits(M) x, integer N, boolean unsigned) */
 
-val Extend : forall 'N 'M, 1 <= 'M & 'M < 'N. (implicit('N),bits('M),bit) -> bits('N) effect {escape}
+val Extend : forall 'N 'M, 1 <= 'M & 'M < 'N. (implicit('N),bits('M),bool) -> bits('N) effect {escape}
 function Extend (n, x, _unsigned) =
   if _unsigned then ZeroExtend(n,x) else SignExtend(n,x)
 
@@ -321,7 +321,7 @@ val NOT : forall 'N, 'N >= 0. bits('N) -> bits('N)
 function NOT(x) = ~(x)
 
 val NOT' : bit -> bit
-function NOT'(x) = ~(x)
+function NOT'(x) = if x == b0 then b1 else b0
 
 /** FUNCTION:shared/functions/common/Ones */
 

--- a/aarch64_small/prelude.sail
+++ b/aarch64_small/prelude.sail
@@ -33,7 +33,6 @@ overload operator << = {shift_bits_left, shift_left}
 overload operator >> = {shift_bits_right, shift_right}
 
 
-val replicate_bits = "replicate_bits" : forall 'n 'm. (bits('n), int('m)) -> bits('n * 'm)
 val operator ^^ = "replicate_bits" : forall 'n 'm. (bits('n), int('m)) -> bits('n * 'm)
 
 
@@ -83,7 +82,6 @@ val or_bits = {c:"or_bits", _: "or_vec"} : forall 'n. (bits('n), bits('n)) -> bi
 overload operator | = {or_bool, or_bits}
 
 
-val not_vec = {c:"not_bits", _:"not_vec"} : forall 'n. bits('n) -> bits('n)
 overload ~ = {not_bool, not_vec}
 
 val eq_anything = {ocaml: "(fun (x, y) -> x = y)", lem: "eq", coq: "generic_eq", _:"eq_anything"} : forall ('a : Type). ('a, 'a) -> bool
@@ -96,20 +94,13 @@ function neq_vec (x, y) = not_bool(eq_bits(x, y))
 val neq_anything = {lem: "neq", coq: "generic_neq"} : forall ('a : Type). ('a, 'a) -> bool
 function neq_anything (x, y) = not_bool(x == y)
 
-overload operator != = {neq_atom, neq_int, neq_vec, neq_anything}
+overload operator != = {neq_int, neq_vec, neq_anything}
 
 
-val add_int = {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", c: "add_int", coq: "Z.add"} : forall 'n 'm.
-  (int('n), int('m)) -> int('n + 'm)
 val add_vec = {c: "add_bits", _: "add_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)
 val add_vec_int = {c: "add_bits_int", _: "add_vec_int"} : forall 'n. (bits('n), int) -> bits('n)
 overload operator + = {add_int, add_vec, add_vec_int}
 
-val sub_int = {ocaml: "sub_int", interpreter: "sub_int", lem: "integerMinus", c: "sub_int", coq: "Z.sub"} : forall 'n 'm.
-  (int('n), int('m)) -> int('n - 'm)
-val sub_nat = {ocaml: "(fun (x,y) -> let n = sub_int (x,y) in if Big_int.less_equal n Big_int.zero then Big_int.zero else n)",
-	       interpreter: "sub_nat", lem: "integerMinus", coq: "sub_nat", c: "sub_nat"}
-            : (nat, nat) -> nat
 val sub_vec = {c: "sub_bits", _: "sub_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)
 val sub_vec_int = {c: "sub_bits_int", _: "sub_vec_int"} : forall 'n. (bits('n), int) -> bits('n)
 overload operator - = {sub_int, sub_vec, sub_vec_int}
@@ -135,11 +126,9 @@ val to_bits : forall 'l, 'l >= 0.(implicit('l), int) -> bits('l)
 function to_bits (l, n) = __raw_GetSlice_int(l, n, 0)
 
 
-val xor_vec = {c: "xor_bits", _: "xor_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)
-
 val int_power = {ocaml: "int_power", interpreter: "int_power", lem: "pow", coq: "pow", c: "pow_int"} : (int, int) -> int
 
-overload operator ^ = {xor_vec, int_power, concat_str}
+overload operator ^ = {xor_vec, int_power}
 
 
 val mask : forall 'l 'm, 'l >= 0 & 'm >= 0. (implicit('l), bits('m)) -> bits('l)


### PR DESCRIPTION
Removed dependence on casts (especially bit <-> bool casts), calling setter functions without parens, and drop some prelude which overlaps with imports from the standard library.