### PR TITLE
Lean: improve early return translation

### DIFF
--- a/src/sail_lean_backend/Sail/Specialization.lean
+++ b/src/sail_lean_backend/Sail/Specialization.lean
@@ -81,6 +81,17 @@ def SailME.run (m : SailME α α) : SailM α := do
     | .error e => pure e
     | .ok e => pure e
 
+def _root_.ExceptT.map_error [Monad m] (e : ExceptT ε m α) (f : ε → ε') : ExceptT ε' m α :=
+  ExceptT.mk <| do
+    match ← e.run with
+    | .ok x => pure $ .ok x
+    | .error e => pure $ .error (f e)
+
+instance [∀ x, CoeT α x α'] : CoeT (SailME α β) e (SailME α' β) where
+  coe := e.map_error (fun x => x)
+
+def SailME.throw (e : α) : SailME α β := MonadExcept.throw e
+
 abbrev ExceptM α := ExceptT α Id
 
 def ExceptM.run (m : ExceptM α α) : α :=

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -38,7 +38,8 @@ type context = {
   kid_id_renames_rev : kid Bindings.t;  (** Inverse of the [kid_id_renames] mapping. *)
   mutable loop_level : int;
   in_sail_monad : bool;  (** Indicates whether we are in an expression of `SailM _` *)
-  in_except_monad : bool;  (** Indicates whether we are in an expression of `ExceptM _ _` *)
+  in_except_monad : document option;
+      (** Indicates whether we are in an expression of `ExceptM _ _` what the return type is. *)
 }
 
 let context_init env global =
@@ -49,7 +50,7 @@ let context_init env global =
     kid_id_renames_rev = global.kid_id_renames_rev;
     loop_level = 0;
     in_sail_monad = false;
-    in_except_monad = false;
+    in_except_monad = None;
   }
 let context_with_env ctx env = { ctx with env }
 
@@ -652,10 +653,10 @@ let name_loop_vars ctx =
 
 let prepend_monad ctx exp doc =
   match (ctx.in_sail_monad, ctx.in_except_monad) with
-  | true, true -> [string "SailME"; string "_"; doc]
-  | true, false -> [string "SailM"; doc]
-  | false, true -> [string "ExceptM"; string "_"; doc]
-  | false, false -> [string "Id"; doc]
+  | true, Some ty -> [string "SailME"; ty; doc]
+  | true, None -> [string "SailM"; doc]
+  | false, Some ty -> [string "ExceptM"; ty; doc]
+  | false, None -> [string "Id"; doc]
 
 let rec doc_match_clause (as_monadic : bool) ctx (Pat_aux (cl, l)) =
   match cl with
@@ -819,7 +820,9 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
           separate hardline [vars_dec_pp; full_loop; wrap_with_pure as_monadic vars_pp]
       | _ -> raise (Reporting.err_unreachable l __POS__ "Unexpected number of arguments for loop combinator")
     end
