### PR TITLE
Lean: translate Boolean type abbreviations

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1233,7 +1233,10 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let vars = doc_typ_quant_only_vars ctx tq in
       let vars = separate space vars in
       nest 2 (flow (break 1) [string "abbrev"; doc_id_ctor id; colon; string "Int"; coloneq; doc_nexp ctx ne])
-  | TD_abbrev (id, tq, A_aux (A_bool nc, _)) -> empty
+  | TD_abbrev (id, TypQ_aux (TypQ_no_forall, _), A_aux (A_bool nc, _)) ->
+      (* We currently cannot handle explicit parameters because of the Int/Nat mismatch. *)
+      nest 2 (flow (break 1) [string "abbrev"; doc_id_ctor id; colon; string "Bool"; coloneq; doc_nconstraint ctx nc])
+  | TD_abbrev _ -> empty
   | TD_variant (id, tq, ar, _) ->
       let pp_tus = concat (List.map (fun tu -> hardline ^^ doc_type_union ctx tu) ar) in
       let rectyp = doc_typ_quant_relevant ctx tq in

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -24,6 +24,8 @@ abbrev xlen_bytes : Int := 8
 
 abbrev xlenbits := (BitVec 64)
 
+abbrev booltype : Bool := xlen = 64
+
 abbrev my_bits k_n := (BitVec k_n)
 
 abbrev Register := PEmpty

--- a/test/lean/typedef.sail
+++ b/test/lean/typedef.sail
@@ -7,6 +7,8 @@ type xlenbits         = bits(xlen)
 
 let xlen = 64
 
+type booltype : Bool = xlen == 64
+
 type my_bits('n) = bitvector('n)
 
 val EXTZ : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)


### PR DESCRIPTION
This is rarely needed since the Sail compiler unfolds most of the uses of type abbreviations, but this fixes an issue in a PR of the RISC-V repo (#870)