### PR TITLE
Emacs: Fix nested comments in emacs mode

### DIFF
--- a/editors/sail-mode.el
+++ b/editors/sail-mode.el
@@ -88,7 +88,7 @@
     (modify-syntax-entry ?> "." st)
     (modify-syntax-entry ?_ "w" st)
     (modify-syntax-entry ?' "w" st)
-    (modify-syntax-entry ?* ". 23" st)
+    (modify-syntax-entry ?* ". 23n" st)
     (modify-syntax-entry ?/ ". 124b" st)
     (modify-syntax-entry ?\n "> b" st)
     st)


### PR DESCRIPTION
If my understanding is correct and `/* */` comments are nestable in sail (which seems to be case from my experimentation even if not said in the manual), then this fixes the Emacs sail mode to highlight comments properly in case of nesting