### PR TITLE
Lean: handle foreach loops that aren't rewritten

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -827,6 +827,22 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
           separate hardline [vars_dec_pp; full_loop; wrap_with_pure as_monadic vars_pp]
       | _ -> raise (Reporting.err_unreachable l __POS__ "Unexpected number of arguments for loop combinator")
     end
+  | E_for (loopvar, from_exp, to_exp, step_exp, Ord_aux (order, _), body) ->
+      let combinator = match order with Ord_inc -> "foreach_Z_up" | Ord_dec -> "foreach_Z_down" in
+      let from_exp_pp, to_exp_pp, step_exp_pp =
+        (doc_exp false ctx from_exp, doc_exp false ctx to_exp, doc_exp false ctx step_exp)
+      in
+      let step_exp_pp = match order with Ord_inc -> step_exp_pp | Ord_dec -> minus ^^ step_exp_pp in
+      let loop_bracket = brackets (separate colon [from_exp_pp; to_exp_pp; step_exp_pp]) ^^ string "i" in
+      let loopvar_pp = doc_id_ctor loopvar in
+      let body_effect = has_effect body in
+      let enter_monad = if body_effect then empty else string "Id.run" in
+      let loop_head =
+        flow (break 1) (remove_empties [enter_monad; string "for"; loopvar_pp; string "in"; loop_bracket; string "do"])
+      in
+      let loop_body = doc_exp body_effect ctx body in
+      let full_loop = prefix 2 1 loop_head loop_body in
+      full_loop
   | E_app ((Id_aux (Id "early_return", _) as f), [arg]) ->
       let throw = if ctx.in_sail_monad then string "SailME.throw " else string "throw " in
       nest 2 (throw ^^ d_of_arg ctx arg)

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -53,7 +53,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex2051# : Bool, k_ex2050# : Bool -/
+/-- Type quantifiers: k_ex2251# : Bool, k_ex2250# : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -259,6 +259,42 @@ def while_print_long (_ : Unit) : Unit := Id.run do
       loop_vars := ((this_is_a_very_long_variable_name_to_stress_the_formatting +i 1) : Int)
     (pure loop_vars) ) : Id Int )
   (pure (print_int "i = " this_is_a_very_long_variable_name_to_stress_the_formatting))
+
+def nothing (_ : Unit) : Unit :=
+  ()
+
+/-- Type quantifiers: m : Int, n : Int -/
+def foreachpure (n : Int) (m : Int) : Unit := Id.run do
+  let x : Int := n
+  let x ← (( do
+    let loop_rr_lower := 0
+    let loop_rr_upper := (m -i 1)
+    let mut loop_vars := x
+    for rr in [loop_rr_lower:loop_rr_upper:1]i do
+      let x := loop_vars
+      loop_vars :=
+        let _ : Unit :=
+          let vec := n
+          Id.run for i in [0:(m -i 1):1]i do (nothing ())
+        (x +i 1)
+    (pure loop_vars) ) : Id Int )
+  (pure ())
+
+/-- Type quantifiers: m : Int, n : Nat, 0 ≤ n -/
+def foreachnotsopure (n : Nat) (m : Int) : SailM Unit := do
+  let x : Nat := n
+  let x ← (( do
+    let loop_rr_lower := 0
+    let loop_rr_upper := (m -i 1)
+    let mut loop_vars := x
+    for rr in [loop_rr_lower:loop_rr_upper:1]i do
+      let x := loop_vars
+      loop_vars ← do
+        let vec := n
+        for i in [0:(m -i 1):1]i do writeReg r x
+        (pure (x +i 1))
+    (pure loop_vars) ) : SailM Nat )
+  (pure ())
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r (← (undefined_nat ()))

--- a/test/lean/loop.sail
+++ b/test/lean/loop.sail
@@ -99,3 +99,29 @@ function while_print_long() = {
   print_int("i = ", this_is_a_very_long_variable_name_to_stress_the_formatting)
 }
 
+val nothing : unit -> unit
+function nothing() : unit = ()
+
+val foreachpure : (int, int) -> unit
+function foreachpure (n : int, m : int) = {
+  x : int = n;
+  foreach (rr from 0 to (m - 1) by 1 in inc) {
+    let 'vec = n in
+      {
+          foreach (i from 0 to (m - 1) by 1 in inc) { nothing(); }
+      };
+    x = x + 1;
+  }
+}
+
+val foreachnotsopure : (nat, int) -> unit
+function foreachnotsopure (n : nat, m : int) = {
+  x : nat = n;
+  foreach (rr from 0 to (m - 1) by 1 in inc) {
+    let 'vec = n in
+      {
+          foreach (i from 0 to (m - 1) by 1 in inc) { r = x; }
+      };
+    x = x + 1;
+  }
+}


### PR DESCRIPTION
In some cases the remove_e_assign rewriting pass does not remove foreach loops, so we need to handle them.