### PR TITLE
Archsem-related changes

### DIFF
--- a/lib/concurrency_interface/read_write_v2.sail
+++ b/lib/concurrency_interface/read_write_v2.sail
@@ -288,6 +288,43 @@ constraint 'addr_size > 0 & 'cap_size_log >= 0
     }
 }
 
+/* This type represent an announcement of an address that will be read or written.
+   All the parameters must match up with the content of the later access.  We assume
+   that the access kind identifies whether the operation is a read, write, or rmw
+   operation.
+ */
+$option -lem_extern_type Mem_address_announce
+$option -coq_extern_type Mem_address_announce
+$option -lean_extern_type Mem_address_announce
+struct Mem_address_announce('n : Int, 'nt : Int, 'addr_size : Int, 'addr_space : Type,
+    'mem_acc : Type), 'n >= 0 & 'nt >= 0 & 'addr_size > 0 = {
+  access_kind : 'mem_acc,
+  address : bits('addr_size),
+  address_space : 'addr_space,
+  size : int('n),
+  num_tag : int('nt),
+}
+
+/* Requests a memory write. If the write cannot happen due to
+   atomicity/exclusive constraints, then the execution path is discarded as
+   impossible (size-0 non deterministic choice). Is the responsability of the
+   Sail model to do the proper non-determinitic choices beforehand */
+outcome sail_mem_address_announce : forall 'n 'nt, 'n >= 0 & (if 'CHERI then 'nt >= 0 else 'nt == 0).
+  Mem_address_announce('n, 'nt, 'addr_size, 'addr_space, 'mem_acc)
+      -> unit
+with
+  'addr_size : Int,
+  'addr_space : Type,
+  'mem_acc : Type,
+  'abort : Type,
+  'CHERI : Bool,
+  'cap_size_log : Int
+constraint 'addr_size > 0 & 'cap_size_log >= 0
+= {
+    // For now, just drop these
+    impl emulator_or_isla(request) = ()
+}
+
 // Used when we want a non memory read/write to appear in Isla's addr relation
 $iftarget isla
 val sail_address_announce = impure "address_announce" : forall 'addrsize, 'addrsize in {32, 64}. (int('addrsize), bits('addrsize)) -> unit

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1497,6 +1497,7 @@ let to_ast_outcome ctx (ev : P.outcome_spec) : outcome_spec * ctx * ctx =
       let outcome_args, inner_ctx = ConvertType.to_ast_typquant kenv ctx outcome_args in
       let typq, ts_ctx = ConvertType.to_ast_typquant kenv inner_ctx typq in
       let typ = ConvertType.to_ast_typ kenv ts_ctx typ in
+      let ctx = { ctx with outcome_names = IdSet.add id ctx.outcome_names } in
       let ctx =
         List.fold_left
           (fun ctx kopt ->
@@ -1504,7 +1505,6 @@ let to_ast_outcome ctx (ev : P.outcome_spec) : outcome_spec * ctx * ctx =
             let k = unaux_kind (kopt_kind kopt) in
             {
               ctx with
-              outcome_names = IdSet.add id ctx.outcome_names;
               outcome_variables =
                 KBindings.update v
                   (function

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -4608,7 +4608,7 @@ let pp_ast_coq library_style (types_file, types_modules) (defs_file, defs_module
               classifier "mem_acc_is_atomic_rmw";
             ]
           @ usual_type "trans_start" @ usual_type "trans_end" @ usual_type "abort" @ usual_type "barrier"
-          @ usual_type "cache_op" @ usual_type "tlb_op" @ usual_type "fault" @ usual_type "sys_reg_id"
+          @ usual_type "cache_op" @ usual_type "tlbi" @ usual_type "exn" @ usual_type "sys_reg_id"
           @ [
               string "End Arch.";
               empty;

--- a/test/c/concurrency_interface_v2.sail
+++ b/test/c/concurrency_interface_v2.sail
@@ -59,6 +59,9 @@ enum my_barrier = Barrier1 | Barrier2
 
 instantiation sail_barrier with 'barrier = my_barrier
 
+instantiation sail_take_exception with 'exn = int
+instantiation sail_return_exception
+
 register R1 : bits(64)
 register R2 : bits(64)
 
@@ -178,6 +181,9 @@ function main() = {
         },
         _ => print_endline("invalid read"),
     };
+
+    sail_take_exception(5);
+    sail_return_exception();
 
     /* Cycle count primitives */
     sail_end_cycle();

--- a/test/c/mk_coq_main.sh
+++ b/test/c/mk_coq_main.sh
@@ -113,11 +113,15 @@ EOF
   cat <<EOF >> "$OUT"
       | Interface.MemWrite n req => fun k => run (k (inl None)) (write_mem st n req)
       | Interface.MemRead n req => fun k => run (k (inl (read_mem st n req))) st
+      | Interface.TakeException _ => fun k => run (k tt) st
+      | Interface.ReturnException _ => fun k => run (k tt) st
 EOF
   else
   cat <<EOF >> "$OUT"
       | Interface.MemWrite n nt req => fun k => run (k (inl None)) (write_mem st n nt req)
       | Interface.MemRead n nt req => fun k => run (k (inl (read_mem st n nt req))) st
+      | Interface.TakeException _ => fun k => run (k tt) st
+      | Interface.ReturnException => fun k => run (k tt) st
 EOF
   fi
   cat <<EOF >> "$OUT"


### PR DESCRIPTION
An extra outcome that we need; fix for `sail_return_exception` instantiation; fix type names in Rocq backend.