### PR TITLE
Build and release for Linux Arm platform 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         version: [4.08.1, 5.2.1]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         exclude:
         - os: macos-latest
           version: 4.08.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,11 @@ jobs:
         etc/ci_core_tests.sh
 
   build-docker:
-    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lower-bounds.yml
+++ b/.github/workflows/lower-bounds.yml
@@ -6,7 +6,7 @@ jobs:
   lower-bounds:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest]
         ocaml-compiler: [5.0.0]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lower-bounds.yml
+++ b/.github/workflows/lower-bounds.yml
@@ -6,7 +6,7 @@ jobs:
   lower-bounds:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         ocaml-compiler: [5.0.0]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: linux-amd64
+          - name: linux-x86_64
             os: ubuntu-latest
             container: rockylinux:8
             ocaml_version: 5.2.1
             opam_arch: i686
             opam_cache_key: rocky8-5.2.1
-          - name: linux-arm64
+          - name: linux-aarch64
             os: ubuntu-24.04-arm
             container: rockylinux:8
             ocaml_version: 5.2.1
@@ -137,10 +137,10 @@ jobs:
 
     - uses: actions/attest-build-provenance@v1
       with:
-        subject-path: _build/sail.tar.gz
+        subject-path: _build/sail-${{ matrix.name }}.tar.gz
 
     - name: Upload tarball
       uses: actions/upload-artifact@v4
       with:
         name: sail-${{ matrix.name }}
