### PR TITLE
Lean: add `Repr` derivers to all generated types

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1186,7 +1186,10 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
   | TD_enum (id, fields, _) ->
       let fields = List.map doc_id_ctor fields in
       let fields = List.map (fun i -> space ^^ pipe ^^ space ^^ i) fields in
-      let derivers = if List.length fields == 0 then [string "BEq"] else [string "Inhabited"; string "BEq"] in
+      let derivers =
+        if List.length fields == 0 then [string "BEq"; string "Repr"]
+        else [string "Inhabited"; string "BEq"; string "Repr"]
+      in
       let enums_doc = concat fields in
       let _ = opens := IdSet.add id !opens in
       let id = doc_id_ctor id in
@@ -1202,7 +1205,7 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       doc_typ_quant_in_comment ctx tq
       ^^ nest 2
            (flow (break 1) (remove_empties [string "structure"; doc_id_ctor id; rectyp; string "where"])
-           ^^ hardline ^^ fields_doc ^^ hardline ^^ string "deriving Inhabited, BEq"
+           ^^ hardline ^^ fields_doc ^^ hardline ^^ string "deriving Inhabited, BEq, Repr"
            )
   | TD_abbrev (id, tq, A_aux (A_typ (Typ_aux (Typ_app (Id_aux (Id "range", _), _), _) as t), _)) ->
       let vars = doc_typ_quant_relevant ctx tq in
@@ -1224,7 +1227,9 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let rectyp = List.map (fun d -> parens d) rectyp |> separate space in
       let _ = opens := IdSet.add id !opens in
       let id = doc_id_ctor id in
