### PR TITLE
Lean: use first official nightly release that includes new code generator

### DIFF
--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -77,7 +77,7 @@ def update (x : BitVec m) (n : Nat) (b : BitVec 1) := updateSubrange' x n _ b
 def updateBE (x : BitVec m) (n : Nat) (b : BitVec 1) := updateSubrange' x (m - n - 1) _ b
 
 def toBin {w : Nat} (x : BitVec w) : String :=
-  List.asString (List.map (fun c => if c then '1' else '0') (List.ofFn (BitVec.getMsb' x)))
+  List.asString (List.map (fun c => if c then '1' else '0') (List.ofFn (BitVec.getMsb x)))
 
 def toFormatted {w : Nat} (x : BitVec w) : String :=
   if (length x % 4) == 0 then

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -94,7 +94,7 @@ let rec fix_id name =
   match name with
   (* Lean keywords to avoid, to expand as needed *)
   | "_lean_wildcard" -> "_"
-  | "rec" | "def" | "at" | "alias" | "break" -> name ^ "'"
+  | "rec" | "def" | "at" | "alias" | "break" | "meta" -> name ^ "'"
   | "main" ->
       the_main_function_has_been_seen := true;
       "sail_main"

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -87,7 +87,7 @@ let opt_lean_executable : bool ref = ref false
 let opt_enable_matchbv : bool ref = ref false
 let opt_disable_matchbv : bool ref = ref true
 
-let lean_version : string = "lean4-pr-releases:pr-release-8577"
+let lean_version : string = "lean4:nightly-2025-06-21"
 let mathlib_version : string = "v4.20.0-rc5"
 
 let lean_options =


### PR DESCRIPTION
This PR updates to `nightly-2025-06-21`, the first lean nightly that includes the new code generator. This includes two minor changes:

- Support for the new `meta` keyword
- Rename of `getMsb'` to `getMsb`

The two changes above also resolve build failures in the current `sail-riscv` repository. We already used the new code generator, but the build we used was from a random PR branch, which is more fragile than a nightly.