### PR TITLE
Various fixes to SV backend

### DIFF
--- a/lib/sv/sail_modules.sv
+++ b/lib/sv/sail_modules.sv
@@ -156,8 +156,8 @@ endfunction
 function automatic string sail_string_of_bits(sail_bits bv);
    string hexstr;
    string trimmed;
-   hexstr = $sformatf("%x", bv.bits);
-   trimmed = hexstr.substr(SAIL_BITS_WIDTH / 4 - (bv.size / 4), SAIL_BITS_WIDTH / 4 - 1).toupper();
+   hexstr = $sformatf("%x", bv.sb_bits);
+   trimmed = hexstr.substr(SAIL_BITS_WIDTH / 4 - (bv.sb_size / 4), SAIL_BITS_WIDTH / 4 - 1).toupper();
    return {"0x", trimmed};
 endfunction
 `endif
@@ -194,7 +194,7 @@ function automatic sail_bits emulator_read_mem(logic [63:0] addrsize, sail_bits 
    logic [SAIL_BITS_WIDTH-1:0] buffer;
    logic [SAIL_INDEX_WIDTH-2:0] i;
 
-   paddr = addr.bits[63:0];
+   paddr = addr.sb_bits[63:0];
 
    for (i = n[SAIL_INDEX_WIDTH-2:0]; i > 0; i = i - 1) begin
 `ifdef SAIL_DPI_MEMORY
@@ -217,7 +217,7 @@ endfunction
 
 function automatic bit emulator_read_tag(logic [63:0] addrsize, sail_bits addr);
    logic [63:0] paddr;
-   paddr = addr.bits[63:0];
+   paddr = addr.sb_bits[63:0];
 `ifdef SAIL_DPI_MEMORY
    return sail_read_tag(paddr);
 `else
@@ -243,8 +243,8 @@ module emulator_write_mem
       logic [SAIL_INDEX_WIDTH-2:0] i;
       sail_memory_writes tmp;
 
-      buffer = value.bits;
-      paddr = addr.bits[63:0];
+      buffer = value.sb_bits;
+      paddr = addr.sb_bits[63:0];
       tmp = in_writes;
 
       for (i = n[SAIL_INDEX_WIDTH-2:0]; i > 0; i = i - 1) begin

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4445,7 +4445,13 @@ let rewrite_unroll_constant_loops _type_env defs =
             let range = list_of_ord_range atyp n_start n_end n_step in
 
             (* Only unroll "small" loops, i.e. those with less than 'max_iter' iterations *)
