### PR TITLE
Don't use current directory '.' when combining filepaths with project root

### DIFF
--- a/src/lib/project.ml
+++ b/src/lib/project.ml
@@ -415,7 +415,7 @@ let rec collect_files = function
   | [] -> []
 
 let add_root root_opt (file, l) =
-  match root_opt with Some root -> (root ^ Filename.dir_sep ^ file, l) | None -> (file, l)
+  match root_opt with None | Some "." -> (file, l) | Some root -> (root ^ Filename.dir_sep ^ file, l)
 
 class structure_visitor (proj : project_structure) =
   object


### PR DESCRIPTION
Avoids an issue where VSCode doesn't recognise `./file.sail` as a valid file path.