### PR TITLE
Lean: disable 'enums' support in match_bv's use of bv_decide

### DIFF
--- a/src/sail_lean_backend/Sail/BitVec.lean
+++ b/src/sail_lean_backend/Sail/BitVec.lean
@@ -228,7 +228,7 @@ def elabMatchBv : TermElab := fun stx typ? =>
       ← if let some rhsElse := rhsElse? then
           `(Function.const _ $rhsElse)
         else
-          `(fun _ => by try bv_decide; try grind)
+          `(fun _ => by try bv_decide -enums)
 
     for ps in pss.reverse, rhs in rhss.reverse do
       let test ← genBVPatMatchTest xs ps


### PR DESCRIPTION
The bv_decide enum support is currently broken in case of monadic code. As it also is not needed we can disable it in match_bv. This fixes a bug in the sail-riscv model. While I could not identify a self-contained sail bug, this Lean code would reproduce the issue:

```
def test : IO Unit := do
  IO.print ""
  let _ : Unit :=
    match_bv 0#8 with
    | d => ()
  pure ()
```

The issue has been reported upstream, such that the eventual fix in Lean will contain the relevant bv_decide test case.

We also disable the use of grind in match_bv, as `try grind` was only added as a workaround to try to hide the underlying `bv_decide` bug. Given that we have a more principled approach, we can remove the use of grind here.