### PR TITLE
Interface bugfixes

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -256,7 +256,11 @@ let rec options =
         " <type variable=value> instantiate an abstract type variable"
       );
       ("-all_modules", Arg.Set opt_all_modules, " use all modules in project file");
-      ("-list_files", Arg.Set Frontend.opt_list_files, " list files used in all project files");
+      ("-list_files", Arg.Unit (fun () -> Frontend.opt_list_files := Some " "), " list files used in all project files");
+      ( "-list_files_separated",
+        Arg.String (fun sep -> Frontend.opt_list_files := Some sep),
+        " list files used in all project files, with a provided separator"
+      );
       ("-config", Arg.String (fun file -> opt_model_config_file := Some file), "<file> model configuration file");
       ("-sail_config", Arg.String (fun file -> opt_sail_config_file := Some file), "<file> sail configuration file");
       ( "-output-schema",

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -53,7 +53,7 @@ module StringMap = Map.Make (String)
 let opt_ddump_initial_ast = ref false
 let opt_ddump_side_effect = ref false
 let opt_ddump_tc_ast = ref false
-let opt_list_files = ref false
+let opt_list_files = ref None
 let opt_reformat : string option ref = ref None
 
 let finalize_ast asserts_termination ctx env ast =
@@ -327,17 +327,19 @@ let load_modules ?target default_sail_dir options env proj root_mod_ids =
       mod_ids
   in
 
-  if !opt_list_files then (
-    let included_files =
-      List.map (fun parsed_module -> if parsed_module.included then parsed_module.files else []) parsed_modules
-      |> List.concat
-    in
-    print_endline
-      (Util.string_of_list " "
-         (fun s -> s)
-         (List.filter_map (function File { filename; _ } -> Some filename | Generated _ -> None) included_files)
-      );
-    exit 0
+  ( match !opt_list_files with
+  | Some sep ->
+      let included_files =
+        List.map (fun parsed_module -> if parsed_module.included then parsed_module.files else []) parsed_modules
+        |> List.concat
+      in
+      print_endline
+        (Util.string_of_list sep
+           (fun s -> s)
+           (List.filter_map (function File { filename; _ } -> Some filename | Generated _ -> None) included_files)
+        );
+      exit 0
+  | None -> ()
   );
 
   let all_files =

--- a/src/lib/frontend.mli
+++ b/src/lib/frontend.mli
@@ -51,7 +51,10 @@ open Ast_util
 val opt_ddump_initial_ast : bool ref
 val opt_ddump_side_effect : bool ref
 val opt_ddump_tc_ast : bool ref
-val opt_list_files : bool ref
+
+(** If [Some sep], then list the files included in the given sail_project file using [sep] as a separator. *)
+val opt_list_files : string option ref
+
 val opt_reformat : string option ref
 
 (** env_update: This function takes a pre abstract instantiation type environment, and makes any abstract types concrete

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5268,10 +5268,12 @@ and check_outcome_instantiation :
   let instantiated = List.fold_left (fun m (kid, inst) -> KBindings.add kid inst m) KBindings.empty instantiated in
 
   (* Instantiate the outcome type with these existing parameters *)
-  let typ =
+  let typq, typ =
     List.fold_left
-      (fun typ (kid, (_, _, existing_arg)) -> typ_subst kid existing_arg typ)
-      typ (KBindings.bindings instantiated)
+      (fun (typq, typ) (kid, (_, _, existing_arg)) ->
+        (typquant_subst kid existing_arg typq, typ_subst kid existing_arg typ)
+      )
+      (typq, typ) (KBindings.bindings instantiated)
   in
 
   (* Check all the constraints on the outcome parameters *)

--- a/test/c/concurrency_interface_v2_var.expect
+++ b/test/c/concurrency_interface_v2_var.expect
@@ -1,0 +1,9 @@
+least significant byte = 0x78
+read memory (no tag read) = 0xABCD1234FFFF5678
+read memory 4 lower bytes (no tag read) = 0xFFFF5678
+read memory 4 higher bytes (no tag read) = 0xABCD1234
+read memory (true tag) = 0xABCD1234FFFF5678
+read memory (false tag) = 0xABCD1234DEAD5678
+read memory 2 bytes (false tag) = 0xDEAD
+c = 1
+0xFFFF

--- a/test/c/concurrency_interface_v2_var.sail
+++ b/test/c/concurrency_interface_v2_var.sail
@@ -1,0 +1,200 @@
+default Order dec
+
+$define CONCURRENCY_INTERFACE_V2
+
+$include <prelude.sail>
+$include <concurrency_interface.sail>
+$include <concurrency_interface/exception.sail>
+
+val id_bits64 : bits(64) -> bits(64)
+
+function id_bits64 bv = bv
+
+val unit_true : unit -> bool
+function unit_true () = true
+
+val unit_false : unit -> bool
+function unit_false () = true
+
+val unit_zero : unit -> int
+function unit_zero () = 0
+
+instantiation sail_mem_read with
+  'addr_size = 64,
+  'addr_space = unit,
+  'mem_acc = unit,
+  mem_acc_is_explicit = unit_true,
+  mem_acc_is_ifetch = unit_false,
+  mem_acc_is_ttw = unit_false,
+  mem_acc_is_relaxed = unit_true,
+  mem_acc_is_rel_acq_rcpc = unit_false,
+  mem_acc_is_rel_acq_rcsc = unit_false,
+  mem_acc_is_standalone = unit_true,
+  mem_acc_is_exclusive = unit_false,
+  mem_acc_is_atomic_rmw = unit_false,
+  'abort = bits(8),
+  'CHERI = true,
+  'cap_size_log = 3
+
+
+
+instantiation sail_mem_write with
+  mem_acc_is_explicit = unit_true,
+  mem_acc_is_ifetch = unit_false,
+  mem_acc_is_ttw = unit_false,
+  mem_acc_is_relaxed = unit_true,
+  mem_acc_is_rel_acq_rcpc = unit_false,
+  mem_acc_is_rel_acq_rcsc = unit_false,
+  mem_acc_is_standalone = unit_true,
+  mem_acc_is_exclusive = unit_false,
+  mem_acc_is_atomic_rmw = unit_false
+
+enum my_barrier = Barrier1 | Barrier2
+
+instantiation sail_barrier with 'barrier = my_barrier
+
+instantiation sail_take_exception with 'exn = int
+instantiation sail_return_exception
+
+register R1 : bits(64)
+register R2 : bits(64)
+
+val main : unit -> unit
+
+function main() = {
+    let w_req : Mem_write_request(8, 1, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0000,
+        address_space = (),
+        size = 8,
+        num_tag = 1,
+        value = [0xAB, 0xCD, 0x12, 0x34, 0xFF, 0xFF, 0x56, 0x78],
+        tags = [true]
+    };
+    print_bits("least significant byte = ", w_req.value[0]);
+    match sail_mem_write(w_req) {
+        Ok(_) => (),
+        Err(abort) => {
+            print_bits("abort = ", abort)
+        }
+    };
+    let r_req : Mem_read_request(8, 0, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0000,
+        address_space = (),
+        size = 8,
+        num_tag = 0
+    };
+    match sail_mem_read(r_req) {
+        Ok((value, v)) => {
+            print_bits("read memory (no tag read) = ", from_bytes_le(value))
+        },
+        _ => print_endline("invalid read"),
+    };
+    let r_req : Mem_read_request(4, 0, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0000,
+        address_space = (),
+        size = 4,
+        num_tag = 0
+    };
+    match sail_mem_read(r_req) {
+        Ok((value, v)) => {
+            print_bits("read memory 4 lower bytes (no tag read) = ", from_bytes_le(value))
+        },
+        _ => print_endline("invalid read"),
+    };
+    let r_req : Mem_read_request(4, 0, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0004,
+        address_space = (),
+        size = 4,
+        num_tag = 0
+    };
+    match sail_mem_read(r_req) {
+        Ok((value, v)) => {
+            print_bits("read memory 4 higher bytes (no tag read) = ", from_bytes_le(value))
+        },
+        _ => print_endline("invalid read"),
+    };
+
+    sail_barrier(Barrier1);
+    let r_req : Mem_read_request(8, 1, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0000,
+        address_space = (),
+        size = 8,
+        num_tag = 1,
+    };
+    match sail_mem_read(r_req) {
+        Ok((value, v)) if v[0] => {
+            print_bits("read memory (true tag) = ", from_bytes_le(value))
+        },
+        _ => print_endline("invalid read"),
+    };
+
+    let w_req : Mem_write_request(2, 0, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0002,
+        address_space = (),
+        size = 2,
+        num_tag = 0,
+        value = [0xDE, 0xAD],
+        tags = []
+    };
+    match sail_mem_write(w_req) {
+        Ok(_) => (),
+        Err(abort) => {
+            print_bits("abort = ", abort)
+        }
+    };
+    let r_req : Mem_read_request(8, 1, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0000,
+        address_space = (),
+        size = 8,
+        num_tag = 1,
+    };
+    match sail_mem_read(r_req) {
+        Ok((value, v)) if v[0] == false => {
+            print_bits("read memory (false tag) = ", from_bytes_le(value))
+        },
+        _ => print_endline("invalid read"),
+    };
+
+    let r_req : Mem_read_request(2, 1, 64, unit, unit) = struct {
+        access_kind = (),
+        address = 0x0000_0000_0060_0002,
+        address_space = (),
+        size = 2,
+        num_tag = 1,
+    };
+    match sail_mem_read(r_req) {
+        Ok((value, v)) if not_bool(v[0]) => {
+            print_bits("read memory 2 bytes (false tag) = ", from_bytes_le(value))
+        },
+        _ => print_endline("invalid read"),
+    };
+
+    sail_take_exception(5);
+    sail_return_exception();
+
+    /* Cycle count primitives */
+    sail_end_cycle();
+    let c = sail_get_cycle_count();
+    print_int("c = ", c);
+
+    /* Instruction and branch announce events */
+    sail_instr_announce(0xABCD_1234);
+    sail_branch_announce(64, 0x0000_0000_0000_4000);
+
+    /* Isla relaxed register support */
+    sail_reset_registers();
+    sail_synchronize_registers();
+
+    /* Isla mark register builtins */
+    sail_mark_register(ref R1, "MARK");
+    sail_mark_register_pair(ref R1, ref R2, "MARK2");
+
+    print_bits("", __monomorphize(0xFFFF));
+}

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -46,6 +46,7 @@ skip_selftests = {
     'config_abstract_bool', # Register type unsupported in state.ml
     'newtype',
     'concurrency_interface_v2',
+    'concurrency_interface_v2_var',
     'config_map_guard',
     'let_assert',
 }

--- a/test/sv/run_tests.py
+++ b/test/sv/run_tests.py
@@ -33,6 +33,7 @@ skip_tests = {
     'simple_while2', # loops
     'simple_while3', # loops
     'concurrency_interface_v2',
+    'concurrency_interface_v2_var'
 }
 
 print("Sail is {}".format(sail))


### PR DESCRIPTION
Fixes a small issue where certain constraints had to be repeated if they appeared in outcome constraints.

Also adds a --list-files-separated flag for better CMake compatibility