### PR TITLE
Add SAIL_FLAGS environment variable

### DIFF
--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -286,3 +286,16 @@ plugins. These options are all prefixed with `d`.
   of the various other debugging options to be fed back into Sail. The
   name comes from the GHC option with the same purpose:
   https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/magic_hash.html
+
+=== Passing options via SAIL_FLAGS
+
+The `SAIL_FLAGS` environment variable can be used to pass additional
+flags to Sail without passing them directly on the command line. The
+arguments contained in this variable are separated by spaces (multiple
+spaces will be treated as a single separator). For more robust
+splitting of arguments, the `SAIL_ENCODED_FLAGS` environment variable
+can be used instead. Here, arguments are separated by the ASCII unit
+separator control character `0x1f`, and are then passed unmodified
+without any trimming of whitespace. If set the `SAIL_ENCODED_FLAGS`
+variable will take precedence and the `SAIL_FLAGS` variable will be
+ignored.

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -206,7 +206,7 @@ let version_check ~required =
   || (required.major = version.major && required.minor < version.minor)
   || (required.major = version.major && required.minor = version.minor && required.patch <= version.patch)
 
-let usage_msg = version_string ^ "\nusage: sail <options> <file1.sail> ... <fileN.sail>\n"
+let usage_msg = "Sail " ^ version_string ^ "\nusage: sail <options> <file1.sail> ... <fileN.sail>\n"
 
 let help options = raise (Arg.Help (Arg.usage_string options usage_msg))
 
@@ -663,7 +663,16 @@ let main () =
       )
   end;
 
-  Arg.parse_dynamic options (fun s -> opt_free_arguments := !opt_free_arguments @ [s]) usage_msg;
+  let argv = Sail_file.sail_argv () in
+  ( try Arg.parse_argv_dynamic argv options (fun s -> opt_free_arguments := !opt_free_arguments @ [s]) usage_msg with
+  | Arg.Bad _ ->
+      prerr_endline usage_msg;
+      prerr_endline "Use 'sail --help' for a list of available arguments.";
+      exit 1
+  | Arg.Help msg ->
+      prerr_endline msg;
+      exit 0
+  );
 
   let config = Option.map parse_json_config_file (get_implicit_config_file !opt_sail_config_file) in
 

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -241,7 +241,7 @@ module SailHandler : FILE_HANDLER = struct
 
   let process ~default_sail_dir ~target_name ~options ctx (filename, comments, defs) =
     let defs = Preprocess.preprocess default_sail_dir target_name options defs in
-    let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [(filename, defs)]) in
+    let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [(Some filename, defs)]) in
     ({ ast with comments = [(filename, comments)] }, ctx)
 
   let check env ast = Type_error.check env ast
@@ -286,7 +286,7 @@ let process_files ~target_name ~default_sail_dir ~options ctx vs_ids regs files 
           ((cont.ctx, IdSet.union vs_ids cont.vs_ids, regs @ cont.regs), ProcessedFile { filename; cont = cont.check })
       | Generated defs ->
           let defs = Preprocess.preprocess default_sail_dir target_name options defs in
-          let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [("", defs)]) in
+          let ast, ctx = Initial_check.process_ast ctx (Parse_ast.Defs [(None, defs)]) in
           ((ctx, vs_ids, regs), ProcessedGenerated ast.defs)
       )
     (ctx, vs_ids, regs) files

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -2168,9 +2168,12 @@ let to_ast ctx (P.Defs files) =
     (List.rev defs, ctx)
   in
   let wrap_file file defs =
-    [mk_def (DEF_pragma ("file_start", Pragma_line (file, P.Unknown))) ()]
-    @ defs
-    @ [mk_def (DEF_pragma ("file_end", Pragma_line (file, P.Unknown))) ()]
+    match file with
+    | None -> defs
+    | Some file ->
+        [mk_def (DEF_pragma ("file_start", Pragma_line (file, P.Unknown))) ()]
+        @ defs
+        @ [mk_def (DEF_pragma ("file_end", Pragma_line (file, P.Unknown))) ()]
   in
   let defs, ctx =
     List.fold_left
