### PR TITLE
aarch64_small: use assert to report errors

### DIFF
--- a/aarch64_small/prelude.sail
+++ b/aarch64_small/prelude.sail
@@ -143,7 +143,7 @@ val print = "print_endline" : string -> unit
 
 val error : forall ('a : Type). string -> 'a effect{escape}
 function error(message) = {
-  print(message); 
+  assert(false, message); 
   exit()
 }
 


### PR DESCRIPTION
Helps with (e.g.) the Rocq version, where the message would otherwise be lost.