### PR TITLE
Add missing const to sail_config_get()

### DIFF
--- a/lib/sail_config.c
+++ b/lib/sail_config.c
@@ -104,7 +104,7 @@ void sail_config_cleanup(void)
   cJSON_Delete((cJSON *)sail_config);
 }
 
-sail_config_json sail_config_get(size_t n, const char *key[])
+sail_config_json sail_config_get(size_t n, const_sail_string const *key)
 {
   sail_config_json result;
   cJSON *json = (cJSON *)sail_config;

--- a/lib/sail_config.h
+++ b/lib/sail_config.h
@@ -77,7 +77,7 @@ void sail_config_cleanup(void);
 /*
  * Get the JSON corresponding to some key.
  */
-sail_config_json sail_config_get(const size_t n, const_sail_string key[]);
+sail_config_json sail_config_get(const size_t n, const_sail_string const *key);
 
 /*
  * Get the JSON corresponding to some key. Rather than an array the


### PR DESCRIPTION
This allows passing e.g. std::vector<const char *>{...}.data() as the parameter