### PR TITLE
Add support for C++ output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ lib/hol/sail-heap
 /test/smt/*.out
 /test/smt/*.smt2
 /test/c/*.c
+/test/c/*.cpp
 /test/c/*.h
 /test/c/*.result
 /test/c/*.err_result

--- a/doc/examples/my_replicate_bits.sail
+++ b/doc/examples/my_replicate_bits.sail
@@ -11,6 +11,7 @@ val shiftl = pure "shiftl" : forall 'm. (bits('m), int) -> bits('m)
 val operator >> = pure {
   ocaml: "shiftr_ocaml",
   c: "shiftr_c",
+  cpp: "shiftr_c",
   lem: "shiftr_lem",
   _: "shiftr"
 } : forall 'm. (bits('m), int) -> bits('m)

--- a/lib/arith.sail
+++ b/lib/arith.sail
@@ -134,13 +134,13 @@ Similarly, we define shifts of 32 and 1 (i.e., powers of two).
 
 The most general shift operations also allow negative shifts which go in the opposite direction, for compatibility with ASL.
 */
-val _shl8 = pure {c: "shl_mach_int", lean: "Int.shiftl", _: "shl_int"} :
+val _shl8 = pure {c: "shl_mach_int", cpp: "shl_mach_int", lean: "Int.shiftl", _: "shl_int"} :
   forall 'n, 0 <= 'n <= 3. (int(8), int('n)) -> {'m, 'm in {8, 16, 32, 64}. int('m)}
 
-val _shl32 = pure {c: "shl_mach_int", lean: "Int.shiftl", _: "shl_int"} :
+val _shl32 = pure {c: "shl_mach_int", cpp: "shl_mach_int", lean: "Int.shiftl", _: "shl_int"} :
   forall 'n, 'n in {0, 1}. (int(32), int('n)) -> {'m, 'm in {32, 64}. int('m)}
 
-val _shl1 = pure {c: "shl_mach_int", lean: "Int.shiftl", _: "shl_int"} :
+val _shl1 = pure {c: "shl_mach_int", cpp: "shl_mach_int", lean: "Int.shiftl", _: "shl_int"} :
   forall 'n, 0 <= 'n <= 3. (int(1), int('n)) -> {'m, 'm in {1, 2, 4, 8}. int('m)}
 
 val _shl_int = pure {
@@ -149,7 +149,7 @@ val _shl_int = pure {
 } : forall 'n, 0 <= 'n. (int, int('n)) -> int
 
 val _shr32 = pure {
-  c: "shr_mach_int",
+  c: "shr_mach_int", cpp: "shr_mach_int",
   lean: "Int.shiftl",
   _: "shr_int"
 } : forall 'n, 0 <= 'n <= 31. (int('n), int(1)) -> {'m, 0 <= 'm <= 15. int('m)}

--- a/lib/concurrency_interface/common.sail
+++ b/lib/concurrency_interface/common.sail
@@ -46,8 +46,8 @@
 
 $sail_internal
 
-$target_set emulator_or_isla isla c ocaml interpreter systemverilog
-$target_set emulator c ocaml interpreter systemverilog
+$target_set emulator_or_isla isla c cpp ocaml interpreter systemverilog
+$target_set emulator c cpp ocaml interpreter systemverilog
 $target_set prover lem coq lean
 
 $ifndef _CONCURRENCY_INTERFACE_COMMON

--- a/lib/concurrency_interface/emulator_memory.sail
+++ b/lib/concurrency_interface/emulator_memory.sail
@@ -54,7 +54,7 @@ $else
 $include <vector_inc.sail>
 $endif
 
-$iftarget c ocaml systemverilog
+$iftarget c cpp ocaml systemverilog
 $define _EMULATOR_MEMORY_PRIMOPS
 $endif
 

--- a/lib/elf.sail
+++ b/lib/elf.sail
@@ -51,14 +51,16 @@ val elf_entry = {
   ocaml: "Elf_loader.elf_entry",
   interpreter: "Elf_loader.elf_entry",
   lem: "elf_entry",
-  c: "elf_entry"
+  c: "elf_entry",
+  cpp: "elf_entry"
 } : unit -> int
 
 val elf_tohost = {
   ocaml: "Elf_loader.elf_tohost",
   interpreter: "Elf_loader.elf_tohost",
   lem: "elf_tohost",
-  c: "elf_tohost"
+  c: "elf_tohost",
+  cpp: "elf_tohost"
 } : unit -> int
 
 $endif

--- a/lib/mapping.sail
+++ b/lib/mapping.sail
@@ -72,6 +72,7 @@ val string_append = pure {
   coq: "String.append",
   lean: "String.append",
   c: "concat_str",
+  cpp: "concat_str",
   _: "string_append"
 } : (string, string) -> string
 

--- a/lib/mono_rewrites.sail
+++ b/lib/mono_rewrites.sail
@@ -225,6 +225,7 @@ val _builtin_unsigned = pure {
   lem: "uint",
   interpreter: "uint",
   c: "sail_unsigned",
+  cpp: "sail_unsigned",
   coq: "uint",
   lean: "BitVec.toNat"
 } : forall 'n. bits('n) -> {'m, 0 <= 'm < 2 ^ 'n. int('m)}
@@ -238,6 +239,7 @@ val _builtin_mod_nat = pure {
   ocaml: "modulus",
   lem: "integerMod",
   c: "tmod_int",
+  cpp: "tmod_int",
   coq: "Z.rem",
   lean: "Nat.mod"
 } : forall 'n 'm, 'n >= 0 & 'm >= 0. (int('n), int('m)) -> {'r, 0 <= 'r < 'm. int('r)}

--- a/lib/regfp.sail
+++ b/lib/regfp.sail
@@ -218,55 +218,55 @@ union instruction_kind = {
 }
 
 val __read_mem
