### PR TITLE
Improve type inference for structs

### DIFF
--- a/language/sail.ott
+++ b/language/sail.ott
@@ -413,6 +413,10 @@ field_pat_wildcard :: 'FP_' ::=
   | _ l :: :: wild
   |     :: :: no_wild
 
+struct_name :: 'SN_' ::=
+  | id :: :: id
+  |    :: :: anon
+
 pat :: 'P_' ::=
   {{ com pattern }}
   {{ aux _ annot }} {{ auxparam 'a }}
@@ -450,7 +454,7 @@ pat :: 'P_' ::=
     {{ com Cons patterns }}
   | pat1 ^^ ... ^^ patn                      :: :: string_append
     {{ com string append pattern, x ^^ y }}
-  | struct { id1 = pat1 , ... , idn = patn , field_pat_wildcard } :: :: struct
+  | struct struct_name { id1 = pat1 , ... , idn = patn , field_pat_wildcard } :: :: struct
     {{ com struct pattern }}
 
 parsing
@@ -509,7 +513,7 @@ exp :: 'E_' ::=
   | exp1 '::' exp2                                    :: :: cons {{ com cons }}
 
   % structs
-  | struct { fexp0 , ... , fexpn }                    :: :: struct {{ com struct }}
+  | struct struct_name { fexp0 , ... , fexpn }        :: :: struct {{ com struct }}
   | { exp with fexp0 , ... , fexpn }                  :: :: struct_update {{ com functional update of struct }}
   | exp . id                                          :: :: field {{ com field projection from struct  }}
 
@@ -664,7 +668,7 @@ mpat :: 'MP_' ::=
   | mpat1 ^^ ... ^^ mpatn              ::   :: string_append
   | mpat : typ                         ::   :: typ
   | mpat as id                         ::   :: as
-  | struct { id1 = mpat1 , ... , idn = mpatn } :: :: struct
+  | struct struct_name { id1 = mpat1 , ... , idn = mpatn } :: :: struct
 
 mpexp :: 'MPat_' ::=
   {{ aux _ annot }} {{ auxparam 'a }}

--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -633,7 +633,7 @@ let rec anf_pat ?(global = false) (P_aux (p_aux, (l, tannot)) as pat) =
         (mk_apat (AP_nil (typ_of_pat pat)))
   | P_lit (L_aux (L_unit, _)) -> mk_apat (AP_wild (typ_of_pat pat))
   | P_as (pat, id) -> mk_apat (AP_as (anf_pat ~global pat, name id, typ_of_pat pat))
-  | P_struct (fpats, FP_no_wild) ->
+  | P_struct (_, fpats, FP_no_wild) ->
       mk_apat (AP_struct (List.map (fun (field, pat) -> (field, anf_pat ~global pat)) fpats, typ_of_pat pat))
   | _ -> Reporting.unreachable l __POS__ ("Could not convert pattern to ANF: " ^ string_of_pat pat) [@coverage off]
 
@@ -845,7 +845,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
       let avals = List.map to_aval aexps in
       let wrap = List.fold_left (fun f g x -> f (g x)) (fun x -> x) (List.map snd avals) in
       wrap (mk_aexp (AE_val (AV_tuple (List.map fst avals))))
-  | E_struct fexps ->
+  | E_struct (_, fexps) ->
       let anf_fexp (FE_aux (FE_fexp (id, exp), _)) =
         let aval, wrap = to_aval (anf exp) in
         ((id, aval), wrap)

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -257,8 +257,8 @@ let rec pat_of_mpat (MP_aux (mpat, annot)) =
   | MP_string_append mpats -> P_aux (P_string_append (List.map pat_of_mpat mpats), annot)
   | MP_typ (mpat, typ) -> P_aux (P_typ (typ, pat_of_mpat mpat), annot)
   | MP_as (mpat, id) -> P_aux (P_as (pat_of_mpat mpat, id), annot)
-  | MP_struct fmpats ->
-      P_aux (P_struct (List.map (fun (field, mpat) -> (field, pat_of_mpat mpat)) fmpats, FP_no_wild), annot)
+  | MP_struct (name, fmpats) ->
+      P_aux (P_struct (name, List.map (fun (field, mpat) -> (field, pat_of_mpat mpat)) fmpats, FP_no_wild), annot)
 
 let kopt_kid (KOpt_aux (KOpt_kind (_, kid), _)) = kid
 let kopt_kind (KOpt_aux (KOpt_kind (k, _), _)) = k
@@ -828,7 +828,7 @@ let rec pattern_vector_subranges (P_aux (aux, _)) =
           Bindings.union (fun _ r1 r2 -> Some (insert_subranges r1 r2)) ranges (pattern_vector_subranges pat)
         )
         Bindings.empty pats
-  | P_struct (fpats, _) ->
+  | P_struct (_, fpats, _) ->
       let pats = List.map snd fpats in
       List.fold_left
         (fun ranges pat ->
@@ -865,7 +865,7 @@ and map_exp_annot_aux f = function
   | E_vector_append (exp1, exp2) -> E_vector_append (map_exp_annot f exp1, map_exp_annot f exp2)
   | E_list xs -> E_list (List.map (map_exp_annot f) xs)
   | E_cons (exp1, exp2) -> E_cons (map_exp_annot f exp1, map_exp_annot f exp2)
-  | E_struct fexps -> E_struct (List.map (map_fexp_annot f) fexps)
+  | E_struct (struct_name, fexps) -> E_struct (struct_name, List.map (map_fexp_annot f) fexps)
   | E_struct_update (exp, fexps) -> E_struct_update (map_exp_annot f exp, List.map (map_fexp_annot f) fexps)
   | E_field (exp, id) -> E_field (map_exp_annot f exp, id)
   | E_match (exp, cases) -> E_match (map_exp_annot f exp, List.map (map_pexp_annot f) cases)
@@ -918,7 +918,8 @@ and map_pat_annot_aux f = function
   | P_vector pats -> P_vector (List.map (map_pat_annot f) pats)
   | P_cons (pat1, pat2) -> P_cons (map_pat_annot f pat1, map_pat_annot f pat2)
   | P_string_append pats -> P_string_append (List.map (map_pat_annot f) pats)
-  | P_struct (fpats, fwild) -> P_struct (List.map (fun (field, pat) -> (field, map_pat_annot f pat)) fpats, fwild)
+  | P_struct (struct_name, fpats, fwild) ->
+      P_struct (struct_name, List.map (fun (field, pat) -> (field, map_pat_annot f pat)) fpats, fwild)
 
 and map_mpexp_annot f (MPat_aux (mpexp, annot)) = MPat_aux (map_mpexp_annot_aux f mpexp, f annot)
 
@@ -947,7 +948,8 @@ and map_mpat_annot_aux f = function
   | MP_string_append mpats -> MP_string_append (List.map (map_mpat_annot f) mpats)
   | MP_typ (mpat, typ) -> MP_typ (map_mpat_annot f mpat, typ)
   | MP_as (mpat, id) -> MP_as (map_mpat_annot f mpat, id)
-  | MP_struct fmpats -> MP_struct (List.map (fun (field, mpat) -> (field, map_mpat_annot f mpat)) fmpats)
+  | MP_struct (struct_name, fmpats) ->
+      MP_struct (struct_name, List.map (fun (field, mpat) -> (field, map_mpat_annot f mpat)) fmpats)
 
 and map_letbind_annot f (LB_aux (lb, annot)) = LB_aux (map_letbind_annot_aux f lb, f annot)
 
@@ -1289,7 +1291,9 @@ let rec string_of_exp (E_aux (exp, _)) =
   | E_config key -> "config " ^ string_of_list "." (fun s -> s) key
   | E_struct_update (exp, fexps) ->
       "struct { " ^ string_of_exp exp ^ " with " ^ string_of_list "; " string_of_fexp fexps ^ " }"
-  | E_struct fexps -> "struct { " ^ string_of_list "; " string_of_fexp fexps ^ " }"
+  | E_struct (struct_name, fexps) ->
+      let name_string = match struct_name with SN_anon -> "" | SN_id id -> " " ^ string_of_id id in
+      "struct" ^ name_string ^ " { " ^ string_of_list "; " string_of_fexp fexps ^ " }"
   | E_var (lexp, binding, exp) ->
       "var " ^ string_of_lexp lexp ^ " = " ^ string_of_exp binding ^ " in " ^ string_of_exp exp
   | E_internal_return exp -> "internal_return (" ^ string_of_exp exp ^ ")"
@@ -1335,9 +1339,10 @@ and string_of_pat (P_aux (pat, _)) =
   | P_as (pat, id) -> "(" ^ string_of_pat pat ^ " as " ^ string_of_id id ^ ")"
   | P_string_append [] -> "\"\""
   | P_string_append pats -> string_of_list " ^ " string_of_pat pats
-  | P_struct (fpats, fwild) ->
+  | P_struct (struct_name, fpats, fwild) ->
+      let name_string = match struct_name with SN_anon -> "" | SN_id id -> " " ^ string_of_id id in
       let wild_string = function FP_wild _ -> ", _" | FP_no_wild -> "" in
-      "struct { "
+      "struct" ^ name_string ^ " { "
       ^ Util.string_of_list ", " (fun (field, pat) -> string_of_id field ^ " = " ^ string_of_pat pat) fpats
       ^ wild_string fwild ^ " }"
 
@@ -1355,8 +1360,9 @@ and string_of_mpat (MP_aux (pat, _)) =
   | MP_string_append pats -> string_of_list " ^ " string_of_mpat pats
   | MP_typ (mpat, typ) -> "(" ^ string_of_mpat mpat ^ " : " ^ string_of_typ typ ^ ")"
   | MP_as (mpat, id) -> "((" ^ string_of_mpat mpat ^ ") as " ^ string_of_id id ^ ")"
-  | MP_struct fmpats ->
-      "struct { "
+  | MP_struct (struct_name, fmpats) ->
+      let name_string = match struct_name with SN_anon -> "" | SN_id id -> " " ^ string_of_id id in
+      "struct" ^ name_string ^ " { "
       ^ Util.string_of_list ", " (fun (field, mpat) -> string_of_id field ^ " = " ^ string_of_mpat mpat) fmpats
       ^ " }"
 
@@ -1394,7 +1400,7 @@ let rec pat_ids (P_aux (pat_aux, _)) =
       List.fold_left IdSet.union IdSet.empty (List.map pat_ids pats)
   | P_cons (pat1, pat2) -> IdSet.union (pat_ids pat1) (pat_ids pat2)
   | P_string_append pats -> List.fold_left IdSet.union IdSet.empty (List.map pat_ids pats)
-  | P_struct (fpats, _) -> List.fold_left IdSet.union IdSet.empty (List.map (fun (_, pat) -> pat_ids pat) fpats)
+  | P_struct (_, fpats, _) -> List.fold_left IdSet.union IdSet.empty (List.map (fun (_, pat) -> pat_ids pat) fpats)
 
 let id_of_fundef (FD_aux (FD_function (_, _, funcls), (l, _))) =
   match
@@ -1812,7 +1818,7 @@ let rec subst id value (E_aux (e_aux, annot) as exp) =
     | E_vector_append (exp1, exp2) -> E_vector_append (subst id value exp1, subst id value exp2)
     | E_list exps -> E_list (List.map (subst id value) exps)
     | E_cons (exp1, exp2) -> E_cons (subst id value exp1, subst id value exp2)
-    | E_struct fexps -> E_struct (List.map (subst_fexp id value) fexps)
+    | E_struct (struct_name, fexps) -> E_struct (struct_name, List.map (subst_fexp id value) fexps)
     | E_struct_update (exp, fexps) -> E_struct_update (subst id value exp, List.map (subst_fexp id value) fexps)
     | E_field (exp, id') -> E_field (subst id value exp, id')
     | E_match (exp, pexps) -> E_match (subst id value exp, List.map (subst_pexp id value) pexps)
@@ -2018,7 +2024,8 @@ let rec locate_pat : 'a. (l -> l) -> 'a pat -> 'a pat =
     | P_list pats -> P_list (List.map (locate_pat f) pats)
     | P_cons (hd_pat, tl_pat) -> P_cons (locate_pat f hd_pat, locate_pat f tl_pat)
     | P_string_append pats -> P_string_append (List.map (locate_pat f) pats)
-    | P_struct (fpats, fwild) -> P_struct (List.map (fun (field, pat) -> (field, locate_pat f pat)) fpats, fwild)
+    | P_struct (struct_name, fpats, fwild) ->
+        P_struct (struct_name, List.map (fun (field, pat) -> (field, locate_pat f pat)) fpats, fwild)
   in
   P_aux (p_aux, (f l, annot))
 
@@ -2047,7 +2054,7 @@ let rec locate : 'a. (l -> l) -> 'a exp -> 'a exp =
     | E_vector_append (exp1, exp2) -> E_vector_append (locate f exp1, locate f exp2)
     | E_list exps -> E_list (List.map (locate f) exps)
     | E_cons (exp1, exp2) -> E_cons (locate f exp1, locate f exp2)
-    | E_struct fexps -> E_struct (List.map (locate_fexp f) fexps)
+    | E_struct (struct_name, fexps) -> E_struct (struct_name, List.map (locate_fexp f) fexps)
     | E_struct_update (exp, fexps) -> E_struct_update (locate f exp, List.map (locate_fexp f) fexps)
     | E_field (exp, id) -> E_field (locate f exp, locate_id f id)
     | E_match (exp, cases) -> E_match (locate f exp, List.map (locate_pexp f) cases)

--- a/src/lib/bitfield.ml
+++ b/src/lib/bitfield.ml
@@ -92,7 +92,7 @@ let get_field_exp range inner_exp =
   in
   aux (List.map mk_slice (indices_of_range range))
 
-let construct_bitfield_struct _ exp = mk_exp (E_struct [mk_fexp (mk_id "bits") exp])
+let construct_bitfield_struct _ exp = mk_exp (E_struct (SN_anon, [mk_fexp (mk_id "bits") exp]))
 
 let construct_bitfield_exp name exp = mk_exp (E_app (prepend_id "Mk_" name, [exp]))
 

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -693,7 +693,7 @@ let rec chunk_pat comments chunks (P_aux (aux, l)) =
       let hd_pat_chunks = rec_chunk_pat hd_pat in
       let tl_pat_chunks = rec_chunk_pat tl_pat in
       Queue.add (Binary (hd_pat_chunks, "::", tl_pat_chunks)) chunks
-  | P_struct fpats ->
+  | P_struct (_, fpats) ->
       let is_fpat_wild = function FP_aux (FP_wild, _) -> true | _ -> false in
       let wild_fpats, field_fpats = List.partition is_fpat_wild fpats in
       let fpats = field_fpats @ wild_fpats in
@@ -841,7 +841,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
   | E_list exps ->
       let exps = chunk_delimit ~delim:"," ~get_loc:(fun (E_aux (_, l)) -> l) ~chunk:chunk_exp comments exps in
       Queue.add (Tuple ("[|", "|]", 0, exps)) chunks
-  | E_struct fexps ->
+  | E_struct (_, fexps) ->
       let fexps = chunk_delimit ~delim:"," ~get_loc:(fun (E_aux (_, l)) -> l) ~chunk:chunk_exp comments fexps in
       Queue.add (Tuple ("struct {", "}", 1, fexps)) chunks
   | E_struct_update (exp, fexps) ->

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -637,7 +637,7 @@ let rec sail_exp_from_json ~at:l env typ =
               fields
             |> Util.option_all
           in
-          Some (mk_exp ~loc:l (E_struct fexps))
+          Some (mk_exp ~loc:l (E_struct (SN_id id, fexps)))
         else if typ_is_variant env base_typ then
           let* id, _ = destruct_typ_args base_typ in
           match obj with

--- a/src/lib/constant_fold.ml
+++ b/src/lib/constant_fold.ml
@@ -69,7 +69,7 @@ and exp_of_value =
   | V_bool true -> mk_lit_exp L_true
   | V_bool false -> mk_lit_exp L_false
   | V_string str -> mk_lit_exp (L_string str)
-  | V_record fields -> mk_exp (E_struct (List.map fexp_of_ctor (StringMap.bindings fields)))
+  | V_record fields -> mk_exp (E_struct (SN_anon, List.map fexp_of_ctor (StringMap.bindings fields)))
   | V_vector vs -> mk_exp (E_vector (List.map exp_of_value vs))
   | V_tuple vs -> mk_exp (E_tuple (List.map exp_of_value vs))
   | V_unit -> mk_lit_exp L_unit
@@ -135,7 +135,7 @@ let rec is_constant (E_aux (e_aux, _) as exp) =
   match e_aux with
   | E_lit _ -> true
   | E_vector exps -> List.for_all is_constant exps
-  | E_struct fexps -> List.for_all is_constant_fexp fexps
+  | E_struct (_, fexps) -> List.for_all is_constant_fexp fexps
   | E_typ (_, exp) -> is_constant exp
   | E_tuple exps -> List.for_all is_constant exps
   | E_id id -> (

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -88,7 +88,7 @@ let rec is_value (E_aux (e, (l, annot))) =
   | E_id id -> is_constructor id
   | E_lit _ -> true
   | E_tuple es | E_vector es -> List.for_all is_value es
-  | E_struct fes -> List.for_all (fun (FE_aux (FE_fexp (_, e), _)) -> is_value e) fes
+  | E_struct (_, fes) -> List.for_all (fun (FE_aux (FE_fexp (_, e), _)) -> is_value e) fes
   | E_app (id, es) -> is_constructor id && List.for_all is_value es
   (* We add casts to undefined to keep the type information in the AST *)
   | E_typ (typ, E_aux (E_lit (L_aux (L_undef, _)), _)) -> true
@@ -457,10 +457,10 @@ let const_props target ast =
       | E_cons (e1, e2) ->
           let e1', e2', assigns = non_det_exp_2 e1 e2 in
           re (E_cons (e1', e2')) assigns
-      | E_struct fes ->
+      | E_struct (struct_name, fes) ->
           let assigned_in_fes = assigned_vars_in_fexps fes in
           let assigns = isubst_minus_set assigns assigned_in_fes in
-          re (E_struct (const_prop_fexps substs assigns fes)) assigns
+          re (E_struct (struct_name, const_prop_fexps substs assigns fes)) assigns
       | E_struct_update (e, fes) ->
           let assigned_in = IdSet.union (assigned_vars_in_fexps fes) (assigned_vars e) in
           let assigns = isubst_minus_set assigns assigned_in in
@@ -468,13 +468,13 @@ let const_props target ast =
           let fes' = const_prop_fexps substs assigns fes in
           begin
             match unaux_exp (fst (uncast_exp e')) with
-            | E_struct fes0 ->
+            | E_struct (struct_name, fes0) ->
                 let apply_fexp (FE_aux (FE_fexp (id, e), _)) (FE_aux (FE_fexp (id', e'), ann)) =
                   if Id.compare id id' = 0 then FE_aux (FE_fexp (id', e), ann) else FE_aux (FE_fexp (id', e'), ann)
                 in
                 let update_fields fexp = List.map (apply_fexp fexp) in
                 let fes0' = List.fold_right update_fields fes' fes0 in
-                re (E_struct fes0') assigns
+                re (E_struct (struct_name, fes0')) assigns
             | _ -> re (E_struct_update (e', fes')) assigns
           end
       | E_field (e, id) ->
@@ -482,7 +482,7 @@ let const_props target ast =
           begin
             let is_field (FE_aux (FE_fexp (id', _), _)) = Id.compare id id' = 0 in
             match unaux_exp e' with
-            | E_struct fes0 when List.exists is_field fes0 ->
+            | E_struct (_, fes0) when List.exists is_field fes0 ->
                 let (FE_aux (FE_fexp (_, e), _)) = List.find is_field fes0 in
                 re (unaux_exp e) assigns
             | _ -> re (E_field (e', id)) assigns

--- a/src/lib/constant_propagation_mutrec.ml
+++ b/src/lib/constant_propagation_mutrec.ml
@@ -62,7 +62,7 @@ let rec is_const_exp exp =
   match unaux_exp exp with
   | E_lit (L_aux ((L_true | L_false | L_one | L_zero | L_num _), _)) -> true
   | E_vector es -> List.for_all is_const_exp es && is_bitvector_typ (typ_of exp)
-  | E_struct fes -> List.for_all is_const_fexp fes
+  | E_struct (_, fes) -> List.for_all is_const_fexp fes
   | E_typ (_, e) -> is_const_exp e
   | _ -> false
 
@@ -78,7 +78,7 @@ let generate_fun_id id args =
     | E_lit (L_aux (L_zero, _)) -> "0"
     | E_lit (L_aux (L_true, _)) -> "T"
     | E_lit (L_aux (L_false, _)) -> "F"
-    | E_struct fes when is_const_exp exp ->
+    | E_struct (_, fes) when is_const_exp exp ->
         let fsuffix (FE_aux (FE_fexp (id, e), _)) = suffix e in
         "struct" ^ Util.zencode_string (string_of_typ (typ_of exp)) ^ "#" ^ String.concat "" (List.map fsuffix fes)
     | E_vector es when is_const_exp exp -> String.concat "" (List.map suffix es)

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -698,7 +698,7 @@ module KindInference = struct
     | P.P_string_append pats ->
         let* pats = mapM (infer_pat ctx) pats in
         wrap (P.P_string_append pats)
-    | P.P_struct fpats ->
+    | P.P_struct (struct_name, fpats) ->
         let* fpats =
           mapM
             (fun (P.FP_aux (aux, l)) ->
@@ -710,7 +710,7 @@ module KindInference = struct
             )
             fpats
         in
-        wrap (P.P_struct fpats)
+        wrap (P.P_struct (struct_name, fpats))
     | P.P_attribute (attr, arg, pat) ->
         let* pat = infer_pat ctx pat in
         wrap (P.P_attribute (attr, arg, pat))
@@ -1222,7 +1222,8 @@ let rec to_ast_pat ctx (P.P_aux (aux, l)) =
         | P.P_list pats -> P_list (List.map (to_ast_pat ctx) pats)
         | P.P_cons (pat1, pat2) -> P_cons (to_ast_pat ctx pat1, to_ast_pat ctx pat2)
         | P.P_string_append pats -> P_string_append (List.map (to_ast_pat ctx) pats)
-        | P.P_struct fpats ->
+        | P.P_struct (struct_name, fpats) ->
+            let struct_name = match struct_name with None -> SN_anon | Some id -> SN_id (to_ast_id ctx id) in
             let wild_fpats, fpats = List.partition is_wild_fpat fpats in
             let field_wildcard =
               match wild_fpats with
@@ -1239,7 +1240,7 @@ let rec to_ast_pat ctx (P.P_aux (aux, l)) =
             check_duplicate_fields
               ~error:(fun f -> Printf.sprintf "Duplicate field '%s' in struct pattern" f)
               ~field_id:fst fpats;
-            P_struct (fpats, field_wildcard)
+            P_struct (struct_name, fpats, field_wildcard)
       in
       P_aux (aux, (l, empty_uannot))
 
@@ -1273,7 +1274,7 @@ and to_ast_exp ctx exp =
         | P.E_attribute _ | P.E_infix _ -> assert false
         | P.E_block exps -> (
             match to_ast_fexps false ctx exps with
-            | Some fexps -> E_struct fexps
+            | Some fexps -> E_struct (SN_anon, fexps)
             | None -> E_block (List.map (to_ast_exp ctx) exps)
           )
         | P.E_id id ->
@@ -1324,9 +1325,10 @@ and to_ast_exp ctx exp =
         | P.E_vector_append (e1, e2) -> E_vector_append (to_ast_exp ctx e1, to_ast_exp ctx e2)
         | P.E_list exps -> E_list (List.map (to_ast_exp ctx) exps)
         | P.E_cons (e1, e2) -> E_cons (to_ast_exp ctx e1, to_ast_exp ctx e2)
-        | P.E_struct fexps -> (
+        | P.E_struct (struct_name, fexps) -> (
+            let struct_name = match struct_name with None -> SN_anon | Some id -> SN_id (to_ast_id ctx id) in
             match to_ast_fexps true ctx fexps with
-            | Some fexps -> E_struct fexps
+            | Some fexps -> E_struct (struct_name, fexps)
             | None -> raise (Reporting.err_unreachable l __POS__ "to_ast_fexps with true returned none")
           )
         | P.E_struct_update (exp, fexps) -> (
@@ -1877,8 +1879,9 @@ let rec to_ast_mpat ctx (P.MP_aux (mpat, l)) =
       | P.MP_cons (pat1, pat2) -> MP_cons (to_ast_mpat ctx pat1, to_ast_mpat ctx pat2)
       | P.MP_string_append pats -> MP_string_append (List.map (to_ast_mpat ctx) pats)
       | P.MP_typ (mpat, typ) -> MP_typ (to_ast_mpat ctx mpat, to_ast_typ ctx typ)
-      | P.MP_struct fmpats ->
-          MP_struct (List.map (fun (field, mpat) -> (to_ast_id ctx field, to_ast_mpat ctx mpat)) fmpats)
+      | P.MP_struct (struct_name, fmpats) ->
+          let struct_name = match struct_name with None -> SN_anon | Some id -> SN_id (to_ast_id ctx id) in
+          MP_struct (struct_name, List.map (fun (field, mpat) -> (to_ast_id ctx field, to_ast_mpat ctx mpat)) fmpats)
       ),
       (l, empty_uannot)
     )
@@ -2323,7 +2326,7 @@ let generate_undefined_record id typq fields =
     mk_fundef
       [
         mk_funcl (prepend_id "undefined_" id) pat
-          (mk_exp (E_struct (List.map (fun (_, id) -> mk_fexp id (mk_lit_exp L_undef)) fields)));
+          (mk_exp (E_struct (SN_anon, List.map (fun (_, id) -> mk_fexp id (mk_lit_exp L_undef)) fields)));
       ];
   ]
 

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -430,12 +430,13 @@ let rec step (E_aux (e_aux, annot) as orig_exp) =
       | Enum _ -> return (exp_of_value (V_member (string_of_id id)))
       | _ -> fail ("Couldn't find id " ^ string_of_id id)
     end
-  | E_struct fexps ->
+  | E_struct (struct_name, fexps) ->
       let evaluated, unevaluated = Util.take_drop is_value_fexp fexps in
       begin
         match unevaluated with
         | FE_aux (FE_fexp (id, exp), fe_annot) :: fexps ->
-            step exp >>= fun exp' -> wrap (E_struct (evaluated @ (FE_aux (FE_fexp (id, exp'), fe_annot) :: fexps)))
+            step exp >>= fun exp' ->
+            wrap (E_struct (struct_name, evaluated @ (FE_aux (FE_fexp (id, exp'), fe_annot) :: fexps)))
         | [] ->
             List.map value_of_fexp fexps
             |> List.fold_left (fun record (field, v) -> StringMap.add field v record) StringMap.empty
@@ -697,7 +698,7 @@ and pattern_match env (P_aux (p_aux, (l, _))) value =
           (hd_match && tl_match, Bindings.merge combine hd_bind tl_bind)
       | None -> (false, Bindings.empty)
     end
-  | P_struct (fpats, _) ->
+  | P_struct (_, fpats, _) ->
       List.fold_left
         (fun (matches, binds) (field, pat) ->
           match StringMap.find_opt (string_of_id field) (coerce_record value) with

--- a/src/lib/mappings.ml
+++ b/src/lib/mappings.ml
@@ -162,10 +162,10 @@ let rec extract_mapping_pats map_uannot is_mapping subst (P_aux (aux, annot)) =
   | P_wild -> (P_aux (P_wild, annot), [])
   | P_lit lit -> (P_aux (P_lit lit, annot), [])
   | P_vector_subrange (id, n, m) -> (P_aux (P_vector_subrange (id, n, m), annot), [])
-  | P_struct (fpats, fwild) ->
+  | P_struct (struct_name, fpats, fwild) ->
       let fields, pats = List.split fpats in
       let pats, found_mapping = extract_mapping_pats_list map_uannot is_mapping subst pats in
-      (P_aux (P_struct (List.combine fields pats, fwild), annot), found_mapping)
+      (P_aux (P_struct (struct_name, List.combine fields pats, fwild), annot), found_mapping)
 
 and extract_mapping_pats_list map_uannot is_mapping subst pats =
   let extracted = List.map (extract_mapping_pats map_uannot is_mapping subst) pats in

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -513,7 +513,7 @@ let freshen_pat_bindings p =
     | P_tuple ps ->
         let ps, vs = List.split (List.map aux ps) in
         (mkp (P_tuple ps), List.concat vs)
-    | P_struct (fps, fwild) ->
+    | P_struct (struct_name, fps, fwild) ->
         let fps, vs =
           List.split
             (List.map
@@ -524,7 +524,7 @@ let freshen_pat_bindings p =
                fps
             )
         in
-        (mkp (P_struct (fps, fwild)), List.concat vs)
+        (mkp (P_struct (struct_name, fps, fwild)), List.concat vs)
     | P_list ps ->
         let ps, vs = List.split (List.map aux ps) in
         (mkp (P_list ps), List.concat vs)
@@ -965,9 +965,9 @@ let split_defs target all_errors (splits : split_req list) env ast =
         | P_vector_concat ps -> relist spl (fun ps -> P_vector_concat ps) ps
         | P_string_append ps -> relist spl (fun ps -> P_string_append ps) ps
         | P_tuple ps -> relist spl (fun ps -> P_tuple ps) ps
-        | P_struct (fps, fwild) ->
+        | P_struct (struct_name, fps, fwild) ->
             let fields, ps = List.split fps in
-            relist spl (fun ps -> P_struct (List.combine fields ps, fwild)) ps
+            relist spl (fun ps -> P_struct (struct_name, List.combine fields ps, fwild)) ps
         | P_list ps -> relist spl (fun ps -> P_list ps) ps
         | P_cons (p1, p2) -> re2 spl (fun p1' p2' -> P_cons (p1', p2')) p1 p2
         | P_vector_subrange _ ->
@@ -1074,7 +1074,7 @@ let split_defs target all_errors (splits : split_req list) env ast =
         | E_vector_append (e1, e2) -> re (E_vector_append (map_exp e1, map_exp e2))
         | E_list es -> re (E_list (List.map map_exp es))
         | E_cons (e1, e2) -> re (E_cons (map_exp e1, map_exp e2))
-        | E_struct fes -> re (E_struct (List.map map_fexp fes))
+        | E_struct (struct_name, fes) -> re (E_struct (struct_name, List.map map_fexp fes))
         | E_struct_update (e, fes) -> re (E_struct_update (map_exp e, List.map map_fexp fes))
         | E_field (e, id) -> re (E_field (map_exp e, id))
         | E_match (e, cases) -> re (E_match (map_exp e, List.concat (List.map map_pexp cases)))
@@ -2338,7 +2338,7 @@ module Analysis = struct
       | E_vector_update_subrange (e1, e2, e3, e4) ->
           let ds, assigns, r = non_det [e1; e2; e3; e4] in
           (merge_deps ds, assigns, r)
-      | E_struct fexps ->
+      | E_struct (_, fexps) ->
           let es = List.map (function FE_aux (FE_fexp (_, e), _) -> e) fexps in
           let ds, assigns, r = non_det es in
           (merge_deps ds, assigns, r)
@@ -2658,7 +2658,7 @@ module Analysis = struct
             (s, v, KidSet.fold (fun kid k -> KBindings.add kid (Have (s, ExtraSplits.empty, LetSplits.empty)) k) kids k)
         | P_app (_, pats) -> of_list pats
         | P_vector pats | P_vector_concat pats | P_string_append pats | P_tuple pats | P_list pats -> of_list pats
-        | P_struct (fpats, _) -> List.map snd fpats |> of_list
+        | P_struct (_, fpats, _) -> List.map snd fpats |> of_list
         | P_cons (p1, p2) -> of_list [p1; p2]
         | P_vector_subrange _ ->
             Reporting.unreachable l __POS__ "vector subrange pattern should be removed before monomorphisation"

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -187,7 +187,7 @@ type pat_aux =
   | P_list of pat list (* list pattern *)
   | P_cons of pat * pat (* cons pattern *)
   | P_string_append of pat list (* string append pattern, x ^^ y *)
-  | P_struct of fpat list (* struct pattern *)
+  | P_struct of id option * fpat list (* struct pattern *)
   | P_attribute of string * attribute_data option * pat
 
 and pat = P_aux of pat_aux * l
@@ -233,7 +233,7 @@ and exp_aux =
   | E_vector_append of exp * exp (* vector concatenation *)
   | E_list of exp list (* list *)
   | E_cons of exp * exp (* cons *)
-  | E_struct of exp list (* struct *)
+  | E_struct of id option * exp list (* struct *)
   | E_struct_update of exp * exp list (* functional update of struct *)
   | E_field of exp * id (* field projection from struct *)
   | E_match of exp * pexp list (* pattern matching *)
@@ -353,7 +353,7 @@ type mpat_aux =
   | MP_string_append of mpat list
   | MP_typ of mpat * atyp
   | MP_as of mpat * id
-  | MP_struct of (id * mpat) list
+  | MP_struct of id option * (id * mpat) list
 
 and mpat = MP_aux of mpat_aux * l
 

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -580,8 +580,8 @@ atomic_pat:
     { mk_pat (P_list []) $startpos $endpos }
   | LsquareBar pat_list RsquareBar
     { mk_pat (P_list $2) $startpos $endpos }
-  | Struct Lcurly separated_nonempty_list_trailing(Comma, fpat) Rcurly
-    { mk_pat (P_struct $3) $startpos $endpos }
+  | Struct id? Lcurly separated_nonempty_list_trailing(Comma, fpat) Rcurly
+    { mk_pat (P_struct ($2, $4)) $startpos $endpos }
 
 fpat:
   | id Eq pat
@@ -805,8 +805,8 @@ atomic_exp:
     { mk_exp (E_vector_subrange ($1, $3, $5)) $startpos $endpos }
   | atomic_exp Lsquare exp Comma exp Rsquare
     { mk_exp (E_app (mk_id (Id "slice") $startpos($2) $endpos, [$1; $3; $5])) $startpos $endpos }
-  | Struct Lcurly fexp_exp_list Rcurly
-    { mk_exp (E_struct $3) $startpos $endpos }
+  | Struct id? Lcurly fexp_exp_list Rcurly
+    { mk_exp (E_struct ($2, $4)) $startpos $endpos }
   | Lcurly exp With fexp_exp_list Rcurly
     { mk_exp (E_struct_update ($2, $4)) $startpos $endpos }
   | Lsquare Rsquare
@@ -1165,8 +1165,8 @@ atomic_mpat:
     { mk_mpat (MP_list $2) $startpos $endpos }
   | atomic_mpat Colon typ_no_caret
     { mk_mpat (MP_typ ($1, $3)) $startpos $endpos }
-  | Struct Lcurly separated_nonempty_list_trailing(Comma, fmpat) Rcurly
-    { mk_mpat (MP_struct $3) $startpos $endpos }
+  | Struct id? Lcurly separated_nonempty_list_trailing(Comma, fmpat) Rcurly
+    { mk_mpat (MP_struct ($2, $4)) $startpos $endpos }
 
 fmpat:
   | id Eq mpat

--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -186,7 +186,8 @@ let number_pat (from : int) (pat : 'a pat) : ('a * int) pat * int =
       | P_list ps -> P_list (List.map (go counter) ps)
       | P_cons (p1, p2) -> P_cons (go counter p1, go counter p2)
       | P_string_append ps -> P_string_append (List.map (go counter) ps)
-      | P_struct (fps, fwild) -> P_struct (List.map (fun (field, p) -> (field, go counter p)) fps, fwild)
+      | P_struct (struct_name, fps, fwild) ->
+          P_struct (struct_name, List.map (fun (field, p) -> (field, go counter p)) fps, fwild)
       | P_id id -> P_id id
       | P_lit lit -> P_lit lit
       | P_wild -> P_wild
@@ -205,7 +206,7 @@ let rec contains_mapping ctx (P_aux (aux, _)) =
   | P_or (p1, p2) | P_cons (p1, p2) -> contains_mapping ctx p1 || contains_mapping ctx p2
   | P_tuple ps | P_vector ps | P_vector_concat ps | P_string_append ps | P_list ps ->
       List.exists (contains_mapping ctx) ps
-  | P_struct (fps, _) -> List.exists (fun (_, p) -> contains_mapping ctx p) fps
+  | P_struct (_, fps, _) -> List.exists (fun (_, p) -> contains_mapping ctx p) fps
 
 let preserved_explanation =
   "Sail cannot simplify the above pattern match:\n"
@@ -287,7 +288,8 @@ module Make (C : Config) = struct
         | P_list ps -> P_list (List.map (go wild) ps)
         | P_cons (p1, p2) -> P_cons (go wild p1, go wild p2)
         | P_string_append ps -> P_string_append (List.map (go wild) ps)
-        | P_struct (fps, fwild) -> P_struct (List.map (fun (field, p) -> (field, go wild p)) fps, fwild)
+        | P_struct (struct_name, fps, fwild) ->
+            P_struct (struct_name, List.map (fun (field, p) -> (field, go wild p)) fps, fwild)
         | P_id id -> P_id id
         | P_lit (L_aux (L_num n, _)) when wild ->
             t := C.add_attribute (gen_loc l) "int_wildcard" (Some (AD_aux (AD_num n, gen_loc l))) !t;
@@ -451,7 +453,7 @@ module Make (C : Config) = struct
     | P_cons (hd_pat, tl_pat) -> GP_cons (generalize ctx head_exp_typ hd_pat, generalize ctx head_exp_typ tl_pat)
     | P_list xs ->
         List.fold_right (fun pat tl_gpat -> GP_cons (generalize ctx head_exp_typ pat, tl_gpat)) xs GP_empty_list
-    | P_struct (fpats, FP_no_wild) -> begin
+    | P_struct (_, fpats, FP_no_wild) -> begin
         let get_field_typs struct_id =
           match Bindings.find_opt struct_id ctx.structs with
           | Some (typq, field_typs) -> (typq, field_typs)
@@ -804,7 +806,7 @@ module Make (C : Config) = struct
     let xs, ys = Util.split_after i unmatcheds in
     let field_elems = Util.take num_fields ys in
     let zs = Util.drop num_fields ys in
-    xs @ (mk_exp (E_struct (List.map2 (fun field elem -> mk_fexp field elem) fields field_elems)) :: zs)
+    xs @ (mk_exp (E_struct (SN_anon, List.map2 (fun field elem -> mk_fexp field elem) fields field_elems)) :: zs)
 
   let rector ctor i unmatcheds =
     let xs, ys = Util.split_after i unmatcheds in

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -280,6 +280,8 @@ module Printer (Config : PRINT_CONFIG) = struct
       | L_string s -> "\"" ^ String.escaped s ^ "\""
       )
 
+  let doc_struct_name = function SN_anon -> string "struct" | SN_id id -> string "struct" ^^ space ^^ doc_id id
+
   let rec doc_pat (P_aux (p_aux, (_, uannot))) =
     let wrap, attrs_doc =
       match get_attributes uannot with
@@ -309,11 +311,11 @@ module Printer (Config : PRINT_CONFIG) = struct
       | P_cons (hd_pat, tl_pat) -> parens (separate space [doc_pat hd_pat; string "::"; doc_pat tl_pat])
       | P_string_append [] -> string "\"\""
       | P_string_append pats -> parens (separate_map (string " ^ ") doc_pat pats)
-      | P_struct (fpats, fwild) ->
+      | P_struct (struct_name, fpats, fwild) ->
           let fpats = List.map (fun (field, pat) -> separate space [doc_id field; equals; doc_pat pat]) fpats in
           let fwild = match fwild with FP_wild _ -> [string "_"] | FP_no_wild -> [] in
           let fpats = fpats @ fwild in
-          separate space [string "struct"; lbrace; separate (comma ^^ space) fpats; rbrace]
+          separate space [doc_struct_name struct_name; lbrace; separate (comma ^^ space) fpats; rbrace]
     in
     wrap (attrs_doc ^^ pat_doc)
 
@@ -442,7 +444,8 @@ module Printer (Config : PRINT_CONFIG) = struct
         ^//^ doc_exp else_exp
     | E_list exps -> string "[|" ^^ separate_map (comma ^^ space) doc_exp exps ^^ string "|]"
     | E_cons (exp1, exp2) -> doc_atomic_exp exp1 ^^ space ^^ string "::" ^^ space ^^ doc_exp exp2
-    | E_struct fexps -> separate space [string "struct"; string "{"; doc_fexps fexps; string "}"]
+    | E_struct (struct_name, fexps) ->
+        separate space [doc_struct_name struct_name; string "{"; doc_fexps fexps; string "}"]
     | E_loop (While, measure, cond, exp) ->
         separate space ([string "while"] @ doc_measure measure @ [doc_exp cond; string "do"; doc_exp exp])
     | E_loop (Until, measure, cond, exp) ->

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -171,7 +171,8 @@ let rewrite_pat rewriters (P_aux (pat, (l, annot))) =
   | P_list pats -> rewrap (P_list (List.map rewrite pats))
   | P_cons (pat1, pat2) -> rewrap (P_cons (rewrite pat1, rewrite pat2))
   | P_string_append pats -> rewrap (P_string_append (List.map rewrite pats))
-  | P_struct (fpats, fwild) -> rewrap (P_struct (List.map (fun (field, pat) -> (field, rewrite pat)) fpats, fwild))
+  | P_struct (struct_name, fpats, fwild) ->
+      rewrap (P_struct (struct_name, List.map (fun (field, pat) -> (field, rewrite pat)) fpats, fwild))
 
 let rewrite_mpat rewriters (MP_aux (pat, (l, annot))) =
   let rewrap p = MP_aux (p, (l, annot)) in
@@ -187,7 +188,8 @@ let rewrite_mpat rewriters (MP_aux (pat, (l, annot))) =
   | MP_list pats -> rewrap (MP_list (List.map rewrite pats))
   | MP_cons (pat1, pat2) -> rewrap (MP_cons (rewrite pat1, rewrite pat2))
   | MP_string_append pats -> rewrap (MP_string_append (List.map rewrite pats))
-  | MP_struct fpats -> rewrap (MP_struct (List.map (fun (field, pat) -> (field, rewrite pat)) fpats))
+  | MP_struct (struct_name, fpats) ->
+      rewrap (MP_struct (struct_name, List.map (fun (field, pat) -> (field, rewrite pat)) fpats))
 
 let rewrite_exp rewriters (E_aux (exp, (l, annot))) =
   let rewrap e = E_aux (e, (l, annot)) in
@@ -217,9 +219,13 @@ let rewrite_exp rewriters (E_aux (exp, (l, annot))) =
   | E_vector_append (v1, v2) -> rewrap (E_vector_append (rewrite v1, rewrite v2))
   | E_list exps -> rewrap (E_list (List.map rewrite exps))
   | E_cons (h, t) -> rewrap (E_cons (rewrite h, rewrite t))
-  | E_struct fexps ->
+  | E_struct (struct_name, fexps) ->
       rewrap
-        (E_struct (List.map (fun (FE_aux (FE_fexp (id, e), fannot)) -> FE_aux (FE_fexp (id, rewrite e), fannot)) fexps))
+        (E_struct
+           ( struct_name,
+             List.map (fun (FE_aux (FE_fexp (id, e), fannot)) -> FE_aux (FE_fexp (id, rewrite e), fannot)) fexps
+           )
+        )
   | E_struct_update (re, fexps) ->
       rewrap
         (E_struct_update
@@ -395,7 +401,7 @@ type ('a, 'pat, 'pat_aux) pat_alg = {
   p_list : 'pat list -> 'pat_aux;
   p_cons : 'pat * 'pat -> 'pat_aux;
   p_string_append : 'pat list -> 'pat_aux;
-  p_struct : (id * 'pat) list * field_pat_wildcard -> 'pat_aux;
+  p_struct : struct_name * (id * 'pat) list * field_pat_wildcard -> 'pat_aux;
   p_aux : 'pat_aux * 'a annot -> 'pat;
 }
 
@@ -416,7 +422,8 @@ let rec fold_pat_aux (alg : ('a, 'pat, 'pat_aux) pat_alg) : 'a pat_aux -> 'pat_a
   | P_list ps -> alg.p_list (List.map (fold_pat alg) ps)
   | P_cons (ph, pt) -> alg.p_cons (fold_pat alg ph, fold_pat alg pt)
   | P_string_append ps -> alg.p_string_append (List.map (fold_pat alg) ps)
-  | P_struct (fpats, fwild) -> alg.p_struct (List.map (fun (field, pat) -> (field, fold_pat alg pat)) fpats, fwild)
+  | P_struct (struct_name, fpats, fwild) ->
+      alg.p_struct (struct_name, List.map (fun (field, pat) -> (field, fold_pat alg pat)) fpats, fwild)
 
 and fold_pat (alg : ('a, 'pat, 'pat_aux) pat_alg) : 'a pat -> 'pat = function
   | P_aux (pat, annot) -> alg.p_aux (fold_pat_aux alg pat, annot)
@@ -434,7 +441,8 @@ let rec fold_mpat_aux (alg : ('a, 'mpat, 'mpat_aux) pat_alg) : 'a mpat_aux -> 'm
   | MP_list ps -> alg.p_list (List.map (fold_mpat alg) ps)
   | MP_cons (ph, pt) -> alg.p_cons (fold_mpat alg ph, fold_mpat alg pt)
   | MP_string_append ps -> alg.p_string_append (List.map (fold_mpat alg) ps)
-  | MP_struct fmpats -> alg.p_struct (List.map (fun (field, mpat) -> (field, fold_mpat alg mpat)) fmpats, FP_no_wild)
+  | MP_struct (struct_name, fmpats) ->
+      alg.p_struct (struct_name, List.map (fun (field, mpat) -> (field, fold_mpat alg mpat)) fmpats, FP_no_wild)
 
 and fold_mpat (alg : ('a, 'mpat, 'mpat_aux) pat_alg) : 'a mpat -> 'mpat = function
   | MP_aux (mpat, annot) -> alg.p_aux (fold_mpat_aux alg mpat, annot)
@@ -458,7 +466,7 @@ let id_pat_alg : ('a, 'a pat, 'a pat_aux) pat_alg =
     p_list = (fun ps -> P_list ps);
     p_cons = (fun (ph, pt) -> P_cons (ph, pt));
     p_string_append = (fun ps -> P_string_append ps);
-    p_struct = (fun (fpats, fwild) -> P_struct (fpats, fwild));
+    p_struct = (fun (struct_name, fpats, fwild) -> P_struct (struct_name, fpats, fwild));
     p_aux = (fun (pat, annot) -> P_aux (pat, annot));
   }
 
@@ -481,9 +489,9 @@ let id_mpat_alg : ('a, 'a mpat option, 'a mpat_aux option) pat_alg =
     p_cons = (fun (ph, pt) -> Option.bind ph (fun ph -> Option.map (fun pt -> MP_cons (ph, pt)) pt));
     p_string_append = (fun ps -> Option.map (fun ps -> MP_string_append ps) (Util.option_all ps));
     p_struct =
-      (fun (fs, _) ->
+      (fun (struct_name, fs, _) ->
         Option.map
-          (fun fs -> MP_struct fs)
+          (fun fs -> MP_struct (struct_name, fs))
           (List.map (fun (id, v) -> Option.map (fun v -> (id, v)) v) fs |> Util.option_all)
       );
     p_aux = (fun (pat, annot) -> Option.map (fun pat -> MP_aux (pat, annot)) pat);
@@ -525,7 +533,7 @@ type ( 'a,
   e_vector_append : 'exp * 'exp -> 'exp_aux;
   e_list : 'exp list -> 'exp_aux;
   e_cons : 'exp * 'exp -> 'exp_aux;
-  e_struct : 'fexp list -> 'exp_aux;
+  e_struct : struct_name * 'fexp list -> 'exp_aux;
   e_struct_update : 'exp * 'fexp list -> 'exp_aux;
   e_field : 'exp * id -> 'exp_aux;
   e_case : 'exp * 'pexp list -> 'exp_aux;
@@ -596,7 +604,7 @@ let rec fold_exp_aux alg = function
   | E_vector_append (e1, e2) -> alg.e_vector_append (fold_exp alg e1, fold_exp alg e2)
   | E_list es -> alg.e_list (List.map (fold_exp alg) es)
   | E_cons (e1, e2) -> alg.e_cons (fold_exp alg e1, fold_exp alg e2)
-  | E_struct fexps -> alg.e_struct (List.map (fold_fexp alg) fexps)
+  | E_struct (struct_name, fexps) -> alg.e_struct (struct_name, List.map (fold_fexp alg) fexps)
   | E_struct_update (e, fexps) -> alg.e_struct_update (fold_exp alg e, List.map (fold_fexp alg) fexps)
   | E_field (e, id) -> alg.e_field (fold_exp alg e, id)
   | E_match (e, pexps) -> alg.e_case (fold_exp alg e, List.map (fold_pexp alg) pexps)
@@ -675,7 +683,7 @@ let id_exp_alg =
     e_vector_append = (fun (e1, e2) -> E_vector_append (e1, e2));
     e_list = (fun es -> E_list es);
     e_cons = (fun (e1, e2) -> E_cons (e1, e2));
-    e_struct = (fun fexps -> E_struct fexps);
+    e_struct = (fun (struct_name, fexps) -> E_struct (struct_name, fexps));
     e_struct_update = (fun (e1, fexp) -> E_struct_update (e1, fexp));
     e_field = (fun (e1, id) -> E_field (e1, id));
     e_case = (fun (e1, pexps) -> E_match (e1, pexps));
@@ -747,10 +755,10 @@ let compute_pat_alg bot join =
     p_cons = (fun ((vh, ph), (vt, pt)) -> (join vh vt, P_cons (ph, pt)));
     p_string_append = split_join (fun ps -> P_string_append ps);
     p_struct =
-      (fun (fpats, fwild) ->
+      (fun (struct_name, fpats, fwild) ->
         let fields, ps = List.split fpats in
         let vs, ps = List.split ps in
-        (join_list vs, P_struct (List.map2 (fun field p -> (field, p)) fields ps, fwild))
+        (join_list vs, P_struct (struct_name, List.map2 (fun field p -> (field, p)) fields ps, fwild))
       );
     p_aux = (fun ((v, pat), annot) -> (v, P_aux (pat, annot)));
   }
@@ -792,9 +800,9 @@ let compute_exp_alg bot join =
     e_list = split_join (fun es -> E_list es);
     e_cons = (fun ((v1, e1), (v2, e2)) -> (join v1 v2, E_cons (e1, e2)));
     e_struct =
-      (fun fexps ->
+      (fun (struct_name, fexps) ->
         let vs, fexps = List.split fexps in
-        (join_list vs, E_struct fexps)
+        (join_list vs, E_struct (struct_name, fexps))
       );
     e_struct_update =
       (fun ((v1, e1), fexps) ->
@@ -876,7 +884,7 @@ let pure_pat_alg bot join =
     p_tuple = join_list;
     p_list = join_list;
     p_string_append = join_list;
-    p_struct = (fun (xs, _) -> join_list (List.map snd xs));
+    p_struct = (fun (_, xs, _) -> join_list (List.map snd xs));
     p_cons = (fun (vh, vt) -> join vh vt);
     p_aux = (fun (v, annot) -> v);
   }
@@ -907,7 +915,7 @@ let pure_exp_alg bot join =
     e_vector_append = (fun (v1, v2) -> join v1 v2);
     e_list = join_list;
     e_cons = (fun (v1, v2) -> join v1 v2);
-    e_struct = (fun vs -> join_list vs);
+    e_struct = (fun (_, vs) -> join_list vs);
     e_struct_update = (fun (v1, vf) -> join_list (v1 :: vf));
     e_field = (fun (v1, id) -> v1);
     e_case = (fun (v1, vps) -> join_list (v1 :: vps));
@@ -1132,7 +1140,7 @@ let default_fold_exp f x (E_aux (e, ann) as exp) =
       let x, e1 = f x e1 in
       let x, e2 = f x e2 in
       (x, re (E_cons (e1, e2)))
-  | E_struct fexps ->
+  | E_struct (struct_name, fexps) ->
       let x, fexps =
         List.fold_left
           (fun (x, fes) fe ->
@@ -1141,7 +1149,7 @@ let default_fold_exp f x (E_aux (e, ann) as exp) =
           )
           (x, []) fexps
       in
-      (x, re (E_struct (List.rev fexps)))
+      (x, re (E_struct (struct_name, List.rev fexps)))
   | E_struct_update (e, fexps) ->
       let x, e = f x e in
       let x, fexps =

--- a/src/lib/rewriter.mli
+++ b/src/lib/rewriter.mli
@@ -110,7 +110,7 @@ type ('a, 'pat, 'pat_aux) pat_alg = {
   p_list : 'pat list -> 'pat_aux;
   p_cons : 'pat * 'pat -> 'pat_aux;
   p_string_append : 'pat list -> 'pat_aux;
-  p_struct : (id * 'pat) list * field_pat_wildcard -> 'pat_aux;
+  p_struct : struct_name * (id * 'pat) list * field_pat_wildcard -> 'pat_aux;
   p_aux : 'pat_aux * 'a annot -> 'pat;
 }
 
@@ -151,7 +151,7 @@ type ( 'a,
   e_vector_append : 'exp * 'exp -> 'exp_aux;
   e_list : 'exp list -> 'exp_aux;
   e_cons : 'exp * 'exp -> 'exp_aux;
-  e_struct : 'fexp list -> 'exp_aux;
+  e_struct : struct_name * 'fexp list -> 'exp_aux;
   e_struct_update : 'exp * 'fexp list -> 'exp_aux;
   e_field : 'exp * id -> 'exp_aux;
   e_case : 'exp * 'pexp list -> 'exp_aux;

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -350,7 +350,10 @@ let remove_vector_concat_pat pat =
       p_list = (fun ps -> P_list (List.map (fun p -> p false) ps));
       p_cons = (fun (p, ps) -> P_cons (p false, ps false));
       p_string_append = (fun ps -> P_string_append (List.map (fun p -> p false) ps));
-      p_struct = (fun (fpats, fwild) -> P_struct (List.map (fun (field, p) -> (field, p false)) fpats, fwild));
+      p_struct =
+        (fun (struct_name, fpats, fwild) ->
+          P_struct (struct_name, List.map (fun (field, p) -> (field, p false)) fpats, fwild)
+        );
       p_aux =
         (fun (pat, ((l, _) as annot)) contained_in_p_as ->
           match pat with
@@ -519,10 +522,10 @@ let remove_vector_concat_pat pat =
           (P_string_append ps, List.flatten decls)
         );
       p_struct =
-        (fun (fpats, fwild) ->
+        (fun (struct_name, fpats, fwild) ->
           let fields, ps = List.split fpats in
           let ps, decls = List.split ps in
-          (P_struct (List.map2 (fun field p -> (field, p)) fields ps, fwild), List.flatten decls)
+          (P_struct (struct_name, List.map2 (fun field p -> (field, p)) fields ps, fwild), List.flatten decls)
         );
       p_cons = (fun ((p, decls), (p', decls')) -> (P_cons (p, p'), decls @ decls'));
       p_aux = (fun ((pat, decls), annot) -> p_aux ((pat, decls), annot));
@@ -708,7 +711,7 @@ let rec is_irrefutable_pattern (P_aux (p, ann)) =
   | P_app (f, args) ->
       Env.is_singleton_union_constructor f (env_of_annot ann) && List.for_all is_irrefutable_pattern args
   | P_vector ps | P_vector_concat ps | P_tuple ps | P_list ps -> List.for_all is_irrefutable_pattern ps
-  | P_struct (fpats, _) ->
+  | P_struct (_, fpats, _) ->
       let ps = List.map snd fpats in
       List.for_all is_irrefutable_pattern ps
   | P_cons (p1, p2) -> is_irrefutable_pattern p1 && is_irrefutable_pattern p2
@@ -767,7 +770,7 @@ let rec subsumes_pat (P_aux (p1, annot1) as pat1) (P_aux (p2, annot2) as pat2) =
       | Some substs1, Some substs2 -> Some (substs1 @ substs2)
       | _ -> None
     )
-  | P_struct (fields1, wild1), P_struct (fields2, wild2) ->
+  | P_struct (_, fields1, wild1), P_struct (_, fields2, wild2) ->
       List.fold_left
         (fun acc (f1, p1) ->
           match List.find_opt (fun (f2, _) -> Id.compare f1 f2 == 0) fields2 with
@@ -872,12 +875,14 @@ let rec pat_to_exp env (P_aux (pat, (l, annot)) as p_aux) =
       let string_append str1 str2 = annot_exp (E_app (mk_id "string_append", [str1; str2])) l env string_typ in
       List.fold_right string_append (List.map pat_to_exp pats) empty_string
     end
-  | P_struct (fpats, FP_no_wild) ->
+  | P_struct (struct_name, fpats, FP_no_wild) ->
       rewrap
         (E_struct
-           (List.map (fun (field, pat) -> FE_aux (FE_fexp (field, pat_to_exp pat), (gen_loc l, empty_tannot))) fpats)
+           ( struct_name,
+             List.map (fun (field, pat) -> FE_aux (FE_fexp (field, pat_to_exp pat), (gen_loc l, empty_tannot))) fpats
+           )
         )
-  | P_struct (_, FP_wild l) -> Reporting.unreachable l __POS__ "pat_to_exp given field wildcard"
+  | P_struct (_, _, FP_wild l) -> Reporting.unreachable l __POS__ "pat_to_exp given field wildcard"
 
 let case_exp e t cs =
   let l = get_loc_exp e in
@@ -1059,7 +1064,7 @@ let rec contains_bitvector_pat (P_aux (pat, annot)) =
   | P_app (_, pats) | P_tuple pats | P_list pats -> List.exists contains_bitvector_pat pats
   | P_cons (p, ps) -> contains_bitvector_pat p || contains_bitvector_pat ps
   | P_string_append ps -> List.exists contains_bitvector_pat ps
-  | P_struct (fpats, _) -> List.exists contains_bitvector_pat (List.map snd fpats)
+  | P_struct (_, fpats, _) -> List.exists contains_bitvector_pat (List.map snd fpats)
 
 let contains_bitvector_pexp = function
   | Pat_aux (Pat_exp (pat, _), _) | Pat_aux (Pat_when (pat, _, _), _) -> contains_bitvector_pat pat
@@ -1094,7 +1099,10 @@ let remove_bitvector_pat (P_aux (_, (l, _)) as pat) =
       p_tuple = (fun ps -> P_tuple (List.map (fun p -> p false) ps));
       p_list = (fun ps -> P_list (List.map (fun p -> p false) ps));
       p_cons = (fun (p, ps) -> P_cons (p false, ps false));
-      p_struct = (fun (fpats, fwild) -> P_struct (List.map (fun (field, p) -> (field, p false)) fpats, fwild));
+      p_struct =
+        (fun (struct_name, fpats, fwild) ->
+          P_struct (struct_name, List.map (fun (field, p) -> (field, p false)) fpats, fwild)
+        );
       p_aux =
         (fun (pat, annot) contained_in_p_as ->
           let env = env_of_annot annot in
@@ -1252,10 +1260,10 @@ let remove_bitvector_pat (P_aux (_, (l, _)) as pat) =
           (P_string_append ps, flatten_guards_decls gdls)
         );
       p_struct =
-        (fun (fpats, fwild) ->
+        (fun (struct_name, fpats, fwild) ->
           let fields, ps = List.split fpats in
           let ps, gdls = List.split ps in
-          (P_struct (List.map2 (fun field p -> (field, p)) fields ps, fwild), flatten_guards_decls gdls)
+          (P_struct (struct_name, List.map2 (fun field p -> (field, p)) fields ps, fwild), flatten_guards_decls gdls)
         );
       p_tuple =
         (fun ps ->
@@ -2421,7 +2429,7 @@ let rewrite_ast_letbind_effects effect_info env =
     | E_list exps -> n_exp_nameL exps (fun exps -> k (pure_rewrap (E_list exps)))
     | E_cons (exp1, exp2) ->
         n_exp_name exp1 (fun exp1 -> n_exp_name exp2 (fun exp2 -> k (pure_rewrap (E_cons (exp1, exp2)))))
-    | E_struct fexps -> n_fexpL fexps (fun fexps -> k (pure_rewrap (E_struct fexps)))
+    | E_struct (struct_name, fexps) -> n_fexpL fexps (fun fexps -> k (pure_rewrap (E_struct (struct_name, fexps))))
     | E_struct_update (exp1, fexps) ->
         n_exp_name exp1 (fun exp1 -> n_fexpL fexps (fun fexps -> k (pure_rewrap (E_struct_update (exp1, fexps)))))
     | E_field (exp1, id) -> n_exp_name exp1 (fun exp1 -> k (pure_rewrap (E_field (exp1, id))))
@@ -3301,7 +3309,7 @@ let rec exp_of_mpat (MP_aux (mpat, (l, annot))) =
         ( E_match (E_aux (E_id id, (l, annot)), [Pat_aux (Pat_exp (pat_of_mpat mpat, exp_of_mpat mpat), (l, annot))]),
           (l, annot)
         )
-  | MP_struct fmpats ->
+  | MP_struct (struct_name, fmpats) ->
       let combined_loc field mpat =
         match (Reporting.simp_loc (id_loc field), Reporting.simp_loc (mpat_loc mpat)) with
         | Some (s, _), Some (_, e) -> Parse_ast.Range (s, e)
@@ -3309,9 +3317,12 @@ let rec exp_of_mpat (MP_aux (mpat, (l, annot))) =
       in
       E_aux
         ( E_struct
-            (List.map
-               (fun (field, mpat) -> FE_aux (FE_fexp (field, exp_of_mpat mpat), (combined_loc field mpat, empty_uannot)))
-               fmpats
+            ( struct_name,
+              List.map
+                (fun (field, mpat) ->
+                  FE_aux (FE_fexp (field, exp_of_mpat mpat), (combined_loc field mpat, empty_uannot))
+                )
+                fmpats
             ),
           (l, annot)
         )
@@ -3717,7 +3728,7 @@ module MakeExhaustive = struct
               (List.map (fun l -> RP_app (id, l)) res_args @ Bindings.find id ctx.constructor_to_rest, progress)
           | _ -> inconsistent ()
         )
-      | P_struct (field_pats, _) ->
+      | P_struct (struct_name, field_pats, _) ->
           let all_ids, res_pats =
             match res_pat with
             | RP_struct res_fields ->
@@ -4537,7 +4548,7 @@ let remove_bitfield_records type_env =
     let e_aux (e, a) =
       let exp = E_aux (e, a) in
       match e with
-      | E_struct [FE_aux (FE_fexp (f, e'), _)] when is_bitfield_exp exp && string_of_id f = "bits" -> e'
+      | E_struct (_, [FE_aux (FE_fexp (f, e'), _)]) when is_bitfield_exp exp && string_of_id f = "bits" -> e'
       | _ -> exp
     in
     let le_vector ((LE_aux (le_aux, _) as lexp), field) =

--- a/src/lib/spec_analysis.ml
+++ b/src/lib/spec_analysis.ml
@@ -114,7 +114,7 @@ let bindings_from_pat p =
     | P_vector ps | P_vector_concat ps | P_string_append ps | P_app (_, ps) | P_tuple ps | P_list ps ->
         List.concat (List.map aux_pat ps)
     | P_cons (p1, p2) -> aux_pat p1 @ aux_pat p2
-    | P_struct (fps, _) -> List.map snd fps |> List.map aux_pat |> List.concat
+    | P_struct (_, fps, _) -> List.map snd fps |> List.map aux_pat |> List.concat
   in
   aux_pat p
 
@@ -176,7 +176,8 @@ let nexp_subst_fns substs =
     | P_tuple ps -> re (P_tuple (List.map s_pat ps))
     | P_list ps -> re (P_list (List.map s_pat ps))
     | P_cons (p1, p2) -> re (P_cons (s_pat p1, s_pat p2))
-    | P_struct (fps, fwild) -> re (P_struct (List.map (fun (field, p) -> (field, s_pat p)) fps, fwild))
+    | P_struct (struct_name, fps, fwild) ->
+        re (P_struct (struct_name, List.map (fun (field, p) -> (field, s_pat p)) fps, fwild))
   in
   let rec s_exp (E_aux (e, (l, annot))) =
     let re e = E_aux (e, (l, s_tannot annot)) in
@@ -203,7 +204,7 @@ let nexp_subst_fns substs =
     | E_vector_append (e1, e2) -> re (E_vector_append (s_exp e1, s_exp e2))
     | E_list es -> re (E_list (List.map s_exp es))
     | E_cons (e1, e2) -> re (E_cons (s_exp e1, s_exp e2))
-    | E_struct fes -> re (E_struct (List.map s_fexp fes))
+    | E_struct (struct_name, fes) -> re (E_struct (struct_name, List.map s_fexp fes))
     | E_struct_update (e, fes) -> re (E_struct_update (s_exp e, List.map s_fexp fes))
     | E_field (e, id) -> re (E_field (s_exp e, id))
     | E_match (e, cases) -> re (E_match (s_exp e, List.map s_pexp cases))

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1630,7 +1630,7 @@ let check_pattern_duplicates env pat =
         collect_duplicates p2
     | P_app (_, ps) | P_vector ps | P_vector_concat ps | P_tuple ps | P_list ps | P_string_append ps ->
         List.iter collect_duplicates ps
-    | P_struct (fpats, _) -> List.iter (fun (_, pat) -> collect_duplicates pat) fpats
+    | P_struct (_, fpats, _) -> List.iter (fun (_, pat) -> collect_duplicates pat) fpats
   in
   collect_duplicates pat;
   match Bindings.choose_opt (Bindings.filter is_duplicate !ids) with
@@ -2132,6 +2132,14 @@ let unwrap_vector_concat_elem ~at:l = function
 
 let vector_concat_elem_is_ok = function VC_elem_ok _ -> true | _ -> false
 
+let check_struct_name l rectyp_id = function
+  | SN_anon -> ()
+  | SN_id id ->
+      if not (Id.compare rectyp_id id = 0) then
+        typ_error
+          (Hint ("struct literal named here", id_loc id, l))
+          (Printf.sprintf "Struct type %s found, %s expected" (string_of_id id) (string_of_id rectyp_id))
+
 module PC_config = struct
   type t = tannot
   let typ_of_t = typ_of_tannot
@@ -2200,13 +2208,14 @@ let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_au
         FE_aux (FE_fexp (field, checked_exp), (l, empty_tannot))
       in
       annot_exp (E_struct_update (checked_exp, List.map check_fexp fexps)) typ
-  | E_struct fexps, _ ->
+  | E_struct (struct_name, fexps), _ ->
       let rectyp_id =
         match Env.expand_synonyms env typ with
         | (Typ_aux (Typ_id rectyp_id, _) | Typ_aux (Typ_app (rectyp_id, _), _)) when Env.is_record rectyp_id env ->
             rectyp_id
         | _ -> typ_error l ("The type " ^ string_of_typ typ ^ " is not a record")
       in
+      check_struct_name l rectyp_id struct_name;
       let record_fields = ref (Env.get_record rectyp_id env |> snd |> List.map snd |> IdSet.of_list) in
       let check_fexp (FE_aux (FE_fexp (field, exp), (l, _))) =
         record_fields := IdSet.remove field !record_fields;
@@ -2220,7 +2229,7 @@ let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_au
         FE_aux (FE_fexp (field, checked_exp), (l, empty_tannot))
       in
       let fexps = List.map check_fexp fexps in
-      if IdSet.is_empty !record_fields then annot_exp (E_struct fexps) typ
+      if IdSet.is_empty !record_fields then annot_exp (E_struct (SN_id rectyp_id, fexps)) typ
       else
         typ_error l
           ("struct literal missing fields: " ^ string_of_list ", " string_of_id (IdSet.elements !record_fields))
@@ -2914,13 +2923,14 @@ and bind_pat env (P_aux (pat_aux, (l, uannot)) as pat) typ =
       let nc = match destruct_atom_bool env typ with Some nc -> nc | None -> assert false in
       (annot_pat (P_lit lit) (atom_bool_typ nc_false), Env.add_constraint (nc_not nc) env, [])
   | P_vector_concat (pat :: pats) -> bind_vector_concat_pat l env uannot pat pats (Some typ)
-  | P_struct (fpats, fwild) ->
+  | P_struct (struct_name, fpats, fwild) ->
       let rectyp_id =
         match Env.expand_synonyms env typ with
         | (Typ_aux (Typ_id rectyp_id, _) | Typ_aux (Typ_app (rectyp_id, _), _)) when Env.is_record rectyp_id env ->
             rectyp_id
         | _ -> typ_error l ("The type " ^ string_of_typ typ ^ " is not a record")
       in
+      check_struct_name l rectyp_id struct_name;
       let record_fields = ref (Env.get_record rectyp_id env |> snd |> List.map snd |> IdSet.of_list) in
       let bind_fpat (fpats, env, guards) (field, pat) =
         record_fields := IdSet.remove field !record_fields;
@@ -2934,7 +2944,8 @@ and bind_pat env (P_aux (pat_aux, (l, uannot)) as pat) typ =
         ((field, typed_pat) :: fpats, env, guards @ new_guards)
       in
       let fpats, env, guards = List.fold_left bind_fpat ([], env, []) fpats in
-      if IdSet.is_empty !record_fields then (annot_pat (P_struct (List.rev fpats, FP_no_wild)) typ, env, guards)
+      if IdSet.is_empty !record_fields then
+        (annot_pat (P_struct (SN_id rectyp_id, List.rev fpats, FP_no_wild)) typ, env, guards)
       else (
         (* If we have a field wildcard .. then insert the missing `field = _` here *)
         match fwild with
@@ -2943,7 +2954,7 @@ and bind_pat env (P_aux (pat_aux, (l, uannot)) as pat) typ =
               List.map (fun id -> (id, mk_pat ~loc:fwild_loc P_wild)) (IdSet.elements !record_fields)
             in
             let missing_fpats, env, guards = List.fold_left bind_fpat ([], env, []) missing_fields in
-            (annot_pat (P_struct (List.rev fpats @ missing_fpats, FP_no_wild)) typ, env, guards)
+            (annot_pat (P_struct (SN_id rectyp_id, List.rev fpats @ missing_fpats, FP_no_wild)) typ, env, guards)
         | FP_no_wild ->
             typ_error l
               ("struct pattern missing fields: " ^ string_of_list ", " string_of_id (IdSet.elements !record_fields))
@@ -3574,6 +3585,44 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
             (Hint ("Has type " ^ string_of_typ (typ_of inferred_exp), exp_loc exp, l))
             ("Type accessed by field expression is not a struct, it has type " ^ string_of_typ (typ_of inferred_exp))
     end
+  | E_struct (struct_name, fexps) -> (
+      match struct_name with
+      | SN_anon -> typ_error l "Cannot infer type of struct literal"
+      | SN_id rectyp_id ->
+          let record_typq, record_fields = Env.get_record rectyp_id env in
+          let record_fields = ref (record_fields |> List.map snd |> IdSet.of_list) in
+          let all_unifiers = ref KBindings.empty in
+          let check_fexp (FE_aux (FE_fexp (field, exp), (l, _))) =
+            record_fields := IdSet.remove field !record_fields;
+            let _, rectyp_q, field_typ = Env.get_accessor rectyp_id field env in
+            let inferred_exp = irule infer_exp env exp in
+            ( try
+                let unifiers = unify l env (tyvars_of_typ field_typ) field_typ (typ_of inferred_exp) in
+                all_unifiers := merge_uvars env l unifiers !all_unifiers
+              with Unification_error (l, m) ->
+                typ_error l ("While inferring type for struct literal of type " ^ string_of_id rectyp_id ^ ": " ^ m)
+            );
+            FE_aux (FE_fexp (field, inferred_exp), (l, empty_tannot))
+          in
+          let fexps = List.map check_fexp fexps in
+          let args =
+            List.map
+              (fun kopt ->
+                match KBindings.find_opt (kopt_kid kopt) !all_unifiers with
+                | Some typ_arg -> typ_arg
+                | None ->
+                    typ_error l
+                      ("Failed to instantiate " ^ string_of_kinded_id kopt ^ " when inferring struct literal of type "
+                     ^ string_of_id rectyp_id
+                      )
+              )
+              (quant_kopts record_typq)
+          in
+          if IdSet.is_empty !record_fields then annot_exp (E_struct (SN_id rectyp_id, fexps)) (app_typ rectyp_id args)
+          else
+            typ_error l
+              ("struct literal missing fields: " ^ string_of_list ", " string_of_id (IdSet.elements !record_fields))
+    )
   | E_tuple exps ->
       let inferred_exps = List.map (irule infer_exp env) exps in
       annot_exp (E_tuple inferred_exps) (mk_typ (Typ_tuple (List.map typ_of inferred_exps)))
@@ -4305,13 +4354,14 @@ and bind_mpat allow_unknown other_env env (MP_aux (mpat_aux, (l, uannot)) as mpa
   | MP_lit (L_aux (L_false, _) as lit) when is_atom_bool typ ->
       let nc = match destruct_atom_bool env typ with Some n -> n | None -> assert false in
       (annot_mpat (MP_lit lit) (atom_bool_typ nc_false), Env.add_constraint (nc_not nc) env, [])
-  | MP_struct fmpats ->
+  | MP_struct (struct_name, fmpats) ->
       let rectyp_id =
         match Env.expand_synonyms env typ with
         | (Typ_aux (Typ_id rectyp_id, _) | Typ_aux (Typ_app (rectyp_id, _), _)) when Env.is_record rectyp_id env ->
             rectyp_id
         | _ -> typ_error l ("The type " ^ string_of_typ typ ^ " is not a record")
       in
+      check_struct_name l rectyp_id struct_name;
       let record_fields = ref (Env.get_record rectyp_id env |> snd |> List.map snd |> IdSet.of_list) in
       let bind_fmpat (fmpats, env, guards) (field, mpat) =
         record_fields := IdSet.remove field !record_fields;
@@ -4325,7 +4375,7 @@ and bind_mpat allow_unknown other_env env (MP_aux (mpat_aux, (l, uannot)) as mpa
         ((field, typed_mpat) :: fmpats, env, guards @ new_guards)
       in
       let fmpats, env, guards = List.fold_left bind_fmpat ([], env, []) fmpats in
-      if IdSet.is_empty !record_fields then (annot_mpat (MP_struct (List.rev fmpats)) typ, env, guards)
+      if IdSet.is_empty !record_fields then (annot_mpat (MP_struct (SN_id rectyp_id, List.rev fmpats)) typ, env, guards)
       else
         typ_error l
           ("struct pattern missing fields: " ^ string_of_list ", " string_of_id (IdSet.elements !record_fields))

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -962,7 +962,7 @@ and doc_pat_no_existential ctxt apat_needed (P_aux (p, (l, annot)) as pat) typ =
       let ppp = doc_op (string "::") p_pp pp_pp in
       if apat_needed then parens ppp else ppp
   | P_string_append _ -> unreachable l __POS__ "string append pattern found in Coq backend, should have been rewritten"
-  | P_struct (fpats, _) ->
+  | P_struct (_, fpats, _) ->
       let type_id =
         match typ with
         | (Typ_aux (Typ_id tid, _) | Typ_aux (Typ_app (tid, _), _)) when Env.is_record tid env -> tid
@@ -1168,7 +1168,7 @@ let merge_new_tyvars ctxt old_env pat new_env =
        they'd do *)
     | P_app (_, ps) | P_vector ps | P_vector_concat ps | P_tuple ps | P_list ps | P_string_append ps ->
         List.fold_left merge_pat m ps
-    | P_struct (fields, _) -> List.fold_left merge_pat m (List.map snd fields)
+    | P_struct (_, fields, _) -> List.fold_left merge_pat m (List.map snd fields)
     | P_cons (p1, p2) -> merge_pat (merge_pat m p1) p2
   in
   let m, r = IdSet.fold remove_binding (pat_ids pat) (ctxt.kid_id_renames, ctxt.kid_id_renames_rev) in
@@ -1899,7 +1899,7 @@ let doc_exp, doc_let =
           | Complex s -> string (autocast_name ^ " (T := fun _sz => " ^ s ^ "%type)") ^^ space ^^ parens epp
         in
         if aexp_needed then parens epp else epp
-    | E_struct fexps ->
+    | E_struct (_, fexps) ->
         let recordtyp =
           match destruct_tannot annot with
           | Some (env, Typ_aux (Typ_id tid, _)) | Some (env, Typ_aux (Typ_app (tid, _), _)) ->

--- a/src/sail_doc_backend/docinfo.ml
+++ b/src/sail_doc_backend/docinfo.ml
@@ -217,7 +217,7 @@ let rec json_of_pat (P_aux (aux, _)) =
   | P_list pats -> seq_pat_json "list" pats
   | P_cons (pat_hd, pat_tl) -> `Assoc [pat_type "cons"; ("hd", json_of_pat pat_hd); ("tl", json_of_pat pat_tl)]
   | P_string_append pats -> seq_pat_json "string_append" pats
-  | P_struct (fpats, fwild) ->
+  | P_struct (_, fpats, fwild) ->
       `Assoc
         [
           pat_type "struct";

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -519,7 +519,7 @@ let rec doc_pat ?(need_parens = false) ?(in_vector = false) ctx in_match_bv (P_a
         )
   | P_var (p, _) -> doc_pat ctx in_match_bv p
   | P_as (pat, id) -> doc_pat ctx in_match_bv pat
-  | P_struct (pats, _) ->
+  | P_struct (_, pats, _) ->
       let pats =
         List.map (fun (id, pat) -> separate space [doc_id_ctor id; coloneq; doc_pat ctx in_match_bv pat]) pats
       in
@@ -960,7 +960,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
       in
       pp_let_line ^^ hardline ^^ doc_exp as_monadic ctx e'
   | E_internal_return e -> doc_exp false ctx e (* ??? *)
-  | E_struct fexps ->
+  | E_struct (_, fexps) ->
       let args = List.map d_of_field fexps in
       wrap_with_pure as_monadic (braces (space ^^ align (separate hardline args) ^^ space))
   | E_field (exp, id) ->

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -619,7 +619,7 @@ let rec doc_pat_lem ctxt apat_needed (P_aux (p, (l, annot)) as pa) =
   | P_vector pats ->
       let ppp = brackets (separate_map semi (doc_pat_lem ctxt true) pats) in
       if apat_needed then parens ppp else ppp
-  | P_struct (fpats, FP_no_wild) ->
+  | P_struct (_, fpats, FP_no_wild) ->
       let doc_field field =
         match destruct_tannot annot with
         | (Some (env, Typ_aux (Typ_id tid, _)) | Some (env, Typ_aux (Typ_app (tid, _), _))) when Env.is_record tid env
@@ -632,7 +632,7 @@ let rec doc_pat_lem ctxt apat_needed (P_aux (p, (l, annot)) as pa) =
            (fun (field, pat) -> separate space [doc_field field; equals; doc_pat_lem ctxt false pat])
            fpats
       ^^ space ^^ string "|>"
-  | P_struct (_, FP_wild l) -> Reporting.unreachable l __POS__ "field wildcard should not have reached lem backend"
+  | P_struct (_, _, FP_wild l) -> Reporting.unreachable l __POS__ "field wildcard should not have reached lem backend"
   | P_vector_concat pats ->
       Reporting.unreachable l __POS__ "vector concatenation patterns should have been removed before pretty-printing"
   | P_tuple pats -> (
@@ -1033,7 +1033,7 @@ let doc_exp_lem, doc_let_lem =
         expV aexp_needed
           e (*parens (expN e ^^ doc_tannot_lem ctxt (env_of full_exp) (effectful (effect_of full_exp)) typ)*)
     | E_tuple exps -> parens (align (group (separate_map (comma ^^ break 1) expN exps)))
-    | E_struct fexps ->
+    | E_struct (_, fexps) ->
         let recordtyp, annotation_needed, env, typ =
           match destruct_tannot annot with
           | Some (env, (Typ_aux (Typ_id tid, _) as typ)) -> (tid, false, env, typ)

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -214,7 +214,7 @@ let rec ocaml_pat ctx (P_aux (pat_aux, (l, _)) as pat) =
       | _ -> zencode_upper ctx id ^^ space ^^ parens (separate_map (comma ^^ space) (ocaml_pat ctx) pats)
     end
   | P_cons (hd_pat, tl_pat) -> ocaml_pat ctx hd_pat ^^ string " :: " ^^ ocaml_pat ctx tl_pat
-  | P_struct (fpats, FP_no_wild) ->
+  | P_struct (_, fpats, FP_no_wild) ->
       lbrace ^^ space
       ^^ separate_map (semi ^^ space) (fun (field, p) -> ocaml_fpat (pat_record_id l pat) ctx field p) fpats
       ^^ space ^^ rbrace
@@ -294,7 +294,7 @@ let rec ocaml_exp ctx (E_aux (exp_aux, (l, _)) as exp) =
              ocaml_atomic_exp ctx e;
            ]
         )
-  | E_struct fexps ->
+  | E_struct (_, fexps) ->
       enclose lbrace rbrace (group (separate_map (semi ^^ break 1) (ocaml_fexp (record_id l exp) ctx) fexps))
   | E_struct_update (exp, fexps) ->
       enclose lbrace rbrace

--- a/test/typecheck/fail/poly_struct_phantom.expect
+++ b/test/typecheck/fail/poly_struct_phantom.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mfail/poly_struct_phantom.sail[0m:14.10-53:
+14[96m |[0m  let x = struct S { f1 = 3, f2 = true, f3 = "test" };
+  [91m |[0m          [91m^-----------------------------------------^[0m
+  [91m |[0m Failed to instantiate ('c : Type) when inferring struct literal of type S

--- a/test/typecheck/fail/poly_struct_phantom.sail
+++ b/test/typecheck/fail/poly_struct_phantom.sail
@@ -1,0 +1,16 @@
+default Order dec
+
+$include <prelude.sail>
+
+struct S('b, 'a, 'c : Type) = {
+  f1 : int,
+  f2 : 'a,
+  f3 : 'b,
+}
+
+val main : unit -> unit
+
+function main() = {
+  let x = struct S { f1 = 3, f2 = true, f3 = "test" };
+  ()
+}

--- a/test/typecheck/fail/struct_bad_name.expect
+++ b/test/typecheck/fail/struct_bad_name.expect
@@ -1,0 +1,8 @@
+[93mType error[0m:
+[96mfail/struct_bad_name.sail[0m:18.22-23:
+18[96m |[0m  let x : S2 = struct S { f1 = 3, f2 = true };
+  [92m |[0m                      [92m^[0m [92mstruct literal named here[0m
+[96mfail/struct_bad_name.sail[0m:18.15-45:
+18[96m |[0m  let x : S2 = struct S { f1 = 3, f2 = true };
+  [91m |[0m               [91m^----------------------------^[0m
+  [91m |[0m Struct type S found, S2 expected

--- a/test/typecheck/fail/struct_bad_name.sail
+++ b/test/typecheck/fail/struct_bad_name.sail
@@ -1,0 +1,20 @@
+default Order dec
+
+$include <prelude.sail>
+
+struct S = {
+  f1 : int,
+  f2 : bool,
+}
+
+struct S2 = {
+  f1 : int,
+  f2 : bool,
+}
+
+val main : unit -> unit
+
+function main() = {
+  let x : S2 = struct S { f1 = 3, f2 = true };
+  ()
+}

--- a/test/typecheck/pass/poly_struct_infer.sail
+++ b/test/typecheck/pass/poly_struct_infer.sail
@@ -1,0 +1,16 @@
+default Order dec
+
+$include <prelude.sail>
+
+struct S('b, 'a) = {
+  f1 : int,
+  f2 : 'a,
+  f3 : 'b,
+}
+
+val main : unit -> unit
+
+function main() = {
+  let x = struct S { f1 = 3, f2 = true, f3 = "test" };
+  ()
+}


### PR DESCRIPTION
Previously a struct expression `struct { .. }` would never be inferred, but this caused issues when a rewrite moved such an expression into a place where its type must be inferred.

The solution is to allow the struct name optionally after the `struct` keyword, so
```
struct S { ... }
```
will be correctly inferred as having type S (it could have additional type parameters, but the name is enough to disambiguate).

The type system will add these names in where omitted so rewrites can more freely move struct literals around.