### PR TITLE
Refactor operator constructors

### DIFF
--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -725,7 +725,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
       let then_aexp = anf then_exp in
       let else_aexp = anf else_exp in
       wrap (mk_aexp (AE_if (cond_val, then_aexp, else_aexp, typ_of exp)))
-  | E_app_infix (x, id, y) -> anf (E_aux (E_app (deinfix id, [x; y]), (l, tannot)))
+  | E_app_infix (x, id, y) -> anf (E_aux (E_app (id, [x; y]), (l, tannot)))
   | E_vector exps ->
       let aexps = List.map anf exps in
       let avals = List.map to_aval aexps in

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -209,6 +209,7 @@ let is_and_bool = function Id_aux (And_bool, _) -> true | _ -> false
 let is_or_bool = function Id_aux (Or_bool, _) -> true | _ -> false
 
 let mk_id ?loc:(l = Parse_ast.Unknown) str = Id_aux (Id str, l)
+let mk_operator ?loc:(l = Parse_ast.Unknown) str = Id_aux (Operator str, l)
 
 let mk_nc ?loc:(l = Parse_ast.Unknown) nc_aux = NC_aux (nc_aux, l)
 
@@ -1174,10 +1175,6 @@ let natural_sort_ids ids =
   let ids = List.map (fun id -> (split_id id, id)) ids in
   let ids = List.stable_sort (fun (n1, _) (n2, _) -> split_id_compare n1 n2) ids in
   List.map snd ids
-
-let deinfix = function Id_aux (Id v, l) -> Id_aux (Operator v, l) | id -> id
-
-let infix_swap = function Id_aux (Operator v, l) -> Id_aux (Id v, l) | id -> deinfix id
 
 let id_of_kid = function Kid_aux (Var v, l) -> Id_aux (Id (String.sub v 1 (String.length v - 1)), l)
 

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -163,6 +163,7 @@ val is_or_bool : id -> bool
 val mk_and_bool : ?loc:l -> unit -> id
 val mk_or_bool : ?loc:l -> unit -> id
 val mk_id : ?loc:l -> string -> id
+val mk_operator : ?loc:l -> string -> id
 val mk_kid : ?loc:l -> string -> kid
 val mk_nc : ?loc:l -> n_constraint_aux -> n_constraint
 val mk_nexp : ?loc:l -> nexp_aux -> nexp
@@ -496,9 +497,6 @@ val id_of_dec_spec : 'a dec_spec -> id
 
 val natural_id_compare : id -> id -> int
 val natural_sort_ids : id list -> id list
-
-val deinfix : id -> id
-val infix_swap : id -> id
 
 val id_of_kid : kid -> id
 val kid_of_id : id -> kid

--- a/src/lib/infix_parser.mly
+++ b/src/lib/infix_parser.mly
@@ -8,13 +8,10 @@ open Parse_ast
 
 let loc n m = Range (n, m)
 
-let mk_id id n m = Id_aux (id, loc n m)
+let mk_id id n m = Id_aux (Id id, loc n m)
+let mk_op op n m = Id_aux (Operator op, loc n m)
 let mk_typ t n m = ATyp_aux (t, loc n m)
 let mk_exp e n m = E_aux (e, loc n m)
-
-let deinfix = function
-  | (Id_aux (Id v, l)) -> Id_aux (Operator v, l)
-  | (Id_aux (Operator v, l)) -> Id_aux (Id v, l)
 
 type lchain =
   LC_lt
@@ -78,158 +75,158 @@ typ_eof:
     { t }
 
 typ0:
-  | typ1 Op0 typ1 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ0l Op0l typ1 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ1 Op0r typ0r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ1 Op0 typ1 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ0l Op0l typ1 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ1 Op0r typ0r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ1 { $1 }
 typ0l:
-  | typ1 Op0 typ1 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ0l Op0l typ1 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ1 Op0 typ1 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ0l Op0l typ1 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ1 { $1 }
 typ0r:
-  | typ1 Op0 typ1 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ1 Op0r typ0r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ1 Op0 typ1 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ1 Op0r typ0r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ1 { $1 }
 
 typ1:
-  | typ2 Op1 typ2 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ1l Op1l typ2 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ2 Op1r typ1r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ2 Op1 typ2 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ1l Op1l typ2 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ2 Op1r typ1r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ2 { $1 }
 typ1l:
-  | typ2 Op1 typ2 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ1l Op1l typ2 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ2 Op1 typ2 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ1l Op1l typ2 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ2 { $1 }
 typ1r:
-  | typ2 Op1 typ2 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ2 Op1r typ1r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ2 Op1 typ2 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ2 Op1r typ1r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ2 { $1 }
 
 typ2:
-  | typ3 Op2 typ3 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ2l Op2l typ3 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ3 Op2r typ2r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ3 Op2 typ3 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ2l Op2l typ3 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ3 Op2r typ2r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ3 { $1 }
 typ2l:
-  | typ3 Op2 typ3 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ2l Op2l typ3 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ3 Op2 typ3 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ2l Op2l typ3 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ3 { $1 }
 typ2r:
-  | typ3 Op2 typ3 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ3 Op2r typ2r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ3 Op2 typ3 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ3 Op2r typ2r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ3 { $1 }
 
 typ3:
-  | typ4 Op3 typ4 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ3l Op3l typ4 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ4 Op3r typ3r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ4 Op3 typ4 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ3l Op3l typ4 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ4 Op3r typ3r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ4 { $1 }
 typ3l:
-  | typ4 Op3 typ4 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ3l Op3l typ4 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ4 Op3 typ4 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ3l Op3l typ4 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ4 { $1 }
 typ3r:
-  | typ4 Op3 typ4 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ4 Op3r typ3r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ4 Op3 typ4 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ4 Op3r typ3r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ4 { $1 }
 
 typ4:
