### PR TITLE
Deprecate --generate-header flag (always generate the header)

### DIFF
--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -939,20 +939,18 @@ let valid_c_identifier = mk_regexp_check "^[A-Za-z_][A-Za-z0-9_]*$"
 let c_int_type_name = mk_regexp_check "^[u]?int[0-9]+_t$"
 
 (* The code generator produces a list of C definitions, some of
-   which should be in the header (if we generate one), and some in
+   which should be in the header, and some in
    the implementation. There are also definitions that are only
    included in the header provided we generate one.
 
-   * Header - goes in header, or implemention if no header generated
-   * HeaderOnly - goes in header, omitted if no header generated
+   * Header - goes in header
    * Impl - goes in implemention
 *)
-type file_doc = Header of document | HeaderOnly of document | Impl of document
+type file_doc = Header of document | Impl of document
 
 let to_impl doc = [Impl doc]
 
 module type CODEGEN_CONFIG = sig
-  val generate_header : bool
   val includes : string list
   val header_includes : string list
   val no_main : bool
@@ -1600,7 +1598,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
               )
         in
         [
-          HeaderOnly setter_prototype;
+          Header setter_prototype;
           Impl (ksprintf string "%s %s;" (sgen_ctyp ctyp) (NameGen.to_string ~prefix:"abstract_" () id));
           Impl setter;
         ]
@@ -1813,11 +1811,11 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         @
         if string_of_id id = "exception" then
           [
-            HeaderOnly (ksprintf string "extern struct %s *current_exception;" (sgen_id id));
+            Header (ksprintf string "extern struct %s *current_exception;" (sgen_id id));
             Impl (ksprintf string "struct %s *current_exception = NULL;" (sgen_id id));
-            HeaderOnly (string "extern bool have_exception;");
+            Header (string "extern bool have_exception;");
             Impl (string "bool have_exception = false;");
-            HeaderOnly (string "extern sail_string *throw_location;");
+            Header (string "extern sail_string *throw_location;");
             Impl (string "sail_string *throw_location = NULL;");
           ]
         else []