-  | E_app ((Id_aux (Id "early_return", _) as f), [arg]) -> nest 2 (string "throw " ^^ d_of_arg ctx arg)
+  | E_app ((Id_aux (Id "early_return", _) as f), [arg]) ->
+      let throw = if ctx.in_sail_monad then string "SailME.throw " else string "throw " in
+      nest 2 (throw ^^ d_of_arg ctx arg)
   | E_app (f, args) -> (
       let _, f_typ = Env.get_val_spec f env in
       let implicits = get_fn_implicits f_typ in
@@ -1041,12 +1044,12 @@ let doc_funcl_init global (FCL_aux (FCL_funcl (id, pexp), annot)) =
   in
   let typ_quant_comment = doc_typ_quant_in_comment ctx tq_all in
   (* Use auto-implicits for type quanitifiers for now and see if this works *)
-  let doc_ret_typ = doc_typ ctx ret_typ in
+  let doc_ret_typ_orig = doc_typ ctx ret_typ in
   let is_monadic = effectful (effect_of exp) in
   let early_return = has_early_return exp in
   let has_loop = has_loop exp in
   (* Add monad for stateful functions *)
-  let doc_ret_typ = if is_monadic then string "SailM " ^^ doc_ret_typ else doc_ret_typ in
+  let doc_ret_typ = if is_monadic then string "SailM " ^^ doc_ret_typ_orig else doc_ret_typ_orig in
   let decl_val = [doc_ret_typ; coloneq] in
   (* Add do block for stateful functions *)
   let dec_val_end =
@@ -1057,7 +1060,9 @@ let doc_funcl_init global (FCL_aux (FCL_funcl (id, pexp), annot)) =
     | false, true, _ -> [string "ExceptM.run"; string "do"]
     | _ -> []
   in
-  let ctx = { ctx with in_sail_monad = is_monadic; in_except_monad = early_return } in
+  let ctx =
+    { ctx with in_sail_monad = is_monadic; in_except_monad = (if early_return then Some doc_ret_typ_orig else None) }
+  in
   let decl_val = decl_val @ dec_val_end in
   let computability = if IdSet.mem id !opt_noncomputable_functions then string "noncomputable" else empty in
   ( typ_quant_comment,

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -205,7 +205,7 @@ let file_to_module (filename : string) =
 
 let file_prelude =
   {|set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -470,7 +470,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -27,7 +27,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -44,7 +44,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -53,7 +53,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -148,7 +148,7 @@ def foreach_earlyreturneffect (n : Nat) : SailM Bool := SailME.run do
     let () := loop_vars
     loop_vars ← do
       bif (i >b 5)
-      then throw (false : Bool)
+      then SailME.throw (false : Bool)
       else writeReg r ((← readReg r) +i 1)
   (pure loop_vars)
   (pure ((← readReg r) >b n))
@@ -166,7 +166,7 @@ def foreach_earlyreturnpure (n : Nat) : Bool := ExceptM.run do
         bif (i >b 5)
         then throw (false : Bool)
         else (pure (res +i i))
-    (pure loop_vars) ) : ExceptM _ Nat )
+    (pure loop_vars) ) : ExceptM Bool Nat )
   (pure (res >b n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -184,7 +184,7 @@ def foreach_inner_earlyreturneffect (n : Nat) : SailM Bool := SailME.run do
         let () := loop_vars_1
         loop_vars_1 ← do
           bif (i >b 5)
-          then throw (false : Bool)
+          then SailME.throw (false : Bool)
           else writeReg r ((← readReg r) +i 1)
       (pure loop_vars_1)
   (pure loop_vars)
@@ -210,7 +210,7 @@ def foreach_inner_earlyreturnpure (n : Nat) : Bool := ExceptM.run do
             then throw (false : Bool)
             else (pure (res +i 1))
         (pure loop_vars_1)
-    (pure loop_vars) ) : ExceptM _ Nat )
+    (pure loop_vars) ) : ExceptM Bool Nat )
   (pure (res >b n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -228,7 +228,7 @@ def foreach_inner_earlyreturneffect_catch (n : Nat) : SailM Bool := SailME.run d
         let () := loop_vars_1
         loop_vars_1 ← do
           bif (i >b 5)
-          then throw (false : Bool)
+          then SailME.throw (false : Bool)
           else writeReg r ((← readReg r) +i 1)
       (pure loop_vars_1)
       writeReg r ((← readReg r) *i 2)
@@ -255,9 +255,9 @@ def foreach_inner_earlyreturnpure_catch (n : Nat) : Bool := ExceptM.run do
               bif (i >b 5)
               then throw (false : Bool)
               else (pure (res +i 1))
-          (pure loop_vars_1) ) : ExceptM _ Nat )
+          (pure loop_vars_1) ) : ExceptM Bool Nat )
         (pure (res *i 2))
-    (pure loop_vars) ) : ExceptM _ Nat )
+    (pure loop_vars) ) : ExceptM Bool Nat )
   (pure (res >b n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -267,7 +267,7 @@ def while_earlyreturneffect (n : Nat) : SailM Bool := SailME.run do
     let () := loop_vars
     loop_vars ← do
       bif ((← readReg r) >b 5)
-      then throw (false : Bool)
+      then SailME.throw (false : Bool)
       else writeReg r ((← readReg r) +i 1)
   (pure loop_vars)
   (pure ((← readReg r) >b n))
@@ -283,7 +283,7 @@ def while_earlyreturnpure (n : Nat) : Bool := ExceptM.run do
         bif (res >b 5)
         then throw (false : Bool)
         else (pure (res +i 1))
-    (pure loop_vars) ) : ExceptM _ Nat )
+    (pure loop_vars) ) : ExceptM Bool Nat )
   (pure (res >b n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -297,7 +297,7 @@ def while_inner_earlyreturneffect (n : Nat) : SailM Bool := SailME.run do
         let () := loop_vars_1
         loop_vars_1 ← do
           bif (n >b 5)
-          then throw (false : Bool)
+          then SailME.throw (false : Bool)
           else writeReg r ((← readReg r) +i 1)
       (pure loop_vars_1)
   (pure loop_vars)
@@ -319,7 +319,7 @@ def while_inner_earlyreturnpure (n : Nat) : Bool := ExceptM.run do
             then throw (false : Bool)
             else (pure (res +i 1))
         (pure loop_vars_1)
-    (pure loop_vars) ) : ExceptM _ Nat )
+    (pure loop_vars) ) : ExceptM Bool Nat )
   (pure (res >b n))
 
 /-- Type quantifiers: n : Nat, 0 ≤ n -/
