### PR TITLE
Deprecate --static option for C backend

### DIFF
--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -85,9 +85,6 @@ There are several Sail options that affect the C output:
 
 * `--c-no-main` Do not generate a `main()` function.
 
-* `--static` Mark generated C functions as static where possible. This
-    is useful for measuring code coverage.
-
 <<<
 === SystemVerilog compilation (Experimental)
 

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -3147,10 +3147,6 @@ generated C.</p>
 <li>
 <p><code>--c-no-main</code> Do not generate a <code>main()</code> function.</p>
 </li>
-<li>
-<p><code>--static</code> Mark generated C functions as static where possible. This
-is useful for measuring code coverage.</p>
-</li>
 </ul>
 </div>
 <div style="page-break-after: always;"></div>
@@ -4598,7 +4594,7 @@ concrete value for it during type-checking. This would look like:</p>
 4 |    X1 = 0xFFFF_FFFF
   |         ^---------^
   | Failed to prove constraint: 32 == xlen
-  | 
+  |
   | constraint from ../examples/abstract_xlen.sail:10.19-23:
   | 10 |register X1 : bits(xlen)
   |    |                   ^--^ This type argument</code></pre>
@@ -5014,7 +5010,7 @@ wildcard cannot be inserted.</p>
 <pre class="rouge highlight"><code>Warning: Required literal ../examples/cannot_wildcard.sail:17.14-17:
 17 |        (Some(0b1), _)         =&gt; print_endline("3"),
    |              ^-^
-   | 
+   |
 Sail cannot simplify the above pattern match:
 This bitvector pattern literal must be kept, as it is required for Sail to show that the surrounding pattern match is complete.
 When translated into prover targets (e.g. Lem, Coq) without native bitvector patterns, they may be unable to verify that the match covers all possible cases.</code></pre>
@@ -6448,7 +6444,7 @@ would get the following error:</p>
 6 |    let x = alfa();
   |            ^--^
   | Not in scope
-  | 
+  |
   | Try requiring module A to bring the following into scope for module B:
   | ../examples/amod.sail:6.4-8:
   | 6 |val alfa : unit -&gt; int

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -61,8 +61,6 @@ open Anf
 
 module Big_int = Nat_big_num
 
-let opt_static = ref false
-let static () = if !opt_static then "static " else ""
 let opt_prefix = ref "z"
 let opt_extra_params = ref None
 let opt_extra_arguments = ref None