@@ -2167,7 +2165,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     match aux with
     | CDEF_register (id, ctyp, _) ->
         [
-          HeaderOnly
+          Header
             (string (Printf.sprintf "// register %s" (string_of_name id))
             ^^ hardline
             ^^ string (Printf.sprintf "extern %s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_name id))
@@ -2313,23 +2311,15 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
     | CTG_tup ctyps -> codegen_tup ctx ctyps
     | CTG_list ctyp -> codegen_list ctx ctyp
 
+  (* Take a single list of `Header doc` and `Impl doc`s, and extract them
+     into two lists - one for the header `doc`s and one for the impl `doc`s. *)
   let merge_file_docs docs =
-    let rec no_header impl = function
-      | [] -> impl
-      | Header doc :: docs -> no_header (impl ^^ doc ^^ twice hardline) docs
-      | HeaderOnly _ :: docs -> no_header impl docs
-      | Impl doc :: docs -> no_header (impl ^^ doc ^^ twice hardline) docs
-    in
-    let rec with_header hdr impl = function
+    let rec collect_file_docs hdr impl = function
       | [] -> (hdr, impl)
-      | (Header doc | HeaderOnly doc) :: docs -> with_header (hdr ^^ doc ^^ twice hardline) impl docs
-      | Impl doc :: docs -> with_header hdr (impl ^^ doc ^^ twice hardline) docs
+      | Header doc :: docs -> collect_file_docs (hdr ^^ doc ^^ twice hardline) impl docs
+      | Impl doc :: docs -> collect_file_docs hdr (impl ^^ doc ^^ twice hardline) docs
     in
-    if not Config.generate_header then (None, no_header empty docs)
-    else (
-      let hdr, impl = with_header empty empty docs in
-      (Some hdr, impl)
-    )
+    collect_file_docs empty empty docs
 
   (** When we generate code for a definition, we need to first generate any auxillary type definitions that are
       required. *)
@@ -2410,7 +2400,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
          some value < 256 (100 seems reasonable). *)
       let cdefs = List.map (Jib_optimize.flatten_cdef ~max_depth:100) cdefs in
 
-      let header_doc_opt, docs = List.map (codegen_def ctx) cdefs |> List.concat |> merge_file_docs in
+      let header_doc, docs = List.map (codegen_def ctx) cdefs |> List.concat |> merge_file_docs in
 
       let coverage_include, coverage_hook_header, coverage_hook =
         let header = string "#include \"sail_coverage.h\"" in
@@ -2613,17 +2603,13 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       let hlhl = twice hardline in
 
       let header =
-        Option.map
-          (fun header ->
-            string "#pragma once" ^^ hlhl ^^ preamble true ^^ hlhl ^^ header ^^ hardline ^^ end_extern_cpp ^^ hardline
-            |> Document.to_string
-          )
-          header_doc_opt
+        string "#pragma once" ^^ hlhl ^^ preamble true ^^ hlhl ^^ header_doc ^^ hardline ^^ end_extern_cpp ^^ hardline
+        |> Document.to_string
       in
       ( header,
         Document.to_string
-          (preamble false
-          ^^ (if Config.generate_header then hardline ^^ Printf.ksprintf string "#include \"%s.h\"" basename else empty)
+          (preamble false ^^ hardline
+          ^^ Printf.ksprintf string "#include \"%s.h\"" basename
           ^^ hlhl ^^ docs ^^ hlhl
           ^^ ( if not Config.no_rts then
                  model_init ^^ hlhl ^^ model_fini ^^ hlhl ^^ model_pre_exit ^^ hlhl ^^ model_main ^^ hlhl

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -80,14 +80,10 @@ val optimize_fixed_int : bool ref
 val optimize_fixed_bits : bool ref
 
 module type CODEGEN_CONFIG = sig
-  (** If this is true, then we will generate a separate header file, otherwise a single C file will be generated without
-      a header file. *)
-  val generate_header : bool
-
   (** A list of includes for the generated C file *)
   val includes : string list
 
-  (** A list of includes for the generated header (if it is created). *)
+  (** A list of includes for the generated header. *)
   val header_includes : string list
 
   (** Do not generate a main function *)
@@ -118,5 +114,5 @@ end
 
 module Codegen (Config : CODEGEN_CONFIG) : sig
   val jib_of_ast : Env.t -> Effects.side_effect_info -> typed_ast -> cdef list * Jib_compile.ctx
-  val compile_ast : Env.t -> Effects.side_effect_info -> string -> typed_ast -> string option * string
+  val compile_ast : Env.t -> Effects.side_effect_info -> string -> typed_ast -> string * string
 end

--- a/src/sail_c_backend/sail_plugin_c.ml
+++ b/src/sail_c_backend/sail_plugin_c.ml
@@ -84,7 +84,8 @@ let c_options =
       Arg.String (fun prefix -> C_backend.opt_prefix := prefix),
       "prefix generated C functions"
     );
-    (Flag.create ~prefix:["c"] "generate_header", Arg.Set opt_generate_header, "generate a separate header file");
+    (* This flag is deprecated and will be removed in future. A header is always generated. *)
+    (Flag.create ~prefix:["c"] "generate_header", Arg.Set opt_generate_header, "");
     ( Flag.create ~prefix:["c"] ~arg:"parameters" "extra_params",
       Arg.String (fun params -> C_backend.opt_extra_params := Some params),
       "generate C functions with additional parameters"
@@ -191,7 +192,6 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
   let reserveds, overrides = collect_c_name_info ast in
 
   let module Codegen = C_backend.Codegen (struct
-    let generate_header = !opt_generate_header
     let includes = !opt_includes_c
     let header_includes = !opt_includes_h
     let no_main = !opt_no_main
@@ -205,24 +205,25 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
     let preserve_types = !opt_preserve_types
   end) in
   Reporting.opt_warnings := true;
+
+  if !opt_generate_header then
+    Reporting.warn "Deprecated" Parse_ast.Unknown
+      "--c-generate-header is deprecated and has no effect; headers are now always generated";
+
   let echo_output, out_file = match out_file with Some f -> (false, f) | None -> (true, "out") in
   let basename = Filename.basename out_file in
 
-  let header_opt, impl = Codegen.compile_ast env effect_info basename ast in
+  let header, impl = Codegen.compile_ast env effect_info basename ast in
 
   let impl_out = Util.open_output_with_check (out_file ^ ".c") in
   output_string impl_out.channel impl;
   flush impl_out.channel;
   Util.close_output_with_check impl_out;
 
-  ( match header_opt with
-  | None -> ()
-  | Some header ->
-      let header_out = Util.open_output_with_check (out_file ^ ".h") in
-      output_string header_out.channel header;
-      flush header_out.channel;
-      Util.close_output_with_check header_out
-  );
+  let header_out = Util.open_output_with_check (out_file ^ ".h") in
+  output_string header_out.channel header;
+  flush header_out.channel;
+  Util.close_output_with_check header_out;
 
   if echo_output then (
     Reporting.warn "Deprecated" Parse_ast.Unknown

--- a/test/c/cabbrev.sail
+++ b/test/c/cabbrev.sail
@@ -2,9 +2,6 @@ default Order dec
 
 $include <prelude.sail>
 
-// We need to generate a separate header
-$option --c-generate-header
-
 // Make sure the my_pair type is included in the C output
 $option --c-preserve-type my_pair
 

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -192,7 +192,6 @@ xml = '<testsuites>\n'
 if 'c' in targets:
     xml += test_c('unoptimized C', '', '--c-no-mangle', False)
     xml += test_c('unoptimized C', '', '', False)
-    xml += test_c('unoptimized C', '', '--c-generate-header', False)
     xml += test_c('optimized C', '-O2', '-O', True)
     xml += test_c('constant folding', '', '-Oconstant_fold', False)
     #xml += test_c('monomorphised C', '-O2', '-O -Oconstant_fold -auto_mono', True)


### PR DESCRIPTION
This is a breaking change but there's probably no reason not to want it. The RISC-V model already uses it.

Removing it simplifies the number of option combinations the C codegen has to consider and test.