### PR TITLE
Fix error message when config items aren't found

### DIFF
--- a/lib/sail_config.c
+++ b/lib/sail_config.c
@@ -95,7 +95,7 @@ sail_config_json sail_config_get(size_t n, const char *key[])
     } else {
       fprintf(stderr, "Failed to access configuration item: '");
       for (int j = 0; j < n; j++) {
-        fprintf(stderr, ".%s", key[i]);
+        fprintf(stderr, ".%s", key[j]);
       }
       fprintf(stderr, "'\n");
       exit(EXIT_FAILURE);


### PR DESCRIPTION
This was printing e.g. `Failed to access configuration item: '.regions.regions'` instead of `Failed to access configuration item: '.memory.regions'`.