### PR TITLE
Simplify some operator handling in parser

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -542,13 +542,13 @@ let chunk_delimit ?delim ~get_loc ~chunk comments xs =
 
 let chunk_infix_token comments chunk_primary (infix_token, _, _) =
   match infix_token with
-  | IT_op id -> Infix_op (string_of_id id)
-  | IT_prefix id -> (
-      match id with
-      | Id_aux (Id "__deref", _) -> Infix_prefix "*"
-      | Id_aux (Id "pow2", _) -> Infix_prefix "2 ^"
-      | Id_aux (Id "negate", _) -> Infix_prefix "-"
-      | _ -> Infix_prefix (string_of_id id)
+  | IT_op op -> Infix_op op
+  | IT_prefix op -> (
+      match op with
+      | "__deref" -> Infix_prefix "*"
+      | "pow2" -> Infix_prefix "2 ^"
+      | "negate" -> Infix_prefix "-"
+      | _ -> Infix_prefix op
     )
   | IT_primary exp ->
       let chunks = Queue.create () in
@@ -572,7 +572,7 @@ let rec chunk_atyp comments chunks (ATyp_aux (aux, l)) =
       let lhs_chunks = rec_chunk_atyp lhs in
       let rhs_chunks = rec_chunk_atyp rhs in
       Queue.add (Binary (lhs_chunks, "in", rhs_chunks)) chunks
-  | ATyp_infix [(IT_primary lhs, _, _); (IT_op (Id_aux (Id op, _)), _, _); (IT_primary rhs, _, _)] ->
+  | ATyp_infix [(IT_primary lhs, _, _); (IT_op op, _, _); (IT_primary rhs, _, _)] ->
       let lhs_chunks = rec_chunk_atyp lhs in
       let rhs_chunks = rec_chunk_atyp rhs in
       Queue.add (Binary (lhs_chunks, op, rhs_chunks)) chunks
@@ -806,7 +806,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
   | E_exit exp ->
       let exp_chunks = rec_chunk_exp exp in
       Queue.add (App (Id_aux (Id "exit", Unknown), [exp_chunks])) chunks
-  | E_infix [(IT_primary lhs, _, _); (IT_op (Id_aux (Id op, _)), _, _); (IT_primary rhs, _, _)] ->
+  | E_infix [(IT_primary lhs, _, _); (IT_op op, _, _); (IT_primary rhs, _, _)] ->
       let lhs_chunks = rec_chunk_exp lhs in
       let rhs_chunks = rec_chunk_exp rhs in
       Queue.add (Binary (lhs_chunks, op, rhs_chunks)) chunks
@@ -1316,12 +1316,10 @@ let rec chunk_def source last_line_span comments chunks (DEF_aux (def, l)) =
               (Pragma (pragma, Ast_util.string_of_attribute_data (AD_aux (AD_object data, Parse_ast.Unknown))))
               chunks
         | DEF_default dts -> chunk_default_typing_spec comments chunks dts
-        | DEF_fixity (prec, n, id) ->
-            pop_comments comments chunks (id_loc id);
+        | DEF_fixity (prec, n, op) ->
+            pop_comments comments chunks l;
             let string_of_prec = function Infix -> "infix" | InfixL -> "infixl" | InfixR -> "infixr" in
-            Queue.add
-              (Atom (Printf.sprintf "%s %s %s" (string_of_prec prec) (Big_int.to_string n) (string_of_id id)))
-              chunks;
+            Queue.add (Atom (Printf.sprintf "%s %s %s" (string_of_prec prec) (Big_int.to_string n) op)) chunks;
             Queue.add (Spacer (true, 1)) chunks
         | DEF_register reg -> chunk_register comments chunks reg
         | DEF_let lb -> chunk_toplevel_let l comments chunks lb

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -79,7 +79,7 @@ type ctx = {
   outcome_names : IdSet.t;
   outcome_variables : kind_aux KBindings.t;
   scattereds : (P.typquant * ctx) Bindings.t;
-  fixities : (prec * int) Bindings.t;
+  fixities : (prec * int) StringMap.t;
   internal_files : StringSet.t;
   target_sets : string list StringMap.t;
 }
@@ -98,7 +98,7 @@ let rec equal_ctx ctx1 ctx2 =
   && Bindings.equal
        (fun (typq1, ctx1) (typq2, ctx2) -> typq1 = typq2 && equal_ctx ctx1 ctx2)
        ctx1.scattereds ctx2.scattereds
-  && Bindings.equal ( = ) ctx1.fixities ctx2.fixities
+  && StringMap.equal ( = ) ctx1.fixities ctx2.fixities
   && StringSet.equal ctx1.internal_files ctx2.internal_files
   && StringMap.equal ( = ) ctx1.target_sets ctx2.target_sets
 
@@ -139,8 +139,8 @@ let merge_ctx l ctx1 ctx2 =
         )
         ctx1.scattereds ctx2.scattereds;
     fixities =