-  | typ5 Op4 typ5 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ4l Op4l typ5 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ5 Op4r typ4r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ5 Op4 typ5 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ4l Op4l typ5 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ5 Op4r typ4r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | lchain { desugar_lchain $1 $startpos $endpos }
   | rchain { desugar_rchain $1 $startpos $endpos }
   | typ5 { $1 }
 typ4l:
-  | typ5 Op4 typ5 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ4l Op4l typ5 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ5 Op4 typ5 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ4l Op4l typ5 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ5 { $1 }
 typ4r:
-  | typ5 Op4 typ5 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ5 Op4r typ4r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ5 Op4 typ5 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ5 Op4r typ4r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ5 { $1 }
 
 typ5:
   | typ6 In typ6 { mk_typ (ATyp_in ($1, $3)) $startpos $endpos }
-  | typ6 Op5 typ6 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ5l Op5l typ6 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ6 Op5r typ5r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ6 Op5 typ6 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ5l Op5l typ6 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ6 Op5r typ5r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ6 { $1 }
 typ5l:
-  | typ6 Op5 typ6 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ5l Op5l typ6 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ6 Op5 typ6 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ5l Op5l typ6 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ6 { $1 }
 typ5r:
-  | typ6 Op5 typ6 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ6 Op5r typ5 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ6 Op5 typ6 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ6 Op5r typ5 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ6 { $1 }
 
 typ6:
-  | typ7 Op6 typ7 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ6l Op6l typ7 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ7 Op6r typ6r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ7 Op6 typ7 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ6l Op6l typ7 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ7 Op6r typ6r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ6l Plus typ7 { mk_typ (ATyp_sum ($1, $3)) $startpos $endpos }
   | typ6l Minus typ7 { mk_typ (ATyp_minus ($1, $3)) $startpos $endpos }
   | typ7 { $1 }
 typ6l:
-  | typ7 Op6 typ7 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ6l Op6l typ7 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ7 Op6 typ7 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ6l Op6l typ7 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ6l Plus typ7 { mk_typ (ATyp_sum ($1, $3)) $startpos $endpos }
   | typ6l Minus typ7 { mk_typ (ATyp_minus ($1, $3)) $startpos $endpos }
   | typ7 { $1 }
 typ6r:
-  | typ7 Op6 typ7 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ7 Op6r typ6r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ7 Op6 typ7 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ7 Op6r typ6r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ7 { $1 }
 
 typ7:
-  | typ8 Op7 typ8 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ7l Op7l typ8 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ8 Op7r typ7r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ8 Op7 typ8 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ7l Op7l typ8 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ8 Op7r typ7r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ7l Star typ8 { mk_typ (ATyp_times ($1, $3)) $startpos $endpos }
   | typ8 { $1 }
 typ7l:
-  | typ8 Op7 typ8 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ7l Op7l typ8 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ8 Op7 typ8 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ7l Op7l typ8 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ7l Star typ8 { mk_typ (ATyp_times ($1, $3)) $startpos $endpos }
   | typ8 { $1 }
 typ7r:
-  | typ8 Op7 typ8 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ8 Op7r typ7r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ8 Op7 typ8 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ8 Op7r typ7r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | typ8 { $1 }
 
 typ8:
-  | typ9 Op8 typ9 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ8l Op8l typ9 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ9 Op8r typ8r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ9 Op8 typ9 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ8l Op8l typ9 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ9 Op8r typ8r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | TwoCaret typ9 { mk_typ (ATyp_exp $2) $startpos $endpos }
   | Minus typ9 { mk_typ (ATyp_neg $2) $startpos $endpos}
   | typ9 { $1 }
 typ8l:
-  | typ9 Op8 typ9 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ8l Op8l typ9 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ9 Op8 typ9 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ8l Op8l typ9 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | TwoCaret typ9 { mk_typ (ATyp_exp $2) $startpos $endpos }
   | Minus typ9 { mk_typ (ATyp_neg $2) $startpos $endpos}
   | typ9 { $1 }
 typ8r:
