### PR TITLE
Lean: change register state to extensional hash maps

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -1,4 +1,4 @@
-import Std.Data.DHashMap
+import Std.Data.ExtDHashMap
 import Std.Data.HashMap
 
 namespace Sail
@@ -375,7 +375,7 @@ section Regs
 variable {Register : Type} {RegisterType : Register → Type} [DecidableEq Register] [Hashable Register]
 
 structure SequentialState (RegisterType : Register → Type) (c : ChoiceSource) where
-  regs : Std.DHashMap Register RegisterType
+  regs : Std.ExtDHashMap Register RegisterType
   choiceState : c.α
   mem : Std.HashMap Nat (BitVec 8)
   tags : Unit
@@ -601,6 +601,9 @@ instance [GetElem? coll Nat elem valid] : GetElem? coll Int elem (λ c i ↦ val
 
 instance : HPow Int Int Int where
   hPow x n := x ^ n.toNat
+
+instance [BEq α] [Hashable α] : Inhabited (Std.ExtDHashMap α β) where
+  default := ∅
 
 infixl:65 " +i "   => fun (x y : Int) => x + y
 infixl:65 " -i "   => fun (x y : Int) => x - y

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -85,8 +85,8 @@ let opt_single_file : bool ref = ref false
 let opt_enable_matchbv : bool ref = ref false
 let opt_disable_matchbv : bool ref = ref true
 
-let lean_version : string = "lean4:nightly-2025-04-07"
-let mathlib_version : string = "nightly-testing-2025-04-07"
+let lean_version : string = "lean4:nightly-2025-05-14"
+let mathlib_version : string = "v4.20.0-rc5"
 
 let lean_options =
   [


### PR DESCRIPTION
This closes #1296.

As proposed by @MackieLoeffel in order to reason about equality of register states.

Also bumps the Lean and Mathlib version.