@@ -333,7 +333,7 @@ def while_inner_earlyreturneffect_catch (n : Nat) : SailM Bool := SailME.run do
         let () := loop_vars_1
         loop_vars_1 ← do
           bif (n >b 5)
-          then throw (false : Bool)
+          then SailME.throw (false : Bool)
           else writeReg r ((← readReg r) +i 1)
       (pure loop_vars_1)
       writeReg r ((← readReg r) *i 2)
@@ -356,14 +356,14 @@ def while_inner_earlyreturnpure_catch (n : Nat) : Bool := ExceptM.run do
               bif (n >b 5)
               then throw (false : Bool)
               else (pure (res +i 1))
-          (pure loop_vars_1) ) : ExceptM _ Nat )
+          (pure loop_vars_1) ) : ExceptM Bool Nat )
         (pure (res *i 2))
-    (pure loop_vars) ) : ExceptM _ Nat )
+    (pure loop_vars) ) : ExceptM Bool Nat )
   (pure (res >b n))
 
 def match_early_return (x : E) : SailM E := SailME.run do
   match x with
-  | A => throw (← do
+  | A => SailME.throw (← do
         readReg r_A)
   | B => writeReg r_B A
   | C => writeReg r_C A
@@ -377,7 +377,7 @@ def match_early_return_inloop (x : E) : SailM E := SailME.run do
     let () := loop_vars
     loop_vars ← do
       match x with
-      | A => throw (← do
+      | A => SailME.throw (← do
             readReg r_A)
       | B => writeReg r_B A
       | C => writeReg r_C A
@@ -393,10 +393,10 @@ def match_early_return_inloop_2 (x : E) : SailM E := SailME.run do
     loop_vars ← do
       let y ← (( do
         match x with
-        | A => throw (← do
+        | A => SailME.throw (← do
               readReg r_A)
         | B => readReg r_B
-        | C => readReg r_C ) : SailME _ E )
+        | C => readReg r_C ) : SailME E E )
       (pure ())
   (pure loop_vars)
   readReg r_B
@@ -410,7 +410,7 @@ def match_early_return_loop (x : E) : SailM E := SailME.run do
       for i in [loop_i_lower:loop_i_upper:1]i do
         let () := loop_vars
         loop_vars ← do
-          throw (← do
+          SailME.throw (← do
               readReg r_A)
       (pure loop_vars))
   | B => writeReg r_B A
@@ -423,9 +423,9 @@ def ite_early_return (x : Bool) : SailM E := SailME.run do
   let y ← (( do
     bif x
     then
-      throw (← do
+      SailME.throw (← do
           readReg r_A)
-    else readReg r_B ) : SailME _ E )
+    else readReg r_B ) : SailME E E )
   readReg r_B
 
 /-- Type quantifiers: k_ex2657# : Bool -/
@@ -440,9 +440,9 @@ def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
       let y ← (( do
         bif x
         then
-          throw (← do
+          SailME.throw (← do
               readReg r_A)
-        else readReg r_B ) : SailME _ E )
+        else readReg r_B ) : SailME E E )
       (pure ())
   (pure loop_vars)
   readReg r_B
@@ -458,7 +458,7 @@ def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
       for i in [loop_i_lower:loop_i_upper:1]i do
         let () := loop_vars
         loop_vars ← do
-          throw (← do
+          SailME.throw (← do
               readReg r_A)
       (pure loop_vars))
   else writeReg r_B A
@@ -473,10 +473,10 @@ def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
   let y ← (( do
     bif x
     then
-      throw (← do
+      SailME.throw (← do
           (unit_type A)
           readReg r_A)
-    else readReg r_B ) : SailME _ E )
+    else readReg r_B ) : SailME E E )
   readReg r_B
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -38,7 +38,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -42,7 +42,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -46,7 +46,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -42,7 +42,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -38,7 +38,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -49,7 +49,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -35,7 +35,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -106,7 +106,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -65,7 +65,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -64,7 +64,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -52,7 +52,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -42,7 +42,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -38,7 +38,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -27,7 +27,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -27,7 +27,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -27,7 +27,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -43,7 +43,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -39,7 +39,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -27,7 +27,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -4,7 +4,7 @@ import Out.Sail.BitVec
 open PreSail
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
@@ -47,7 +47,7 @@ import Out.Defs
 import Out.Specialization
 
 set_option maxHeartbeats 1_000_000_000
-set_option maxRecDepth 10_000
+set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 


### PR DESCRIPTION
1. Explicitly print the type of the exception in the encoding of early
   returns.
2. Use a specialized function `SailME.throw` to throw to avoid needing
   to do typeclass instance synthesis and instead do unification.

This solves a type error in the Arm model.