@@ -2525,7 +2528,7 @@ let ast_of_def_string_with ?inline ocaml_pos ctx f str =
       let tok = Lexing.lexeme lexbuf in
       raise (Reporting.err_syntax pos ("current token: " ^ tok))
   in
-  let ast, ctx = Reporting.forbid_errors ocaml_pos (fun ast -> process_ast ctx ast) (P.Defs [("", f [def])]) in
+  let ast, ctx = Reporting.forbid_errors ocaml_pos (fun ast -> process_ast ctx ast) (P.Defs [(None, f [def])]) in
   opt_magic_hash := internal;
   (ast, ctx)
 

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -481,4 +481,4 @@ and lexp = LE_aux of lexp_aux * l
 
 type defs =
   (* Definition sequence *)
-  | Defs of (string * def list) list
+  | Defs of (string option * def list) list

--- a/src/lib/sail_file.ml
+++ b/src/lib/sail_file.ml
@@ -102,10 +102,25 @@ type info = {
 let new_info ~owner ~given_path ~canonical_path ~contents =
   { owner; given_path; canonical_path; contents; next_edit = 0; edits = Array.make 64 None }
 
+let sail_argv () =
+  let actual_argv = Sys.argv in
+  let from_env =
+    match Sys.getenv_opt "SAIL_ENCODED_FLAGS" with
+    | Some flags ->
+        (* Split on ASCII unit separator, like CARGO_ENCODED_RUSTFLAGS in Rust *)
+        String.split_on_char '\x1f' flags
+    | None -> (
+        match Sys.getenv_opt "SAIL_FLAGS" with
+        | Some flags -> String.split_on_char ' ' flags |> List.filter (fun flag -> flag <> "")
+        | None -> []
+      )
+  in
+  Array.append actual_argv (Array.of_list from_env)
+
 let files : (int, info) Hashtbl.t =
   let tbl = Hashtbl.create 64 in
   let repl_contents = Array.make 1 "0000001,0000016" in
-  let argv_contents = Sys.argv in
+  let argv_contents = sail_argv () in
   Hashtbl.add tbl interactive_repl
     (new_info ~owner:Compiler ~given_path:"REPL" ~canonical_path:"REPL" ~contents:repl_contents);
   Hashtbl.add tbl argv (new_info ~owner:Compiler ~given_path:"ARGV" ~canonical_path:"ARGV" ~contents:argv_contents);

--- a/src/lib/sail_file.mli
+++ b/src/lib/sail_file.mli
@@ -49,8 +49,14 @@ type handle = private int
 (** This is a special handle that contains inputs to the sail -i REPL *)
 val interactive_repl : handle
 
-(** This is a special handle that treats the Sail argv array as a file for error reporting *)
+(** This is a special handle that treats the Sail argv array as a file for error reporting, with one member of the argv
+    array per line. *)
 val argv : handle
+
+(** This returns the argv array used by Sail. It combines OCaml's Sys.argv with the value of either SAIL_ENCODED_FLAGS
+    (arguments separated by the ASCII unit separator [0x1f]) or SAIL_FLAGS (space separated) using the first only if
+    both are present. *)
+val sail_argv : unit -> string Array.t
 
 val repl_prompt_line : unit -> int
 

--- a/src/lib/splice.ml
+++ b/src/lib/splice.ml
@@ -113,7 +113,7 @@ let annotate_ast ast =
 
 let splice ctx ast file =
   let parsed_ast = Initial_check.parse_file file |> snd in
-  let repl_ast, _ = Initial_check.process_ast ctx (Parse_ast.Defs [(file, parsed_ast)]) in
+  let repl_ast, _ = Initial_check.process_ast ctx (Parse_ast.Defs [(Some file, parsed_ast)]) in
   let repl_ast = map_ast_annot (fun (l, _) -> (l, Type_check.empty_tannot)) repl_ast in
   let repl_ast = annotate_ast repl_ast in
   let repl_ids, repl_specs = scan_ast repl_ast in


### PR DESCRIPTION
Allows passing flags to Sail without requiring modifications to Makefiles or other build scripts. Also support a SAIL_ENCODED_FLAGS variable that parses like CARGO_ENCODED_RUSTFLAGS for more robust usage by build systems and scripts.

Fix an issue where generated code would get bogus $file_start and $file_end directives with an empty argument.