### PR TITLE
Add test case for #1323

### DIFF
--- a/test/c/test_constraints.sail
+++ b/test/c/test_constraints.sail
@@ -1,0 +1,16 @@
+
+
+type regidx_range('n) = 'n <= 1 & 'n >= 0
+
+newtype regidx('n), regidx_range('n) = Regidx : int('n)
+
+type s_regidx = { 'n, regidx_range('n) . regidx('n) }
+
+mapping int_string : int <-> string = {
+  0 <-> "0",
+  1 <-> "1",
+}
+
+mapping encdec_reg : s_regidx <-> string = { 
+  Regidx(r) <-> int_string(r),
+}

--- a/test/typecheck/pass/test_constraints.sail
+++ b/test/typecheck/pass/test_constraints.sail
@@ -1,0 +1,16 @@
+
+
+type regidx_range('n) = 'n <= 1 & 'n >= 0
+
+newtype regidx('n), regidx_range('n) = Regidx : int('n)
+
+type s_regidx = { 'n, regidx_range('n) . regidx('n) }
+
+mapping int_string : int <-> string = {
+  0 <-> "0",
+  1 <-> "1",
+}
+
+mapping encdec_reg : s_regidx <-> string = { 
+  Regidx(r) <-> int_string(r),
+}


### PR DESCRIPTION
add testcase for #1323

I added two same test files, one is placed in the typecheck directory and the other in the c directory

```
type regidx_range('n) = 'n <= 1 & 'n >= 0

newtype regidx('n), regidx_range('n) = Regidx : int('n)

type s_regidx = { 'n, regidx_range('n) . regidx('n) }

mapping int_string : int <-> string = {
  0 <-> "0",
  1 <-> "1",
}

mapping encdec_reg : s_regidx <-> string = { 
  Regidx(r) <-> int_string(r),
}
```

@Alasdair you can see only the one in c folder failed

![image](https://github.com/user-attachments/assets/00c27beb-0e11-4fd1-ba97-96b14a47a359)
