### PR TITLE
SV: Add option to turn assertions into exceptions

### DIFF
--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -289,6 +289,7 @@ module type CONFIG = sig
   val use_real : bool
   val branch_coverage : out_channel option
   val track_throw : bool
+  val assert_to_exception : bool
   val use_void : bool
   val eager_control_flow : bool
   val preserve_types : IdSet.t
@@ -386,6 +387,13 @@ module Make (C : CONFIG) = struct
     | _ -> []
 
   let unit_cval = V_lit (VL_unit, CT_unit)
+
+  let assert_exception l msg =
+    let exception_ctyp = CT_variant (mk_id "exception", []) in
+    let e = ngensym () in
+    ( [idecl l exception_ctyp e; ifuncall l (CL_id (e, exception_ctyp)) (mk_id "__assertion_failed#", []) [msg]],
+      V_id (e, exception_ctyp)
+    )
 
   let get_variable_ctyp id ctx =
     match NameMap.find_opt id ctx.locals with
@@ -1198,7 +1206,21 @@ module Make (C : CONFIG) = struct
       )
     | AE_app (Pure_extern id, args, _) -> compile_extern l ctx id args
     | AE_app (Extern id, args, typ) ->
-        if string_of_id id = "sail_config_get" then compile_config l ctx args typ else compile_extern l ctx id args
+        let str = string_of_id id in
+        if str = "sail_assert" && C.assert_to_exception then (
+          match args with
+          | [cond; msg] ->
+              let cond_setup, cond_cval, cond_cleanup = compile_aval l ctx cond in
+              let msg_setup, msg_cval, _ = compile_aval l ctx msg in
+              let exn_setup, exn_cval = assert_exception l msg_cval in
+              ( cond_setup @ [iif l cond_cval [] (msg_setup @ exn_setup @ [ithrow l exn_cval])] @ cond_cleanup,
+                (fun clexp -> icopy l clexp unit_cval),
+                []
+              )
+          | _ -> Reporting.unreachable l __POS__ "Bad arity for sail_assert"
+        )
+        else if str = "sail_config_get" then compile_config l ctx args typ
+        else compile_extern l ctx id args
     | AE_val aval ->
         let setup, cval, cleanup = compile_aval l ctx aval in
         (setup, (fun clexp -> icopy l clexp cval), cleanup)
@@ -1330,6 +1352,7 @@ module Make (C : CONFIG) = struct
         let aexp_setup, aexp_call, aexp_cleanup = compile_aexp ctx aexp in
         let try_return_id = ngensym () in
         let post_exception_handlers_label = label "post_exception_handlers_" in
+        let exn_cval = V_id (current_exception, ctyp_of_typ ctx (mk_typ (Typ_id (mk_id "exception")))) in
         let compile_case (apat, guard, body, case_uannot) =
           let trivial_guard =
             match guard with
@@ -1339,7 +1362,6 @@ module Make (C : CONFIG) = struct
             | _ -> false
           in
           let try_label = label "try_" in
-          let exn_cval = V_id (current_exception, ctyp_of_typ ctx (mk_typ (Typ_id (mk_id "exception")))) in
           let pre_destructure, destructure, destructure_cleanup, ctx =
             compile_match ctx apat exn_cval (fun l b -> ijump l b try_label)
           in
@@ -1369,6 +1391,18 @@ module Make (C : CONFIG) = struct
             ijump l (V_call (Bnot, [V_id (have_exception, CT_bool)])) post_exception_handlers_label;
             icopy l (CL_id (have_exception, CT_bool)) (V_lit (VL_bool false, CT_bool));
           ]
