### PR TITLE
Update links to Lem

### DIFF
--- a/doc/asciidoc/manual.bib
+++ b/doc/asciidoc/manual.bib
@@ -118,7 +118,7 @@
   OPTkey =       {},
   OPTauthor =    {The Lem team},
   title =        {Lem implementation},
-  howpublished = {\url{https://bitbucket.org/Peter_Sewell/lem/}},
+  howpublished = {\url{https://github.com/rems-project/lem}},
   OPTmonth =     {},
   year =         {2017},
   OPTnote =      {},
@@ -196,7 +196,7 @@
  acmid = {1987395},
  publisher = {Springer-Verlag},
  address = {Berlin, Heidelberg},
-} 
+}
 
 @Misc{diy,
   OPTkey =       {},
@@ -239,7 +239,7 @@
  acmid = {2682944},
  publisher = {FMCAD Inc},
  address = {Austin, TX},
-} 
+}
 
 @inproceedings{DBLP:conf/itp/Fox12,
   author    = {Anthony C. J. Fox},
@@ -275,7 +275,7 @@
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {Relaxed memory models, semantics, verified compilation},
-} 
+}
 
 
 @incollection{shi2011,
@@ -326,9 +326,9 @@ language={English}
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {declarative machine descriptions, instruction selection, retargetable compilers},
-} 
+}
 
- 
+
 @ARTICLE{Leroy-backend,
   AUTHOR = {Xavier Leroy},
   TITLE = {A formally verified compiler back-end},
@@ -390,7 +390,7 @@ language={English}
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {ML, compiler bootstrapping, compiler verification, machine code verification, read-eval-print loop, verified garbage collection., verified parsing, verified type checking},
-} 
+}
 
 
 
@@ -410,7 +410,7 @@ language={English}
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {Coq, assembly code, dependent types},
-} 
+}
 
 
 @inproceedings{DBLP:conf/pldi/MorrisettTTTG12,
@@ -729,4 +729,3 @@ This is a necessary step towards semantics for real-world shared-memory concurre
   note =         {Revision 0.95. Document Number  MD00082},
   OPTannote =    {}
 }
-

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -7155,7 +7155,7 @@ arbitrary sequence of characters that does not contain <code>]</code>.</p>
 <p><a id="Lem-icfp2014"></a>[9] D. P. Mulligan, S. Owens, K. E. Gray, T. Ridge, and P. Sewell, “Lem: reusable engineering of real-world semantics,” in <em>Proceedings of ICFP 2014: the 19th ACM SIGPLAN International Conference on Functional Programming</em>, 2014, pp. 175–188, doi: 10.1145/2628136.2628143.</p>
 </div>
 <div class="paragraph">
-<p><a id="Lemcode"></a>[10] “Lem implementation.” <a href="https://bitbucket.org/Peter_Sewell/lem/" class="bare">bitbucket.org/Peter_Sewell/lem/</a> , 2017.</p>
+<p><a id="Lemcode"></a>[10] “Lem implementation.” <a href="https://github.com/rems-project/lem" class="bare">github.com/rems-project/lem</a> , 2017.</p>
 </div>
 <div class="paragraph">
 <p><a id="UCAM-CL-TR-868"></a>[11] R. N. M. Watson <em>et al.</em>, “Bluespec Extensible RISC Implementation: BERI Hardware reference,” University of Cambridge, Computer Laboratory, UCAM-CL-TR-868, Apr. 2015. [Online]. Available: <a href="http://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-868.pdf" class="bare">www.cl.cam.ac.uk/techreports/UCAM-CL-TR-868.pdf</a>.</p>


### PR DESCRIPTION
The bitbucket repo is long gone. It does seem slightly odd to update the URL on a reference marked as 2017, but that's probably better than a dead link.