-  = impure { ocaml: "Platform.read_mem", c: "platform_read_mem", _: "read_mem" }
+  = impure { ocaml: "Platform.read_mem", c: "platform_read_mem", cpp: "platform_read_mem", _: "read_mem" }
   : forall 'n 'addrsize, 'n > 0 & 'addrsize in {32, 64}.
   (read_kind, int('addrsize), bits('addrsize), int('n)) -> bits(8 * 'n)
 
 val __read_memt
-  = impure { ocaml: "Platform.read_memt", c: "platform_read_memt", _: "read_memt" }
+  = impure { ocaml: "Platform.read_memt", c: "platform_read_memt", cpp: "platform_read_memt", _: "read_memt" }
   : forall 'n 'addrsize, 'n > 0 & 'addrsize in {32, 64}.
   (read_kind, bits('addrsize), int('n)) -> (bits(8 * 'n), bit)
 
 val __write_mem_ea
-  = impure { ocaml: "Platform.write_mem_ea", c: "platform_write_mem_ea", _: "write_mem_ea" }
+  = impure { ocaml: "Platform.write_mem_ea", c: "platform_write_mem_ea", cpp: "platform_write_mem_ea", _: "write_mem_ea" }
   : forall 'n 'addrsize, 'n > 0 & 'addrsize in {32, 64}.
   (write_kind, int('addrsize), bits('addrsize), int('n)) -> unit
 
 val __write_mem
-  = impure { ocaml: "Platform.write_mem", c: "platform_write_mem", _: "write_mem" }
+  = impure { ocaml: "Platform.write_mem", c: "platform_write_mem", cpp: "platform_write_mem", _: "write_mem" }
   : forall 'n 'addrsize, 'n > 0 & 'addrsize in {32, 64}.
   (write_kind, int('addrsize), bits('addrsize), int('n), bits(8 * 'n)) -> bool
 
 val __write_memt
-  = impure { ocaml: "Platform.write_memt", c: "platform_write_memt", _: "write_memt" }
+  = impure { ocaml: "Platform.write_memt", c: "platform_write_memt", cpp: "platform_write_memt", _: "write_memt" }
   : forall 'n 'addrsize, 'n > 0 & 'addrsize in {32, 64}.
   (write_kind, bits('addrsize), int('n), bits(8 * 'n), bit) -> bool
 
 val __write_tag
-  = impure { ocaml: "Platform.write_tag", c: "platform_write_tag", _: "write_tag" }
+  = impure { ocaml: "Platform.write_tag", c: "platform_write_tag", cpp: "platform_write_tag", _: "write_tag" }
   : forall 'addrsize, 'addrsize in {32, 64}.
   (write_kind, bits('addrsize), bit) -> bool
 
 val __excl_res
-  = impure { ocaml: "Platform.excl_res", c: "platform_excl_res", _: "excl_result" }
+  = impure { ocaml: "Platform.excl_res", c: "platform_excl_res", cpp: "platform_excl_res", _: "excl_result" }
   : unit -> bool
 
 val __barrier
-  = impure { ocaml: "Platform.barrier", c: "platform_barrier", _: "barrier" }
+  = impure { ocaml: "Platform.barrier", c: "platform_barrier", cpp: "platform_barrier", _: "barrier" }
   : barrier_kind -> unit
 
 val __branch_announce
-  = impure { ocaml: "Platform.branch_announce", c: "platform_branch_announce", _ : "branch_announce" }
+  = impure { ocaml: "Platform.branch_announce", c: "platform_branch_announce", cpp: "platform_branch_announce", _ : "branch_announce" }
   : forall 'addrsize, 'addrsize in {32, 64}.
   (int('addrsize), bits('addrsize)) -> unit
 
 val __cache_maintenance
-  = impure { ocaml: "Platform.cache_maintenance", c: "platform_cache_maintenance", _ : "cache_maintenance" }
+  = impure { ocaml: "Platform.cache_maintenance", c: "platform_cache_maintenance", cpp: "platform_cache_maintenance", _ : "cache_maintenance" }
   : forall 'addrsize, 'addrsize in {32, 64}.
   (cache_op_kind, int('addrsize), bits('addrsize)) -> unit
 
 val __instr_announce
-  = impure { ocaml: "Platform.instr_announce", c: "platform_instr_announce", _: "instr_announce" }
+  = impure { ocaml: "Platform.instr_announce", c: "platform_instr_announce", cpp: "platform_instr_announce", _: "instr_announce" }
   : forall 'n, 'n > 0.
   bits('n) -> unit
 

--- a/lib/trace.sail
+++ b/lib/trace.sail
@@ -48,19 +48,19 @@ $ifndef _TRACE
 $define _TRACE
 
 val enable_tracing = pure {
-  c: "enable_tracing"
+  c: "enable_tracing", cpp: "enable_tracing"
 } : unit -> unit
 
 function enable_tracing() = ()
 
 val disable_tracing = pure {
-  c: "disable_tracing"
+  c: "disable_tracing", cpp: "disable_tracing"
 } : unit -> unit
 
 function disable_tracing() = ()
 
 val is_tracing = pure {
-  c: "is_tracing"
+  c: "is_tracing", cpp: "is_tracing"
 } : unit -> bool
 
 function is_tracing() = false

--- a/lib/vector.sail
+++ b/lib/vector.sail
@@ -71,6 +71,7 @@ val neq_bits = pure {
   lem: "neq_vec",
   coq: "neq_vec",
   c: "neq_bits",
+  cpp: "neq_bits",
   lean: "_lean_bne"
 } : forall 'n. (bits('n), bits('n)) -> bool
 

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -81,7 +81,7 @@ let ngensym = symbol_generator ()
 let c_error ?loc:(l = Parse_ast.Unknown) message = raise (Reporting.err_general l ("\nC backend: " ^ message))
 
 (**************************************************************************)
-(* 2. Converting sail types to C types                                    *)
+(* Converting Sail types to C types                                       *)
 (**************************************************************************)
 
 let max_int n = Big_int.pred (Big_int.pow_int_positive 2 (n - 1))
@@ -936,17 +936,25 @@ let valid_c_identifier = mk_regexp_check "^[A-Za-z_][A-Za-z0-9_]*$"
 
 let c_int_type_name = mk_regexp_check "^[u]?int[0-9]+_t$"
 
-(* The code generator produces a list of C definitions, some of
-   which should be in the header, and some in
-   the implementation. There are also definitions that are only
-   included in the header provided we generate one.
-
-   * Header - goes in header
-   * Impl - goes in implemention
+(* The code generator produces a list of C/C++ definitions and declarations
+   which go in different places depending on their type and whether we
+   are generating C or C++ code.
 *)
-type file_doc = Header of document | Impl of document
-
-let to_impl doc = [Impl doc]
+type file_doc =
+  (* Declaration of a custom type (typedef int foo;). This goes in a namespace in C++. *)
+  | TypeDeclaration of document
+  (* Model function declaration. This goes in a struct in C++ to become a struct method. *)
+  | FunctionDeclaration of document
+  (* Function definitions. These always go in the .c/.cpp file. *)
+  | FunctionDefinition of document
+  (* Variable declaration (extern int foo;) and definition (int foo = 4;).
+     In C++ we only take the definition and put it in the struct.
+     In C the declaration goes in the header and the definition goes in the impl. *)
+  | VariableDeclaration of document
+  | VariableDefinition of document
+  (* Pure static utility functions created for the model's types, e.g. to initialise
+     enums, access vector elements, etc. These don't have corresponding declarations. *)
+  | StaticFunctionDefinition of document
 
 module type CODEGEN_CONFIG = sig
   val includes : string list
@@ -960,6 +968,10 @@ module type CODEGEN_CONFIG = sig
   val branch_coverage : out_channel option
   val assert_to_exception : bool
   val preserve_types : IdSet.t
+  val cpp : bool
+  val cpp_class_name : string
+  val cpp_namespace : string
+  val cpp_derive_from : string option
 end
 
 module Codegen (Config : CODEGEN_CONFIG) = struct
@@ -969,6 +981,17 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     if String.length s < String.length prefix then false else String.sub s 0 (String.length prefix) = prefix
 
   let has_sail_prefix s = has_prefix "sail_" s || has_prefix "Sail_" s || has_prefix "SAIL_" s
+
+  (* Prefix to function name in definitions. *)
+  let class_impl_prefix () = if Config.cpp then Config.cpp_class_name ^ "::" else ""
+
+  (* = {} is required to zero-initialise the types. In C output mode this is unnecessary because
+    they are emitted as globals and are therefore automatically zero-initialised. However in C++ mode they
+    become struct members and aren't initialised. The `sail_set_abstract_()` function assumes that they
+    have been initialised.
+
+    Note, `int foo = {};` is legal in C23, so we can use it unconditionally eventually. *)
+  let variable_zero_init () = if Config.cpp then " = {}" else ""
 
   module NameGen =
     Name_generator.Make
@@ -1501,8 +1524,15 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         | Init_static VL_undefined -> ksprintf string "  static %s %s;" (sgen_ctyp ctyp) (sgen_name id)
         | Init_static vl -> ksprintf string "  static %s %s = %s;" (sgen_ctyp ctyp) (sgen_name id) (sgen_value vl)
         | Init_json_key parts ->
-            ksprintf string "  sail_config_key %s = {%s};" (sgen_name id)
-              (Util.string_of_list ", " (fun part -> "\"" ^ part ^ "\"") parts)
+            let name = sgen_name id in
+            (* Separate declaration and assignment avoids errors about goto's crossing the initialisation
+               when compiling this code as C++. Unfortunately this also means we can't use an initialiser
+               list to assign its value. We could move all of these to the top of the function but
+               I don't know how to do that. *)
+            ksprintf string "  const_sail_string %s[%d];" name (List.length parts)
+            ^^ Util.fold_left_index
+                 (fun i acc part -> acc ^^ hardline ^^ ksprintf string "  %s[%d] = \"%s\";" name i part)
+                 empty parts
       )
     | I_reinit (ctyp, id, cval) ->
         codegen_instr fid ctx (ireset l ctyp id) ^^ hardline ^^ codegen_conversion l ctx (CL_id (id, ctyp)) cval
@@ -1578,7 +1608,9 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           | CTDI_none ->
               ( ksprintf string "void sail_set_abstract_%s(%s v);" (string_of_id id) (sgen_ctyp ctyp),
                 c_function ~return:"void"
-                  (ksprintf string "sail_set_abstract_%s(%s v)" (string_of_id id) (sgen_ctyp ctyp))
+                  (ksprintf string "%ssail_set_abstract_%s(%s v)" (class_impl_prefix ()) (string_of_id id)
+                     (sgen_ctyp ctyp)
+                  )
                   [
                     ( if is_stack_ctyp ctx ctyp then
                         ksprintf c_stmt "%s = v" (NameGen.to_string ~prefix:"abstract_" () id)
@@ -1591,14 +1623,18 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           | CTDI_instrs init ->
               ( ksprintf string "void sail_set_abstract_%s(void);" (string_of_id id),
                 c_function ~return:"void"
-                  (ksprintf string "sail_set_abstract_%s(void)" (string_of_id id))
+                  (ksprintf string "%ssail_set_abstract_%s(void)" (class_impl_prefix ()) (string_of_id id))
                   [separate_map hardline (codegen_instr (mk_id "set_abstract") ctx) init]
               )
         in
         [
-          Header setter_prototype;
-          Impl (ksprintf string "%s %s;" (sgen_ctyp ctyp) (NameGen.to_string ~prefix:"abstract_" () id));
-          Impl setter;
+          FunctionDeclaration setter_prototype;
+          FunctionDefinition setter;
+          VariableDefinition
+            (ksprintf string "%s %s%s;" (sgen_ctyp ctyp)
+               (NameGen.to_string ~prefix:"abstract_" () id)
+               (variable_zero_init ())
+            );
         ]
     | CTD_enum (id, (first_id :: _ as ids)) ->
         let enum_name = sgen_id id in
@@ -1612,19 +1648,19 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           string (Printf.sprintf "static enum %s UNDEFINED(%s)(unit u) { return %s; }" name name (sgen_id first_id))
         in
         [
-          Header
+          TypeDeclaration
             (string (Printf.sprintf "// enum %s" (string_of_id id))
             ^^ hardline
             ^^ separate space
                  [string "enum"; codegen_id id; lbrace; separate_map (comma ^^ space) codegen_id ids; rbrace ^^ semi]
             );
-          Impl enum_eq;
-          Impl enum_undefined;
+          StaticFunctionDefinition enum_eq;
+          StaticFunctionDefinition enum_undefined;
         ]
     | CTD_enum (id, []) -> c_error ("Cannot compile empty enum " ^ string_of_id id)
     | CTD_abbrev (id, ctyp) ->
         [
-          Header
+          TypeDeclaration
             (ksprintf string "// type abbreviation %s" (string_of_id id)
             ^^ hardline
             ^^ separate space [string "typedef"; string (sgen_ctyp ctyp); codegen_id id]
@@ -1666,19 +1702,23 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         let struct_field (id, ctyp) = string (sgen_ctyp ctyp) ^^ space ^^ codegen_id id in
 
         [
-          Header
+          TypeDeclaration
             (string (Printf.sprintf "// struct %s" (string_of_id id))
             ^^ hardline ^^ string "struct" ^^ space ^^ codegen_id id ^^ space
             ^^ surround 2 0 lbrace (separate_map (semi ^^ hardline) struct_field ctors ^^ semi) rbrace
             ^^ semi
             );
-          Impl struct_copy;
+          StaticFunctionDefinition struct_copy;
         ]
         @ ( if not (is_stack_ctyp ctx struct_ctyp) then
-              [Impl (derive sail_create); Impl (derive sail_recreate); Impl (derive sail_kill)]
+              [
+                StaticFunctionDefinition (derive sail_create);
+                StaticFunctionDefinition (derive sail_recreate);
+                StaticFunctionDefinition (derive sail_kill);
+              ]
             else []
           )
-        @ [Impl struct_eq]
+        @ [StaticFunctionDefinition struct_eq]
     | CTD_variant (id, _, tus) ->
         let codegen_tu (ctor_id, ctyp) =
           separate space [string "struct"; lbrace; string (sgen_ctyp ctyp); codegen_id ctor_id ^^ semi; rbrace]
@@ -1775,7 +1815,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           c_function ~return:"static bool" (sail_equal n "struct %s op1, struct %s op2" n n) [codegen_eq_tests tus]
         in
         [
-          Header
+          TypeDeclaration
             (string (Printf.sprintf "// union %s" (string_of_id id))
             ^^ hardline ^^ string "enum" ^^ space
             ^^ string ("kind_" ^ sgen_id id)
@@ -1787,7 +1827,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
                    rbrace ^^ semi;
                  ]
             );
-          Header
+          TypeDeclaration
             (string "struct" ^^ space ^^ codegen_id id ^^ space
             ^^ surround 2 0 lbrace
                  (separate space [string "enum"; string ("kind_" ^ sgen_id id); string "kind" ^^ semi]
@@ -1798,23 +1838,23 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
                  rbrace
             ^^ semi
             );
-          Impl codegen_init;
-          Impl codegen_reinit;
-          Impl codegen_clear;
-          Impl codegen_setter;
-          Impl codegen_eq;
+          StaticFunctionDefinition codegen_init;
+          StaticFunctionDefinition codegen_reinit;
+          StaticFunctionDefinition codegen_clear;
+          StaticFunctionDefinition codegen_setter;
+          StaticFunctionDefinition codegen_eq;
         ]
-        @ List.map (fun tu -> Impl (codegen_ctor tu)) tus
+        @ List.map (fun tu -> StaticFunctionDefinition (codegen_ctor tu)) tus
         (* If this is the exception type, then we setup up some global variables to deal with exceptions. *)
         @
         if string_of_id id = "exception" then
           [
-            Header (ksprintf string "extern struct %s *current_exception;" (sgen_id id));
-            Impl (ksprintf string "struct %s *current_exception = NULL;" (sgen_id id));
-            Header (string "extern bool have_exception;");
-            Impl (string "bool have_exception = false;");
-            Header (string "extern sail_string *throw_location;");
-            Impl (string "sail_string *throw_location = NULL;");
+            VariableDeclaration (ksprintf string "extern struct %s *current_exception;" (sgen_id id));
+            VariableDefinition (ksprintf string "struct %s *current_exception = NULL;" (sgen_id id));
+            VariableDeclaration (string "extern bool have_exception;");
+            VariableDefinition (string "bool have_exception = false;");
+            VariableDeclaration (string "extern sail_string *throw_location;");
+            VariableDefinition (string "sail_string *throw_location = NULL;");
           ]
         else []
 
@@ -1942,17 +1982,17 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         ^^ ksprintf string "  *rop = NULL;\n" ^^ string "}"
       in
       [
-        Header codegen_node;
-        Impl codegen_list_init;
-        Impl codegen_inc_reference_count;
-        Impl codegen_dec_reference_count;
-        Impl codegen_list_clear;
-        Impl codegen_list_recreate;
-        Impl codegen_list_copy;
-        Impl codegen_cons;
-        Impl codegen_pick;
-        Impl codegen_list_equal;
-        Impl codegen_list_undefined;
+        TypeDeclaration codegen_node;
+        StaticFunctionDefinition codegen_list_init;
+        StaticFunctionDefinition codegen_inc_reference_count;
+        StaticFunctionDefinition codegen_dec_reference_count;
+        StaticFunctionDefinition codegen_list_clear;
+        StaticFunctionDefinition codegen_list_recreate;
+        StaticFunctionDefinition codegen_list_copy;
+        StaticFunctionDefinition codegen_cons;
+        StaticFunctionDefinition codegen_pick;
+        StaticFunctionDefinition codegen_list_equal;
+        StaticFunctionDefinition codegen_list_undefined;
       ]
     )
 
@@ -2130,20 +2170,20 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       begin
         generated := IdSet.add id !generated;
         [
-          Header vector_typedef;
-          Impl vector_decl;
-          Impl vector_clear;
-          Impl vector_init;
-          Impl vector_reinit;
-          Impl vector_undefined;
-          Impl vector_access;
-          Impl fast_vector_access;
-          Impl vector_set;
-          Impl vector_update;
-          Impl vector_equal;
-          Impl vector_length;
-          Impl internal_vector_update;
-          Impl internal_vector_init;
+          TypeDeclaration vector_typedef;
+          StaticFunctionDefinition vector_decl;
+          StaticFunctionDefinition vector_clear;
+          StaticFunctionDefinition vector_init;
+          StaticFunctionDefinition vector_reinit;
+          StaticFunctionDefinition vector_undefined;
+          StaticFunctionDefinition vector_access;
+          StaticFunctionDefinition fast_vector_access;
+          StaticFunctionDefinition vector_set;
+          StaticFunctionDefinition vector_update;
+          StaticFunctionDefinition vector_equal;
+          StaticFunctionDefinition vector_length;
+          StaticFunctionDefinition internal_vector_update;
+          StaticFunctionDefinition internal_vector_init;
         ]
       end
     )
@@ -2159,26 +2199,32 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     | I_aux (I_decl (ctyp, id), _) -> sail_create ~prefix:"  " ~suffix:";" (sgen_ctyp_name ctyp) "&%s" (sgen_name id)
     | _ -> assert false
 
+  (* Generate C code for a global register, constant (let), function definition, etc. *)
   let codegen_def' ctx (CDEF_aux (aux, _)) =
     match aux with
     | CDEF_register (id, ctyp, _) ->
-        [
-          Header
+        let definition =
+          VariableDefinition
             (string (Printf.sprintf "// register %s" (string_of_name id))
             ^^ hardline
-            ^^ string (Printf.sprintf "extern %s %s;" (sgen_ctyp ctyp) (sgen_name id))
-            );
-          Impl
-            (string (Printf.sprintf "// register %s" (string_of_name id))
-            ^^ hardline
-            ^^ string (Printf.sprintf "%s %s;" (sgen_ctyp ctyp) (sgen_name id))
-            );
-        ]
+            ^^ string (Printf.sprintf "%s %s%s;" (sgen_ctyp ctyp) (sgen_name id) (variable_zero_init ()))
+            )
+        in
+        if Config.cpp then [definition]
+        else
+          [
+            VariableDeclaration
+              (string (Printf.sprintf "// register %s" (string_of_name id))
+              ^^ hardline
+              ^^ string (Printf.sprintf "extern %s %s;" (sgen_ctyp ctyp) (sgen_name id))
+              );
+            definition;
+          ]
     | CDEF_val (id, _, arg_ctyps, ret_ctyp, _) ->
         if ctx_is_extern id ctx then []
         else if is_stack_ctyp ctx ret_ctyp then
           [
-            Header
+            FunctionDeclaration
               (string
                  (Printf.sprintf "%s %s(%s%s);" (sgen_ctyp ret_ctyp) (sgen_function_id id) (extra_params ())
                     (Util.string_of_list ", " sgen_const_ctyp arg_ctyps)
@@ -2187,7 +2233,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           ]
         else
           [
-            Header
+            FunctionDeclaration
               (string
                  (Printf.sprintf "void %s(%s%s *rop, %s);" (sgen_function_id id) (extra_params ()) (sgen_ctyp ret_ctyp)
                     (Util.string_of_list ", " sgen_const_ctyp arg_ctyps)
@@ -2226,12 +2272,16 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
             | Return_plain ->
                 assert (is_stack_ctyp ctx ret_ctyp);
                 string (sgen_ctyp ret_ctyp)
-                ^^ space ^^ codegen_function_id id
+                ^^ space
+                ^^ string (class_impl_prefix ())
+                ^^ codegen_function_id id
                 ^^ parens (string (extra_params ()) ^^ string args)
                 ^^ hardline
             | Return_via gs ->
                 assert (not (is_stack_ctyp ctx ret_ctyp));
-                string "void" ^^ space ^^ codegen_function_id id
+                string "void" ^^ space
+                ^^ string (class_impl_prefix ())
+                ^^ codegen_function_id id
                 ^^ parens
                      (string (extra_params ())
                      ^^ string (sgen_ctyp ret_ctyp ^ " *" ^ sgen_name gs ^ ", ")
@@ -2240,7 +2290,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
                 ^^ hardline
           in
           [
-            Impl
+            FunctionDefinition
               (function_header ^^ string "{"
               ^^ jump 0 2 (separate_map hardline (codegen_instr id ctx) instrs)
               ^^ hardline ^^ string "}"
@@ -2249,38 +2299,61 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         end
     | CDEF_type ctype_def -> codegen_type_def ctx ctype_def
     | CDEF_startup (id, instrs) ->
-        let startup_header = string (Printf.sprintf "void startup_%s(void)" (sgen_function_id id)) in
-        separate_map hardline codegen_decl instrs
-        ^^ twice hardline ^^ startup_header ^^ hardline ^^ string "{"
-        ^^ jump 0 2 (separate_map hardline (codegen_alloc ctx) instrs)
-        ^^ hardline ^^ string "}"
-        |> to_impl
+        let startup_header =
+          string (Printf.sprintf "void %sstartup_%s(void)" (class_impl_prefix ()) (sgen_function_id id))
+        in
+        let startup_impl =
+          separate_map hardline codegen_decl instrs
+          ^^ twice hardline ^^ startup_header ^^ hardline ^^ string "{"
+          ^^ jump 0 2 (separate_map hardline (codegen_alloc ctx) instrs)
+          ^^ hardline ^^ string "}"
+        in
+        let startup_decl = string (Printf.sprintf "void startup_%s(void);" (sgen_function_id id)) in
+        if Config.cpp then [FunctionDefinition startup_impl; FunctionDeclaration startup_decl]
+        else [FunctionDefinition startup_impl]
     | CDEF_finish (id, instrs) ->
-        let finish_header = string (Printf.sprintf "void finish_%s(void)" (sgen_function_id id)) in
-        separate_map hardline codegen_decl (List.filter is_decl instrs)
-        ^^ twice hardline ^^ finish_header ^^ hardline ^^ string "{"
-        ^^ jump 0 2 (separate_map hardline (codegen_instr id ctx) instrs)
-        ^^ hardline ^^ string "}"
-        |> to_impl
+        let finish_header =
+          string (Printf.sprintf "void %sfinish_%s(void)" (class_impl_prefix ()) (sgen_function_id id))
+        in
+        let finish_impl =
+          separate_map hardline codegen_decl (List.filter is_decl instrs)
+          ^^ twice hardline ^^ finish_header ^^ hardline ^^ string "{"
+          ^^ jump 0 2 (separate_map hardline (codegen_instr id ctx) instrs)
+          ^^ hardline ^^ string "}"
+        in
+        let finish_decl = string (Printf.sprintf "void finish_%s(void);" (sgen_function_id id)) in
+        if Config.cpp then [FunctionDefinition finish_impl; FunctionDeclaration finish_decl]
+        else [FunctionDefinition finish_impl]
     | CDEF_let (number, bindings, instrs) ->
         let instrs = add_local_labels instrs in
         let setup = List.concat (List.map (fun (id, ctyp) -> [idecl (id_loc id) ctyp (name id)]) bindings) in
         let cleanup = List.concat (List.map (fun (id, ctyp) -> [iclear ~loc:(id_loc id) ctyp (name id)]) bindings) in
-        separate_map hardline
-          (fun (id, ctyp) -> string (Printf.sprintf "%s %s;" (sgen_ctyp ctyp) (sgen_id id)))
-          bindings
-        ^^ hardline
-        ^^ string (Printf.sprintf "static void create_letbind_%d(void) " number)
-        ^^ string "{"
-        ^^ jump 0 2 (separate_map hardline (codegen_alloc ctx) setup)
-        ^^ hardline
-        ^^ jump 0 2 (separate_map hardline (codegen_instr (mk_id "let") { ctx with no_raw = true }) instrs)
-        ^^ hardline ^^ string "}" ^^ hardline
-        ^^ string (Printf.sprintf "static void kill_letbind_%d(void) " number)
-        ^^ string "{"
-        ^^ jump 0 2 (separate_map hardline (codegen_instr (mk_id "let") ctx) cleanup)
-        ^^ hardline ^^ string "}"
-        |> to_impl
+        let variable_defs =
+          separate_map hardline
+            (fun (id, ctyp) -> string (Printf.sprintf "%s %s%s;" (sgen_ctyp ctyp) (sgen_id id) (variable_zero_init ())))
+            bindings
+          ^^ hardline
+        in
+        let function_decls =
+          string (Printf.sprintf "void create_letbind_%d(void);" number)
+          ^^ hardline
+          ^^ string (Printf.sprintf "void kill_letbind_%d(void);" number)
+          ^^ hardline
+        in
+        let impl =
+          string (Printf.sprintf "void %screate_letbind_%d(void) " (class_impl_prefix ()) number)
+          ^^ string "{"
+          ^^ jump 0 2 (separate_map hardline (codegen_alloc ctx) setup)
+          ^^ hardline
+          ^^ jump 0 2 (separate_map hardline (codegen_instr (mk_id "let") { ctx with no_raw = true }) instrs)
+          ^^ hardline ^^ string "}" ^^ hardline
+          ^^ string (Printf.sprintf "void %skill_letbind_%d(void) " (class_impl_prefix ()) number)
+          ^^ string "{"
+          ^^ jump 0 2 (separate_map hardline (codegen_instr (mk_id "let") ctx) cleanup)
+          ^^ hardline ^^ string "}"
+        in
+
+        [VariableDefinition variable_defs; FunctionDeclaration function_decls; FunctionDefinition impl]
     | CDEF_pragma _ -> []
 
   (** As we generate C we need to generate specialized version of tuple, list, and vector type. These must be generated
@@ -2300,20 +2373,43 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       ->
         []
 
+  (* Generate types and utility functions for non-bitvector vectors, tuples and lists.
+     The functions are pure, and only emitted in the implementation file as static functions. *)
   let codegen_ctg ctx = function
     | CTG_vector ctyp -> codegen_vector ctx ctyp
     | CTG_tup ctyps -> codegen_tup ctx ctyps
     | CTG_list ctyp -> codegen_list ctx ctyp
 
-  (* Take a single list of `Header doc` and `Impl doc`s, and extract them
-     into two lists - one for the header `doc`s and one for the impl `doc`s. *)
+  (* Take a single list of `Header doc`, `VariableDeclaration doc`, etc. and split them
+     into separate lists each with only one type of `doc`. *)
+  type file_docs_by_type = {
+    type_decl : document;
+    func_decl : document;
+    func_def : document;
+    var_decl : document;
+    var_def : document;
+    static_func_def : document;
+  }
+
   let merge_file_docs docs =
-    let rec collect_file_docs hdr impl = function
-      | [] -> (hdr, impl)
-      | Header doc :: docs -> collect_file_docs (hdr ^^ doc ^^ twice hardline) impl docs
-      | Impl doc :: docs -> collect_file_docs hdr (impl ^^ doc ^^ twice hardline) docs
-    in
-    collect_file_docs empty empty docs
+    List.fold_left
+      (fun acc -> function
+        | TypeDeclaration doc -> { acc with type_decl = acc.type_decl ^^ doc ^^ twice hardline }
+        | FunctionDeclaration doc -> { acc with func_decl = acc.func_decl ^^ doc ^^ twice hardline }
+        | FunctionDefinition doc -> { acc with func_def = acc.func_def ^^ doc ^^ twice hardline }
+        | VariableDeclaration doc -> { acc with var_decl = acc.var_decl ^^ doc ^^ twice hardline }
+        | VariableDefinition doc -> { acc with var_def = acc.var_def ^^ doc ^^ twice hardline }
+        | StaticFunctionDefinition doc -> { acc with static_func_def = acc.static_func_def ^^ doc ^^ twice hardline }
+        )
+      {
+        type_decl = empty;
+        func_decl = empty;
+        func_def = empty;
+        var_decl = empty;
+        var_def = empty;
+        static_func_def = empty;
+      }
+      docs
 
   (** When we generate code for a definition, we need to first generate any auxillary type definitions that are
       required. *)
@@ -2379,6 +2475,162 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       IdSet.empty cdefs
     |> IdSet.elements
 
+  (* Generate the `model_init()` and `model_fini()` functions
+     which initialise and clean up the model (allocating/deallocating
+     GMP variables, setting initial register values, etc.). *)
+  let gen_model_init_fini ctx cdefs =
+    let exception_type = sgen_id (mk_id "exception") in
+
+    let exn_boilerplate =
+      if not (Bindings.mem (mk_id "exception") ctx.variants) then ([], [])
+      else
+        ( [
+            sprintf "  current_exception = sail_new(struct %s);" exception_type;
+            sprintf "  CREATE(%s)(current_exception);" exception_type;
+            "  throw_location = sail_new(sail_string);";
+            "  CREATE(sail_string)(throw_location);";
+          ],
+          [
+            "  if (have_exception) {fprintf(stderr, \"Exiting due to uncaught exception: %s\\n\", *throw_location);}";
+            sprintf "  KILL(%s)(current_exception);" exception_type;
+            "  sail_free(current_exception);";
+            "  KILL(sail_string)(throw_location);";
+            "  sail_free(throw_location);";
+            "  if (have_exception) {exit(EXIT_FAILURE);}";
+          ]
+        )
+    in
+
+    let letbind_initializers = List.map (fun n -> Printf.sprintf "  create_letbind_%d();" n) (List.rev ctx.letbinds) in
+    let letbind_finalizers = List.map (fun n -> Printf.sprintf "  kill_letbind_%d();" n) ctx.letbinds in
+
+    let set_abstract_types =
+      Bindings.bindings ctx.abstracts
+      |> List.filter_map (fun (id, (_, initialised)) ->
+             match initialised with
+             | Initialised -> Some (Printf.sprintf "  sail_set_abstract_%s();" (Ast_util.string_of_id id))
+             (* Skip abstract types that haven't been initialised; we can't initialise them automatically. *)
+             | Uninitialised -> None
+         )
+    in
+
+    let startup cdefs = List.map sgen_startup (List.filter is_cdef_startup cdefs) in
+    let finish cdefs = List.map sgen_finish (List.filter is_cdef_finish cdefs) in
+
+    let early_regs = c_ast_registers ~early:true cdefs in
+    let regs = c_ast_registers ~early:false cdefs in
+
+    let register_init_clear (id, ctyp, instrs) =
+      if is_stack_ctyp ctx ctyp then (List.map (sgen_instr (mk_id "reg") ctx) instrs, [])
+      else
+        ( [Printf.sprintf "  CREATE(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_name id)]
+          @ List.map (sgen_instr (mk_id "reg") ctx) instrs,
+          [Printf.sprintf "  KILL(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_name id)]
+        )
+    in
+
+    let init_config_id = mk_id "__InitConfig" in
+
+    let model_init =
+      separate hardline
+        (List.map string
+           ([Printf.sprintf "void %smodel_init(void)" (class_impl_prefix ()); "{"; "  setup_rts();"]
+           @ fst exn_boilerplate
+           @ List.concat (List.map (fun r -> fst (register_init_clear r)) early_regs)
+           @ set_abstract_types @ startup cdefs @ letbind_initializers
+           @ List.concat (List.map (fun r -> fst (register_init_clear r)) regs)
+           @ (if regs = [] then [] else [Printf.sprintf "  %s(UNIT);" (sgen_function_id (mk_id "initialize_registers"))])
+           @ ( if ctx_has_val_spec init_config_id ctx then
+                 [Printf.sprintf "  %s(UNIT);" (sgen_function_id init_config_id)]
+               else []
+             )
+           @ ["}"]
+           )
+        )
+    in
+
+    let model_fini =
+      separate hardline
+        (List.map string
+           ([Printf.sprintf "void %smodel_fini(void)" (class_impl_prefix ()); "{"]
+           @ List.concat (List.map (fun r -> snd (register_init_clear r)) regs)
+           @ letbind_finalizers
+           @ List.concat (List.map (fun r -> snd (register_init_clear r)) early_regs)
+           @ finish cdefs @ ["  cleanup_rts();"] @ snd exn_boilerplate @ ["}"]
+           )
+        )
+    in
+
+    [FunctionDefinition model_init; FunctionDefinition model_fini]
+
+  (* For C++ generate a constructor and destructor to allocate and free abstract
+     types that aren't handled in model_init() and model_fini(). These
+     cannot be initialised in model_init() because they must be set by
+     sail_set_abstract_...() before model_init() runs. They aren't necessary
+     in C because in C they are globals so they get automatically zero-initialised
+     and Valgrind doesn't care about globals leaking. *)
+  let gen_constructor_destructor ctx cdefs =
+    let names_and_types =
+      Bindings.bindings ctx.abstracts
+      |> List.map (fun (id, (ctyp, _)) -> (NameGen.to_string ~prefix:"abstract_" () id, ctyp))
+    in
+
+    let create_abstract (name, ctyp) =
+      if is_stack_ctyp ctx ctyp then empty else sail_create ~suffix:";" (sgen_ctyp_name ctyp) "&%s" name
+    in
+
+    let kill_abstract (name, ctyp) =
+      if is_stack_ctyp ctx ctyp then empty else sail_kill ~suffix:";" (sgen_ctyp_name ctyp) "&%s" name
+    in
+
+    let constructor_decl = ksprintf string "%s();" Config.cpp_class_name in
+    let constructor_def =
+      ksprintf string "%s::%s() {" Config.cpp_class_name Config.cpp_class_name
+      ^^ jump 2 1 (separate_map hardline create_abstract names_and_types)
+      ^^ string "}"
+    in
+    let destructor_decl = ksprintf string "~%s();" Config.cpp_class_name in
+    let destructor_def =
+      ksprintf string "%s::~%s() {" Config.cpp_class_name Config.cpp_class_name
+      ^^ jump 2 1 (separate_map hardline kill_abstract names_and_types)
+      ^^ string "}"
+    in
+
+    let copy_constructor_decl = ksprintf string "%s(const %s&) = delete;" Config.cpp_class_name Config.cpp_class_name in
+    [
+      FunctionDeclaration constructor_decl;
+      FunctionDefinition constructor_def;
+      FunctionDeclaration destructor_decl;
+      FunctionDefinition destructor_def;
+      FunctionDeclaration copy_constructor_decl;
+    ]
+
+  (* Generate a constant array that points to all the unit test functions. *)
+  let gen_unit_test_defs ctx cdefs =
+    let unit_tests = get_unit_tests cdefs in
+
+    (* `static constexpr` is another option but it doesn't work for function pointers until C++20. *)
+    let inline = if Config.cpp then "inline " else "" in
+
+    [
+      VariableDefinition
+        ((* Number of unit tests. *)
+         [sprintf "%sstatic const size_t SAIL_TEST_COUNT = %d;" inline (List.length unit_tests)]
+         (* Pointers to unit test functions, with NULL entry for convenience. *)
+         @ [
+             sprintf "%sstatic unit (%s*const SAIL_TESTS[%d])(unit) = {" inline (class_impl_prefix ())
+               (List.length unit_tests + 1);
+           ]
+         @ List.map (fun id -> sprintf "  &%s%s," (class_impl_prefix ()) (sgen_function_id id)) unit_tests
+         @ ["  NULL"; "};"]
+         (* Unit test names, with NULL entry for convenience. *)
+         @ [sprintf "%sstatic const char* const SAIL_TEST_NAMES[%d] = {" inline (List.length unit_tests + 1)]
+         @ List.map (fun id -> sprintf "  \"%s\"," (String.escaped (string_of_id id))) unit_tests
+         @ ["  NULL"; "};"]
+        |> List.map string |> separate hardline
+        );
+    ]
+
   let compile_ast env effect_info basename ast =
     try
       let cdefs, ctx = jib_of_ast env effect_info ast in
@@ -2394,7 +2646,19 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
          some value < 256 (100 seems reasonable). *)
       let cdefs = List.map (Jib_optimize.flatten_cdef ~max_depth:100) cdefs in
 
-      let header_doc, docs = List.map (codegen_def ctx) cdefs |> List.concat |> merge_file_docs in
+      let docs = List.map (codegen_def ctx) cdefs |> List.concat in
+
+      let docs = docs @ gen_model_init_fini ctx cdefs @ gen_unit_test_defs ctx cdefs in
+      let docs = if Config.cpp then docs @ gen_constructor_destructor ctx cdefs else docs in
+
+      let docs_by_type = docs |> merge_file_docs in
+
+      let extern_cpp_begin =
+        if Config.cpp then [] else [string "#ifdef __cplusplus"; string "extern \"C\" {"; string "#endif"]
+      in
+      let extern_cpp_end =
+        if Config.cpp then [] else [string ""; string "#ifdef __cplusplus"; string "}"; string "#endif"]
+      in
 
       let coverage_include, coverage_hook_header, coverage_hook =
         let header = string "#include \"sail_coverage.h\"" in
@@ -2416,99 +2680,16 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           @ List.map
               (fun h -> string (Printf.sprintf "#include \"%s\"" h))
               (if in_header then Config.header_includes else Config.includes)
-          @ [string "#ifdef __cplusplus"; string "extern \"C\" {"; string "#endif"]
+          @ extern_cpp_begin
           @ if in_header then coverage_hook_header else coverage_hook
           )
       in
 
-      let exception_type = sgen_id (mk_id "exception") in
-
-      let exn_boilerplate =
-        if not (Bindings.mem (mk_id "exception") ctx.variants) then ([], [])
-        else
-          ( [
-              sprintf "  current_exception = sail_new(struct %s);" exception_type;
-              sprintf "  CREATE(%s)(current_exception);" exception_type;
-              "  throw_location = sail_new(sail_string);";
-              "  CREATE(sail_string)(throw_location);";
-            ],
-            [
-              "  if (have_exception) {fprintf(stderr, \"Exiting due to uncaught exception: %s\\n\", *throw_location);}";
-              sprintf "  KILL(%s)(current_exception);" exception_type;
-              "  sail_free(current_exception);";
-              "  KILL(sail_string)(throw_location);";
-              "  sail_free(throw_location);";
-              "  if (have_exception) {exit(EXIT_FAILURE);}";
-            ]
-          )
-      in
-
-      let letbind_initializers =
-        List.map (fun n -> Printf.sprintf "  create_letbind_%d();" n) (List.rev ctx.letbinds)
-      in
-      let letbind_finalizers = List.map (fun n -> Printf.sprintf "  kill_letbind_%d();" n) ctx.letbinds in
-
-      let set_abstract_types =
-        Bindings.bindings ctx.abstracts
-        |> List.filter_map (fun (id, (_, initialised)) ->
-               match initialised with
-               | Initialised -> Some (Printf.sprintf "  sail_set_abstract_%s();" (Ast_util.string_of_id id))
-               (* Skip abstract types that haven't been initialised; we can't initialise them automatically. *)
-               | Uninitialised -> None
-           )
-      in
-
-      let startup cdefs = List.map sgen_startup (List.filter is_cdef_startup cdefs) in
-      let finish cdefs = List.map sgen_finish (List.filter is_cdef_finish cdefs) in
-
-      let early_regs = c_ast_registers ~early:true cdefs in
-      let regs = c_ast_registers ~early:false cdefs in
-
-      let register_init_clear (id, ctyp, instrs) =
-        if is_stack_ctyp ctx ctyp then (List.map (sgen_instr (mk_id "reg") ctx) instrs, [])
-        else
-          ( [Printf.sprintf "  CREATE(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_name id)]
-            @ List.map (sgen_instr (mk_id "reg") ctx) instrs,
-            [Printf.sprintf "  KILL(%s)(&%s);" (sgen_ctyp_name ctyp) (sgen_name id)]
-          )
-      in
-
-      let init_config_id = mk_id "__InitConfig" in
-
-      let model_init =
-        separate hardline
-          (List.map string
-             (["void model_init(void)"; "{"; "  setup_rts();"]
-             @ fst exn_boilerplate
-             @ List.concat (List.map (fun r -> fst (register_init_clear r)) early_regs)
-             @ set_abstract_types @ startup cdefs @ letbind_initializers
-             @ List.concat (List.map (fun r -> fst (register_init_clear r)) regs)
-             @ ( if regs = [] then []
-                 else [Printf.sprintf "  %s(UNIT);" (sgen_function_id (mk_id "initialize_registers"))]
-               )
-             @ ( if ctx_has_val_spec init_config_id ctx then
-                   [Printf.sprintf "  %s(UNIT);" (sgen_function_id init_config_id)]
-                 else []
-               )
-             @ ["}"]
-             )
-          )
-      in
-
-      let model_fini =
-        separate hardline
-          (List.map string
-             (["void model_fini(void)"; "{"]
-             @ List.concat (List.map (fun r -> snd (register_init_clear r)) regs)
-             @ letbind_finalizers
-             @ List.concat (List.map (fun r -> snd (register_init_clear r)) early_regs)
-             @ finish cdefs @ ["  cleanup_rts();"] @ snd exn_boilerplate @ ["}"]
-             )
-          )
-      in
+      (* model_pre_exit() has to be `extern "C"` because it is called from rts.c. *)
+      let extern_c = if Config.cpp then "extern \"C\" " else "" in
 
       let model_pre_exit =
-        (["void model_pre_exit()"; "{"]
+        ([sprintf "%svoid model_pre_exit()" extern_c; "{"]
         @
         if Option.is_some Config.branch_coverage then
           [
@@ -2524,52 +2705,69 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       in
 
       let model_main =
-        [
-          "int model_main(int argc, char *argv[])";
-          "{";
-          "  model_init();";
-          "  if (process_arguments(argc, argv)) exit(EXIT_FAILURE);";
-          Printf.sprintf "  %s(UNIT);" (sgen_function_id (mk_id "main"));
-          "  model_fini();";
-          "  model_pre_exit();";
-          "  return EXIT_SUCCESS;";
-          "}";
-        ]
+        ( if Config.cpp then
+            [
+              "int model_main(int argc, char *argv[])";
+              "{";
+              Printf.sprintf "  %s::%s model;" Config.cpp_namespace Config.cpp_class_name;
+              "  model.model_init();";
+              "  if (process_arguments(argc, argv)) exit(EXIT_FAILURE);";
+              Printf.sprintf "  model.%s(UNIT);" (sgen_function_id (mk_id "main"));
+              "  model.model_fini();";
+              "  model_pre_exit();";
+              "  return EXIT_SUCCESS;";
+              "}";
+            ]
+          else
+            [
+              "int model_main(int argc, char *argv[])";
+              "{";
+              "  model_init();";
+              "  if (process_arguments(argc, argv)) exit(EXIT_FAILURE);";
+              Printf.sprintf "  %s(UNIT);" (sgen_function_id (mk_id "main"));
+              "  model_fini();";
+              "  model_pre_exit();";
+              "  return EXIT_SUCCESS;";
+              "}";
+            ]
+        )
         |> List.map string |> separate hardline
-      in
-
-      let unit_tests = get_unit_tests cdefs in
-
-      let unit_test_defs =
-        (* Number of unit tests. *)
-        [sprintf "const size_t SAIL_TEST_COUNT = %d;" (List.length unit_tests)]
-        (* Pointers to unit test functions, with NULL entry for convenience. *)
-        @ [sprintf "unit (*const SAIL_TESTS[%d])(unit) = {" (List.length unit_tests + 1)]
-        @ List.map (fun id -> sprintf "  %s," (sgen_function_id id)) unit_tests
-        @ ["  NULL"; "};"]
-        (* Unit test names, with NULL entry for convenience. *)
-        @ [sprintf "const char* const SAIL_TEST_NAMES[%d] = {" (List.length unit_tests + 1)]
-        @ List.map (fun id -> sprintf "  \"%s\"," (String.escaped (string_of_id id))) unit_tests
-        @ ["  NULL"; "};"]
-        |> separate_map hardline string
       in
 
       (* A simple function to run the unit tests. It isn't called from anywhere
          by default and you don't need to use it - you can use SAIL_TESTS directly
          in your own custom test runner. *)
       let model_test =
-        [
-          "void model_test(void)";
-          "{";
-          "  for (size_t i = 0; i < SAIL_TEST_COUNT; ++i) {";
-          "    model_init();";
-          "    printf(\"Testing %s\\n\", SAIL_TEST_NAMES[i]);";
-          "    SAIL_TESTS[i](UNIT);";
-          "    printf(\"Pass\\n\");";
-          "    model_fini();";
-          "  }";
-          "}";
-        ]
+        ( if Config.cpp then
+            [
+              "void model_test(void)";
+              "{";
+              sprintf "  %s::%s model;" Config.cpp_namespace Config.cpp_class_name;
+              sprintf "  for (size_t i = 0; i < %s::%s::SAIL_TEST_COUNT; ++i) {" Config.cpp_namespace
+                Config.cpp_class_name;
+              "    model.model_init();";
+              sprintf "    printf(\"Testing %%s\\n\", %s::%s::SAIL_TEST_NAMES[i]);" Config.cpp_namespace
+                Config.cpp_class_name;
+              sprintf "    (model.*%s::%s::SAIL_TESTS[i])(UNIT);" Config.cpp_namespace Config.cpp_class_name;
+              "    printf(\"Pass\\n\");";
+              "    model.model_fini();";
+              "  }";
+              "}";
+            ]
+          else
+            [
+              "void model_test(void)";
+              "{";
+              "  for (size_t i = 0; i < SAIL_TEST_COUNT; ++i) {";
+              "    model_init();";
+              "    printf(\"Testing %s\\n\", SAIL_TEST_NAMES[i]);";
+              "    SAIL_TESTS[i](UNIT);";
+              "    printf(\"Pass\\n\");";
+              "    model_fini();";
+              "  }";
+              "}";
+            ]
+        )
         |> List.map string |> separate hardline
       in
 
@@ -2593,25 +2791,56 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
                 )
           )
       in
-      let end_extern_cpp = separate hardline (List.map string [""; "#ifdef __cplusplus"; "}"; "#endif"]) in
+
       let hlhl = twice hardline in
 
+      (* If compiling in C++ mode wrap the header in a struct { }. *)
+      let header_doc =
+        if Config.cpp then (
+          let derive_from = match Config.cpp_derive_from with Some s -> " : " ^ s | None -> "" in
+          ksprintf string "namespace %s {" Config.cpp_namespace
+          ^^ hardline ^^ docs_by_type.type_decl
+          ^^ ksprintf string "class %s%s {" Config.cpp_class_name derive_from
+          ^^ hardline ^^ string "public:" ^^ hardline
+          (* All of the types, functions and register declarations. *)
+          ^^ jump 2 1
+               (docs_by_type.func_decl ^^ docs_by_type.var_def ^^ string "void model_init();" ^^ hardline
+              ^^ string "void model_fini();" ^^ hardline
+               )
+          (* End of struct *)
+          ^^ string "};"
+          ^^ hardline ^^ string "} // namespace" ^^ hardline
+        )
+        else docs_by_type.type_decl ^^ docs_by_type.func_decl ^^ docs_by_type.var_decl
+      in
+
       let header =
-        string "#pragma once" ^^ hlhl ^^ preamble true ^^ hlhl ^^ header_doc ^^ hardline ^^ end_extern_cpp ^^ hardline
+        string "#pragma once" ^^ hlhl ^^ preamble true ^^ hlhl ^^ header_doc ^^ hardline
+        ^^ separate hardline extern_cpp_end ^^ hardline
         |> Document.to_string
       in
-      ( header,
+
+      let impl_doc =
+        if Config.cpp then
+          ksprintf string "namespace %s {" Config.cpp_namespace
+          ^^ hlhl ^^ docs_by_type.static_func_def ^^ docs_by_type.func_def
+          ^^ ksprintf string "} // namespace %s" Config.cpp_namespace
+          ^^ hardline
+        else docs_by_type.static_func_def ^^ docs_by_type.var_def ^^ docs_by_type.func_def
+      in
+
+      let impl =
         Document.to_string
           (preamble false ^^ hardline
           ^^ Printf.ksprintf string "#include \"%s.h\"" basename
-          ^^ hlhl ^^ docs ^^ hlhl
-          ^^ ( if not Config.no_rts then
-                 model_init ^^ hlhl ^^ model_fini ^^ hlhl ^^ model_pre_exit ^^ hlhl ^^ model_main ^^ hlhl
-               else empty
-             )
-          ^^ unit_test_defs ^^ hlhl ^^ model_test ^^ hlhl ^^ actual_main ^^ hardline ^^ end_extern_cpp ^^ hardline
+          ^^ hlhl ^^ impl_doc ^^ hlhl
+          (* TODO: Does no_rts actually work? Won't actual_main try to call model_main which is missing? *)
+          ^^ (if not Config.no_rts then model_pre_exit ^^ hlhl ^^ model_main ^^ hlhl else empty)
+          ^^ model_test ^^ hlhl ^^ actual_main ^^ hardline ^^ separate hardline extern_cpp_end ^^ hardline
           )
-      )
+      in
+
+      (header, impl)
     with Type_error.Type_error (l, err) ->
       c_error ~loc:l ("Unexpected type error when compiling to C:\n" ^ fst (Type_error.string_of_type_error err))
 end

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -107,6 +107,18 @@ module type CODEGEN_CONFIG = sig
   val assert_to_exception : bool
 
   val preserve_types : Ast_util.IdSet.t
+
+  (** If set generate a C++ class for the model instead of global C functions/variables. *)
+  val cpp : bool
+
+  (** Name of the C++ class. *)
+  val cpp_class_name : string
+
+  (* C++ namespace name. *)
+  val cpp_namespace : string
+
+  (* Optional classes/structs to derive from. *)
+  val cpp_derive_from : string option
 end
 
 module Codegen (Config : CODEGEN_CONFIG) : sig

--- a/src/sail_c_backend/sail_plugin_c.ml
+++ b/src/sail_c_backend/sail_plugin_c.ml
@@ -62,17 +62,20 @@ let opt_no_mangle = ref false
 let opt_no_rts = ref false
 let opt_preserve_types = ref IdSet.empty
 let opt_specialize_c = ref false
+let opt_cpp_class_name = ref "Model"
+let opt_cpp_namespace = ref "model"
+let opt_cpp_derive_from = ref None
 
 let c_options =
   [
-    (Flag.create ~prefix:["c"] "build", Arg.Set opt_build, "build the generated C output automatically");
+    (Flag.create ~prefix:["c"] "build", Arg.Set opt_build, "build the generated C/C++ output automatically");
     ( Flag.create ~prefix:["c"] ~arg:"filename" "include",
       Arg.String (fun i -> opt_includes_c := i :: !opt_includes_c),
-      "provide additional include for C output"
+      "provide additional include for C/C++ implementation output"
     );
     ( Flag.create ~prefix:["c"] ~arg:"filename" "header_include",
       Arg.String (fun i -> opt_includes_h := i :: !opt_includes_h),
-      "provide additional include for C header output"
+      "provide additional include for C/C++ header output"
     );
     (Flag.create ~prefix:["c"] "no_mangle", Arg.Set opt_no_mangle, "produce readable names");
     (Flag.create ~prefix:["c"] "no_main", Arg.Set opt_no_main, "do not generate the main() function");
@@ -83,31 +86,31 @@ let c_options =
     );
     ( Flag.create ~prefix:["c"] ~arg:"prefix" "prefix",
       Arg.String (fun prefix -> C_backend.opt_prefix := prefix),
-      "prefix generated C functions"
+      "prefix generated C/C++ functions"
     );
     (* This flag is deprecated and will be removed in future. A header is always generated. *)
     (Flag.create ~prefix:["c"] "generate_header", Arg.Set opt_generate_header, "");
     ( Flag.create ~prefix:["c"] ~arg:"parameters" "extra_params",
       Arg.String (fun params -> C_backend.opt_extra_params := Some params),
-      "generate C functions with additional parameters"
+      "generate C/C++ functions with additional parameters"
     );
     ( Flag.create ~prefix:["c"] ~arg:"arguments" "extra_args",
       Arg.String (fun args -> C_backend.opt_extra_arguments := Some args),
-      "supply extra argument to every generated C function call"
+      "supply extra argument to every generated C/C++ function call"
     );
-    (Flag.create ~prefix:["c"] "specialize", Arg.Set opt_specialize_c, "specialize integer arguments in C output");
+    (Flag.create ~prefix:["c"] "specialize", Arg.Set opt_specialize_c, "specialize integer arguments in C/C++ output");
     ( Flag.create ~prefix:["c"] "preserve",
       Arg.String (fun str -> Specialize.add_initial_calls (IdSet.singleton (mk_id str))),
-      "make sure the provided function identifier is preserved in C output"
+      "make sure the provided function identifier is preserved in C/C++ output"
     );
     (Flag.create ~prefix:["c"] "assert_to_exception", Arg.Set opt_assert_to_exception, "turn assertions into exceptions");
     ( Flag.create ~prefix:["c"] "preserve_type",
       Arg.String (fun str -> opt_preserve_types := IdSet.add (mk_id str) !opt_preserve_types),
-      "make sure the provided type identifier is preserved in the C output"
+      "make sure the provided type identifier is preserved in the C/C++ output"
     );
     ( Flag.create ~prefix:["c"] "fold_unit",
       Arg.String (fun str -> Constant_fold.opt_fold_to_unit := Util.split_on_char ',' str),
-      "remove comma separated list of functions from C output, replacing them with unit"
+      "remove comma separated list of functions from C/C++ output, replacing them with unit"
     );
     ( Flag.create ~prefix:["c"] ~arg:"file" "coverage",
       Arg.String (fun str -> opt_branch_coverage := Some (open_out str)),
@@ -121,7 +124,7 @@ let c_options =
           Arg.Set Initial_check.opt_fast_undefined;
           Arg.Set C_backend.optimize_alias;
         ],
-      "turn on optimizations for C compilation"
+      "turn on optimizations for C/C++ compilation"
     );
     ( Flag.create ~prefix:["c"] ~hide_prefix:true "Ofixed_int",
       Arg.Set C_backend.optimize_fixed_int,
@@ -133,6 +136,23 @@ let c_options =
     );
     (* This flag is deprecated and will be removed in future. *)
     (Flag.create ~prefix:["c"] ~hide_prefix:true "static", Arg.Set opt_static, "");
+  ]
+
+(* Additional options when compiling in C++ mode. *)
+let cpp_options =
+  [
+    ( Flag.create ~prefix:["cpp"] ~arg:"identifier" "class_name",
+      Arg.String (fun args -> opt_cpp_class_name := args),
+      "C++ class name (default 'Model')"
+    );
+    ( Flag.create ~prefix:["cpp"] ~arg:"identifier" "namespace",
+      Arg.String (fun args -> opt_cpp_namespace := args),
+      "C++ namespace name (default 'model')"
+    );
+    ( Flag.create ~prefix:["cpp"] ~arg:"list" "derive_from",
+      Arg.String (fun args -> opt_cpp_derive_from := Some args),
+      "List of classes/structs to derive the model class from, e.g. 'public foo, private bar'"
+    );
   ]
 
 let c_rewrites =
@@ -187,7 +207,7 @@ let collect_c_name_info ast =
     ast.defs;
   (!reserved, !overrides)
 
-let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
+let c_target is_cpp out_file { ast; effect_info; env; default_sail_dir; _ } =
   let reserveds, overrides = collect_c_name_info ast in
 
   let module Codegen = C_backend.Codegen (struct
@@ -202,6 +222,10 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
     let branch_coverage = !opt_branch_coverage
     let assert_to_exception = !opt_assert_to_exception
     let preserve_types = !opt_preserve_types
+    let cpp = is_cpp
+    let cpp_class_name = !opt_cpp_class_name
+    let cpp_namespace = !opt_cpp_namespace
+    let cpp_derive_from = !opt_cpp_derive_from
   end) in
   Reporting.opt_warnings := true;
 
@@ -217,7 +241,9 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
 
   let header, impl = Codegen.compile_ast env effect_info basename ast in
 
-  let impl_out = Util.open_output_with_check (out_file ^ ".c") in
+  let impl_ext = if is_cpp then ".cpp" else ".c" in
+
+  let impl_out = Util.open_output_with_check (out_file ^ impl_ext) in
   output_string impl_out.channel impl;
   flush impl_out.channel;
   Util.close_output_with_check impl_out;
@@ -247,5 +273,11 @@ let _ =
   Pragma.register "c_in_main_post";
   Pragma.register "c_reserved";
   Pragma.register "c_override";
-  Target.register ~name:"c" ~options:c_options ~rewrites:c_rewrites ~supports_abstract_types:true
-    ~supports_runtime_config:true c_target
+  ignore
+    (Target.register ~name:"c" ~options:c_options ~rewrites:c_rewrites ~supports_abstract_types:true
+       ~supports_runtime_config:true (c_target false)
+    );
+  ignore
+    (Target.register ~name:"cpp" ~options:cpp_options ~rewrites:c_rewrites ~supports_abstract_types:true
+       ~supports_runtime_config:true (c_target true)
+    )

--- a/test/c/abstract_sizeof_no_use.sail
+++ b/test/c/abstract_sizeof_no_use.sail
@@ -6,7 +6,7 @@ type xlen : Int
 
 constraint xlen in {32, 64}
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_set_abstract_xlen(32);
 $else
 $option --instantiate xlen=32

--- a/test/c/abstract_type.sail
+++ b/test/c/abstract_type.sail
@@ -10,7 +10,7 @@ constraint xlen in {32, 64}
 // here to make this work as a single file test case).
 //
 // Otherwise, use the --instantiate flag to set it at build time.
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_set_abstract_xlen(32);
 $else
 $option --instantiate xlen=32

--- a/test/c/assign_rename_bug.sail
+++ b/test/c/assign_rename_bug.sail
@@ -10,6 +10,7 @@ $option -undefined_gen
 
 val sub_vec_int = {
   c: "sub_bits_int",
+  cpp: "sub_bits_int",
   systemverilog: "sub_bits_int",
   lean: "BitVec.subInt",
   _: "sub_vec_int"

--- a/test/c/cabbrev.sail
+++ b/test/c/cabbrev.sail
@@ -28,7 +28,7 @@ $c_override {
 }
 
 // Just so this test works in non-C backends
-$iftarget c
+$iftarget c cpp
 val mk_pair = pure "mk_pair" : unit -> my_pair
 $else
 val mk_pair : unit -> my_pair

--- a/test/c/config_abstract_bool.sail
+++ b/test/c/config_abstract_bool.sail
@@ -2,9 +2,8 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_abstract_bool.json");
-$c_in_main sail_set_abstract_have_ext();
 $c_in_main_post sail_config_cleanup();
 $else
 $option --config ../c/config_abstract_bool.json

--- a/test/c/config_abstract_clash.sail
+++ b/test/c/config_abstract_clash.sail
@@ -1,9 +1,8 @@
 default Order dec
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_abstract_clash.json");
-$c_in_main sail_set_abstract_xlen();
 $c_in_main_post sail_config_cleanup();
 $else
 $option --config ../c/config_abstract_clash.json

--- a/test/c/config_abstract_type.sail
+++ b/test/c/config_abstract_type.sail
@@ -7,9 +7,8 @@ constraint xlen in {32, 64}
 
 // This test is similar to abstract_type.sail, but instantiating the
 // type from the configuration file rather than the command line.
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_abstract_type.json");
-$c_in_main sail_set_abstract_xlen();
 $c_in_main_post sail_config_cleanup();
 $else
 $option --config ../c/config_abstract_type.json

--- a/test/c/config_abstract_type2.sail
+++ b/test/c/config_abstract_type2.sail
@@ -7,9 +7,8 @@ constraint xlen >= 0
 
 // This test is similar to abstract_type.sail, but instantiating the
 // type from the configuration file rather than the command line.
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_abstract_type.json");
-$c_in_main sail_set_abstract_xlen();
 $c_in_main_post sail_config_cleanup();
 $else
 $option --config ../c/config_abstract_type.json

--- a/test/c/config_abstract_type3.sail
+++ b/test/c/config_abstract_type3.sail
@@ -9,9 +9,8 @@ constraint xlen in {32, 64}
 
 // This test is similar to abstract_type.sail, but instantiating the
 // type from the configuration file rather than the command line.
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_abstract_type.json");
-$c_in_main sail_set_abstract_xlen();
 $c_in_main_post sail_config_cleanup();
 $else
 $option --config ../c/config_abstract_type.json

--- a/test/c/config_bit.sail
+++ b/test/c/config_bit.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_bit.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_bits_format.sail
+++ b/test/c/config_bits_format.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_bits_format.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_bool.sail
+++ b/test/c/config_bool.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_bool.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_enum.sail
+++ b/test/c/config_enum.sail
@@ -3,7 +3,7 @@ default Order dec
 $include <prelude.sail>
 $include <option.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_enum.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_int.sail
+++ b/test/c/config_int.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_int.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_let.sail
+++ b/test/c/config_let.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_let.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_map_guard.sail
+++ b/test/c/config_map_guard.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_map_guard.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_register_new.sail
+++ b/test/c/config_register_new.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_register_new.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_struct.sail
+++ b/test/c/config_struct.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_struct.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_test.sail
+++ b/test/c/config_test.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_test.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_union.sail
+++ b/test/c/config_union.sail
@@ -3,7 +3,7 @@ default Order dec
 $include <prelude.sail>
 $include <option.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_union.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_unit.sail
+++ b/test/c/config_unit.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_unit.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_vec_list.sail
+++ b/test/c/config_vec_list.sail
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_vec_list.json");
 $c_in_main_post sail_config_cleanup();
 $else

--- a/test/c/config_xlen.sail
+++ b/test/c/config_xlen.sail
@@ -1,8 +1,7 @@
 default Order dec
 
-$iftarget c
+$iftarget c cpp
 $c_in_main sail_config_set_file("config_xlen.json");
-$c_in_main sail_set_abstract_xlen();
 $c_in_main_post sail_config_cleanup();
 $else
 $option --config ../c/config_xlen.json

--- a/test/c/enum_match.sail
+++ b/test/c/enum_match.sail
@@ -1,6 +1,6 @@
 
 val "eq_anything" : forall ('a : Type). ('a, 'a) -> bool
-val eq_atom = {ocaml: "eq_int", lem: "eq", c: "eq_int", coq: "Z.eqb"} : forall 'n 'm. (atom('n), atom('m)) -> bool
+val eq_atom = {ocaml: "eq_int", lem: "eq", c: "eq_int", cpp: "eq_int", coq: "Z.eqb"} : forall 'n 'm. (atom('n), atom('m)) -> bool
 
 overload operator == = {eq_atom, eq_anything}
 

--- a/test/c/pointer_assign.sail
+++ b/test/c/pointer_assign.sail
@@ -12,7 +12,7 @@ let STATUS_2 = 0x0000_0004
 
 val read_register = "reg_deref" : forall ('a : Type). register('a) -> 'a effect {rreg}
 
-val or_bits = { c: "or_bits", _: "or_vec" } : forall 'n, 'n >= 0. (bits('n), bits('n)) -> bits('n)
+val or_bits = { c: "or_bits", cpp: "or_bits", _: "or_vec" } : forall 'n, 'n >= 0. (bits('n), bits('n)) -> bits('n)
 
 overload operator | = {or_bits}
 

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -26,20 +26,40 @@ def no_valgrind():
     except FileNotFoundError:
         return True
 
-def test_c(name, c_opts, sail_opts, valgrind, compiler='cc'):
+def test_c(name, c_opts, sail_opts, valgrind, compiler='cc', actually_cpp=False):
     banner('Testing {} with C options: {} Sail options: {} valgrind: {}'.format(name, c_opts, sail_opts, valgrind))
     results = Results(name)
     if valgrind and no_valgrind():
         print('skipping because no valgrind found')
         return results.finish()
+
+    if actually_cpp:
+        extension = "cpp"
+        target_opt = "--cpp"
+        # TODO: This is awkward because we compile the C and C++ code in C++ mode, so you can't
+        # use #ifdef __cplusplus to decide whether to `use model::my_pair_in_c`. Probably the
+        # best fix is to add a #define like `-DSAIL_TEST_COMPILING_C_AS_CPP` or something.
+        results.expect_failure("cabbrev.sail", "my_pair_in_c is declared in a namespace in C++")
+        # This tests access to a global variable `zxlen_val` which doesn't exist in C++ mode.
+        # It's now a struct member variable.
+        results.expect_failure("xlen_val.sail", "assumes variables are still global")
+        # TODO: These use `$c_in_main` to add a call to `sail_set_abstract_xlen(32)` to `main()`
+        # but for C++ it needs to go in `model_main()` and be `model.sail_set_abstract_xlen(32)`.
+        results.expect_failure("abstract_sizeof_no_use.sail", "difficult to call model.sail_set_abstract_... in the right place")
+        results.expect_failure("abstract_type.sail", "difficult to call model.sail_set_abstract_... in the right place")
+
+    else:
+        extension = "c"
+        target_opt = "-c"
+
     for filenames in chunks(os.listdir('.'), parallel()):
         tests = {}
         for filename in filenames:
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('\'{}\' --no-warn -c {} {} -o {}'.format(sail, sail_opts, filename, basename))
-                step('{} {} {}.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
+                step('\'{}\' --no-warn {} {} {} -o {}'.format(sail, target_opt, sail_opts, filename, basename))
+                step('{} {} {}.{} \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}.bin'.format(compiler, c_opts, basename, extension, sail_dir, sail_dir, basename))
                 step('./{}.bin > {}.result 2> {}.err_result'.format(basename, basename, basename),
                      expected_status = 1 if basename.startswith('fail') else 0,
                      stderr_file='{}.err_result'.format(basename))
@@ -49,7 +69,7 @@ def test_c(name, c_opts, sail_opts, valgrind, compiler='cc'):
                 if valgrind and not basename.startswith('fail'):
                     step("valgrind --leak-check=full --track-origins=yes --errors-for-leak-kinds=all --error-exitcode=2 ./{}.bin".format(basename),
                          expected_status = 1 if basename.startswith('fail') else 0)
-                step('rm {}.c {}.bin {}.result'.format(basename, basename, basename))
+                step('rm {}.{} {}.bin {}.result'.format(basename, extension, basename, basename))
                 print_ok(filename)
                 sys.exit()
         results.collect(tests)
@@ -157,6 +177,7 @@ def test_coq(name):
     results.expect_failure("simple_while.sail", "Loop without termination measure")
     results.expect_failure("simple_while2.sail", "Loop without termination measure")
     results.expect_failure("simple_while3.sail", "Loop without termination measure")
+    results.expect_failure("struct.sail", "bug: codegen can't handle a struct with a field that has the same name as the struct")
     for filenames in chunks(os.listdir('.'), parallel()):
         tests = {}
         for filename in filenames:
@@ -199,8 +220,13 @@ if 'c' in targets:
     xml += test_c('address sanitised', '-O2 -fsanitize=address -g', '-O', False)
 
 if 'cpp' in targets:
+    # Compiling the C as if it was C++.
     xml += test_c('unoptimized C with C++ compiler', '-xc++', '', False, compiler='c++')
     xml += test_c('optimized C with C++ compiler', '-xc++ -O2', '-O', True, compiler='c++')
+
+    # Actual C++ output.
+    xml += test_c('unoptimized C++', '', '', False, compiler='c++', actually_cpp=True)
+    xml += test_c('optimized C++', '-O2', '-O', True, compiler='c++', actually_cpp=True)
 
 if 'interpreter' in targets:
     xml += test_interpreter('interpreter')

--- a/test/c/struct.expect
+++ b/test/c/struct.expect
@@ -1,3 +1,4 @@
 x.A = 0x8
 x.A = 0xF
-(struct {A = 0b1111, B = 0b11} : test).B = 0b11
+(struct {A = 0b1111, B = 0b11, test = 0b1} : test).B = 0b11
+x.test = 0b1

--- a/test/c/struct.sail
+++ b/test/c/struct.sail
@@ -6,14 +6,18 @@ val "print_bits" : forall 'n. (string, bitvector('n, dec)) -> unit
 struct test = {
   A : bitvector(4, dec),
   B : bitvector(2, dec),
+  // Same name as struct can cause issues without careful codegen.
+  test : bitvector(1, dec),
 }
 
 $[jib_debug]
 function main (() : unit) -> unit = {
-  x : test = struct { A = 0b1010, B = 0b11 };
+  x : test = struct { A = 0b1010, B = 0b11, test = 0b1 };
   x.A = 0b1000;
   print_bits("x.A = ", x.A);
   x.A = 0b1111;
   print_bits("x.A = ", x.A);
-  print_bits("(struct {A = 0b1111, B = 0b11} : test).B = ", (struct {A = 0b1111, B = 0b11} : test).B);
+  print_bits("(struct {A = 0b1111, B = 0b11, test = 0b1} : test).B = ",
+              (struct {A = 0b1111, B = 0b11, test = 0b1} : test).B);
+  print_bits("x.test = ", x.test);
 }

--- a/test/c/test_attribute.sail
+++ b/test/c/test_attribute.sail
@@ -23,7 +23,7 @@ function test_2() -> unit = {
 
 $c_in_main_post model_test();
 
-$iftarget c
+$iftarget c cpp
 
 function main() -> unit = {
   print_endline("ok");

--- a/test/c/xlen_val.sail
+++ b/test/c/xlen_val.sail
@@ -16,7 +16,7 @@ $c_override {
 
 let xlen_val = sizeof(xlen)
 
-val test = { c: "test" } : int(32) -> int(64)
+val test = { c: "test", cpp: "test" } : int(32) -> int(64)
 
 function test(_) = 64
 

--- a/test/format/default/val.expect
+++ b/test/format/default/val.expect
@@ -2,7 +2,7 @@ default Order dec
 $include <prelude.sail>
 
 val foo = impure { _: "foo" } : unit -> unit // foo
-val bar = impure { c: "foo_c", _: "foo" } : (
+val bar = impure { c: "foo_c", cpp: "foo_c", _: "foo" } : (
         unit,
         unit,
         unit,

--- a/test/format/val.sail
+++ b/test/format/val.sail
@@ -3,7 +3,7 @@ $include <prelude.sail>
 
 val foo = impure { _: "foo" } : unit -> unit // foo
 
-val bar = impure { c: "foo_c", _: "foo" } : (unit, unit, unit, vector(16, dec, vector(32, dec, int)), unit, unit, unit, vector(32, dec, int)) -> unit
+val bar = impure { c: "foo_c", cpp: "foo_c", _: "foo" } : (unit, unit, unit, vector(16, dec, vector(32, dec, int)), unit, unit, unit, vector(32, dec, int)) -> unit
 
 val baz : unit -> unit // baz
 val quuz : unit -> unit

--- a/test/interactive/pass/slice2.expected
+++ b/test/interactive/pass/slice2.expected
@@ -28,13 +28,13 @@ default Order dec
 
 
 
-val add_atom = pure {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", c: "add_int", coq: "Z.add"}: forall 'n 'm.
+val add_atom = pure {ocaml: "add_int", interpreter: "add_int", lem: "integerAdd", c: "add_int", cpp: "add_int", coq: "Z.add"}: forall 'n 'm.
   (int('n), int('m)) -> int('n + 'm)
 
 
 
 
-val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", c: "mult_int", coq: "Z.mul"}: forall 'n 'm.
+val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", c: "mult_int", cpp: "mult_int", coq: "Z.mul"}: forall 'n 'm.
   (int('n), int('m)) -> int('n * 'm)
 
 
@@ -44,7 +44,7 @@ val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", c:
 
 
 
-$sail_internal 
+$sail_internal
 
 
 

--- a/test/interactive/pass/slice3.expected
+++ b/test/interactive/pass/slice3.expected
@@ -36,7 +36,7 @@ default Order dec
 
 
 
-val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", c: "mult_int", coq: "Z.mul"}: forall 'n 'm.
+val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", c: "mult_int", cpp: "mult_int", coq: "Z.mul"}: forall 'n 'm.
   (int('n), int('m)) -> int('n * 'm)
 
 
@@ -46,7 +46,7 @@ val mult_atom = pure {ocaml: "mult", interpreter: "mult", lem: "integerMult", c:
 
 
 
-$sail_internal 
+$sail_internal
 
 
 

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -509,7 +509,7 @@ open CacheOp
 open Barrier
 open AccessType
 
-/-- Type quantifiers: k_ex5911# : Bool, k_ex5910# : Bool -/
+/-- Type quantifiers: k_ex6037# : Bool, k_ex6036# : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/mapping.sail
+++ b/test/lean/mapping.sail
@@ -53,6 +53,7 @@ val string_append = pure {
   coq: "String.append",
   lean: "String.append",
   c: "concat_str",
+  cpp: "concat_str",
   _: "string_append"
 } : (string, string) -> string
 

--- a/test/mono/builtins.sail
+++ b/test/mono/builtins.sail
@@ -12,7 +12,8 @@ val UInt = pure {
   ocaml: "uint",
   lem: "uint",
   interpreter: "uint",
-  c: "sail_uint"
+  c: "sail_uint",
+  cpp: "sail_uint"
 } : forall 'n. bits('n) -> range(0, 2 ^ 'n - 1)
 
 /* Test constant propagation's implementation of builtins

--- a/test/mono/mutrecmono.sail
+++ b/test/mono/mutrecmono.sail
@@ -7,7 +7,8 @@ val UInt = pure {
   ocaml: "uint",
   lem: "uint",
   interpreter: "uint",
-  c: "sail_uint"
+  c: "sail_uint",
+  cpp: "sail_uint"
 } : forall 'n. bits('n) -> range(0, 2 ^ 'n - 1)
 
 

--- a/test/mono/times8div8.sail
+++ b/test/mono/times8div8.sail
@@ -7,7 +7,7 @@ function extzv(m,v) = sail_zero_extend(v, m)
 
 val ex_int : int -> {'n, true. int('n)}
 function ex_int 'n = n
-val quotient = pure {ocaml: "quotient", lem: "integerDiv", c: "div_int"} : (int, int) -> int
+val quotient = pure {ocaml: "quotient", lem: "integerDiv", c: "div_int", cpp: "div_int"} : (int, int) -> int
 overload operator / = {quotient}
 
 /* Byte/bits size conversions are a pain */


### PR DESCRIPTION
This adds support for generating C++ code. The model is wrapped in a struct, which means you can create multiple instances of it (e.g. to simulate multicore CPUs).

The structure of the C++ code is like this:

```
// Header
namespace model {
<types>
struct Model <: optional base classes> {
  <function declarations>
  <variable definitions>
};
}

// Impl
namespace model {
<function definitions>
}
```

This is the only way I found to do it without major changes. We can't put the types in Model because there's nothing like `using namespace <SomeClass>::*;` in C++.
