### PR TITLE
c: Use `const char *` for names in the RTS/ELF API to improve C++ compatibility.

### DIFF
--- a/lib/elf.c
+++ b/lib/elf.c
@@ -438,7 +438,7 @@ void loadELFHdr(const char* buffer, const int total_file_size, bool allow_pie, c
     }
 }
 
-void load_elf_at_offset(char *filename, bool allow_pie, const int64_t pie_load_offset, bool *is32bit_p, uint64_t *entry) {
+void load_elf_at_offset(const char *filename, bool allow_pie, const int64_t pie_load_offset, bool *is32bit_p, uint64_t *entry) {
     // Read input file into memory
     char* buffer = NULL;
     int   size   = 0;
@@ -465,7 +465,7 @@ fail:
     exit(EXIT_FAILURE);
 }
 
-void load_elf(char *filename, bool *is32bit_p, uint64_t *entry) {
+void load_elf(const char *filename, bool *is32bit_p, uint64_t *entry) {
     load_elf_at_offset(filename, false, 0, is32bit_p, entry);
 }
 

--- a/lib/elf.h
+++ b/lib/elf.h
@@ -55,12 +55,12 @@ extern "C" {
 #endif
 
 // Loads only ET_EXEC executable files.
-void load_elf(char *filename, bool *is32bit_p, uint64_t *entry);
+void load_elf(const char *filename, bool *is32bit_p, uint64_t *entry);
 
 // Loads ET_EXEC or ET_DYN (if allow_pie is true), or only ET_EXEC (if allow_pie is false).
 // If allow_pie is true, pie_load_offset is added to the load offsets specified in the file.
 // If allow_pie is false, pie_load_offset is ignored.
-void load_elf_at_offset(char *filename, bool allow_pie, const int64_t pie_load_offset, bool *is32bit_p, uint64_t *entry);
+void load_elf_at_offset(const char *filename, bool allow_pie, const int64_t pie_load_offset, bool *is32bit_p, uint64_t *entry);
 
 int  lookup_sym(const char *filename, const char *symname, uint64_t *value);
 

--- a/lib/rts.c
+++ b/lib/rts.c
@@ -440,7 +440,7 @@ unit load_raw(fbits addr, const_sail_string file)
   return UNIT;
 }
 
-void load_image(char *file)
+void load_image(const char *file)
 {
   FILE *fp = fopen(file, "r");
 
@@ -546,7 +546,7 @@ void trace_retend(void) {
   if (g_trace_enabled) fputs("\n", stderr);
 }
 
-void trace_start(char *name)
+void trace_start(const char *name)
 {
   if (g_trace_enabled) {
     fprintf(stderr, "[TRACE] ");

--- a/lib/rts.h
+++ b/lib/rts.h
@@ -160,7 +160,7 @@ bool emulator_write_mem_exclusive(const uint64_t addr_size,
 
 unit load_raw(fbits addr, const_sail_string file);
 
-void load_image(char *);
+void load_image(const char *);
 
 /* ***** Tracing ***** */
 
@@ -203,7 +203,7 @@ void trace_unknown(void);
 void trace_argsep(void);
 void trace_argend(void);
 void trace_retend(void);
-void trace_start(char *);
+void trace_start(const char *);
 void trace_end(void);
 
 /*


### PR DESCRIPTION
`process_arguments` is unchanged due to its use of `getopt`.