-      let derivers = if List.length ar == 0 then [string "BEq"] else [string "Inhabited"; string "BEq"] in
+      let derivers =
+        if List.length ar == 0 then [string "BEq"; string "Repr"] else [string "Inhabited"; string "BEq"; string "Repr"]
+      in
       doc_typ_quant_in_comment ctx tq
       ^^ nest 2
            (nest 2 (flow space (remove_empties [string "inductive"; id; rectyp; string "where"]))
@@ -1320,7 +1325,7 @@ let register_enums registers =
     [
       string "inductive Register : Type where";
       separate_map hardline (fun (_, id, _) -> string "  | " ^^ doc_id_ctor id) registers;
-      string "  deriving DecidableEq, Hashable";
+      string "  deriving DecidableEq, Hashable, Repr";
       string "open Register";
       empty;
     ]

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev MAIRType := (BitVec 64)
 
@@ -25,41 +25,41 @@ abbrev S1PIRType := (BitVec 64)
 abbrev S2PIRType := (BitVec 64)
 
 inductive SecurityState where | SS_NonSecure | SS_Root | SS_Realm | SS_Secure
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev PARTIDtype := (BitVec 16)
 
 abbrev PMGtype := (BitVec 8)
 
 inductive PARTIDspaceType where | PIdSpace_Secure | PIdSpace_Root | PIdSpace_Realm | PIdSpace_NonSecure
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure MPAMinfo where
   mpam_sp : PARTIDspaceType
   partid : PARTIDtype
   pmg : PMGtype
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive AccessType where | AccessType_IFETCH | AccessType_GPR | AccessType_ASIMD | AccessType_SVE | AccessType_SME | AccessType_IC | AccessType_DC | AccessType_DCZero | AccessType_AT | AccessType_NV2 | AccessType_SPE | AccessType_GCS | AccessType_GPTW | AccessType_TTW
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive VARange where | VARange_LOWER | VARange_UPPER
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive MemAtomicOp where | MemAtomicOp_GCSSS1 | MemAtomicOp_ADD | MemAtomicOp_BIC | MemAtomicOp_EOR | MemAtomicOp_ORR | MemAtomicOp_SMAX | MemAtomicOp_SMIN | MemAtomicOp_UMAX | MemAtomicOp_UMIN | MemAtomicOp_SWP | MemAtomicOp_CAS
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive CacheOp where | CacheOp_Clean | CacheOp_Invalidate | CacheOp_CleanInvalidate
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive CacheOpScope where | CacheOpScope_SetWay | CacheOpScope_PoU | CacheOpScope_PoC | CacheOpScope_PoE | CacheOpScope_PoP | CacheOpScope_PoDP | CacheOpScope_PoPA | CacheOpScope_ALLU | CacheOpScope_ALLUIS
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive CacheType where | CacheType_Data | CacheType_Tag | CacheType_Data_Tag | CacheType_Instruction
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive CachePASpace where | CPAS_NonSecure | CPAS_Any | CPAS_RealmNonSecure | CPAS_Realm | CPAS_Root | CPAS_SecureNonSecure | CPAS_Secure
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure AccessDescriptor where
   acctype : AccessType
@@ -95,25 +95,25 @@ structure AccessDescriptor where
   tagchecked : Bool
   tagaccess : Bool
   mpam : MPAMinfo
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive MemType where | MemType_Normal | MemType_Device
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive DeviceType where | DeviceType_GRE | DeviceType_nGRE | DeviceType_nGnRE | DeviceType_nGnRnE
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure MemAttrHints where
   attrs : (BitVec 2)
   hints : (BitVec 2)
   transient : Bool
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Shareability where | Shareability_NSH | Shareability_ISH | Shareability_OSH
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive MemTagType where | MemTag_Untagged | MemTag_AllocationTagged | MemTag_CanonicallyTagged
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure MemoryAttributes where
   memtype : MemType
@@ -124,29 +124,29 @@ structure MemoryAttributes where
   tags : MemTagType
   notagaccess : Bool
   xs : (BitVec 1)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive PASpace where | PAS_NonSecure | PAS_Secure | PAS_Root | PAS_Realm
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure FullAddress where
   paspace : PASpace
   address : (BitVec 56)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive GPCF where | GPCF_None | GPCF_AddressSize | GPCF_Walk | GPCF_EABT | GPCF_Fail
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure GPCFRecord where
   gpf : GPCF
   level : Int
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Fault where | Fault_None | Fault_AccessFlag | Fault_Alignment | Fault_Background | Fault_Domain | Fault_Permission | Fault_Translation | Fault_AddressSize | Fault_SyncExternal | Fault_SyncExternalOnWalk | Fault_SyncParity | Fault_SyncParityOnWalk | Fault_GPCFOnWalk | Fault_GPCFOnOutput | Fault_AsyncParity | Fault_AsyncExternal | Fault_TagCheck | Fault_Debug | Fault_TLBConflict | Fault_BranchTarget | Fault_HWUpdateAccessFlag | Fault_Lockdown | Fault_Exclusive | Fault_ICacheMaint
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive ErrorState where | ErrorState_UC | ErrorState_UEU | ErrorState_UEO | ErrorState_UER | ErrorState_CE | ErrorState_Uncategorized | ErrorState_IMPDEF
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure FaultRecord where
   statuscode : Fault
@@ -169,13 +169,13 @@ structure FaultRecord where
   domain : (BitVec 4)
   merrorstate : ErrorState
   debugmoe : (BitVec 4)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive MBReqDomain where | MBReqDomain_Nonshareable | MBReqDomain_InnerShareable | MBReqDomain_OuterShareable | MBReqDomain_FullSystem
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive MBReqTypes where | MBReqTypes_Reads | MBReqTypes_Writes | MBReqTypes_All
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure CacheRecord where
   acctype : AccessType
@@ -196,13 +196,13 @@ structure CacheRecord where
   asid : (BitVec 16)
   security : SecurityState
   cpas : CachePASpace
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Regime where | Regime_EL3 | Regime_EL30 | Regime_EL2 | Regime_EL20 | Regime_EL10
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive TGx where | TGx_4KB | TGx_16KB | TGx_64KB
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure S1TTWParams where
   ha : (BitVec 1)
@@ -245,7 +245,7 @@ structure S1TTWParams where
   dc : (BitVec 1)
   sif : (BitVec 1)
   mair : MAIRType
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure S2TTWParams where
   ha : (BitVec 1)
@@ -279,7 +279,7 @@ structure S2TTWParams where
   ee : (BitVec 1)
   ptw : (BitVec 1)
   vm : (BitVec 1)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure TranslationInfo where
   regime : Regime
@@ -291,16 +291,16 @@ structure TranslationInfo where
   s1params : (Option S1TTWParams)
   s2params : (Option S2TTWParams)
   memattrs : MemoryAttributes
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive TLBILevel where | TLBILevel_Any | TLBILevel_Last
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive TLBIOp where | TLBIOp_DALL | TLBIOp_DASID | TLBIOp_DVA | TLBIOp_IALL | TLBIOp_IASID | TLBIOp_IVA | TLBIOp_ALL | TLBIOp_ASID | TLBIOp_IPAS2 | TLBIPOp_IPAS2 | TLBIOp_VAA | TLBIOp_VA | TLBIPOp_VAA | TLBIPOp_VA | TLBIOp_VMALL | TLBIOp_VMALLS12 | TLBIOp_RIPAS2 | TLBIPOp_RIPAS2 | TLBIOp_RVAA | TLBIOp_RVA | TLBIPOp_RVAA | TLBIPOp_RVA | TLBIOp_RPA | TLBIOp_PAALL
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive TLBIMemAttr where | TLBI_AllAttr | TLBI_ExcludeXS
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure TLBIRecord where
   op : TLBIOp
@@ -318,7 +318,7 @@ structure TLBIRecord where
   d128 : Bool
   ttl : (BitVec 4)
   tg : (BitVec 2)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive arm_acc_type where
   | SAcc_ASIMD (_ : Bool)
@@ -332,18 +332,18 @@ inductive arm_acc_type where
   | SAcc_SPE (_ : Unit)
   | SAcc_GCS (_ : Unit)
   | SAcc_GPTW (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure TLBIInfo where
   rec' : TLBIRecord
   shareability : Shareability
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure DxB where
   domain : MBReqDomain
   types : MBReqTypes
   nXS : Bool
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Barrier where
   | Barrier_DSB (_ : DxB)
@@ -352,7 +352,7 @@ inductive Barrier where
   | Barrier_SSBB (_ : Unit)
   | Barrier_PSSBB (_ : Unit)
   | Barrier_SB (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev boolean := (BitVec 1)
 
@@ -368,7 +368,7 @@ inductive ast where
   | ExclusiveOr (_ : (reg_index × reg_index × reg_index))
   | DataMemoryBarrier (_ : Unit)
   | CompareAndBranch (_ : (reg_index × (BitVec 64)))
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | R0
@@ -403,7 +403,7 @@ inductive Register : Type where
   | R29
   | R30
   | _PC
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -16,13 +16,13 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev cr_type := (BitVec 8)
 
 inductive Register : Type where
   | R
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -16,17 +16,17 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive E where | A | B | C
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | r
   | r_C
   | r_B
   | r_A
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -16,10 +16,10 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive E where | A | B | C
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -16,11 +16,11 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | dummy
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -16,12 +16,12 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | B
   | R
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -16,11 +16,11 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | r
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/map_tactics.expected.lean
+++ b/test/lean/map_tactics.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -16,10 +16,10 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive word_width where | BYTE | HALF | WORD | DOUBLE
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -16,16 +16,16 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive E where | A | B | C
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | r_C
   | r_B
   | r_A
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev reg_index := Nat
 
@@ -53,7 +53,7 @@ inductive Register : Type where
   | R29
   | R30
   | _PC
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -16,12 +16,12 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | BIT
@@ -30,7 +30,7 @@ inductive Register : Type where
   | INT
   | R1
   | R0
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev xlen : Int := 64
 
@@ -27,18 +27,18 @@ abbrev xlenbits := (BitVec 64)
 abbrev regbits := (BitVec 5)
 
 inductive iop where | RISCV_ADDI | RISCV_SLTI | RISCV_SLTIU | RISCV_XORI | RISCV_ORI | RISCV_ANDI
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive ast where
   | ITYPE (_ : ((BitVec 12) × regbits × regbits × iop))
   | LOAD (_ : ((BitVec 12) × regbits × regbits))
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive Register : Type where
   | Xs
   | nextPC
   | PC
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 open Register
 
 abbrev RegisterType : Register → Type

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -16,12 +16,12 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure My_struct where
   field1 : Int
   field2 : (BitVec 1)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 /-- Type quantifiers: k_n : Int, k_vasize : Int, k_pa : Type, k_ts : Type, k_arch_ak : Type, k_n > 0
   ∧ k_vasize ≥ 0 -/
@@ -33,7 +33,7 @@ structure My_mem_write_request
   size : Int
   value : (Option (BitVec (8 * k_n)))
   tag : (Option Bool)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -16,14 +16,14 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive e_test where | VAL
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure s_test where
   f : e_test
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -16,10 +16,10 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive E where | A | B | C
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -16,7 +16,7 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev xlen : Int := 64
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -16,11 +16,11 @@ abbrev bits k_n := (BitVec k_n)
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive virtaddr where
   | virtaddr (_ : (BitVec 32))
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -13,22 +13,22 @@ open Sail
 structure rectangle where
   width : Int
   height : Int
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 structure circle where
   radius : Int
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 inductive shape where
   | Rectangle (_ : rectangle)
   | Circle (_ : circle)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 /-- Type quantifiers: k_a : Type -/
 inductive my_option (k_a : Type) where
   | MySome (_ : k_a)
   | MyNone (_ : Unit)
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Repr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim


### PR DESCRIPTION
Fixes #1295.