+          @ ( if C.assert_to_exception then
+                [
+                  iif l
+                    (V_ctor_kind (exn_cval, (mk_id "__assertion_failed#", [])))
+                    []
+                    [
+                      icopy l (CL_id (have_exception, CT_bool)) (V_lit (VL_bool true, CT_bool));
+                      igoto post_exception_handlers_label;
+                    ];
+                ]
+              else []
+            )
           @ List.concat (List.map compile_case cases)
           @ [
               (* fallthrough *)
@@ -1745,6 +1779,11 @@ module Make (C : CONFIG) = struct
           | Tu_aux (Tu_ty_id (typ, id), _) ->
               let ctx = { ctx with local_env = Env.add_typquant (id_loc id) typq ctx.local_env } in
               (ctyp_of_typ ctx typ, id)
+        in
+        let tus =
+          if string_of_id id = "exception" && C.assert_to_exception then
+            tus @ [Tu_aux (Tu_ty_id (string_typ, mk_id "__assertion_failed#"), mk_def_annot (gen_loc l) ())]
+          else tus
         in
         let ctus =
           List.fold_left (fun ctus (ctyp, id) -> Bindings.add id ctyp ctus) Bindings.empty (List.map compile_tu tus)
@@ -2833,16 +2872,34 @@ module Make (C : CONFIG) = struct
     let cdefs = List.concat (List.rev chunks) in
 
     (* If we don't have an exception type, add a dummy one *)
-    let dummy_exn = mk_id "__dummy_exn#" in
     let cdefs, ctx =
       if not (Bindings.mem (mk_id "exception") ctx.variants) then
-        ( CDEF_aux
-            (CDEF_type (CTD_variant (mk_id "exception", [], [(dummy_exn, CT_unit)])), mk_def_annot Parse_ast.Unknown ())
-          :: cdefs,
-          {
-            ctx with
-            variants = Bindings.add (mk_id "exception") ([], Bindings.singleton dummy_exn CT_unit) ctx.variants;
-          }
+        if C.assert_to_exception then (
+          let assertion_failed = mk_id "__assertion_failed#" in
+          ( CDEF_aux
+              ( CDEF_type (CTD_variant (mk_id "exception", [], [(assertion_failed, CT_string)])),
+                mk_def_annot Parse_ast.Unknown ()
+              )
+            :: cdefs,
+            {
+              ctx with
+              variants =
+                Bindings.add (mk_id "exception") ([], Bindings.singleton assertion_failed CT_string) ctx.variants;
+            }
+          )
+        )
+        else (
+          let dummy_exn = mk_id "__dummy_exn#" in
+          ( CDEF_aux
+              ( CDEF_type (CTD_variant (mk_id "exception", [], [(dummy_exn, CT_unit)])),
+                mk_def_annot Parse_ast.Unknown ()
+              )
+            :: cdefs,
+            {
+              ctx with
+              variants = Bindings.add (mk_id "exception") ([], Bindings.singleton dummy_exn CT_unit) ctx.variants;
+            }
+          )
         )
       else (cdefs, ctx)
     in

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -99,11 +99,12 @@ val ctx_has_val_spec : id -> ctx -> bool
 
     The target is the name that would appear in a valspec extern section, i.e.
 
+    {v
     val foo = { systemverilog: "bar", c: "baz" } = ...
+    v}
 
-    would mean "systemverilog" and "c" would be valid for_target parameters.
-    If unspecified it will get the current target name from the Target module.
-    If unspecified and there is no current target, it defaults to "c". *)
+    would mean "systemverilog" and "c" would be valid for_target parameters. If unspecified it will get the current
+    target name from the Target module. If unspecified and there is no current target, it defaults to "c". *)
 val initial_ctx : ?for_target:string -> Env.t -> Effects.side_effect_info -> ctx
 
 val transparent_newtype : ctx -> ctyp -> ctyp
@@ -152,6 +153,9 @@ module type CONFIG = sig
   (** If true track the location of the last exception thrown, useful for debugging C but we want to turn it off for SMT
       generation where we can't use strings *)
   val track_throw : bool
+
+  (** Assertions in the Sail code will be compiled to exceptions in the Jib output *)
+  val assert_to_exception : bool
 
   val use_void : bool
 

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -202,6 +202,7 @@ let c_return exp = string "return" ^^ space ^^ exp ^^ semi
 
 module C_config (Opts : sig
   val branch_coverage : out_channel option
+  val assert_to_exception : bool
   val preserve_types : IdSet.t
 end) : CONFIG = struct
   (** Convert a sail type into a C-type. This function can be quite slow, because it uses ctx.local_env and SMT to
@@ -528,6 +529,7 @@ end) : CONFIG = struct
   let use_real = false
   let branch_coverage = Opts.branch_coverage
   let track_throw = true
+  let assert_to_exception = Opts.assert_to_exception
   let use_void = false
   let eager_control_flow = false
   let preserve_types = Opts.preserve_types
@@ -947,6 +949,7 @@ module type CODEGEN_CONFIG = sig
   val reserved_words : Util.StringSet.t
   val overrides : string Name_generator.Overrides.t
   val branch_coverage : out_channel option
+  val assert_to_exception : bool
   val preserve_types : IdSet.t
 end
 
@@ -2321,6 +2324,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
   let jib_of_ast env effect_info ast =
     let module Jibc = Make (C_config (struct
       let branch_coverage = Config.branch_coverage
+      let assert_to_exception = Config.assert_to_exception
       let preserve_types = Config.preserve_types
     end)) in
     let ctx = initial_ctx env effect_info in

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -111,6 +111,8 @@ module type CODEGEN_CONFIG = sig
       about all the possible branches will be written to the provided output channel. *)
   val branch_coverage : out_channel option
 
+  val assert_to_exception : bool
+
   val preserve_types : Ast_util.IdSet.t
 end
 

--- a/src/sail_c_backend/sail_plugin_c.ml
+++ b/src/sail_c_backend/sail_plugin_c.ml
@@ -49,6 +49,7 @@ open Libsail
 open Ast_util
 open Interactive.State
 
+let opt_assert_to_exception = ref false
 let opt_branch_coverage = ref None
 let opt_build = ref false
 let opt_generate_header = ref false
@@ -97,6 +98,7 @@ let c_options =
       Arg.String (fun str -> Specialize.add_initial_calls (IdSet.singleton (mk_id str))),
       "make sure the provided function identifier is preserved in C output"
     );