-            if !opt_unroll_loops_max_iter <> 0 && List.length range > !opt_unroll_loops_max_iter then E_aux (e, annot)
+            if !opt_unroll_loops_max_iter <> 0 && List.length range > !opt_unroll_loops_max_iter then (
+              let (l : Parse_ast.l), _tannot = annot in
+              raise @@ Reporting.err_general l
+              @@ Printf.sprintf
+                   "Cannot unroll the loop because it has more iterations (%d) than the maximum allowed (%d)\n"
+                   (List.length range) !opt_unroll_loops_max_iter
+            )
             else (
               (* Build the final expression, a block of n times the body *)
               let bodies = List.map (fun z -> rewrite_exp_replace_id_with_num "i" z e_loop_body) range in

--- a/src/sail_sv_backend/generate_primop2.ml
+++ b/src/sail_sv_backend/generate_primop2.ml
@@ -32,15 +32,15 @@ let sail_bits width =
   let index_top = required_width (Big_int.of_int (width - 1)) in
   [
     nf "typedef struct packed {";
-    pf "    logic [%d:0] size;" index_top;
-    pf "    logic [%d:0] bits;" (width - 1);
+    pf "    logic [%d:0] sb_size;" index_top;
+    pf "    logic [%d:0] sb_bits;" (width - 1);
     nf "} sail_bits;";
     "";
     pf "localparam SAIL_BITS_WIDTH = %d;" width;
     pf "localparam SAIL_INDEX_WIDTH = %d;" (index_top + 1);
     "";
-    pf "function automatic logic [%d:0] sail_bits_size(sail_bits bv); return bv.size; endfunction" index_top;
-    pf "function automatic logic [%d:0] sail_bits_value(sail_bits bv); return bv.bits; endfunction" (width - 1);
+    pf "function automatic logic [%d:0] sail_bits_size(sail_bits bv); return bv.sb_size; endfunction" index_top;
+    pf "function automatic logic [%d:0] sail_bits_value(sail_bits bv); return bv.sb_bits; endfunction" (width - 1);
   ]
 
 let sail_int width = [pf "typedef logic [%d:0] sail_int;" (width - 1)]

--- a/src/sail_sv_backend/generate_primop2.ml
+++ b/src/sail_sv_backend/generate_primop2.ml
@@ -231,8 +231,8 @@ module Make
                         (List.map mk_statement
                            [
                              svs_raw (sprintf "zeros = \"%s\"" (String.make width '0')) ~outputs:[zeros];
-                             svs_raw (sprintf "hexstr.hextoa(b.bits)") ~inputs:[b] ~outputs:[hexstr];
-                             svs_raw (sprintf "binstr.bintoa(b.bits)") ~inputs:[b] ~outputs:[binstr];
+                             svs_raw (sprintf "hexstr.hextoa(b.sb_bits)") ~inputs:[b] ~outputs:[hexstr];
+                             svs_raw (sprintf "binstr.bintoa(b.sb_bits)") ~inputs:[b] ~outputs:[binstr];
                              svs_raw
                                (sprintf "%s = {in_str, s}" (string_of_name ~zencode:false (tempstr 0)))
                                ~inputs:[in_str; s]
@@ -246,7 +246,7 @@ module Make
                    if (n + 1) mod 4 == 0 then
                      svs_raw
                        (sprintf
-                          "if (b.size == %d) %s = {%s, $sformatf(\"0x%%s\", zeros.substr(0, %d - hexstr.len()), \
+                          "if (b.sb_size == %d) %s = {%s, $sformatf(\"0x%%s\", zeros.substr(0, %d - hexstr.len()), \
                            hexstr.toupper()), \"\\n\"}; else %s = %s"
                           (n + 1)
                           (string_of_name ~zencode:false (tempstr (n + 1)))
@@ -260,7 +260,7 @@ module Make
                    else
                      svs_raw
                        (sprintf
-                          "if (b.size == %d) %s = {%s, $sformatf(\"0b%%s\", zeros.substr(0, %d - binstr.len()), \
+                          "if (b.sb_size == %d) %s = {%s, $sformatf(\"0b%%s\", zeros.substr(0, %d - binstr.len()), \
                            binstr), \"\\n\"}; else %s = %s"
                           (n + 1)
                           (string_of_name ~zencode:false (tempstr (n + 1)))

--- a/src/sail_sv_backend/globals.ml
+++ b/src/sail_sv_backend/globals.ml
@@ -1,0 +1,187 @@
+(* This module contains a bunch of hacks to prepend global references with an SV macro.
+
+    {1. Initial problem}
+
+    For compatibility with EDA tools, global signals cannot be defined at toplevel.
+
+    For example, below generated SV will throw [unresolved reference to my_global] :
+
+    {[
+      logic  another_toplevel_signal;
+      logic  toplevel_signal;  // <<------ Global declared at toplevel
+
+      module sail_setup_let_42 (
+          output logic toplevel_signal_1
+        );
+        always_comb begin
+          if (another_toplevel_signal)
+              toplevel_signal_1 = 42;
+    else
+      toplevel_signal_1 = 24;
+    end
+      endmodule
+
+      module yyy (input logic myin);
+        logic y;
+        assign y = toplevel_signal; // <<------ Global reference unresovled
+          endmodule
+
+      module sail_toplevel ();
+        sail_setup_let_42 sail_setup_inst_42(toplevel_signal);
+        always_comb begin
+        end
+          endmodule
+    ]}
+
+    {2. Suggested solution}
+
+    This module contains a set of hacks to insert at various places during JIB-SV conversion
+    which will yield the following changes :
+    1. Moving the declaration of globals from toplevel into the [sail_toplevel] module
+    2. Prepend references to globals with a macro where the user will insert the hierarchical path
+       to the [sail_toplevel] instance.
+
+    However there are a few additional things to do to make it work :
+    3. Prepending should NOT be done in the sail_toplevel module (because this is where the globals are declared)
+    4. Prepending in the the [sail_setup_let_] modules (where the globals are initialized),
+       should ideally be done everywhere in the module but NOT on the output (we don't want [output logic `SAIL_GLOBALS.my_global]).
+       But removing prepending only on the output is an intrusive change in the sail codebase,
+       so what we'll do is just remove the output,
+       and the [sail_setup_let_] module will drive the globals via the hierarchical reference.
+    5. The very last thing is also on the [sail_setup_let_] modules,
+       for the global [`SAIL_GLOBALS.my_global], the [sail_setup_let_] module
+       will drive [`SAIL_GLOBALS.my_global_1] (notice the [_1]).
+       And we haven't found a non-impactful easy way to just remove the [_1] in the [sail_setup_let_] modules,
+       so we'll just add a "duplicate" [my_global_1] signal in [sail_toplevel] and assign it to [my_global] to make the connection.
+
+    With all those changes, the diff will be :
+
+    {[
+      + `define SAIL_GLOBALS path.to.sail_toplevel_instance          // will be manually added by the user
+                                    +
+                                    - logic  another_toplevel_signal;                              // (1.) moved to sail_toplevel
+                                                                                                                    - logic  toplevel_signal;                                      // (1.) moved to sail_toplevel
+
+      module sail_setup_let_42 (
+          -   output `SAIL_GLOBALS.logic toplevel_signal_1               // (4.) remove output
+        );
+        always_comb begin
+          +     if (`SAIL_GLOBALS.another_toplevel_signal)               // (2.) prepending
+                   +       `SAIL_GLOBALS.toplevel_signal_1 = 42;                  // (2.) prepending
+    else
+      +       `SAIL_GLOBALS.toplevel_signal_1 = 24;                  // (2.) prepending
+    end
+      endmodule
+
+      module yyy (input logic myin);
+        logic y;
+        +   assign y = `SAIL_GLOBALS.toplevel_signal;                  // (2.) prepending (Global reference is fixed !)
+          endmodule
+
+      module sail_toplevel ();
+        + logic  another_toplevel_signal;                              // (1.) moved to sail_toplevel
+                                                                                        + logic  toplevel_signal;                                      // (1.) moved to sail_toplevel
+                                                                                                                                                                        + logic  another_toplevel_signal_1;                            // (5.) Adding duplicate (driven by sail_setup_let)
+                                                                                                                                                                                                                                       + logic  toplevel_signal_1;                                    // (5.) Adding duplicate (driven by seail_setup_let)
+                                                                                                                                                                                                                                                                                                      -   sail_setup_let_42 sail_setup_inst_42();
+        +   sail_setup_let_42 sail_setup_inst_42(toplevel_signal);     // (4.) Remove output
+          always_comb begin
+          +     toplevel_signal = toplevel_signal_1;                     // (5.) Assign from duplicate (driven by sail_setup_let)
+                                                                         +     another_toplevel_signal = another_toplevel_signal_1;     // (5.) Assign from duplicate (driven by sail_setup_let)
+        end
+          endmodule
+    ]}
+
+*)
+
+open Libsail
+
+open Ast
+open Ast_util
+open Jib
+open Jib_compile
+open Jib_util
+open Jib_visitor
+open PPrint
+open Printf
+open Smt_exp
+
+open Generate_primop2
+open Sv_ir
+open Sv_attribute
+
+module IntSet = Util.IntSet
+module IntMap = Util.IntMap
+module StringMap = Util.StringMap
+
+(** In order to prefix all the global references, we "interecept" a SV pprint function [NameGen.to_string], and prepend
+    when the thing to print is a global reference. To do so, we must have the list of globals somewhere, this is the
+    purpose of below [list] variable. It contains the list of globals :
+    - filled once at the "initialization point" when going through all global declarations
+    - Used at each call of [NameGen.to_string] (the "interception point") to compare the variable to print against the
+      globals.
+
+    It is a mutable reference because it's the least impactful way (in terms of git rebasing) to bring it from the
+    "initialization point" to the "interception point". *)
+let list : (Libsail__Ast.id * ctyp) list ref = ref []
+
+(** Prepending should be done everywhere except in the sail_toplevel module (where globals are locally declared). To do
+    so, we use below [active] switch and [toggle] function. When calling [pp_module], [toggle] will set [active] to
+    [false] if and only if we're pprinting the [sail_toplevel] module. *)
+let active : bool ref = ref true
+
+let get_strlist () = List.map (fun (id, _) -> string_of_id id) !list
+
+(** This is the function filling the list of globals, to be called at the "initialization point". *)
+let add id ctyp = list := (id, ctyp) :: !list
+
+(** This is the function doing the actual prepending (and comparing against the global list), to be called at the
+    "interception point". *)
+let prepend prefix_opt s =
+  let prefix = match prefix_opt with Some s -> s ^ "." | None -> "" in
+  if !active && List.mem s (get_strlist ()) then prefix ^ s else s
+
+let pp () =
+  let print_id id = print_endline @@ Printf.sprintf "global let(id) : %s" id in
+  List.iter print_id @@ get_strlist ()
+
+(** This is the function used to diable prepending for the [sail_toplevel] module, to be called at the top of
+    [pp_module] *)
+let toggle module_name = active := not @@ String.equal "sail_toplevel" module_name
+
+(** Because of issue (4.) mentioned in the [Globals] doc above, we remove all output of the [sail_setup_let_] modules.
+
+    This manual hack raises an exception in the List.map2 function which is called with a list of 1 returned value
+    [my_global_1] and 0 output (the previously removed [my_global_1].
+
+    This function intercepts and discards that exception since the behaviour is expected. *)
+let map2 f l1 l2 =
+  match l1 with
+  | [] -> [] (* Case when connecting sail_setup_let_ modules, with 1 return value but 0 output *)
+  | _ -> List.map2 f l1 l2
+
+module Gen = struct
+  (* returns a list of globals and their duplicates (eponymous with "_1" at the end) *)
+  (* e.g. for [a, b, c] it will return [a, a_1, b, b_1, c, c_1] *)
+  (* This is used in toplevel, where all globals are declared, *)
+  let list_with_dup global_prefix =
+    if Option.is_none global_prefix then []
+    else List.flatten @@ List.map (fun (id, ctyp) -> [(id, ctyp); (append_id id "_1", ctyp)]) !list
+
+  let top_ids global_prefix = List.map (fun (id, _ctyp) -> name id) @@ list_with_dup global_prefix
+
+  (** This function generates the list of declarations to add in [sail_toplevel] *)
+  let top_defs global_prefix = List.map (fun (id, ctyp) -> SVD_var (name id, ctyp)) @@ list_with_dup global_prefix
+
+  let asgn (id, _ctyp) =
+    let s = string_of_id id in
+    let s_dup = Printf.sprintf "%s_1" s in
+    let id_dup = mk_id s_dup in
+    mk_statement @@ svs_raw (Printf.sprintf "%s = %s" s s_dup) ~inputs:[name id; name id_dup]
+
+  (** This function generates the assignments to add in the [sail_toplevel] [always_comb] block *)
+  let always_comb_assignments global_prefix = if Option.is_none global_prefix then [] else List.map asgn !list
+end
+(* module Gen *)
+
+let remove_top_vars global_prefix in_module = Option.is_some global_prefix && Option.is_none in_module

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -88,6 +88,7 @@ let natural_name_compare variable_locations n1 n2 =
 let natural_sort_names names = List.stable_sort (natural_name_compare Bindings.empty) names
 
 module type CONFIG = sig
+  val recursion_depth : int
   val max_unknown_integer_width : int
   val max_unknown_bitvector_width : int
   val line_directives : bool
@@ -111,6 +112,7 @@ module Make (Config : CONFIG) = struct
   module Primops =
     Generate_primop2.Make
       (struct
+        let recursion_depth = Config.recursion_depth
         let max_unknown_bitvector_width = Config.max_unknown_bitvector_width
         let max_unknown_integer_width = Config.max_unknown_integer_width
         let no_strings = Config.no_strings
@@ -2020,7 +2022,11 @@ module Make (Config : CONFIG) = struct
     }
 
   let rec pp_module ctx m =
-    let params = if m.recursive then space ^^ string "#(parameter RECURSION_DEPTH = 10)" ^^ space else empty in
+    let params =
+      if m.recursive then
+        space ^^ string (Printf.sprintf "#(parameter RECURSION_DEPTH = %d)" Config.recursion_depth) ^^ space
+      else empty
+    in
     let ports =
       match (m.input_ports, m.output_ports) with
       | [], [] -> semi

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -96,6 +96,7 @@ module type CONFIG = sig
   val no_assertions : bool
   val never_pack_unions : bool
   val union_padding : bool
+  val no_unions : bool
   val unreachable : string list
   val comb : bool
   val ignore : string list
@@ -447,7 +448,7 @@ module Make (Config : CONFIG) = struct
           ^^ separate space
                [
                  string "typedef";
-                 string "union";
+                 (if Config.no_unions then string "struct" else string "union");
                  string "packed";
                  group
                    (lbrace

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -2139,7 +2139,14 @@ module Make (Config : CONFIG) = struct
   and pp_def ctx in_module (SVD_aux (aux, _)) =
     match aux with
     | SVD_null -> empty
-    | SVD_var (id, ctyp) -> wrap_type ctyp (pp_name id) ^^ semi
+    | SVD_var (id, ctyp) -> (
+        let doc = wrap_type ctyp (pp_name id) ^^ semi in
+        match id with
+        | Have_exception 0 ->
+            let stmt = SVS_aux (SVS_assign (SVP_id id, Bool_lit false), Unknown) in
+            doc ^^ hardline ^^ string "assign " ^^ pp_statement ~terminator:semi stmt
+        | _ -> doc
+      )
     | SVD_initial statement -> string "initial" ^^ space ^^ pp_statement ~terminator:semi statement
     | SVD_always_ff statement ->
         let posedge_clk = char '@' ^^ parens (string "posedge" ^^ space ^^ string "clk") in

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -68,6 +68,11 @@ module StringMap = Util.StringMap
 
 let ngensym = symbol_generator ()
 
+let symgen_asrt = symbol_generator ()
+let ngen_asrt () =
+  let n = match symgen_asrt () with Gen (_, n, _) -> n | _ -> failwith "symgen_asrt should return a Gen(int, _, _)" in
+  name @@ mk_id @@ Printf.sprintf "asrt_cond_%d" n
+
 let natural_name_compare variable_locations n1 n2 =
   let open Lexing in
   let name_compare id1 id2 ssa_num1 ssa_num2 =
@@ -105,6 +110,8 @@ module type CONFIG = sig
   val fun_to_wires : (string * int) list
   val dpi_sets : StringSet.t
   val skip_cyclic : bool
+  val no_assert_fatal : bool
+  val assert_as_property : bool
 end
 
 module Make (Config : CONFIG) = struct
@@ -899,7 +906,7 @@ module Make (Config : CONFIG) = struct
                       Fn ("or", [Fn ("not", [pathcond]); Fn ("not", [Var (Name (mk_id "assert_reachable#", -1))]); cond])
                   | None -> cond
                 in
-                wrap (SVS_block [SVS_aux (SVS_assert (cond, msg), l); SVS_aux (SVS_assign (ret, Unit), l)])
+                wrap (SVS_block [SVS_aux (SVS_assert (ngen_asrt (), cond, msg), l); SVS_aux (SVS_assign (ret, Unit), l)])
             | _ -> Reporting.unreachable l __POS__ "Invalid arguments for sail_assert"
           )
         else if Id.compare id (mk_id "sail_cons") = 0 then extern_generate l ctx creturn id "sail_cons" args
@@ -999,10 +1006,17 @@ module Make (Config : CONFIG) = struct
     match aux with
     | SVS_comment str -> concat_map string ["/* "; str; " */"]
     | SVS_split_comb -> string "/* split comb */"
-    | SVS_assert (cond, msg) ->
-        separate space
-          [string "if"; parens (pp_smt cond) ^^ semi; string "else"; string "$fatal" ^^ parens (pp_smt msg)]
-        ^^ terminator
+    | SVS_assert (name, cond, msg) ->
+        ( if not Config.no_assert_fatal then
+            separate space
+              [string "if"; parens (pp_smt cond) ^^ semi; string "else"; string "$fatal" ^^ parens (pp_smt msg)]
+            ^^ terminator
+          else empty
+        )
+        ^^
+        if Config.assert_as_property then
+          separate space [pp_name name; string " = "; parens (pp_smt cond)] ^^ terminator
+        else empty
     | SVS_foreach (i, exp, stmt) ->
         separate space [string "foreach"; parens (pp_smt exp ^^ brackets (pp_sv_name i))]
         ^^ nest 4 (hardline ^^ pp_statement ~terminator:empty stmt)
@@ -2025,7 +2039,42 @@ module Make (Config : CONFIG) = struct
       defs = List.map mk_def defs;
     }
 
+  class assertion_name_enumerator names : svir_visitor =
+    object
+      inherit empty_svir_visitor
+
+      method! vctyp _ = SkipChildren
+
+      method! vstatement s =
+        match s with
+        | SVS_aux (SVS_assert (name, _, _), _) ->
+            names := name :: !names;
+            DoChildren
+        | _ -> DoChildren
+    end
+
+  let get_asrt_names m =
+    (* Takes a sv_module and returns a list of names of assertions in the module *)
+    let names = ref [] in
+    ignore (visit_sv_def (new assertion_name_enumerator names) (mk_def (SVD_module m)));
+    !names
+
   let rec pp_module ctx m =
+    let params =
+      if m.recursive then
+        space ^^ string (Printf.sprintf "#(parameter RECURSION_DEPTH = %d)" Config.recursion_depth) ^^ space
+      else empty
+    in
+
+    let asrt_names = get_asrt_names m in
+    let assertion =
+      match String.concat " && " (List.map (string_of_name ~zencode:false) asrt_names) with
+      | "" -> empty
+      | s -> hardline ^^ string ("assert property (" ^ s ^ ");")
+    in
+    let asrt_defs = List.map (fun n -> SVD_aux (SVD_var (n, CT_bool), Unknown)) asrt_names in
+    let assertion = if Config.assert_as_property then assertion else empty in
+    let asrt_defs = if Config.assert_as_property then asrt_defs else [] in
     let params =
       if m.recursive then
         space ^^ string (Printf.sprintf "#(parameter RECURSION_DEPTH = %d)" Config.recursion_depth) ^^ space
@@ -2053,7 +2102,7 @@ module Make (Config : CONFIG) = struct
       else doc
     in
     string "module" ^^ space ^^ pp_sv_name m.name ^^ params ^^ ports
-    ^^ generate (nest 4 (hardline ^^ separate_map hardline (pp_def ctx (Some m.name)) m.defs))
+    ^^ generate (nest 4 (hardline ^^ separate_map hardline (pp_def ctx (Some m.name)) (asrt_defs @ m.defs) ^^ assertion))
     ^^ hardline ^^ string "endmodule"
 
   and pp_fundef f =

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -96,6 +96,7 @@ module type CONFIG = sig
   val recursion_depth : int
   val max_unknown_integer_width : int
   val max_unknown_bitvector_width : int
+  val global_prefix : string option
   val line_directives : bool
   val no_strings : bool
   val no_packed : bool

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -99,6 +99,7 @@ module type CONFIG = sig
   val union_padding : bool
   val no_unions : bool
   val unreachable : string list
+  val no_write_flush : bool
   val comb : bool
   val ignore : string list
   val fun_to_wires : (string * int) list
@@ -1919,7 +1920,10 @@ module Make (Config : CONFIG) = struct
               | _ -> assert false
               )
             exposed_registers
-        @ [mk_statement (svs_raw "sail_flush_writes(out_memory_writes)" ~inputs:[Name (mk_id "out_memory_writes", -1)])]
+        @
+        if Config.no_write_flush then []
+        else
+          [mk_statement (svs_raw "sail_flush_writes(out_memory_writes)" ~inputs:[Name (mk_id "out_memory_writes", -1)])]
       in
       if clk then (
         let reset_regs, inout_regs =

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -168,7 +168,7 @@ module Make (Config : CONFIG) = struct
       end)
       ()
 
-  let pp_id_string id = NameGen.to_string () id
+  let pp_id_string id = Globals.prepend Config.global_prefix @@ NameGen.to_string () id
 
   let pp_id id = string (pp_id_string id)
 
@@ -1629,7 +1629,7 @@ module Make (Config : CONFIG) = struct
     let get_final_name name = match NameMap.find_opt name final_names with Some n -> n | None -> name in
 
     let output_ports : sv_module_port list =
-      List.map2
+      Globals.map2
         (fun var ret_ctyp -> { name = get_final_name var; external_name = ""; typ = ret_ctyp })
         return_vars ret_ctyps
       @ List.map
@@ -1907,7 +1907,8 @@ module Make (Config : CONFIG) = struct
               module_name;
               instance_name = sprintf "sail_inst_let_%d" n;
               input_connections = [];
-              output_connections = List.map (fun id -> SVP_id (name id)) ids;
+              output_connections =
+                (if Option.is_some Config.global_prefix then [] else List.map (fun id -> SVP_id (name id)) ids);
             }
         )
         (IntMap.bindings spec_info.global_let_numbers)
@@ -1935,6 +1936,7 @@ module Make (Config : CONFIG) = struct
               | _ -> assert false
               )
             exposed_registers
+        @ Globals.Gen.always_comb_assignments Config.global_prefix
         @
         if Config.no_write_flush then []
         else
@@ -2010,7 +2012,8 @@ module Make (Config : CONFIG) = struct
       | _ -> ([], [mk_port Jib_util.return ret_ctyp])
     in
     let defs =
-      (if inout_regs then [] else List.map register_def (register_inputs @ register_outputs))
+      Globals.Gen.top_defs Config.global_prefix
+      @ (if inout_regs then [] else List.map register_def (register_inputs @ register_outputs))
       @ throws_outputs @ channel_outputs @ memory_writes @ return_def @ initialize_letbindings @ initialize_registers
       @ List.of_seq (Queue.to_seq qdefs)
       @ comb_queue funwires_input @ [instantiate_main] @ comb_queue funwires_output @ [always_block]
@@ -2061,6 +2064,7 @@ module Make (Config : CONFIG) = struct
     !names
 
   let rec pp_module ctx m =
+    Globals.toggle @@ Sv_ir.string_of_sv_name (m : sv_module).name;
     let params =
       if m.recursive then
         space ^^ string (Printf.sprintf "#(parameter RECURSION_DEPTH = %d)" Config.recursion_depth) ^^ space
@@ -2140,6 +2144,7 @@ module Make (Config : CONFIG) = struct
   and pp_def ctx in_module (SVD_aux (aux, _)) =
     match aux with
     | SVD_null -> empty
+    | SVD_var (id, ctyp) when Globals.remove_top_vars Config.global_prefix in_module -> empty
     | SVD_var (id, ctyp) -> (
         let doc = wrap_type ctyp (pp_name id) ^^ semi in
         match id with
@@ -2453,7 +2458,7 @@ module Make (Config : CONFIG) = struct
         let module_name = SVN_string (sprintf "sail_setup_let_%d" n) in
         let setup_module =
           svir_module
-            ~return_vars:(List.map (fun (id, _) -> name id) bindings)
+            ~return_vars:(if Option.is_some Config.global_prefix then [] else List.map (fun (id, _) -> name id) bindings)
             spec_info ctx module_name [] [] (List.map snd bindings)
             (setup @ [iundefined CT_unit])
         in

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -198,7 +198,7 @@ module Make (Config : CONFIG) = struct
     | CT_fbits width -> ksprintf simple_type "logic [%d:0]" (width - 1)
     | CT_sbits max_width ->
         let logic = sprintf "logic [%d:0]" (max_width - 1) in
-        ksprintf simple_type "struct packed { logic [7:0] size; %s bits; }" logic
+        ksprintf simple_type "struct packed { logic [7:0] sb_size; %s sb_bits; }" logic
     | CT_lbits -> simple_type "sail_bits"
     | CT_fint width when two_state -> ksprintf simple_type "bit [%d:0]" (width - 1)
     | CT_fint width -> ksprintf simple_type "logic [%d:0]" (width - 1)
@@ -624,9 +624,9 @@ module Make (Config : CONFIG) = struct
        SMTLIB bvsrem: Sign follows dividend *)
     | Fn ("bvsrem", [x; y]) -> opt_parens (separate space [sv_signed (pp_smt x); string "%"; sv_signed (pp_smt y)])
     | Fn ("select", [x; i]) -> pp_smt_parens x ^^ lbracket ^^ pp_smt i ^^ rbracket
-    | Fn ("contents", [Var v]) -> pp_name v ^^ dot ^^ string "bits"
+    | Fn ("contents", [Var v]) -> pp_name v ^^ dot ^^ string "sb_bits"
     | Fn ("contents", [x]) -> string "sail_bits_value" ^^ parens (pp_smt x)
-    | Fn ("len", [Var v]) -> pp_name v ^^ dot ^^ string "size"
+    | Fn ("len", [Var v]) -> pp_name v ^^ dot ^^ string "sb_size"
     | Fn ("len", [x]) -> string "sail_bits_size" ^^ parens (pp_smt x)
     | Fn ("cons", [x; xs]) -> lbrace ^^ pp_smt x ^^ comma ^^ space ^^ pp_smt xs ^^ rbrace
     | Fn ("str.++", xs) ->

--- a/src/sail_sv_backend/jib_sv.mli
+++ b/src/sail_sv_backend/jib_sv.mli
@@ -73,6 +73,7 @@ module type CONFIG = sig
 
   val never_pack_unions : bool
   val union_padding : bool
+  val no_unions : bool
   val unreachable : string list
   val comb : bool
   val ignore : string list

--- a/src/sail_sv_backend/jib_sv.mli
+++ b/src/sail_sv_backend/jib_sv.mli
@@ -50,6 +50,9 @@ open Libsail
 open Ast_util
 
 module type CONFIG = sig
+  (** Set recursion depth for recursive SystemVerilog modules *)
+  val recursion_depth : int
+
   (** If Sail does not know a precise bitwidth for an integer variable, it will use this width. *)
   val max_unknown_integer_width : int
 

--- a/src/sail_sv_backend/jib_sv.mli
+++ b/src/sail_sv_backend/jib_sv.mli
@@ -60,6 +60,9 @@ module type CONFIG = sig
       representation which can hold bitvectors of at most this length. *)
   val max_unknown_bitvector_width : int
 
+  (** Prefix global signals with the provided name *)
+  val global_prefix : string option
+
   (** Output SystemVerilog line directives where possible *)
   val line_directives : bool
 

--- a/src/sail_sv_backend/jib_sv.mli
+++ b/src/sail_sv_backend/jib_sv.mli
@@ -103,6 +103,9 @@ module type CONFIG = sig
   (** If true we will simply skip generating the body of any cyclic (i.e. contains a loop that has not been unrolled)
       definitions, and print a warning instead. This allows generation to proceed for other parts of the spec. *)
   val skip_cyclic : bool
+
+  val no_assert_fatal : bool
+  val assert_as_property : bool
 end
 
 module Make (Config : CONFIG) : sig

--- a/src/sail_sv_backend/jib_sv.mli
+++ b/src/sail_sv_backend/jib_sv.mli
@@ -78,6 +78,7 @@ module type CONFIG = sig
   val union_padding : bool
   val no_unions : bool
   val unreachable : string list
+  val no_write_flush : bool
   val comb : bool
   val ignore : string list
 

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -95,6 +95,7 @@ let opt_no_packed = ref false
 let opt_no_assertions = ref false
 let opt_never_pack_unions = ref false
 let opt_padding = ref false
+let opt_no_unions = ref false
 let opt_nomem = ref false
 
 let opt_assert_to_exception = ref false
@@ -171,6 +172,7 @@ let verilog_options =
       Arg.Int (fun i -> opt_max_unknown_bitvector_width := i),
       "set the maximum width for bitvectors with unknown width"
     );
+    (Flag.create ~prefix:["sv"] "no_unions", Arg.Set opt_no_unions, " don't emit any union, instead emit struct");
     (Flag.create ~prefix:["sv"] "no_strings", Arg.Set opt_no_strings, "don't emit any strings, instead emit units");
     (Flag.create ~prefix:["sv"] "no_packed", Arg.Set opt_no_packed, "don't emit packed datastructures");
     (Flag.create ~prefix:["sv"] "no_assertions", Arg.Set opt_no_assertions, "ignore all Sail asserts");
@@ -458,6 +460,7 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
     let no_assertions = !opt_no_assertions
     let never_pack_unions = !opt_never_pack_unions
     let union_padding = !opt_padding
+    let no_unions = !opt_no_unions
     let unreachable = !opt_unreachable
     let comb = !opt_comb
     let ignore = [] (* List.map fst !opt_fun2wires *)

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -84,6 +84,8 @@ let opt_line_directives = ref false
 
 let opt_comb = ref false
 
+let opt_no_write_flush = ref false
+
 let opt_inregs = ref false
 let opt_outregs = ref false
 
@@ -164,6 +166,10 @@ let verilog_options =
     );
     (Flag.create ~prefix:["sv"] "lines", Arg.Set opt_line_directives, "output `line directives");
     (Flag.create ~prefix:["sv"] "comb", Arg.Set opt_comb, "output an always_comb block instead of initial block");
+    ( Flag.create ~prefix:["sv"] "no_write_flush",
+      Arg.Set opt_no_write_flush,
+      "don't emit potentially unsupported sail_write_flush() in main module."
+    );
     (Flag.create ~prefix:["sv"] "inregs", Arg.Set opt_inregs, "take register values from inputs");
     (Flag.create ~prefix:["sv"] "outregs", Arg.Set opt_outregs, "output register values");
     ( Flag.create ~prefix:["sv"] ~arg:"n" "recursion_depth",
@@ -470,6 +476,7 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
     let no_unions = !opt_no_unions
     let unreachable = !opt_unreachable
     let comb = !opt_comb
+    let no_write_flush = !opt_no_write_flush
     let ignore = [] (* List.map fst !opt_fun2wires *)
     let fun_to_wires = !opt_fun_to_wires
     let dpi_sets = !opt_dpi_sets

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -87,6 +87,8 @@ let opt_comb = ref false
 let opt_inregs = ref false
 let opt_outregs = ref false
 
+let opt_recursion_depth = ref 10
+
 let opt_max_unknown_integer_width = ref 128
 let opt_max_unknown_bitvector_width = ref 128
 
@@ -164,6 +166,10 @@ let verilog_options =
     (Flag.create ~prefix:["sv"] "comb", Arg.Set opt_comb, "output an always_comb block instead of initial block");
     (Flag.create ~prefix:["sv"] "inregs", Arg.Set opt_inregs, "take register values from inputs");
     (Flag.create ~prefix:["sv"] "outregs", Arg.Set opt_outregs, "output register values");
+    ( Flag.create ~prefix:["sv"] ~arg:"n" "recursion_depth",
+      Arg.Int (fun i -> opt_recursion_depth := i),
+      "set the depth of recursive SV modules"
+    );
     ( Flag.create ~prefix:["sv"] ~arg:"n" "int_size",
       Arg.Int (fun i -> opt_max_unknown_integer_width := i),
       "set the maximum width for unknown integers"
@@ -452,6 +458,7 @@ let make_genlib_file filename =
 
 let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
   let module SV = Jib_sv.Make (struct
+    let recursion_depth = !opt_recursion_depth
     let max_unknown_integer_width = !opt_max_unknown_integer_width
     let max_unknown_bitvector_width = !opt_max_unknown_bitvector_width
     let line_directives = !opt_line_directives

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -69,6 +69,8 @@ let opt_includes = ref []
 
 let opt_toplevel = ref "main"
 
+let opt_global_prefix = ref None
+
 type verilate_mode = Verilator_none | Verilator_compile | Verilator_run
 
 let opt_verilate = ref Verilator_none
@@ -132,6 +134,10 @@ let verilog_options =
           opt_toplevel := s
         ),
       "Sail function to use as toplevel module"
+    );
+    ( Flag.create ~prefix:["sv"] "global_prefix",
+      Arg.String (fun s -> opt_global_prefix := Some s),
+      "declare global signals in a named module instead of toplevel"
     );
     ( Flag.create ~prefix:["sv"; "verilate"] ~arg:"compile|run" ~override:"sv_verilate" "mode",
       Arg.String
@@ -226,8 +232,14 @@ let verilog_options =
       Arg.String (fun s -> opt_dpi_sets := StringSet.add s !opt_dpi_sets),
       "Use SystemVerilog DPI-C for a set of primitives (e.g. memory)"
     );
-    (Flag.create ~prefix:["sv"] "no_assert_fatal", Arg.Set opt_no_assert_fatal, "Do not generate '$fatal' code for assertions");
-    (Flag.create ~prefix:["sv"] "assert_as_property", Arg.Set opt_assert_as_property, "Generate SV properties for assertions");
+    ( Flag.create ~prefix:["sv"] "no_assert_fatal",
+      Arg.Set opt_no_assert_fatal,
+      "Do not generate '$fatal' code for assertions"
+    );
+    ( Flag.create ~prefix:["sv"] "assert_as_property",
+      Arg.Set opt_assert_as_property,
+      "Generate SV properties for assertions"
+    );
   ]
 
 let verilog_rewrites =
@@ -471,6 +483,7 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
     let recursion_depth = !opt_recursion_depth
     let max_unknown_integer_width = !opt_max_unknown_integer_width
     let max_unknown_bitvector_width = !opt_max_unknown_bitvector_width
+    let global_prefix = !opt_global_prefix
     let line_directives = !opt_line_directives
     let no_strings = !opt_no_strings
     let no_packed = !opt_no_packed

--- a/src/sail_sv_backend/sail_plugin_sv.ml
+++ b/src/sail_sv_backend/sail_plugin_sv.ml
@@ -101,6 +101,8 @@ let opt_never_pack_unions = ref false
 let opt_padding = ref false
 let opt_no_unions = ref false
 let opt_nomem = ref false
+let opt_no_assert_fatal = ref false
+let opt_assert_as_property = ref false
 
 let opt_assert_to_exception = ref false
 let opt_skip_cyclic = ref false
@@ -224,6 +226,8 @@ let verilog_options =
       Arg.String (fun s -> opt_dpi_sets := StringSet.add s !opt_dpi_sets),
       "Use SystemVerilog DPI-C for a set of primitives (e.g. memory)"
     );
+    (Flag.create ~prefix:["sv"] "no_assert_fatal", Arg.Set opt_no_assert_fatal, "Do not generate '$fatal' code for assertions");
+    (Flag.create ~prefix:["sv"] "assert_as_property", Arg.Set opt_assert_as_property, "Generate SV properties for assertions");
   ]
 
 let verilog_rewrites =
@@ -481,6 +485,8 @@ let verilog_target out_opt { ast; effect_info; env; default_sail_dir; _ } =
     let fun_to_wires = !opt_fun_to_wires
     let dpi_sets = !opt_dpi_sets
     let skip_cyclic = !opt_skip_cyclic
+    let no_assert_fatal = !opt_no_assert_fatal
+    let assert_as_property = !opt_assert_as_property
   end) in
   let open SV in
   let sail_dir = Reporting.get_sail_dir default_sail_dir in

--- a/src/sail_sv_backend/sv_analysis.ml
+++ b/src/sail_sv_backend/sv_analysis.ml
@@ -251,7 +251,12 @@ let collect_spec_info ctx cdefs =
       (fun (names, nums) cdef ->
         match cdef with
         | CDEF_aux (CDEF_let (n, bindings, _), _) ->
-            ( List.fold_left (fun acc (id, _) -> NameSet.add (name id) acc) names bindings,
+            ( List.fold_left
+                (fun acc (id, ctyp) ->
+                  Globals.add id ctyp;
+                  NameSet.add (name id) acc
+                )
+                names bindings,
               IntMap.add n (List.map fst bindings) nums
             )
         | _ -> (names, nums)

--- a/src/sail_sv_backend/sv_ir.ml
+++ b/src/sail_sv_backend/sv_ir.ml
@@ -136,7 +136,7 @@ and sv_statement_aux =
   | SVS_case of { head_exp : smt_exp; cases : (smt_exp * sv_statement) list; fallthrough : sv_statement option }
   | SVS_if of smt_exp * sv_statement option * sv_statement option
   | SVS_block of sv_statement list
-  | SVS_assert of smt_exp * smt_exp
+  | SVS_assert of Jib.name * smt_exp * smt_exp
   | SVS_foreach of sv_name * smt_exp * sv_statement
   | SVS_for of sv_for * sv_statement
   | SVS_raw of string * Jib.name list * Jib.name list
@@ -285,10 +285,10 @@ let rec visit_sv_statement (vis : svir_visitor) outer_statement =
         let fallthrough' = map_no_copy_opt (visit_sv_statement vis) fallthrough in
         if head_exp == head_exp' && cases == cases' && fallthrough == fallthrough' then no_change
         else SVS_aux (SVS_case { head_exp = head_exp'; cases = cases'; fallthrough = fallthrough' }, l)
-    | SVS_assert (cond, msg) ->
+    | SVS_assert (name, cond, msg) ->
         let cond' = visit_smt_exp vis cond in
         let msg' = visit_smt_exp vis msg in
-        if cond == cond' && msg == msg' then no_change else SVS_aux (SVS_assert (cond', msg'), l)
+        if cond == cond' && msg == msg' then no_change else SVS_aux (SVS_assert (name, cond', msg'), l)
     | SVS_foreach (i, exp, stmt) ->
         let exp' = visit_smt_exp vis exp in
         let stmt' = visit_sv_statement vis stmt in

--- a/src/sail_sv_backend/sv_ir.mli
+++ b/src/sail_sv_backend/sv_ir.mli
@@ -132,7 +132,7 @@ and sv_statement_aux =
   | SVS_case of { head_exp : smt_exp; cases : (smt_exp * sv_statement) list; fallthrough : sv_statement option }
   | SVS_if of smt_exp * sv_statement option * sv_statement option
   | SVS_block of sv_statement list
-  | SVS_assert of smt_exp * smt_exp
+  | SVS_assert of Jib.name * smt_exp * smt_exp
   | SVS_foreach of sv_name * smt_exp * sv_statement
   | SVS_for of sv_for * sv_statement
   | SVS_raw of string * Jib.name list * Jib.name list

--- a/src/sail_sv_backend/sv_optimize.ml
+++ b/src/sail_sv_backend/sv_optimize.ml
@@ -596,7 +596,7 @@ module RemoveUnusedVariables = struct
         begin
           match else_stmt_opt with Some else_stmt -> statement_uses stack uses else_stmt | None -> ()
         end
-    | SVS_assert (cond, msg) ->
+    | SVS_assert (name, cond, msg) ->
         smt_uses stack uses cond;
         smt_uses stack uses msg
     | SVS_case { head_exp; cases; fallthrough } ->


### PR DESCRIPTION
This PR contains various fixes that we (me and @NicolasVanPhan ) have implemented to enable the work we are doing.

Sorry to dump a big list of things all at once, I'm happy to split this in to several smaller PRs if you would prefer (for example if there's some things we could merge now, and others that need reworking, that's fine.

Most of the changes are adding configuration options for the SV backend, to support specific needs of our verification workflow, since the tools we are using (Questa and Jasper) are more strict than Verilator is when reading SV code.

There are some more radical changes in here too. These are:
 - [SV backend] Add option to convert assertions into SV properties, and option to avoid $fatal
 - [Globals] Move toplevel globals to top module

These both touch a lot more areas of code than the other commits. The first of these is generically useful to anyone wanting to use an SV verification tool to check that assertions in sail code hold. The change to how globals work is also a part of this, since we found it is required to make Questa or Jasper accept the generated SV.

Since this is a big pile of commits that all do different things, it's probably best to review commit-by-commit rather than review the whole PR changeset at once.

Thanks! :)