### PR TITLE
Lean: bump Lean version to lean4-nightly:nightly-2025-05-26

### DIFF
--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -85,7 +85,7 @@ let opt_single_file : bool ref = ref false
 let opt_enable_matchbv : bool ref = ref false
 let opt_disable_matchbv : bool ref = ref true
 
-let lean_version : string = "lean4:nightly-2025-05-14"
+let lean_version : string = "lean4:nightly-2025-05-26"
 let mathlib_version : string = "v4.20.0-rc5"
 
 let lean_options =


### PR DESCRIPTION
Activates a Lean fix that speeds up the elaboration of the RISCV AST type.