### PR TITLE
Raise an error for invalid config enums values

### DIFF
--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -829,7 +829,8 @@ module Make (C : CONFIG) = struct
                     rest;
                 ]
               )
-              [] members
+              [ibad_config l]
+              members
           in
           ( [idecl l enum_ctyp enum_name; idecl l CT_string enum_str]
             @ setup


### PR DESCRIPTION
If you have a `config` value for an enum but then put a value in the JSON that doesn't match any of the config names then it would just not initialise the variable. This changes it to at least give an error. The actual error message is really bad but it is better than nothing!

Fixes #1273 

Note it looks like the same problem exists for matching abstract length values in `select_abstract()` but I didn't understand how `if_chain` works so I didn't try and fix that.