-      Bindings.merge
-        (compatible ( = ) (fun id -> "Operator " ^ string_of_id id ^ " declared with multiple fixities"))
+      StringMap.merge
+        (compatible ( = ) (fun op -> "Operator " ^ op ^ " declared with multiple fixities"))
         ctx1.fixities ctx2.fixities;
     internal_files = StringSet.union ctx1.internal_files ctx2.internal_files;
     target_sets =
@@ -282,32 +282,29 @@ let parse_infix :
            | P.IT_primary x, s, e -> (mk_primary x, s, e)
            | P.IT_prefix id, s, e -> (
                match id with
-               | Id_aux (Id "pow2", _) -> (TwoCaret, s, e)
-               | Id_aux (Id "negate", _) -> (Minus, s, e)
-               | Id_aux (Id "__deref", _) -> (Star, s, e)
+               | "pow2" -> (TwoCaret, s, e)
+               | "negate" -> (Minus, s, e)
+               | "__deref" -> (Star, s, e)
                | _ -> raise (Reporting.err_general (P.Range (s, e)) "Unknown prefix operator")
              )
-           | P.IT_op id, s, e -> (
-               match id with
-               | Id_aux (Id "+", _) -> (Plus, s, e)
-               | Id_aux (Id "-", _) -> (Minus, s, e)
-               | Id_aux (Id "*", _) -> (Star, s, e)
-               | Id_aux (Id "<", _) -> (Lt, s, e)
-               | Id_aux (Id ">", _) -> (Gt, s, e)
-               | Id_aux (Id "<=", _) -> (LtEq, s, e)
-               | Id_aux (Id ">=", _) -> (GtEq, s, e)
-               | Id_aux (Id "::", _) -> (ColonColon, s, e)
-               | Id_aux (Id "@", _) -> (At, s, e)
-               | Id_aux (Id "in", _) -> (In, s, e)
+           | P.IT_op op, s, e -> (
+               match op with
+               | "+" -> (Plus, s, e)
+               | "-" -> (Minus, s, e)
+               | "*" -> (Star, s, e)
+               | "<" -> (Lt, s, e)
+               | ">" -> (Gt, s, e)
+               | "<=" -> (LtEq, s, e)
+               | ">=" -> (GtEq, s, e)
+               | "::" -> (ColonColon, s, e)
+               | "@" -> (At, s, e)
+               | "in" -> (In, s, e)
                | _ -> (
-                   match Bindings.find_opt (to_ast_id ctx id) ctx.fixities with
-                   | Some (prec, level) -> (to_infix_parser_op (prec, level, id), s, e)
-                   | None ->
-                       raise
-                         (Reporting.err_general
-                            (P.Range (s, e))
-                            ("Undeclared fixity for operator " ^ string_of_parse_id id)
-                         )
+                   match StringMap.find_opt op ctx.fixities with
+                   | Some (prec, level) ->
+                       let id = P.Id_aux (P.Id op, P.Range (s, e)) in
+                       (to_infix_parser_op (prec, level, id), s, e)
+                   | None -> raise (Reporting.err_general (P.Range (s, e)) ("Undeclared fixity for operator " ^ op))
                  )
              )
            )
