### PR TITLE
sail_sv_backend: swap element ordering for unpacked array

### DIFF
--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -208,7 +208,7 @@ module Make (Config : CONFIG) = struct
         else ksprintf simple_type "logic [%d:0]" (width - 1)
     | CT_ref ctyp -> ksprintf simple_type "sail_reg_%s" (Util.zencode_string (string_of_ctyp ctyp))
     | CT_fvector (len, ctyp) ->
-        let outer_index = sprintf "[%d:0]" (len - 1) in
+        let outer_index = sprintf "[%d]" len in
         begin
           match sv_ctyp ~two_state ctyp with
           | ty, Some inner_index -> (ty, Some (inner_index ^ outer_index))


### PR DESCRIPTION
In SystemVerilog, unpacked arrays are typically in the form of `[0:LEN-1]` instead of `[LEN-1:0]` (which is the convention for packed arrays). In fact, commonly people just use `[LEN]` and this is a shorthand for `[0:LEN-1]`.

Currently sail_sv_backend always use `[LEN-1:0]` even for unpacked arrays; this causes the whole array to be flipped even the user passed in an array declared with `[LEN]`.

For reference, the SystemVerilog spec says:
> Each fixed-size dimension shall be represented by an address range, such as `[1:1024]`, or a single positive
number to specify the size of a fixed-size unpacked array, as in C. In other words, `[size]` becomes the
same as `[0:size-1]`.

[lowRISC style guide](https://github.com/lowRISC/style-guides/blame/master/VerilogCodingStyle.md#unpacked-ordering) says:
> Declare unpacked arrays in big-endian fashion (for instance, [n:m] where n <= m). Never declare an unpacked array in little-endian order, such as `[size-1:0]`.
>
> Declare zero-based unpacked arrays using the shorter notation [size]. It is understood that [size] is equivalent to the big-endian declaration `[0:size-1]`.

For some additional background, Ibex formal verification (https://github.com/lowRISC/ibex/pull/2245) is failing due to this subtle mismatch.

cc @Alasdair as code owner
cc @marnovandermaas @mndstrmr for its relevance in Ibex formal verification