+    (Flag.create ~prefix:["c"] "assert_to_exception", Arg.Set opt_assert_to_exception, "turn assertions into exceptions");
     ( Flag.create ~prefix:["c"] "preserve_type",
       Arg.String (fun str -> opt_preserve_types := IdSet.add (mk_id str) !opt_preserve_types),
       "make sure the provided type identifier is preserved in the C output"
@@ -199,6 +201,7 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
     let reserved_words = reserveds
     let overrides = overrides
     let branch_coverage = !opt_branch_coverage
+    let assert_to_exception = !opt_assert_to_exception
     let preserve_types = !opt_preserve_types
   end) in
   Reporting.opt_warnings := true;

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -1312,6 +1312,7 @@ end) : Jib_compile.CONFIG = struct
   let use_real = true
   let branch_coverage = None
   let track_throw = false
+  let assert_to_exception = false
   let use_void = false
   let eager_control_flow = true
   let preserve_types = IdSet.empty

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -97,6 +97,7 @@ module type CONFIG = sig
   val unreachable : string list
   val comb : bool
   val ignore : string list
+  val fun2wires : (string * int) list
   val dpi_sets : StringSet.t
 end
 

--- a/src/sail_sv_backend/jib_sv.mli
+++ b/src/sail_sv_backend/jib_sv.mli
@@ -77,6 +77,8 @@ module type CONFIG = sig
   val comb : bool
   val ignore : string list
 
+  val fun2wires : (string * int) list
+
   (** The SystemVerilog DPI (direct programming interface) lets the
       generated SystemVerilog directly call C functions. A Sail
       external function for the [systemverilog] target can be translated

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -180,8 +180,16 @@ let verilog_options =
     );
     (Flag.create ~prefix:["sv"] "nomem", Arg.Set opt_nomem, "don't emit a dynamic memory implementation");
     ( Flag.create ~prefix:["sv"] ~arg:"functionname" "fun2wires",
-      Arg.String (fun fn -> opt_fun2wires := fn :: !opt_fun2wires),
-      "Use input/output ports instead of emitting a function call"
+      Arg.String
+        (fun str ->
+          match String.index_opt str ':' with
+          | Some pos ->
+              opt_fun2wires :=
+                (String.sub str (pos + 1) (String.length str - pos - 1), int_of_string (String.sub str 0 pos))
+                :: !opt_fun2wires
+          | None -> opt_fun2wires := (str, 1) :: !opt_fun2wires
+        ),
+      "<slots>:<functionname> Use input/output ports instead of emitting a function call"
     );
     ( Flag.create ~prefix:["sv"] ~arg:"n" "specialize",
       Arg.Int (fun i -> opt_int_specialize := Some i),
@@ -338,6 +346,7 @@ module Verilog_config (C : JIB_CONFIG) : Jib_compile.CONFIG = struct
   let struct_value = false
   let tuple_value = false
   let track_throw = false
+  let assert_to_exception = true
   let branch_coverage = None
   let use_real = false
   let use_void = false
@@ -438,7 +447,8 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
     let union_padding = !opt_padding
     let unreachable = !opt_unreachable
     let comb = !opt_comb
-    let ignore = !opt_fun2wires
+    let fun2wires = !opt_fun2wires
+    let ignore = List.map fst !opt_fun2wires
     let dpi_sets = !opt_dpi_sets
   end) in
   let open SV in
@@ -472,12 +482,13 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
     ^^ twice hardline
   in
 
+  (*
   let exception_vars =
     string "bit sail_reached_unreachable;" ^^ hardline ^^ string "bit sail_have_exception;" ^^ hardline
     ^^ (if !opt_no_strings then string "sail_unit" else string "string")
     ^^ space ^^ string "sail_throw_location;" ^^ twice hardline
   in
-
+  *)
   let spec_info = Sv_analysis.collect_spec_info ctx cdefs in
 
   let svir, fn_ctyps =


### PR DESCRIPTION
Allows handing exceptions and assertion failures in a uniform way in the generated SystemVerilog output.