@@ -2068,10 +2065,10 @@ let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : untyped_def list ctx
     end
   | P.DEF_overload (id, ids) -> ([DEF_aux (DEF_overload (to_ast_id ctx id, List.map (to_ast_id ctx) ids), annot)], ctx)
   | P.DEF_fixity (prec, n, op) ->
-      let op = to_ast_id ctx op in
+      let id = mk_id ~loc:l op in
       let prec = to_ast_prec prec in
-      ( [DEF_aux (DEF_fixity (prec, n, op), annot)],
-        { ctx with fixities = Bindings.add op (prec, Big_int.to_int n) ctx.fixities }
+      ( [DEF_aux (DEF_fixity (prec, n, id), annot)],
+        { ctx with fixities = StringMap.add op (prec, Big_int.to_int n) ctx.fixities }
       )
   | P.DEF_type t_def -> to_ast_typedef ctx annot t_def
   | P.DEF_fundef f_def ->
@@ -2237,8 +2234,8 @@ let initial_ctx =
     scattereds = Bindings.empty;
     fixities =
       List.fold_left
-        (fun m (k, prec, level) -> Bindings.add (mk_id k) (prec, level) m)
-        Bindings.empty
+        (fun m (k, prec, level) -> StringMap.add k (prec, level) m)
+        StringMap.empty
         [
           ("^", InfixR, 8);
           ("|", InfixR, 2);

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -101,7 +101,7 @@ type kid = Kid_aux of kid_aux * l
 
 type id = Id_aux of id_aux * l
 
-type 'a infix_token = IT_primary of 'a | IT_op of id | IT_prefix of id
+type 'a infix_token = IT_primary of 'a | IT_op of string | IT_prefix of string
 
 type lit_aux =
   | (* Literal constant *)
@@ -451,7 +451,7 @@ type def_aux =
   | DEF_impl of funcl (* impl definition *)
   | DEF_let of letbind (* value definition *)
   | DEF_overload of id * id list (* operator overload specifications *)
-  | DEF_fixity of prec * Big_int.num * id (* fixity declaration *)
+  | DEF_fixity of prec * Big_int.num * string (* fixity declaration *)
   | DEF_val of val_spec (* top-level type constraint *)
   | DEF_outcome of outcome_spec * def list (* top-level outcome definition *)
   | DEF_instantiation of id * subst list (* instantiation *)

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -266,63 +266,41 @@ separated_nonempty_list_trailing(SEP, ELEM):
     { x :: xs }
 
 id:
-  | Id { mk_id (Id $1) $startpos $endpos }
-
-  | Op OpId { mk_id (Operator $2) $startpos $endpos }
+  | Id       { mk_id (Id $1) $startpos $endpos }
+  | Op OpId  { mk_id (Operator $2) $startpos $endpos }
   | Op Minus { mk_id (Operator "-") $startpos $endpos }
-  | Op Bar { mk_id (Operator "|") $startpos $endpos }
+  | Op Bar   { mk_id (Operator "|") $startpos $endpos }
   | Op Caret { mk_id (Operator "^") $startpos $endpos }
-  | Op Star { mk_id (Operator "*") $startpos $endpos }
+  | Op Star  { mk_id (Operator "*") $startpos $endpos }
 
 op_no_caret:
-  | OpId
-    { mk_id (Id $1) $startpos $endpos }
-  | Minus
-    { mk_id (Id "-") $startpos $endpos }
-  | Bar
-    { mk_id (Id "|") $startpos $endpos }
-  | Star
-    { mk_id (Id "*") $startpos $endpos }
-  | In
-    { mk_id (Id "in") $startpos $endpos }
+  | OpId  { $1 }
+  | Minus { "-" }
+  | Bar   { "|" }
+  | Star  { "*" }
+  | In    { "in" }
 
 op:
-  | OpId
-    { mk_id (Id $1) $startpos $endpos }
-  | Minus
-    { mk_id (Id "-") $startpos $endpos }
-  | Bar
-    { mk_id (Id "|") $startpos $endpos }
-  | Caret
-    { mk_id (Id "^") $startpos $endpos }
-  | Star
-    { mk_id (Id "*") $startpos $endpos }
-  | In
-    { mk_id (Id "in") $startpos $endpos }
+  | OpId  { $1 }
+  | Minus { "-" }
+  | Bar   { "|" }
+  | Star  { "*" }
+  | In    { "in" }
+  | Caret { "^" }
 
 exp_op:
-  | OpId
-    { mk_id (Id $1) $startpos $endpos }
-  | Minus
-    { mk_id (Id "-") $startpos $endpos }
-  | Bar
-    { mk_id (Id "|") $startpos $endpos }
-  | At
-    { mk_id (Id "@") $startpos $endpos }
-  | ColonColon
-    { mk_id (Id "::") $startpos $endpos }
-  | Caret
-    { mk_id (Id "^") $startpos $endpos }
-  | Star
-    { mk_id (Id "*") $startpos $endpos }
+  | OpId       { $1 }
+  | Minus      { "-" }
+  | Bar        { "|" }
+  | At         { "@" }
+  | ColonColon { "::" }
+  | Caret      { "^" }
+  | Star       { "*" }
 
 pat_op:
-  | At
-    { mk_id (Id "@") $startpos $endpos }
-  | ColonColon
-    { mk_id (Id "::") $startpos $endpos }
-  | Caret
-    { mk_id (Id "^") $startpos $endpos }
+  | At         { mk_id (Id "@") $startpos $endpos }
+  | ColonColon { mk_id (Id "::") $startpos $endpos }
+  | Caret      { mk_id (Id "^") $startpos $endpos }
 
 id_list:
   | id
@@ -352,11 +330,11 @@ typ_eof:
   |
     { [] }
   | TwoCaret
-    { [(IT_prefix (mk_id (Id "pow2") $startpos $endpos), $startpos, $endpos)] }
+    { [(IT_prefix "pow2", $startpos, $endpos)] }
   | Minus
-    { [(IT_prefix (mk_id (Id "negate") $startpos $endpos), $startpos, $endpos)] }
+    { [(IT_prefix "negate", $startpos, $endpos)] }
   | Star
-    { [(IT_prefix (mk_id (Id "__deref") $startpos $endpos), $startpos, $endpos)] }
+    { [(IT_prefix "__deref", $startpos, $endpos)] }
 
 postfix_typ:
   | t = atomic_typ
@@ -706,11 +684,11 @@ operators in expressions, with both left, right and non-associative operators */
   |
     { [] }
   | TwoCaret
-    { [(IT_prefix (mk_id (Id "pow2") $startpos $endpos), $startpos, $endpos)] }
+    { [(IT_prefix "pow2", $startpos, $endpos)] }
   | Minus
-    { [(IT_prefix (mk_id (Id "negate") $startpos $endpos), $startpos, $endpos)] }
+    { [(IT_prefix "negate", $startpos, $endpos)] }
   | Star
-    { [(IT_prefix (mk_id (Id "__deref") $startpos $endpos), $startpos, $endpos)] }
+    { [(IT_prefix "__deref", $startpos, $endpos)] }
 
 exp0:
   | prefix = prefix_op;
@@ -1358,7 +1336,7 @@ def_aux:
   | Impl funcl
     { DEF_impl $2 }
   | Fixity
-    { let (prec, n, op) = $1 in DEF_fixity (prec, n, Id_aux (Id op, loc $startpos $endpos)) }
+    { let (prec, n, op) = $1 in DEF_fixity (prec, n, op) }
   | val_spec_def
     { DEF_val $1 }
   | outcome_spec_def Eq Lcurly defs_list Rcurly


### PR DESCRIPTION
The identifier type was being used unnecesarily when handling strings for operator parsing.