@@ -2168,12 +2166,12 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           Header
             (string (Printf.sprintf "// register %s" (string_of_name id))
             ^^ hardline
-            ^^ string (Printf.sprintf "extern %s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_name id))
+            ^^ string (Printf.sprintf "extern %s %s;" (sgen_ctyp ctyp) (sgen_name id))
             );
           Impl
             (string (Printf.sprintf "// register %s" (string_of_name id))
             ^^ hardline
-            ^^ string (Printf.sprintf "%s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_name id))
+            ^^ string (Printf.sprintf "%s %s;" (sgen_ctyp ctyp) (sgen_name id))
             );
         ]
     | CDEF_val (id, _, arg_ctyps, ret_ctyp, _) ->
@@ -2182,8 +2180,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           [
             Header
               (string
-                 (Printf.sprintf "%s%s %s(%s%s);" (static ()) (sgen_ctyp ret_ctyp) (sgen_function_id id)
-                    (extra_params ())
+                 (Printf.sprintf "%s %s(%s%s);" (sgen_ctyp ret_ctyp) (sgen_function_id id) (extra_params ())
                     (Util.string_of_list ", " sgen_const_ctyp arg_ctyps)
                  )
               );
@@ -2192,8 +2189,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           [
             Header
               (string
-                 (Printf.sprintf "%svoid %s(%s%s *rop, %s);" (static ()) (sgen_function_id id) (extra_params ())
-                    (sgen_ctyp ret_ctyp)
+                 (Printf.sprintf "void %s(%s%s *rop, %s);" (sgen_function_id id) (extra_params ()) (sgen_ctyp ret_ctyp)
                     (Util.string_of_list ", " sgen_const_ctyp arg_ctyps)
                  )
               );
@@ -2229,15 +2225,13 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
             match ret_arg with
             | Return_plain ->
                 assert (is_stack_ctyp ctx ret_ctyp);
-                (if !opt_static then string "static " else empty)
-                ^^ string (sgen_ctyp ret_ctyp)
+                string (sgen_ctyp ret_ctyp)
                 ^^ space ^^ codegen_function_id id
                 ^^ parens (string (extra_params ()) ^^ string args)
                 ^^ hardline
             | Return_via gs ->
                 assert (not (is_stack_ctyp ctx ret_ctyp));
-                (if !opt_static then string "static " else empty)
-                ^^ string "void" ^^ space ^^ codegen_function_id id
+                string "void" ^^ space ^^ codegen_function_id id
                 ^^ parens
                      (string (extra_params ())
                      ^^ string (sgen_ctyp ret_ctyp ^ " *" ^ sgen_name gs ^ ", ")
@@ -2255,14 +2249,14 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         end
     | CDEF_type ctype_def -> codegen_type_def ctx ctype_def
     | CDEF_startup (id, instrs) ->
-        let startup_header = string (Printf.sprintf "%svoid startup_%s(void)" (static ()) (sgen_function_id id)) in
+        let startup_header = string (Printf.sprintf "void startup_%s(void)" (sgen_function_id id)) in
         separate_map hardline codegen_decl instrs
         ^^ twice hardline ^^ startup_header ^^ hardline ^^ string "{"
         ^^ jump 0 2 (separate_map hardline (codegen_alloc ctx) instrs)
         ^^ hardline ^^ string "}"
         |> to_impl
     | CDEF_finish (id, instrs) ->
-        let finish_header = string (Printf.sprintf "%svoid finish_%s(void)" (static ()) (sgen_function_id id)) in
+        let finish_header = string (Printf.sprintf "void finish_%s(void)" (sgen_function_id id)) in
         separate_map hardline codegen_decl (List.filter is_decl instrs)
         ^^ twice hardline ^^ finish_header ^^ hardline ^^ string "{"
         ^^ jump 0 2 (separate_map hardline (codegen_instr id ctx) instrs)
@@ -2273,7 +2267,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         let setup = List.concat (List.map (fun (id, ctyp) -> [idecl (id_loc id) ctyp (name id)]) bindings) in
         let cleanup = List.concat (List.map (fun (id, ctyp) -> [iclear ~loc:(id_loc id) ctyp (name id)]) bindings) in
         separate_map hardline
-          (fun (id, ctyp) -> string (Printf.sprintf "%s%s %s;" (static ()) (sgen_ctyp ctyp) (sgen_id id)))
+          (fun (id, ctyp) -> string (Printf.sprintf "%s %s;" (sgen_ctyp ctyp) (sgen_id id)))
           bindings
         ^^ hardline
         ^^ string (Printf.sprintf "static void create_letbind_%d(void) " number)
@@ -2484,7 +2478,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       let model_init =
         separate hardline
           (List.map string
-             ([Printf.sprintf "%svoid model_init(void)" (static ()); "{"; "  setup_rts();"]
+             (["void model_init(void)"; "{"; "  setup_rts();"]
              @ fst exn_boilerplate
              @ List.concat (List.map (fun r -> fst (register_init_clear r)) early_regs)
              @ set_abstract_types @ startup cdefs @ letbind_initializers
@@ -2504,7 +2498,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
       let model_fini =
         separate hardline
           (List.map string
-             ([Printf.sprintf "%svoid model_fini(void)" (static ()); "{"]
+             (["void model_fini(void)"; "{"]
              @ List.concat (List.map (fun r -> snd (register_init_clear r)) regs)
              @ letbind_finalizers
              @ List.concat (List.map (fun r -> snd (register_init_clear r)) early_regs)
@@ -2531,7 +2525,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
 
       let model_main =
         [
-          Printf.sprintf "%sint model_main(int argc, char *argv[])" (static ());
+          "int model_main(int argc, char *argv[])";
           "{";
           "  model_init();";
           "  if (process_arguments(argc, argv)) exit(EXIT_FAILURE);";
@@ -2565,7 +2559,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
          in your own custom test runner. *)
       let model_test =
         [
-          Printf.sprintf "%svoid model_test(void)" (static ());
+          "void model_test(void)";
           "{";
           "  for (size_t i = 0; i < SAIL_TEST_COUNT; ++i) {";
           "    model_init();";

--- a/src/sail_c_backend/c_backend.mli
+++ b/src/sail_c_backend/c_backend.mli
@@ -51,9 +51,6 @@ open Type_check
 
 (** Global compilation options *)
 
-(** Define generated functions as static *)
-val opt_static : bool ref
-
 (** Ordinarily we use plain z-encoding to name-mangle generated Sail identifiers into a form suitable for C. If
     opt_prefix is set, then the "z" which is added on the front of each generated C function will be replaced by
     opt_prefix. E.g. opt_prefix := "sail_" would give sail_my_function rather than zmy_function. *)

--- a/src/sail_c_backend/sail_plugin_c.ml
+++ b/src/sail_c_backend/sail_plugin_c.ml
@@ -53,6 +53,7 @@ let opt_assert_to_exception = ref false
 let opt_branch_coverage = ref None
 let opt_build = ref false
 let opt_generate_header = ref false
+let opt_static = ref false
 let opt_includes_c : string list ref = ref []
 let opt_includes_h : string list ref = ref []
 let opt_no_lib = ref false
@@ -130,10 +131,8 @@ let c_options =
       Arg.Set C_backend.optimize_fixed_bits,
       "assume fixed size bitvectors rather than arbitrary precision bitvectors"
     );
-    ( Flag.create ~prefix:["c"] ~hide_prefix:true "static",
-      Arg.Set C_backend.opt_static,
-      "make generated C functions static"
-    );
+    (* This flag is deprecated and will be removed in future. *)
+    (Flag.create ~prefix:["c"] ~hide_prefix:true "static", Arg.Set opt_static, "");
   ]
 
 let c_rewrites =
@@ -209,6 +208,9 @@ let c_target out_file { ast; effect_info; env; default_sail_dir; _ } =
   if !opt_generate_header then
     Reporting.warn "Deprecated" Parse_ast.Unknown
       "--c-generate-header is deprecated and has no effect; headers are now always generated";
+
+  if !opt_static then
+    Reporting.warn "Deprecated" Parse_ast.Unknown "--static is deprecated and no longer has any effect";
 
   let echo_output, out_file = match out_file with Some f -> (false, f) | None -> (true, "out") in
   let basename = Filename.basename out_file in


### PR DESCRIPTION
This option marked some functions and variables as `static`, apparently to help with code coverage. It may also help with performance or code size but that's unlikely to make a significant difference because Sail's performance is absolutely dominated by GMP.

The option wasn't actually tested anywhere and I think it wouldn't have worked with `--generate-header` anyway since it would output invalid `extern static ..` code. Since `--generate-header` has been removed it makes sense to also remove this, and reduce the number of code gen options.