-        path: _build/sail.tar.gz
+        path: _build/sail-${{ matrix.name }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,28 +89,28 @@ jobs:
         git config --global --add safe.directory '*'
         git fetch --unshallow
 
-    # - name: Restore cached ~/.opam
-    #   id: cache-opam-restore
-    #   uses: actions/cache/restore@v4
-    #   with:
-    #     path: ~/.opam
-    #     key: ${{ matrix.opam_cache_key }}
+    - name: Restore cached ~/.opam
+      id: cache-opam-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.opam
+        key: ${{ matrix.opam_cache_key }}
 
-    # - name: Init opam
-    #   if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-    #   run: |
-    #     # Sandboxing doesn't work in Docker.
-    #     opam init --disable-sandboxing --yes --no-setup --shell=sh --compiler=${{ matrix.ocaml_version }} && \
-    #     eval "$(opam env)" && \
-    #     ocaml --version
+    - name: Init opam
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      run: |
+        # Sandboxing doesn't work in Docker.
+        opam init --disable-sandboxing --yes --no-setup --shell=sh --compiler=${{ matrix.ocaml_version }} && \
+        eval "$(opam env)" && \
+        ocaml --version
 
-    # - name: Save cached opam
-    #   if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-    #   id: cache-opam-save
-    #   uses: actions/cache/save@v4
-    #   with:
-    #     path: ~/.opam
-    #     key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+    - name: Save cached opam
+      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+      id: cache-opam-save
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.opam
+        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
 
     - name: Install Sail
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: linux-x86_64
+          - name: Linux-x86_64
             os: ubuntu-latest
             container: rockylinux:8
             ocaml_version: 5.2.1
             opam_arch: i686
             opam_cache_key: rocky8-5.2.1
-          - name: linux-aarch64
+          - name: Linux-aarch64
             os: ubuntu-24.04-arm
             container: rockylinux:8
             ocaml_version: 5.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,28 +89,28 @@ jobs:
         git config --global --add safe.directory '*'
         git fetch --unshallow
 
-    - name: Restore cached ~/.opam
-      id: cache-opam-restore
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.opam
-        key: ${{ matrix.opam_cache_key }}
+    # - name: Restore cached ~/.opam
+    #   id: cache-opam-restore
+    #   uses: actions/cache/restore@v4
+    #   with:
+    #     path: ~/.opam
+    #     key: ${{ matrix.opam_cache_key }}
 
-    - name: Init opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      run: |
-        # Sandboxing doesn't work in Docker.
-        opam init --disable-sandboxing --yes --no-setup --shell=sh --compiler=${{ matrix.ocaml_version }} && \
-        eval "$(opam env)" && \
-        ocaml --version
+    # - name: Init opam
+    #   if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+    #   run: |
+    #     # Sandboxing doesn't work in Docker.
+    #     opam init --disable-sandboxing --yes --no-setup --shell=sh --compiler=${{ matrix.ocaml_version }} && \
+    #     eval "$(opam env)" && \
+    #     ocaml --version
 
-    - name: Save cached opam
-      if: steps.cache-opam-restore.outputs.cache-hit != 'true'
-      id: cache-opam-save
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.opam
-        key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
+    # - name: Save cached opam
+    #   if: steps.cache-opam-restore.outputs.cache-hit != 'true'
+    #   id: cache-opam-save
+    #   uses: actions/cache/save@v4
+    #   with:
+    #     path: ~/.opam
+    #     key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
 
     - name: Install Sail
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             container: rockylinux:8
             ocaml_version: 5.2.1
             opam_arch: arm64
-            opam_cache_key: rocky8-5.2.1
+            opam_cache_key: rocky8-5.2.1-arm
           # MacOS disabled for now due to code signing and notarisation requirements
           # - name: mac-arm64 */
           #   os: macos-latest */

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
             container: rockylinux:8
             ocaml_version: 5.2.1
             opam_cache_key: rocky8-5.2.1
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            container: rockylinux:8
+            ocaml_version: 5.2.1
+            opam_cache_key: rocky8-5.2.1
           # MacOS disabled for now due to code signing and notarisation requirements
           # - name: mac-arm64 */
           #   os: macos-latest */

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,13 @@ jobs:
             os: ubuntu-latest
             container: rockylinux:8
             ocaml_version: 5.2.1
+            opam_arch: i686
             opam_cache_key: rocky8-5.2.1
           - name: linux-arm64
             os: ubuntu-24.04-arm
             container: rockylinux:8
             ocaml_version: 5.2.1
+            opam_arch: arm64
             opam_cache_key: rocky8-5.2.1
           # MacOS disabled for now due to code signing and notarisation requirements
           # - name: mac-arm64 */
@@ -63,7 +65,7 @@ jobs:
           rsync \
           which \
           cargo
-        curl -L -o /usr/local/bin/opam https://github.com/ocaml/opam/releases/download/2.1.5/opam-2.1.5-i686-linux
+        curl -L -o /usr/local/bin/opam https://github.com/ocaml/opam/releases/download/2.1.5/opam-2.1.5-${{ matrix.opam_arch }}-linux
         chmod +x /usr/local/bin/opam
 
     - name: System dependencies (Mac)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifdef TARBALL_EXTRA_BIN
 	cp $(TARBALL_EXTRA_BIN) _build/tarball/sail/bin/
 endif
 	cp lib/coverage/libsail_coverage.a _build/tarball/sail/share/sail/lib/coverage/
-	tar czvf _build/sail.tar.gz -C _build/tarball sail
+	tar czvf _build/sail-linux-$(uname -m).tar.gz -C _build/tarball sail
 
 coverage:
 	dune build --release --instrument-with bisect_ppx

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifdef TARBALL_EXTRA_BIN
 	cp $(TARBALL_EXTRA_BIN) _build/tarball/sail/bin/
 endif
 	cp lib/coverage/libsail_coverage.a _build/tarball/sail/share/sail/lib/coverage/
-	tar czvf _build/sail-linux-$(uname -m).tar.gz -C _build/tarball sail
+	tar czvf _build/sail-linux-$(shell uname -m).tar.gz -C _build/tarball sail
 
 coverage:
 	dune build --release --instrument-with bisect_ppx

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifdef TARBALL_EXTRA_BIN
 	cp $(TARBALL_EXTRA_BIN) _build/tarball/sail/bin/
 endif
 	cp lib/coverage/libsail_coverage.a _build/tarball/sail/share/sail/lib/coverage/
-	tar czvf _build/sail-linux-$(shell uname -m).tar.gz -C _build/tarball sail
+	tar czvf _build/sail-$(shell uname -s)-$(shell uname -m).tar.gz -C _build/tarball sail
 
 coverage:
 	dune build --release --instrument-with bisect_ppx


### PR DESCRIPTION
This PR addresses issue #1368 by adding support for building and releasing binaries targeting the `linux/arm64` platform.

This enhancement is crucial for running SAIL on ARM-based Linux environments, including:
- ARM servers are commonly used in cloud infrastructure
- Linux containers on ARM machines, such as newer Apple MacBooks

The PR modifies release names to be `sail-Linux-x86_64` and `sail-Linux-aarch64` from `sail` only. This is done according to `uname` naming choices. This may affect downstream users relying on the old naming. 