-  | typ9 Op8 typ9 { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ9 Op8r typ8r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | typ9 Op8 typ9 { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ9 Op8r typ8r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | TwoCaret typ9 { mk_typ (ATyp_exp $2) $startpos $endpos }
   | Minus typ9 { mk_typ (ATyp_neg $2) $startpos $endpos}
   | typ9 { $1 }
 
 typ9:
-  | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ9l Op9l atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | atomic_typ Op9r typ9r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ9l Op9l atomic_typ { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | atomic_typ Op9r typ9r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | atomic_typ { $1 }
 typ9l:
-  | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | typ9l Op9l atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | typ9l Op9l atomic_typ { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | atomic_typ { $1 }
 typ9r:
-  | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
-  | atomic_typ Op9r typ9r { mk_typ (ATyp_app (deinfix $2, [$1; $3])) $startpos $endpos }
+  | atomic_typ Op9 atomic_typ { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
+  | atomic_typ Op9r typ9r { mk_typ (ATyp_app ($2, [$1; $3])) $startpos $endpos }
   | atomic_typ { $1 }
 
 lchain:
@@ -318,10 +315,10 @@ exp3r:
 
 exp4:
   | exp5 Op4 exp5 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | exp5 Lt exp5 { mk_exp (E_app_infix ($1, mk_id (Id "<") $startpos($2) $endpos($2), $3)) $startpos $endpos }
-  | exp5 Gt exp5 { mk_exp (E_app_infix ($1, mk_id (Id ">") $startpos($2) $endpos($2), $3)) $startpos $endpos }
-  | exp5 LtEq exp5 { mk_exp (E_app_infix ($1, mk_id (Id "<=") $startpos($2) $endpos($2), $3)) $startpos $endpos }
-  | exp5 GtEq exp5 { mk_exp (E_app_infix ($1, mk_id (Id ">=") $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp5 Lt exp5 { mk_exp (E_app_infix ($1, mk_op "<" $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp5 Gt exp5 { mk_exp (E_app_infix ($1, mk_op ">" $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp5 LtEq exp5 { mk_exp (E_app_infix ($1, mk_op "<=" $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp5 GtEq exp5 { mk_exp (E_app_infix ($1, mk_op ">=" $startpos($2) $endpos($2), $3)) $startpos $endpos }
   | exp4l Op4l exp5 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp5 Op4r exp4r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp5 { $1 }
@@ -356,14 +353,14 @@ exp6:
   | exp7 Op6 exp7 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp6l Op6l exp7 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp7 Op6r exp6r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | exp6l Plus exp7 { mk_exp (E_app_infix ($1, mk_id (Id "+") $startpos($2) $endpos($2), $3)) $startpos $endpos }
-  | exp6l Minus exp7 { mk_exp (E_app_infix ($1, mk_id (Id "-") $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp6l Plus exp7 { mk_exp (E_app_infix ($1, mk_op "+" $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp6l Minus exp7 { mk_exp (E_app_infix ($1, mk_op "-" $startpos($2) $endpos($2), $3)) $startpos $endpos }
   | exp7 { $1 }
 exp6l:
   | exp7 Op6 exp7 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp6l Op6l exp7 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | exp6l Plus exp7 { mk_exp (E_app_infix ($1, mk_id (Id "+") $startpos($2) $endpos($2), $3)) $startpos $endpos }
-  | exp6l Minus exp7 { mk_exp (E_app_infix ($1, mk_id (Id "-") $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp6l Plus exp7 { mk_exp (E_app_infix ($1, mk_op "+" $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp6l Minus exp7 { mk_exp (E_app_infix ($1, mk_op "-" $startpos($2) $endpos($2), $3)) $startpos $endpos }
   | exp7 { $1 }
 exp6r:
   | exp7 Op6 exp7 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
@@ -374,12 +371,12 @@ exp7:
   | exp8 Op7 exp8 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp7l Op7l exp8 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp8 Op7r exp7r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | exp7l Star exp8 { mk_exp (E_app_infix ($1, mk_id (Id "*") $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp7l Star exp8 { mk_exp (E_app_infix ($1, mk_op "*" $startpos($2) $endpos($2), $3)) $startpos $endpos }
   | exp8 { $1 }
 exp7l:
   | exp8 Op7 exp8 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp7l Op7l exp8 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | exp7l Star exp8 { mk_exp (E_app_infix ($1, mk_id (Id "*") $startpos($2) $endpos($2), $3)) $startpos $endpos }
+  | exp7l Star exp8 { mk_exp (E_app_infix ($1, mk_op "*" $startpos($2) $endpos($2), $3)) $startpos $endpos }
   | exp8 { $1 }
 exp7r:
   | exp8 Op7 exp8 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
@@ -390,17 +387,17 @@ exp8:
   | exp9 Op8 exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp8l Op8l exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp9 Op8r exp8r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | TwoCaret exp9 { mk_exp (E_app (mk_id (Id "pow2") $startpos($1) $endpos($1), [$2])) $startpos $endpos }
+  | TwoCaret exp9 { mk_exp (E_app (mk_id "pow2" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
   | exp9 { $1 }
 exp8l:
   | exp9 Op8 exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp8l Op8l exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | TwoCaret exp9 { mk_exp (E_app (mk_id (Id "pow2") $startpos($1) $endpos($1), [$2])) $startpos $endpos }
+  | TwoCaret exp9 { mk_exp (E_app (mk_id "pow2" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
   | exp9 { $1 }
 exp8r:
   | exp9 Op8 exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp9 Op8r exp8r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
-  | TwoCaret exp9 { mk_exp (E_app (mk_id (Id "pow2") $startpos($1) $endpos($1), [$2])) $startpos $endpos }
+  | TwoCaret exp9 { mk_exp (E_app (mk_id "pow2" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
   | exp9 { $1 }
 
 exp9:

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -302,7 +302,7 @@ let parse_infix :
                | _ -> (
                    match StringMap.find_opt op ctx.fixities with
                    | Some (prec, level) ->
-                       let id = P.Id_aux (P.Id op, P.Range (s, e)) in
+                       let id = P.Id_aux (P.Operator op, P.Range (s, e)) in
                        (to_infix_parser_op (prec, level, id), s, e)
                    | None -> raise (Reporting.err_general (P.Range (s, e)) ("Undeclared fixity for operator " ^ op))
                  )
@@ -1461,9 +1461,9 @@ and to_ast_record_try ctx (P.E_aux (exp, l) : P.exp) : uannot fexp option * (l *
   match exp with
   | P.E_app_infix (left, op, r) -> (
       match (left, op) with
-      | P.E_aux (P.E_id id, li), P.Id_aux (P.Id "=", leq) ->
+      | P.E_aux (P.E_id id, li), P.Id_aux (P.Operator "=", leq) ->
           (Some (FE_aux (FE_fexp (to_ast_id ctx id, to_ast_exp ctx r), (l, empty_uannot))), None)
-      | P.E_aux (_, li), P.Id_aux (P.Id "=", leq) ->
+      | P.E_aux (_, li), P.Id_aux (P.Operator "=", leq) ->
           (None, Some (li, "Expected an identifier to begin this field assignment"))
       | P.E_aux (P.E_id id, li), P.Id_aux (_, leq) ->
           (None, Some (leq, "Expected a field assignment to be identifier = expression"))

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -1306,7 +1306,7 @@ module AtomToItself = struct
           E_aux
             ( E_app_infix
                 ( E_aux (E_app (mk_id "size_itself_int", [E_aux (E_id var, annot)]), annot),
-                  mk_id "==",
+                  mk_operator "==",
                   E_aux (E_lit lit, annot)
                 ),
               annot
@@ -1530,7 +1530,7 @@ module AtomToItself = struct
             let vars, new_guards = (List.concat vars, List.concat new_guards) in
             let body = List.fold_left (add_var_rebind true) body vars in
             let merge_guards g1 g2 : tannot exp =
-              E_aux (E_app_infix (g1, mk_id "&", g2), (Generated Unknown, empty_tannot))
+              E_aux (E_app_infix (g1, mk_operator "&", g2), (Generated Unknown, empty_tannot))
             in
             let guard =
               match (guard, new_guards) with
@@ -3194,7 +3194,7 @@ module MonoRewrites = struct
           | Some zlen ->
               (* Give the length explicitly rather than relying on the context;
                  it might not be sufficiently constrained. *)
-              let total = mk_exp (E_app_infix (zlen, mk_id "+", len1)) in
+              let total = mk_exp (E_app_infix (zlen, mk_operator "+", len1)) in
               try_cast_to_typ (mk_exp (E_app (mk_id "slice_mask", [total; zlen; len1])))
           | None -> E_app (id, args)
         end
@@ -3205,7 +3205,7 @@ module MonoRewrites = struct
               (* Give the length explicitly rather than relying on the context;
                  it might not be sufficiently constrained. *)
               let len1 = mk_exp (E_lit (L_aux (L_num (Nat_big_num.of_int (String.length lit)), Unknown))) in
-              let total = mk_exp (E_app_infix (zlen, mk_id "+", len1)) in
+              let total = mk_exp (E_app_infix (zlen, mk_operator "+", len1)) in
               try_cast_to_typ (mk_exp (E_app (mk_id "slice_mask", [total; zlen; len1])))
           | None -> E_app (id, args)
         end
@@ -3217,7 +3217,7 @@ module MonoRewrites = struct
           | Some zlen ->
               (* Give the length explicitly rather than relying on the context;
                  it might not be sufficiently constrained. *)
-              let total = mk_exp (E_app_infix (zlen, mk_id "+", len2)) in
+              let total = mk_exp (E_app_infix (zlen, mk_operator "+", len2)) in
               let zero = mk_exp (E_lit (mk_lit (L_num Nat_big_num.zero))) in
               try_cast_to_typ (mk_exp (E_app (mk_id "slice_mask", [total; zero; len2])))
           | None -> E_app (id, args)
@@ -3229,7 +3229,7 @@ module MonoRewrites = struct
               (* Give the length explicitly rather than relying on the context;
                  it might not be sufficiently constrained. *)
               let len2 = mk_exp (E_lit (L_aux (L_num (Nat_big_num.of_int (String.length lit)), Unknown))) in
-              let total = mk_exp (E_app_infix (zlen, mk_id "+", len2)) in
+              let total = mk_exp (E_app_infix (zlen, mk_operator "+", len2)) in
               let zero = mk_exp (E_lit (mk_lit (L_num Nat_big_num.zero))) in
               try_cast_to_typ (mk_exp (E_app (mk_id "slice_mask", [total; zero; len2])))
           | None -> E_app (id, args)
@@ -3239,14 +3239,14 @@ module MonoRewrites = struct
         ->
           let one = mk_exp (E_lit (mk_lit (L_num (Big_int.of_int 1)))) in
           let len2 = mk_exp (E_app (mk_id "length", [vector2])) in
-          let total = mk_exp (E_app_infix (len1, mk_id "+", len2)) in
+          let total = mk_exp (E_app_infix (len1, mk_operator "+", len2)) in
           try_cast_to_typ
             (E_aux
                ( E_app
                    ( mk_id "update_subrange_bits",
                      [
                        E_aux (E_app (ones1, [total]), (Unknown, empty_tannot));
-                       mk_exp (E_app_infix (len2, mk_id "-", one));
+                       mk_exp (E_app_infix (len2, mk_operator "-", one));
                        mk_exp (E_lit (mk_lit (L_num Big_int.zero)));
                        vector2;
                      ]
@@ -3291,7 +3291,7 @@ module MonoRewrites = struct
           let one = mk_exp (E_lit (mk_lit (L_num (Big_int.of_int 1)))) in
           let length2 = mk_exp (E_app (mk_id "length", [vector2])) in
           let indices2 =
-            if is_subrange op then [mk_exp (E_app_infix (length2, mk_id "-", one)); zero] else [zero; length2]
+            if is_subrange op then [mk_exp (E_app_infix (length2, mk_operator "-", one)); zero] else [zero; length2]
           in
           try_cast_to_typ
             (E_aux (E_app (mk_id op', [vector1; start1; length1; vector2] @ indices2), (Unknown, empty_tannot)))
@@ -3388,8 +3388,8 @@ module MonoRewrites = struct
             mk_exp
               (E_app_infix
                  ( start,
-                   mk_id "+",
-                   mk_exp (E_app_infix (len, mk_id "-", mk_exp (E_lit (mk_lit (L_num (Big_int.of_int 1))))))
+                   mk_operator "+",
+                   mk_exp (E_app_infix (len, mk_operator "-", mk_exp (E_lit (mk_lit (L_num (Big_int.of_int 1))))))
                  )
               )
           in
@@ -3719,10 +3719,10 @@ module MonoRewrites = struct
         let new_annot = (Generated l, empty_tannot) in
         let vector = List.find (fun exp -> is_bitvector_typ (typ_of exp)) zero_extend_args in
         let len = E_aux (E_app (mk_id "length", [vector]), new_annot) in
-        let mid_point_high = E_aux (E_app_infix (end1, mk_id "+", len), new_annot) in
+        let mid_point_high = E_aux (E_app_infix (end1, mk_operator "+", len), new_annot) in
         let mid_point_low =
           E_aux
-            ( E_app_infix (mid_point_high, mk_id "-", E_aux (E_lit (mk_lit (L_num (Big_int.of_int 1))), new_annot)),
+            ( E_app_infix (mid_point_high, mk_operator "-", E_aux (E_lit (mk_lit (L_num (Big_int.of_int 1))), new_annot)),
               new_annot
             )
         in

--- a/src/lib/nl_flow.ml
+++ b/src/lib/nl_flow.ml
@@ -86,11 +86,15 @@ let modify_unsigned id value (E_aux (aux, annot) as exp) =
       | Some uid ->
           E_aux
             ( E_let
-                (lb, add_assert (mk_exp (E_app_infix (mk_exp (E_id uid), mk_id "!=", mk_lit_exp (L_num value)))) exp'),
+                ( lb,
+                  add_assert (mk_exp (E_app_infix (mk_exp (E_id uid), mk_operator "!=", mk_lit_exp (L_num value)))) exp'
+                ),
               annot
             )
     end
   | _ -> exp
+
+let is_equals = function Id_aux (Operator "==", _) -> true | _ -> false
 
 let analyze' exps =
   match exps with
@@ -98,7 +102,7 @@ let analyze' exps =
       match cond with
       | E_aux (E_app_infix (E_aux (E_id id, _), op, E_aux (E_lit lit, _)), _)
       | E_aux (E_app_infix (E_aux (E_lit lit, _), op, E_aux (E_id id, _)), _)
-        when string_of_id op = "==" && is_bitvector_literal lit ->
+        when is_equals op && is_bitvector_literal lit ->
           let value = bitvector_unsigned lit in
           List.map (modify_unsigned id value) exps
       | _ -> exps

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -88,16 +88,14 @@ let simp_infix_typ = function
   | ATyp_aux (ATyp_infix [(IT_primary typ, _, _)], _) -> typ
   | typ -> typ
 
-let rec same_pat_ops (Id_aux (_, l) as op) = function
-  | ((Id_aux (_, l') as op'), _) :: ops ->
-     if string_of_id op = string_of_id op' then
-       same_pat_ops op ops
+let rec same_pat_ops op l = function
+  | (op', l', _) :: ops ->
+     if op = op' then
+       same_pat_ops op l ops
      else
        raise (Reporting.err_syntax_loc
-                (Parse_ast.Hint (string_of_id op ^ " here", l, l'))
-                (Printf.sprintf "Use parenthesis to group operators in pattern. Operators %s and %s found at same level."
-                                (string_of_id op)
-                                (string_of_id op')))
+                (Parse_ast.Hint (op ^ " here", l, l'))
+                (Printf.sprintf "Use parenthesis to group operators in pattern. Operators %s and %s found at same level." op op'))
   | [] -> ()
 
 let mk_typ t n m = ATyp_aux (t, loc n m)
@@ -298,9 +296,9 @@ exp_op:
   | Star       { "*" }
 
 pat_op:
-  | At         { mk_id (Id "@") $startpos $endpos }
-  | ColonColon { mk_id (Id "::") $startpos $endpos }
-  | Caret      { mk_id (Id "^") $startpos $endpos }
+  | At         { "@" }
+  | ColonColon { "::" }
+  | Caret      { "^" }
 
 id_list:
   | id
@@ -488,26 +486,26 @@ typschm_eof:
     { $1 }
 
 pat1:
-  | p = atomic_pat; ps = list(op = pat_op; q = atomic_pat { (op, q) })
+  | p = atomic_pat; ps = list(op = pat_op; q = atomic_pat { (op, loc $startpos(op) $endpos(op), q) })
     { match ps with
       | [] -> p
-      | (op, _) :: rest ->
-         same_pat_ops op rest;
-         match string_of_id op with
+      | (op, l, _) :: rest ->
+         same_pat_ops op l rest;
+         match op with
          | "@" ->
-            mk_pat (P_vector_concat (p :: List.map snd ps)) $startpos $endpos
+            mk_pat (P_vector_concat (p :: List.map (fun (_, _, x) -> x) ps)) $startpos $endpos
          | "::" ->
             let rec cons_list = function
-              | [(_, x)] -> x
-              | ((_, x) :: xs) -> mk_pat (P_cons (x, cons_list xs)) (first_pat_range $startpos x) $endpos
+              | [(_, _, x)] -> x
+              | ((_, _, x) :: xs) -> mk_pat (P_cons (x, cons_list xs)) (first_pat_range $startpos x) $endpos
               | _ -> assert false in
             mk_pat (P_cons (p, cons_list ps)) $startpos $endpos
          | "^" ->
-            mk_pat (P_string_append (p :: List.map snd ps)) $startpos $endpos
+            mk_pat (P_string_append (p :: List.map (fun (_, _, x) -> x) ps)) $startpos $endpos
          | _ ->
             raise (Reporting.err_syntax_loc
                      (loc $startpos $endpos)
-                     ("Unrecognised operator " ^ string_of_id op ^ " in pattern."))
+                     ("Unrecognised operator " ^ op ^ " in pattern."))
     }
 
 pat:
@@ -1086,26 +1084,25 @@ fun_def_list:
     { $1 :: $2 }
 
 mpat:
-  | p = atomic_mpat; ps = list(op = pat_op; q = atomic_mpat { (op, q) })
+  | p = atomic_mpat; ps = list(op = pat_op; q = atomic_mpat { (op, loc $startpos(op) $endpos(op), q) })
     { match ps with
       | [] -> p
-      | (op, _) :: rest ->
-         same_pat_ops op rest;
-         match string_of_id op with
+      | (op, l, _) :: rest ->
+         same_pat_ops op l rest;
+         match op with
          | "@" ->
-            mk_mpat (MP_vector_concat (p :: List.map snd ps)) $startpos $endpos
+            mk_mpat (MP_vector_concat (p :: List.map (fun (_, _, x) -> x) ps)) $startpos $endpos
          | "::" ->
             let rec cons_list = function
-              | [(_, x)] -> x
-              | ((_, x) :: xs) -> mk_mpat (MP_cons (x, cons_list xs)) (first_mpat_range $startpos x) $endpos
+              | [(_, _, x)] -> x
+              | ((_, _, x) :: xs) -> mk_mpat (MP_cons (x, cons_list xs)) (first_mpat_range $startpos x) $endpos
               | _ -> assert false in
             mk_mpat (MP_cons (p, cons_list ps)) $startpos $endpos
          | "^" ->
-            mk_mpat (MP_string_append (p :: List.map snd ps)) $startpos $endpos
+            mk_mpat (MP_string_append (p :: List.map (fun (_, _, x) -> x) ps)) $startpos $endpos
          | _ ->
-            raise (Reporting.err_syntax_loc
-                     (loc $startpos $endpos)
-                     ("Unrecognised operator " ^ string_of_id op ^ " in mapping pattern."))
+            let l = loc $startpos $endpos in
+            raise (Reporting.err_syntax_loc l ("Unrecognised operator " ^ op ^ " in mapping pattern."))
     }
   | p = atomic_mpat; As; id = id
     { mk_mpat (MP_as (p, id)) $startpos $endpos }

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -800,9 +800,9 @@ atomic_exp:
 
 fexp_exp:
   | atomic_exp Eq exp
-    { mk_exp (E_app_infix ($1, mk_id (Id "=") $startpos($2) $endpos($2), $3)) $startpos $endpos }
+    { mk_exp (E_app_infix ($1, mk_id (Operator "=") $startpos($2) $endpos($2), $3)) $startpos $endpos }
   | id
-    { mk_exp (E_app_infix (mk_exp (E_id $1) $startpos $endpos, mk_id (Id "=") $startpos $endpos, mk_exp (E_id $1) $startpos $endpos)) $startpos $endpos }
+    { mk_exp (E_app_infix (mk_exp (E_id $1) $startpos $endpos, mk_id (Operator "=") $startpos $endpos, mk_exp (E_id $1) $startpos $endpos)) $startpos $endpos }
 
 fexp_exp_list:
   | fexp_exp

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -337,20 +337,20 @@ module Printer (Config : PRINT_CONFIG) = struct
         (fun r (x, y) -> Bindings.add x y r)
         Bindings.empty
         [
-          (mk_id "^", (InfixR, 8));
-          (mk_id "*", (InfixL, 7));
-          (mk_id "/", (InfixL, 7));
-          (mk_id "%", (InfixL, 7));
-          (mk_id "+", (InfixL, 6));
-          (mk_id "-", (InfixL, 6));
-          (mk_id "!=", (Infix, 4));
-          (mk_id ">", (Infix, 4));
-          (mk_id "<", (Infix, 4));
-          (mk_id ">=", (Infix, 4));
-          (mk_id "<=", (Infix, 4));
-          (mk_id "==", (Infix, 4));
-          (mk_id "&", (InfixR, 3));
-          (mk_id "|", (InfixR, 2));
+          (mk_operator "^", (InfixR, 8));
+          (mk_operator "*", (InfixL, 7));
+          (mk_operator "/", (InfixL, 7));
+          (mk_operator "%", (InfixL, 7));
+          (mk_operator "+", (InfixL, 6));
+          (mk_operator "-", (InfixL, 6));
+          (mk_operator "!=", (Infix, 4));
+          (mk_operator ">", (Infix, 4));
+          (mk_operator "<", (Infix, 4));
+          (mk_operator ">=", (Infix, 4));
+          (mk_operator "<=", (Infix, 4));
+          (mk_operator "==", (Infix, 4));
+          (mk_operator "&", (InfixR, 3));
+          (mk_operator "|", (InfixR, 2));
         ]
     in
     ref (fixities' : (prec * int) Bindings.t)
@@ -502,7 +502,7 @@ module Printer (Config : PRINT_CONFIG) = struct
         | Some (name, false), _ ->
             handle_setter (mk_id name) (lazy (doc_exp (E_aux (E_app (mk_id name, exps), (l, uannot)))))
         | None, [x; y] when Config.resugar && match id with Id_aux (Operator _, _) -> true | _ -> false ->
-            doc_exp (E_aux (E_app_infix (x, infix_swap id, y), (l, uannot)))
+            doc_exp (E_aux (E_app_infix (x, id, y), (l, uannot)))
         | None, [v; n] when Config.resugar && Id.compare id (mk_id "vector_access") = 0 ->
             doc_atomic_exp v ^^ char '[' ^^ doc_exp n ^^ char ']'
         | None, [v; n; m] when Config.resugar && Id.compare id (mk_id "vector_subrange") = 0 ->

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -1378,7 +1378,7 @@ let rewrite_ast_remove_numeral_pats env =
     | L_aux (L_num n, l) ->
         let id = fresh_id "l__" Parse_ast.Unknown in
         let typ = atom_typ (nconstant n) in
-        let guard = mk_exp (E_app_infix (mk_exp (E_id id), mk_id "==", mk_lit_exp (L_num n))) in
+        let guard = mk_exp (E_app_infix (mk_exp (E_id id), mk_operator "==", mk_lit_exp (L_num n))) in
         (* Check expression in reasonable approx of environment to resolve overriding *)
         let env = Env.add_local id (Immutable, typ) outer_env in
         let checked_guard = check_exp env guard bool_typ in
@@ -2128,12 +2128,12 @@ let rewrite_vector_concat_assignments env defs =
   let sub m n =
     match (m, n) with
     | E_aux (E_lit (L_aux (L_num m, _)), _), E_aux (E_lit (L_aux (L_num n, _)), _) -> lit_int (Big_int.sub m n)
-    | _, _ -> mk_exp (E_app_infix (m, mk_id "-", n))
+    | _, _ -> mk_exp (E_app_infix (m, mk_operator "-", n))
   in
   let add m n =
     match (m, n) with
     | E_aux (E_lit (L_aux (L_num m, _)), _), E_aux (E_lit (L_aux (L_num n, _)), _) -> lit_int (Big_int.add m n)
-    | _, _ -> mk_exp (E_app_infix (m, mk_id "+", n))
+    | _, _ -> mk_exp (E_app_infix (m, mk_operator "+", n))
   in
 
   let assign_tuple e_aux annot =
@@ -2604,7 +2604,7 @@ let rewrite_ast_pat_lits rewrite_lit env ast =
           let env = env_of_annot p_annot in
           let typ = typ_of_annot p_annot in
           let id = mk_id ("p" ^ string_of_int !counter ^ "#") in
-          let guard = mk_exp (E_app_infix (mk_exp (E_id id), mk_id "==", mk_exp (E_lit lit))) in
+          let guard = mk_exp (E_app_infix (mk_exp (E_id id), mk_operator "==", mk_exp (E_lit lit))) in
           let guard = check_exp (Env.add_local id (Immutable, typ) env) guard bool_typ in
           guards := guard :: !guards;
           incr counter;
@@ -3175,9 +3175,13 @@ let rewrite_ast_not_pats env =
             let guard_exp =
               match (orig_guard, guards) with
               | Some guard, _ ->
-                  List.fold_left (fun exp1 (_, _, exp2) -> mk_exp (E_app_infix (exp1, mk_id "&", exp2))) guard guards
+                  List.fold_left
+                    (fun exp1 (_, _, exp2) -> mk_exp (E_app_infix (exp1, mk_operator "&", exp2)))
+                    guard guards
               | None, (_, _, guard) :: guards ->
-                  List.fold_left (fun exp1 (_, _, exp2) -> mk_exp (E_app_infix (exp1, mk_id "&", exp2))) guard guards
+                  List.fold_left
+                    (fun exp1 (_, _, exp2) -> mk_exp (E_app_infix (exp1, mk_operator "&", exp2)))
+                    guard guards
               | _ ->
                   raise
                     (Reporting.err_unreachable (fst annot) __POS__

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1233,15 +1233,17 @@ and rewrite_arg l env = function
   | A_aux (A_bool nc, _) -> rewrite_nc env nc
   | A_aux (A_typ typ, _) -> Reporting.unreachable l __POS__ "Found Type-kinded parameter during sizeof rewriting"
 
-and rewrite_nc_aux l env = function
-  | NC_ge (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, mk_id ">=", rewrite_sizeof l env n2)
-  | NC_gt (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, mk_id ">", rewrite_sizeof l env n2)
-  | NC_le (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, mk_id "<=", rewrite_sizeof l env n2)
-  | NC_lt (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, mk_id "<", rewrite_sizeof l env n2)
-  | NC_equal (arg1, arg2) -> E_app_infix (rewrite_arg l env arg1, mk_id "==", rewrite_arg l env arg2)
-  | NC_not_equal (arg1, arg2) -> E_app_infix (rewrite_arg l env arg1, mk_id "!=", rewrite_arg l env arg2)
-  | NC_and (nc1, nc2) -> E_app_infix (rewrite_nc env nc1, mk_id "&", rewrite_nc env nc2)
-  | NC_or (nc1, nc2) -> E_app_infix (rewrite_nc env nc1, mk_id "|", rewrite_nc env nc2)
+and rewrite_nc_aux l env =
+  let op s = Id_aux (Operator s, l) in
+  function
+  | NC_ge (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, op ">=", rewrite_sizeof l env n2)
+  | NC_gt (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, op ">", rewrite_sizeof l env n2)
+  | NC_le (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, op "<=", rewrite_sizeof l env n2)
+  | NC_lt (n1, n2) -> E_app_infix (rewrite_sizeof l env n1, op "<", rewrite_sizeof l env n2)
+  | NC_equal (arg1, arg2) -> E_app_infix (rewrite_arg l env arg1, op "==", rewrite_arg l env arg2)
+  | NC_not_equal (arg1, arg2) -> E_app_infix (rewrite_arg l env arg1, op "!=", rewrite_arg l env arg2)
+  | NC_and (nc1, nc2) -> E_app_infix (rewrite_nc env nc1, op "&", rewrite_nc env nc2)
+  | NC_or (nc1, nc2) -> E_app_infix (rewrite_nc env nc1, op "|", rewrite_nc env nc2)
   | NC_false -> E_lit (mk_lit L_false)
   | NC_true -> E_lit (mk_lit L_true)
   | NC_set (_, []) -> E_lit (mk_lit L_false)
@@ -1807,7 +1809,7 @@ let rec build_overload_tree env f xs annot =
 
 and build_overload_tree_arg env (E_aux (aux, annot) as exp) =
   match aux with
-  | E_app_infix (x, op, y) when Env.is_overload (deinfix op) env -> build_overload_tree env (deinfix op) [x; y] annot
+  | E_app_infix (x, op, y) when Env.is_overload op env -> build_overload_tree env op [x; y] annot
   | E_app (f, xs) when Env.is_overload f env -> build_overload_tree env f xs annot
   | E_id v -> begin
       match Env.lookup_id v env with
@@ -2261,7 +2263,7 @@ let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_au
     end
   | E_vector_append (v1, E_aux (E_vector [], _)), _ -> check_exp env v1 typ
   | E_vector_append (v1, v2), _ -> check_exp env (E_aux (E_app (mk_id "append", [v1; v2]), (l, uannot))) typ
-  | E_app_infix (x, op, y), _ -> check_exp env (E_aux (E_app (deinfix op, [x; y]), (l, uannot))) typ
+  | E_app_infix (x, op, y), _ -> check_exp env (E_aux (E_app (op, [x; y]), (l, uannot))) typ
   | E_app (f, [E_aux (E_constraint nc, _)]), _ when string_of_id f = "_prove" ->
       Env.wf_constraint ~at:l env nc;
       if prove __POS__ env nc then annot_exp (E_lit (L_aux (L_unit, Parse_ast.Unknown))) unit_typ
@@ -2701,7 +2703,7 @@ and check_case env pat_typ pexp typ =
         | Some (h, t) ->
             Some
               (List.fold_left
-                 (fun acc guard -> mk_exp ~loc:(hint_loc (exp_loc guard)) (E_app_infix (acc, mk_id "&", guard)))
+                 (fun acc guard -> mk_exp ~loc:(hint_loc (exp_loc guard)) (E_app_infix (acc, mk_operator "&", guard)))
                  h t
               )
         | None -> None
@@ -2719,9 +2721,9 @@ and check_case env pat_typ pexp typ =
   | exception (Type_error _ as typ_exn) -> (
       match pat with
       | P_aux (P_lit lit, (l, _)) ->
-          let guard' = mk_exp (E_app_infix (mk_exp (E_id (mk_id "p#")), mk_id "==", mk_exp (E_lit lit))) in
+          let guard' = mk_exp (E_app_infix (mk_exp (E_id (mk_id "p#")), mk_operator "==", mk_exp (E_lit lit))) in
           let guard =
-            match guard with None -> guard' | Some guard -> mk_exp (E_app_infix (guard, mk_id "&", guard'))
+            match guard with None -> guard' | Some guard -> mk_exp (E_app_infix (guard, mk_operator "&", guard'))
           in
           check_case env pat_typ (Pat_aux (Pat_when (mk_pat ~loc:l (P_id (mk_id "p#")), guard, case), (l, uannot))) typ
       | _ -> raise typ_exn
@@ -2736,7 +2738,7 @@ and check_mpexp other_env env mpexp typ =
       in
       let guard =
         match guard with
-        | Some (h, t) -> Some (List.fold_left (fun acc guard -> mk_exp (E_app_infix (acc, mk_id "&", guard))) h t)
+        | Some (h, t) -> Some (List.fold_left (fun acc guard -> mk_exp (E_app_infix (acc, mk_operator "&", guard))) h t)
         | None -> None
       in
       let checked_guard, _ =
@@ -3016,7 +3018,7 @@ and bind_pat env (P_aux (pat_aux, (l, uannot)) as pat) typ =
           | P_lit lit ->
               let var = fresh_var () in
               let guard =
-                locate (fun _ -> l) (mk_exp (E_app_infix (mk_exp (E_id var), mk_id "==", mk_exp (E_lit lit))))
+                locate (fun _ -> l) (mk_exp (E_app_infix (mk_exp (E_id var), mk_operator "==", mk_exp (E_lit lit))))
               in
               let typed_pat, env, guards = bind_pat env (mk_pat ~loc:l (P_id var)) typ in
               (typed_pat, env, guard :: guards)
@@ -3703,7 +3705,7 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
   | E_typ (typ, exp) ->
       let checked_exp = crule check_exp env exp typ in
       annot_exp (E_typ (typ, checked_exp)) typ
-  | E_app_infix (x, op, y) -> infer_exp env (E_aux (E_app (deinfix op, [x; y]), (l, uannot)))
+  | E_app_infix (x, op, y) -> infer_exp env (E_aux (E_app (op, [x; y]), (l, uannot)))
   (* Treat a multiple argument constructor as a single argument constructor taking a tuple, Ctor(x, y) -> Ctor((x, y)). *)
   | E_app (ctor, x :: y :: zs) when Env.is_union_constructor ctor env ->
       typ_print (lazy ("Inferring multiple argument constructor: " ^ string_of_id ctor));
@@ -4435,7 +4437,7 @@ and bind_mpat allow_unknown other_env env (MP_aux (mpat_aux, (l, uannot)) as mpa
           match mpat_aux with
           | MP_lit lit ->
               let var = fresh_var () in
-              let guard = mk_exp ~loc:l (E_app_infix (mk_exp (E_id var), mk_id "==", mk_exp (E_lit lit))) in
+              let guard = mk_exp ~loc:l (E_app_infix (mk_exp (E_id var), mk_operator "==", mk_exp (E_lit lit))) in
               let typed_mpat, env, guards = bind_mpat allow_unknown other_env env (mk_mpat (MP_id var)) typ in
               (typed_mpat, env, guard :: guards)
           | _ -> raise typ_exn

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -1113,7 +1113,7 @@ let doc_exp_lem, doc_let_lem =
     | E_throw e -> align (liftR (separate space [string "throw"; expY e]))
     | E_exit e -> liftR (separate space [string "exit"; expY e])
     | E_assert (e1, e2) -> align (liftR (separate space [string "assert_exp"; expY e1; expY e2]))
-    | E_app_infix (e1, id, e2) -> expV aexp_needed (E_aux (E_app (deinfix id, [e1; e2]), (l, annot)))
+    | E_app_infix (e1, id, e2) -> expV aexp_needed (E_aux (E_app (id, [e1; e2]), (l, annot)))
     | E_var (lexp, eq_exp, in_exp) -> raise (report l __POS__ "E_vars should have been removed before pretty-printing")
     | E_internal_plet (pat, e1, e2) ->
         let bind, bind_unit = if ctxt.monadic then (">>=", ">>") else (">>$=", ">>$") in


### PR DESCRIPTION
Change how operators are represented internally.

- Previously `Id x` was always used for identifiers in their 'normal' positions so in `x ++ y`, the `++` would be `Id "++"` if changed to the non-infix form `operator ++(x, y)`, or in a declaration `val operator ++ : ...` it would be `Operator "++"` (mimicking the keyword).

- Now the Operator constructor is used for anything that is syntactically an operator, irrespective of where it is, and `Id` is always used for regular non-operator identifiers.

Technically with this change we could scrap the distinction between `Id` and `Operator` entirely, but that would mean we would have to inspect the contents of the string to distinguish infix operators from regular identifiers.