### PR TITLE
Add location to all assertion strings

### DIFF
--- a/lib/int128/rts.c
+++ b/lib/int128/rts.c
@@ -16,11 +16,14 @@ void sail_match_failure(const_sail_string msg)
   exit(EXIT_FAILURE);
 }
 
-unit sail_assert(bool b, const_sail_string msg)
+unit sail_assert(bool b, const_sail_string msg, const_sail_string loc)
 {
   if (b) return UNIT;
-  fprintf(stderr, "Assertion failed: %s\n", msg);
-  exit(EXIT_FAILURE);
+  if (msg[0] == '\0') {
+    fprintf(stderr, "Assertion failed at %s\n", loc);
+  } else {
+    fprintf(stderr, "Assertion failed at %s: %s\n", loc, msg);
+  }  exit(EXIT_FAILURE);
 }
 
 unit sail_exit(unit u)
@@ -244,7 +247,7 @@ bool write_ram(const sail_int addr_size,     // Either 32 or 64
       // Then shift buf 8 bits right.
       mpz_fdiv_q_2exp(write_buf, write_buf, 8);
     }
-    
+
     return true;
   }
 }
@@ -253,7 +256,7 @@ sbits fast_read_ram(const int64_t data_size,
 		    const uint64_t addr)
 {
   uint64_t r = 0;
-  
+
   uint64_t byte;
   for(uint64_t i = (uint64_t) data_size; i > 0; --i) {
     byte = read_mem(addr + (i - 1));

--- a/lib/int128/rts.h
+++ b/lib/int128/rts.h
@@ -16,7 +16,7 @@ void sail_match_failure(const_sail_string msg);
  * sail_assert implements the assert construct in Sail. If any
  * assertion fails we immediately exit the model.
  */
-unit sail_assert(bool b, const_sail_string msg);
+unit sail_assert(bool b, const_sail_string msg, const_sail_string loc);
 
 unit sail_exit(unit);
 

--- a/lib/sail_config.c
+++ b/lib/sail_config.c
@@ -71,29 +71,29 @@ void sail_config_set_string(const char *json)
     else {
         snprintf(error_message, sizeof error_message, "Failed to parse JSON configuration at offset %ld", parse_end - json);
     }
-    sail_assert(false, error_message);
+    sail_assert(false, error_message, "sail_config_set_string()");
   }
 }
 
 void sail_config_set_file(const char *path)
 {
   FILE *f = fopen(path, "rb");
-  sail_assert(f != NULL, "Failed to open configuration file");
+  sail_assert(f != NULL, "Failed to open configuration file", path);
 
   int rc = fseek(f, 0, SEEK_END);
-  sail_assert(rc != -1, "Failed to seek to end of configuration file");
+  sail_assert(rc != -1, "Failed to seek to end of configuration file", path);
 
   long fsize = ftell(f);
-  sail_assert(fsize != -1, "Failed to get size of configuration file");
+  sail_assert(fsize != -1, "Failed to get size of configuration file", path);
 
   rc = fseek(f, 0, SEEK_SET);
-  sail_assert(rc != -1, "Failed to seek to start of configuration file");
+  sail_assert(rc != -1, "Failed to seek to start of configuration file", path);
 
   char *buffer = (char *)sail_malloc(fsize + 1);
 
   size_t ret_size = fread(buffer, fsize, 1, f);
 
-  sail_assert(ret_size == 1, "Failed to read configuration");
+  sail_assert(ret_size == 1, "Failed to read configuration", path);
 
   buffer[fsize] = 0;
   fclose(f);
@@ -102,7 +102,7 @@ void sail_config_set_file(const char *path)
   // sail_config_set_string() relies on null termination
   // to find the end of the string.
   for (size_t i = 0; i < fsize; ++i) {
-    sail_assert(buffer[i] != 0, "Null byte in JSON configuration");
+    sail_assert(buffer[i] != 0, "Null byte in JSON configuration", path);
   }
 
   sail_config_set_string(buffer);
@@ -289,7 +289,7 @@ void sail_config_unwrap_int(sail_int *n, const sail_config_json config)
 {
   cJSON *json = (cJSON *)config;
   if (mpz_set_str(*n, json->valuestring, 10) == -1) {
-    sail_assert(false, "Failed to parse integer from configuration");
+    sail_assert(false, "Failed to parse integer from configuration", "sail_config_unwrap_int()");
   }
 }
 

--- a/lib/sail_failure.c
+++ b/lib/sail_failure.c
@@ -56,10 +56,14 @@ void sail_match_failure(const_sail_string msg)
   exit(EXIT_FAILURE);
 }
 
-unit sail_assert(bool b, const_sail_string msg)
+unit sail_assert(bool b, const_sail_string msg, const_sail_string loc)
 {
   if (b) return UNIT;
-  fprintf(stderr, "Assertion failed: %s\n", msg);
+  if (msg[0] == '\0') {
+    fprintf(stderr, "Assertion failed at %s\n", loc);
+  } else {
+    fprintf(stderr, "Assertion failed at %s: %s\n", loc, msg);
+  }
   exit(EXIT_FAILURE);
 }
 

--- a/lib/sail_failure.h
+++ b/lib/sail_failure.h
@@ -63,7 +63,7 @@ void sail_match_failure(const_sail_string msg);
  * sail_assert implements the assert construct in Sail. If any
  * assertion fails we immediately exit the model.
  */
-unit sail_assert(bool b, const_sail_string msg);
+unit sail_assert(bool b, const_sail_string msg, const_sail_string loc);
 
 #ifdef __cplusplus
 }

--- a/lib/sv/sail.sv
+++ b/lib/sv/sail.sv
@@ -25,7 +25,9 @@ function automatic sail_unit sail_prerr(sail_unit s);
    return SAIL_UNIT;
 endfunction // sail_prerr
 
-function automatic sail_unit sail_assert(bit b, sail_unit msg);
+// TODO: Is this actually used? It looks like asserts actually get written to
+// if (not condition) then $fatal(msg);
+function automatic sail_unit sail_assert(bit b, sail_unit loc, sail_unit msg);
    return SAIL_UNIT;
 endfunction // sail_assert
 
@@ -55,9 +57,9 @@ function automatic sail_unit sail_prerr(string s);
    return SAIL_UNIT;
 endfunction // sail_prerr
 
-function automatic sail_unit sail_assert(bit b, string msg);
+function automatic sail_unit sail_assert(bit b, string loc, string msg);
    if (!b) begin
-      $display("%s", msg);
+      $error("Assertion failed at %s: %s", loc, msg);
    end;
    return SAIL_UNIT;
 endfunction // sail_assert

--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -780,17 +780,14 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
       let aexp = anf ret_exp in
       let aval, wrap = to_aval aexp in
       wrap (mk_aexp (AE_return (aval, typ_of exp)))
-  | E_assert (exp1, exp2) ->
+  | E_assert (exp1, exp2, exp3) ->
       let aexp1 = anf exp1 in
       let aexp2 = anf exp2 in
+      let aexp3 = anf exp3 in
       let aval1, wrap1 = to_aval aexp1 in
       let aval2, wrap2 = to_aval aexp2 in
-      (* Add the location of the assertion as a parameter. *)
-      let loc_string = Reporting.short_loc_to_string l in
-      let loc_aexp = mk_aexp (ae_lit (L_aux (L_string loc_string, l)) string_typ) in
-      let loc_aval, loc_wrap = to_aval loc_aexp in
-      (* TODO: What are these wrap functions? Do I need to use loc_wrap? *)
-      wrap1 (wrap2 (mk_aexp (AE_app (Extern (mk_id "sail_assert", None), [aval1; aval2; loc_aval], unit_typ))))
+      let aval3, wrap3 = to_aval aexp3 in
+      wrap1 (wrap2 ( wrap3(mk_aexp (AE_app (Extern (mk_id "sail_assert", None), [aval1; aval2; aval3], unit_typ)))))
   | E_cons (exp1, exp2) ->
       let aexp1 = anf exp1 in
       let aexp2 = anf exp2 in

--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -785,7 +785,12 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
       let aexp2 = anf exp2 in
       let aval1, wrap1 = to_aval aexp1 in
       let aval2, wrap2 = to_aval aexp2 in
-      wrap1 (wrap2 (mk_aexp (AE_app (Extern (mk_id "sail_assert", None), [aval1; aval2], unit_typ))))
+      (* Add the location of the assertion as a parameter. *)
+      let loc_string = Reporting.short_loc_to_string l in
+      let loc_aexp = mk_aexp (ae_lit (L_aux (L_string loc_string, l)) string_typ) in
+      let loc_aval, loc_wrap = to_aval loc_aexp in
+      (* TODO: What are these wrap functions? Do I need to use loc_wrap? *)
+      wrap1 (wrap2 (mk_aexp (AE_app (Extern (mk_id "sail_assert", None), [aval1; aval2; loc_aval], unit_typ))))
   | E_cons (exp1, exp2) ->
       let aexp1 = anf exp1 in
       let aexp2 = anf exp2 in

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -932,7 +932,7 @@ and map_exp_annot_aux f = function
   | E_exit exp -> E_exit (map_exp_annot f exp)
   | E_throw exp -> E_throw (map_exp_annot f exp)
   | E_return exp -> E_return (map_exp_annot f exp)
-  | E_assert (test, msg) -> E_assert (map_exp_annot f test, map_exp_annot f msg)
+  | E_assert (test, msg, loc) -> E_assert (map_exp_annot f test, map_exp_annot f msg, map_exp_annot f loc)
   | E_internal_value v -> E_internal_value v
   | E_var (lexp, exp1, exp2) -> E_var (map_lexp_annot f lexp, map_exp_annot f exp1, map_exp_annot f exp2)
   | E_internal_plet (pat, exp1, exp2) ->
@@ -1340,7 +1340,7 @@ let rec string_of_exp (E_aux (exp, _)) =
       "while " ^ string_of_measure measure ^ string_of_exp cond ^ " do " ^ string_of_exp body
   | E_loop (Until, measure, cond, body) ->
       "repeat " ^ string_of_measure measure ^ string_of_exp body ^ " until " ^ string_of_exp cond
-  | E_assert (test, msg) -> "assert(" ^ string_of_exp test ^ ", " ^ string_of_exp msg ^ ")"
+  | E_assert (test, msg, _loc) -> "assert(" ^ string_of_exp test ^ ", " ^ string_of_exp msg ^ ")"
   | E_exit exp -> "exit " ^ string_of_exp exp
   | E_throw exp -> "throw " ^ string_of_exp exp
   | E_cons (x, xs) -> string_of_exp x ^ " :: " ^ string_of_exp xs
@@ -1886,7 +1886,7 @@ let rec subst id value (E_aux (e_aux, annot) as exp) =
     | E_ref id' -> E_ref id'
     | E_throw exp -> E_throw (subst id value exp)
     | E_try (exp, pexps) -> E_try (subst id value exp, List.map (subst_pexp id value) pexps)
-    | E_assert (exp1, exp2) -> E_assert (subst id value exp1, subst id value exp2)
+    | E_assert (exp1, exp2, exp3) -> E_assert (subst id value exp1, subst id value exp2, subst id value exp3)
     | E_internal_value v -> E_internal_value v
     | E_var (lexp, exp1, exp2) -> E_var (subst_lexp id value lexp, subst id value exp1, subst id value exp2)
     | E_internal_assume (nc, exp) -> E_internal_assume (nc, subst id value exp)
@@ -2109,7 +2109,7 @@ let rec locate : 'a. (l -> l) -> 'a exp -> 'a exp =
     | E_ref id -> E_ref (locate_id f id)
     | E_throw exp -> E_throw (locate f exp)
     | E_try (exp, cases) -> E_try (locate f exp, List.map (locate_pexp f) cases)
-    | E_assert (exp, message) -> E_assert (locate f exp, locate f message)
+    | E_assert (exp, message, loc) -> E_assert (locate f exp, locate f message, locate f loc)
     | E_constraint constr -> E_constraint (locate_nc f constr)
     | E_var (lexp, exp1, exp2) -> E_var (locate_lexp f lexp, locate f exp1, locate f exp2)
     | E_internal_plet (pat, exp1, exp2) -> E_internal_plet (locate_pat f pat, locate f exp1, locate f exp2)

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -568,9 +568,9 @@ let const_props target env ast =
       | E_return e ->
           let e', _ = const_prop_exp substs assigns e in
           re (E_return e') Bindings.empty
-      | E_assert (e1, e2) ->
-          let e1', e2', assigns = non_det_exp_2 e1 e2 in
-          re (E_assert (e1', e2')) assigns
+      | E_assert (e1, e2, e3) ->
+          let e1', e2', e3', assigns = non_det_exp_3 e1 e2 e3 in
+          re (E_assert (e1', e2', e3')) assigns
       | E_internal_assume (nc, e) ->
           let e', _ = const_prop_exp substs assigns e in
           re (E_internal_assume (nc, e')) assigns

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -20,7 +20,7 @@ module Coq_def_annot =
   type 'a record = { doc_comment : string option;
                      attrs : (Parse_ast.l * (string * attribute_data option))
                              list;
-                     visibility : visibility; loc : Parse_ast.l; env : 
+                     visibility : visibility; loc : Parse_ast.l; env :
                      'a }
  end
 
@@ -226,7 +226,7 @@ and 'a exp_aux =
 | E_ref of id
 | E_throw of 'a exp
 | E_try of 'a exp * 'a pexp list
-| E_assert of 'a exp * 'a exp
+| E_assert of 'a exp * 'a exp * 'a exp
 | E_var of 'a lexp * 'a exp * 'a exp
 | E_internal_plet of 'a pat * 'a exp * 'a exp
 | E_internal_return of 'a exp

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -20,7 +20,7 @@ module Coq_def_annot :
   type 'a record = { doc_comment : string option;
                      attrs : (Parse_ast.l * (string * attribute_data option))
                              list;
-                     visibility : visibility; loc : Parse_ast.l; env : 
+                     visibility : visibility; loc : Parse_ast.l; env :
                      'a }
  end
 
@@ -226,7 +226,7 @@ and 'a exp_aux =
 | E_ref of id
 | E_throw of 'a exp
 | E_try of 'a exp * 'a pexp list
-| E_assert of 'a exp * 'a exp
+| E_assert of 'a exp * 'a exp * 'a exp
 | E_var of 'a lexp * 'a exp * 'a exp
 | E_internal_plet of 'a pat * 'a exp * 'a exp
 | E_internal_return of 'a exp

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -420,8 +420,8 @@ module Make =
      | E_try (head_exp, arms) ->
        E_aux ((E_try ((substitute n v head_exp),
          (map (substitute_arm n v) arms))), annot0)
-     | E_assert (x0, msg) ->
-       E_aux ((E_assert ((substitute n v x0), (substitute n v msg))), annot0)
+     | E_assert (x0, msg, loc) ->
+       E_aux ((E_assert ((substitute n v x0), (substitute n v msg), (substitute n v loc))), annot0)
      | E_var (l, x0, body) ->
        E_aux ((E_var ((substitute_lexp n v l), (substitute n v x0),
          (substitute n v body))), annot0)
@@ -1052,8 +1052,8 @@ module Make =
                then wrap (E_block xs0)
                else Monad.bind (step0 x0) (fun x' ->
                       wrap (E_block (x' :: xs0)))
-             | E_assert (e0, e1) ->
-               let x0 = E_aux ((E_assert (e0, e1)), annot1) in
+             | E_assert (e0, e1, e2) ->
+               let x0 = E_aux ((E_assert (e0, e1, e2)), annot1) in
                if is_value x0
                then wrap (E_block xs0)
                else Monad.bind (step0 x0) (fun x' ->
@@ -1441,7 +1441,7 @@ module Make =
               | Monad.Caught exn ->
                 wrap (E_match ((E_aux ((E_internal_value exn), annot0)),
                   (app arms (T.fallthrough :: []))))))
-       | E_assert (x, msg) ->
+       | E_assert (x, msg, loc) ->
          Monad.bind (get_bool x) (fun b ->
            match b with
            | Evaluated b0 ->
@@ -1453,9 +1453,9 @@ module Make =
                  else Monad.Assertion_failed s0
                | Unevaluated ->
                  Monad.bind (step0 msg) (fun msg' ->
-                   wrap (E_assert (x, msg'))))
+                   wrap (E_assert (x, msg', loc))))
            | Unevaluated ->
-             Monad.bind (step0 x) (fun x' -> wrap (E_assert (x', msg))))
+             Monad.bind (step0 x) (fun x' -> wrap (E_assert (x', msg, loc))))
        | E_var (l, x, body) ->
          wrap (E_block ((E_aux ((E_assign (l, x)), annot0)) :: (body :: [])))
        | E_internal_plet (_, _, _) -> Monad.Runtime_type_error (fst annot0)

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1365,7 +1365,9 @@ and to_ast_exp ctx exp =
         | P.E_throw exp -> E_throw (to_ast_exp ctx exp)
         | P.E_config key -> E_config [key]
         | P.E_return exp -> E_return (to_ast_exp ctx exp)
-        | P.E_assert (cond, msg) -> E_assert (to_ast_exp ctx cond, to_ast_exp ctx msg)
+        | P.E_assert (cond, msg) ->
+            let loc = E_lit (L_aux (L_string (Reporting.short_loc_to_string l), l)) in
+            E_assert (to_ast_exp ctx cond, to_ast_exp ctx msg, mk_exp loc)
         | P.E_internal_plet (pat, exp1, exp2) ->
             if !opt_magic_hash then E_internal_plet (to_ast_pat ctx pat, to_ast_exp ctx exp1, to_ast_exp ctx exp2)
             else raise (Reporting.err_general l "Internal plet construct found without -dmagic_hash")

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -1206,7 +1206,8 @@ module Make (C : CONFIG) = struct
         let str = string_of_id id in
         if str = "sail_assert" && C.assert_to_exception then (
           match args with
-          | [cond; msg] ->
+          | [cond; msg; _loc] ->
+              (* TODO: Should we include the location in the assertion message? *)
               let cond_setup, cond_cval, cond_cleanup = compile_aval l ctx cond in
               let msg_setup, msg_cval, _ = compile_aval l ctx msg in
               let exn_setup, exn_cval = assert_exception l msg_cval in

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -595,7 +595,7 @@ let stop_at_false_assertions e =
               let e2, stop = exp e2 in
               (E_aux (E_let (LB_aux (LB_val (p, e1), lbann), e2), ann), stop)
         end
-    | E_assert (e1, _) when exp_false e1 -> (ea, Some (typ_of_annot ann))
+    | E_assert (e1, _, _) when exp_false e1 -> (ea, Some (typ_of_annot ann))
     | E_throw e -> (ea, Some (typ_of_annot ann))
     | _ -> (ea, None)
   in
@@ -631,7 +631,7 @@ let apply_pat_choices choices =
         | _ -> exp
       )
   in
-  let rewrite_assert (e1, e2) = E_assert (rewrite_assert_cond e1, e2) in
+  let rewrite_assert (e1, e2, e3) = E_assert (rewrite_assert_cond e1, e2, e3) in
   let rewrite_case (e, cases) =
     match List.assoc (exp_loc e) choices with
     | choice, max, subst -> (
@@ -1123,7 +1123,7 @@ let split_defs target all_errors (splits : split_req list) env ast =
         | E_throw e -> re (E_throw e)
         | E_try (e, cases) -> re (E_try (map_exp e, List.concat (List.map map_pexp cases)))
         | E_return e -> re (E_return (map_exp e))
-        | E_assert (e1, e2) -> re (E_assert (map_exp e1, map_exp e2))
+        | E_assert (e1, e2, e3) -> re (E_assert (map_exp e1, map_exp e2, map_exp e3))
         | E_var (le, e1, e2) -> re (E_var (map_lexp le, map_exp e1, map_exp e2))
         | E_internal_plet (p, e1, e2) -> re (E_internal_plet (check_single_pat p, map_exp e1, map_exp e2))
         | E_internal_return e -> re (E_internal_return (map_exp e))
@@ -2458,7 +2458,7 @@ module Analysis = struct
           in
           let ds, assigns, rs = split3 (List.map analyse_handler cases) in
           (merge_deps (deps :: ds), List.fold_left dep_bindings_merge Bindings.empty assigns, List.fold_left merge r rs)
-      | E_assert (e1, _) -> analyse_sub env assigns e1
+      | E_assert (e1, _, _) -> analyse_sub env assigns e1
       | E_internal_assume (nc, e1) -> analyse_sub env assigns e1
       | E_internal_plet _ | E_internal_return _ | E_internal_value _ ->
           raise
@@ -2788,7 +2788,7 @@ module Analysis = struct
         let kbound = kids_bound_by_pat p in
         let sets2 = KBindings.filter (fun kid _ -> not (KidSet.mem kid kbound)) sets2 in
         merge_set_asserts_by_kid sets1 sets2
-    | E_assert (exp1, _) -> sets_from_assert exp1
+    | E_assert (exp1, _, _) -> sets_from_assert exp1
     | _ -> KBindings.empty
 
   let print_set_assertions set_assertions =
@@ -4218,7 +4218,7 @@ module BitvectorSizeCasts = struct
             let result_typ = Env.base_typ_of env (typ_of_annot ann) in
             let rec aux = function
               | [] -> []
-              | (E_aux (E_assert (assert_exp, msg), _) as h) :: t ->
+              | (E_aux (E_assert (assert_exp, _msg, _loc), _) as h) :: t ->
                   (* Check the assertion for constraints that instantiate kids *)
                   let is_known_kid kid = KBindings.mem kid (Env.get_typ_vars env) in
                   begin

--- a/src/lib/nl_flow.ml
+++ b/src/lib/nl_flow.ml
@@ -70,7 +70,8 @@ let rec pat_id (P_aux (aux, _)) =
 
 let add_assert cond (E_aux (aux, (l, uannot)) as exp) =
   let msg = mk_lit_exp (L_string "") in
-  let assertion = locate (fun _ -> gen_loc l) (mk_exp (E_assert (cond, msg))) in
+  let loc = E_lit (L_aux (L_string (Reporting.short_loc_to_string l), l)) in
+  let assertion = locate (fun _ -> gen_loc l) (mk_exp (E_assert (cond, msg, mk_exp loc))) in
   match aux with
   | E_block exps -> E_aux (E_block (assertion :: exps), (l, empty_uannot))
   | _ -> E_aux (E_block (assertion :: [exp]), (l, uannot))

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -592,8 +592,8 @@ module Printer (Config : PRINT_CONFIG) = struct
     | E_app (id, exps) when not Config.resugar -> doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps)
     | E_app (id, exps) when List.length exps != 2 -> doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps)
     | E_constraint nc -> string "constraint" ^^ parens (doc_nc nc)
-    | E_assert (exp1, E_aux (E_lit (L_aux (L_string "", _)), _)) -> string "assert" ^^ parens (doc_exp exp1)
-    | E_assert (exp1, exp2) -> string "assert" ^^ parens (doc_exp exp1 ^^ comma ^^ space ^^ doc_exp exp2)
+    | E_assert (exp1, E_aux (E_lit (L_aux (L_string "", _)), _), _) -> string "assert" ^^ parens (doc_exp exp1)
+    | E_assert (exp1, exp2, _) -> string "assert" ^^ parens (doc_exp exp1 ^^ comma ^^ space ^^ doc_exp exp2)
     | E_exit exp -> string "exit" ^^ parens (doc_exp exp)
     | E_vector exps -> brackets (separate_map (comma ^^ space) doc_exp exps)
     | E_internal_value v ->

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -236,7 +236,7 @@ let rewrite_exp rewriters (E_aux (exp, (l, annot))) =
   | E_exit e -> rewrap (E_exit (rewrite e))
   | E_throw e -> rewrap (E_throw (rewrite e))
   | E_return e -> rewrap (E_return (rewrite e))
-  | E_assert (e1, e2) -> rewrap (E_assert (rewrite e1, rewrite e2))
+  | E_assert (e1, e2, e3) -> rewrap (E_assert (rewrite e1, rewrite e2, rewrite e3))
   | E_var (lexp, e1, e2) ->
       rewrap
         (E_var
@@ -535,7 +535,7 @@ type ( 'a,
   e_throw : 'exp -> 'exp_aux;
   e_config : string list -> 'exp_aux;
   e_return : 'exp -> 'exp_aux;
-  e_assert : 'exp * 'exp -> 'exp_aux;
+  e_assert : 'exp * 'exp * 'exp -> 'exp_aux;
   e_var : 'lexp * 'exp * 'exp -> 'exp_aux;
   e_internal_plet : 'pat * 'exp * 'exp -> 'exp_aux;
   e_internal_return : 'exp -> 'exp_aux;
@@ -600,7 +600,7 @@ let rec fold_exp_aux alg = function
   | E_throw e -> alg.e_throw (fold_exp alg e)
   | E_config key -> alg.e_config key
   | E_return e -> alg.e_return (fold_exp alg e)
-  | E_assert (e1, e2) -> alg.e_assert (fold_exp alg e1, fold_exp alg e2)
+  | E_assert (e1, e2, e3) -> alg.e_assert (fold_exp alg e1, fold_exp alg e2, fold_exp alg e3)
   | E_var (lexp, e1, e2) -> alg.e_var (fold_lexp alg lexp, fold_exp alg e1, fold_exp alg e2)
   | E_internal_plet (pat, e1, e2) -> alg.e_internal_plet (fold_pat alg.pat_alg pat, fold_exp alg e1, fold_exp alg e2)
   | E_internal_return e -> alg.e_internal_return (fold_exp alg e)
@@ -674,7 +674,7 @@ let id_exp_alg =
     e_throw = (fun e1 -> E_throw e1);
     e_config = (fun key -> E_config key);
     e_return = (fun e1 -> E_return e1);
-    e_assert = (fun (e1, e2) -> E_assert (e1, e2));
+    e_assert = (fun (e1, e2, e3) -> E_assert (e1, e2, e3));
     e_var = (fun (lexp, e2, e3) -> E_var (lexp, e2, e3));
     e_internal_plet = (fun (pat, e1, e2) -> E_internal_plet (pat, e1, e2));
     e_internal_return = (fun e -> E_internal_return e);
@@ -798,7 +798,7 @@ let compute_exp_alg bot join =
     e_throw = (fun (v1, e1) -> (v1, E_throw e1));
     e_config = (fun key -> (bot, E_config key));
     e_return = (fun (v1, e1) -> (v1, E_return e1));
-    e_assert = (fun ((v1, e1), (v2, e2)) -> (join v1 v2, E_assert (e1, e2)));
+    e_assert = (fun ((v1, e1), (v2, e2), (v3, e3)) -> (join_list [v1; v2; v3], E_assert (e1, e2, e3)));
     e_var = (fun ((vl, lexp), (v2, e2), (v3, e3)) -> (join_list [vl; v2; v3], E_var (lexp, e2, e3)));
     e_internal_plet = (fun ((vp, pat), (v1, e1), (v2, e2)) -> (join_list [vp; v1; v2], E_internal_plet (pat, e1, e2)));
     e_internal_return = (fun (v, e) -> (v, E_internal_return e));
@@ -893,7 +893,7 @@ let pure_exp_alg bot join =
     e_throw = (fun v1 -> v1);
     e_config = (fun _ -> bot);
     e_return = (fun v1 -> v1);
-    e_assert = (fun (v1, v2) -> join v1 v2);
+    e_assert = (fun (v1, v2, v3) -> join_list [v1; v2; v3]);
     e_var = (fun (vl, v2, v3) -> join_list [vl; v2; v3]);
     e_internal_plet = (fun (vp, v1, v2) -> join_list [vp; v1; v2]);
     e_internal_return = (fun v -> v);
@@ -1145,10 +1145,11 @@ let default_fold_exp f x (E_aux (e, ann) as exp) =
   | E_return e ->
       let x, e = f x e in
       (x, re (E_return e))
-  | E_assert (e1, e2) ->
+  | E_assert (e1, e2, e3) ->
       let x, e1 = f x e1 in
       let x, e2 = f x e2 in
-      (x, re (E_assert (e1, e2)))
+      let x, e3 = f x e3 in
+      (x, re (E_assert (e1, e2, e3)))
   | E_var (lexp, e1, e2) ->
       let x, lexp = default_fold_lexp f x lexp in
       let x, e1 = f x e1 in

--- a/src/lib/rewriter.mli
+++ b/src/lib/rewriter.mli
@@ -159,7 +159,7 @@ type ( 'a,
   e_throw : 'exp -> 'exp_aux;
   e_config : string list -> 'exp_aux;
   e_return : 'exp -> 'exp_aux;
-  e_assert : 'exp * 'exp -> 'exp_aux;
+  e_assert : 'exp * 'exp * 'exp -> 'exp_aux;
   e_var : 'lexp * 'exp * 'exp -> 'exp_aux;
   e_internal_plet : 'pat * 'exp * 'exp -> 'exp_aux;
   e_internal_return : 'exp -> 'exp_aux;

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -1030,8 +1030,9 @@ let rewrite_guarded_clauses fun_only mk_fallthrough l env pat_typ typ
 
 let mk_pattern_match_failure_pexp l env pat_typ typ =
   let p = P_aux (P_wild, (gen_loc l, mk_tannot env pat_typ)) in
-  let msg = "Pattern match failure at " ^ Reporting.short_loc_to_string l in
-  let a = mk_exp ~loc:(gen_loc l) (E_assert (mk_lit_exp L_false, mk_lit_exp (L_string msg))) in
+  let msg = "Pattern match failure"  in
+  let loc = Reporting.short_loc_to_string l in
+  let a = mk_exp ~loc:(gen_loc l) (E_assert (mk_lit_exp L_false, mk_lit_exp (L_string msg), mk_lit_exp (L_string loc))) in
   let b = mk_exp ~loc:(gen_loc l) (E_exit (mk_lit_exp L_unit)) in
   let (E_aux (_, (_, ann)) as e) = check_exp env (mk_exp ~loc:(gen_loc l) (E_block [a; b])) typ in
   construct_pexp (p, None, e, (gen_loc l, ann))
@@ -2421,8 +2422,8 @@ let rewrite_ast_letbind_effects effect_info env =
     | E_constraint nc -> k (rewrap (E_constraint nc))
     | E_assign (lexp, exp1) -> n_lexp lexp (fun lexp -> n_exp_name exp1 (fun exp1 -> k (rewrap (E_assign (lexp, exp1)))))
     | E_exit exp' -> k (E_aux (E_exit (n_exp_term (needs_monad exp') exp'), annot))
-    | E_assert (exp1, exp2) ->
-        n_exp_name exp1 (fun exp1 -> n_exp_name exp2 (fun exp2 -> k (rewrap (E_assert (exp1, exp2)))))
+    | E_assert (exp1, exp2, exp3) ->
+        n_exp_name exp1 (fun exp1 -> n_exp_name exp2 (fun exp2 -> n_exp_name exp3 (fun exp3 -> k (rewrap (E_assert (exp1, exp2, exp3))))))
     | E_var (lexp, exp1, exp2) ->
         n_lexp lexp (fun lexp -> n_exp exp1 (fun exp1 -> rewrap (E_var (lexp, exp1, n_exp exp2 k))))
     | E_internal_return exp1 ->
@@ -3088,7 +3089,7 @@ let rewrite_ast_remove_superfluous_letbinds env =
             let (E_aux (_, e1annot)) = exp1 in
             E_aux (E_internal_return exp1, e1annot)
         | _, (E_aux (E_throw e, a), _), _ -> E_aux (E_throw e, a)
-        | (pat, _), ((E_aux (E_assert (c, msg), a) as assert_exp), _), _ -> begin
+        | (pat, _), ((E_aux (E_assert (c, _msg, _loc), a) as assert_exp), _), _ -> begin
             match typ_of c with
             | Typ_aux (Typ_app (Id_aux (Id "atom_bool", _), [A_aux (A_bool nc, _)]), _)
               when prove __POS__ (env_of c) (nc_not nc) ->
@@ -4167,7 +4168,9 @@ let rewrite_explicit_measure effect_info env ast =
                     ),
                   (loc, empty_tannot)
                 ),
-              E_aux (E_lit (L_aux (L_string "recursion limit reached", loc)), (loc, empty_tannot))
+              E_aux (E_lit (L_aux (L_string "recursion limit reached", loc)), (loc, empty_tannot)),
+              (* TODO: Where is this? *)
+              E_aux (E_lit (L_aux (L_string "generated code", loc)), (loc, empty_tannot))
             ),
           (loc, empty_tannot)
         )
@@ -4283,7 +4286,8 @@ let rewrite_loops_with_escape_effect env defs =
     E_aux
       ( E_assert
           ( E_aux (E_lit (L_aux (L_true, Unknown)), dummy_ann),
-            E_aux (E_lit (L_aux (L_string "loop dummy assert", Unknown)), dummy_ann)
+            E_aux (E_lit (L_aux (L_string "loop dummy assert", Unknown)), dummy_ann),
+            E_aux (E_lit (L_aux (L_string "loop dummy location", Unknown)), dummy_ann)
           ),
         dummy_ann
       )

--- a/src/lib/smt_gen.ml
+++ b/src/lib/smt_gen.ml
@@ -1526,6 +1526,8 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
   let ternary_primop f =
     Some (fun args ret_ctyp -> match args with [v1; v2; v3] -> f v1 v2 v3 ret_ctyp | _ -> arity_error)
 
+  let ternary_primop_simple f = Some (fun args _ -> match args with [v1; v2; v3] -> f v1 v2 v3 | _ -> arity_error)
+
   let builtin ?(allow_io = true) ?(undefined = Undefined_disable) = function
     | "eq_bit" -> binary_primop (binary_smt "=")
     | "eq_bool" -> binary_primop (binary_smt "=")
@@ -1651,10 +1653,11 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
             return (Fn (op, [bv]))
         )
     | "sail_assert" when allow_io ->
-        binary_primop_simple (fun b msg ->
+        ternary_primop_simple (fun b msg loc ->
             let* b = smt_cval b in
             let* msg = smt_cval msg in
-            return (Fn ("sail_assert", [b; msg]))
+            let* loc = smt_cval loc in
+            return (Fn ("sail_assert", [b; msg; loc]))
         )
     | "reg_deref" when allow_io ->
         unary_primop_simple (fun reg_ref ->

--- a/src/lib/spec_analysis.ml
+++ b/src/lib/spec_analysis.ml
@@ -207,7 +207,7 @@ let nexp_subst_fns substs =
     | E_assign (le, e) -> re (E_assign (s_lexp le, s_exp e))
     | E_exit e -> re (E_exit (s_exp e))
     | E_return e -> re (E_return (s_exp e))
-    | E_assert (e1, e2) -> re (E_assert (s_exp e1, s_exp e2))
+    | E_assert (e1, e2, e3) -> re (E_assert (s_exp e1, s_exp e2, s_exp e3))
     | E_var (le, e1, e2) -> re (E_var (s_lexp le, s_exp e1, s_exp e2))
     | E_internal_plet (p, e1, e2) -> re (E_internal_plet (s_pat p, s_exp e1, s_exp e2))
     | E_internal_return e -> re (E_internal_return (s_exp e))

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1974,13 +1974,6 @@ let irule r env exp =
     let bt = Printexc.get_raw_backtrace () in
     Printexc.raise_with_backtrace (Type_error (l, err)) bt
 
-(* This function adds useful assertion messages to asserts missing them *)
-let assert_msg = function
-  | E_aux (E_lit (L_aux (L_string "", _)), (l, _)) ->
-      let open Reporting in
-      locate (fun _ -> l) (mk_lit_exp (L_string (short_loc_to_string l)))
-  | msg -> msg
-
 let strip_exp exp = map_exp_annot (fun (l, tannot) -> (l, untyped_annot tannot)) exp
 let strip_pat pat = map_pat_annot (fun (l, tannot) -> (l, untyped_annot tannot)) pat
 let strip_pexp pexp = map_pexp_annot (fun (l, tannot) -> (l, untyped_annot tannot)) pexp
@@ -2644,7 +2637,6 @@ and check_block' f_p env exps ret_typ =
           let _, exps = check_block' f_p env exps ret_typ in
           (s_p, annotated_exp :: exps)
       | E_aux (E_assert (constr_exp, msg), (assert_l, _)), _ ->
-          let msg = assert_msg msg in
           let constr_exp = crule check_exp env constr_exp bool_typ in
           let checked_msg = crule check_exp env msg string_typ in
           let env, added_constraint =
@@ -3901,7 +3893,6 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
       | None -> typ_error l "Could not infer type of list literal"
     end
   | E_assert (test, msg) ->
-      let msg = assert_msg msg in
       let checked_test = crule check_exp env test bool_typ in
       let checked_msg = crule check_exp env msg string_typ in
       annot_exp (E_assert (checked_test, checked_msg)) unit_typ

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -2425,7 +2425,7 @@ let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_au
       (* Propagate constraint assertions on the lhs of monadic binds to the rhs *)
       let inner_env =
         match bind_exp with
-        | E_aux (E_assert (constr_exp, _), _) -> begin
+        | E_aux (E_assert (constr_exp, _, _), _) -> begin
             match assert_constraint inner_env true constr_exp with
             | Some nc ->
                 typ_print (lazy ("Adding constraint " ^ string_of_n_constraint nc ^ " for assert"));
@@ -2636,9 +2636,10 @@ and check_block' f_p env exps ret_typ =
           in
           let _, exps = check_block' f_p env exps ret_typ in
           (s_p, annotated_exp :: exps)
-      | E_aux (E_assert (constr_exp, msg), (assert_l, _)), _ ->
+      | E_aux (E_assert (constr_exp, msg, loc), (assert_l, _)), _ ->
           let constr_exp = crule check_exp env constr_exp bool_typ in
           let checked_msg = crule check_exp env msg string_typ in
+          let checked_loc = crule check_exp env loc string_typ in
           let env, added_constraint =
             match assert_constraint env true constr_exp with
             | Some nc ->
@@ -2646,7 +2647,7 @@ and check_block' f_p env exps ret_typ =
                 (Env.add_constraint ~reason:(assert_l, "assertion") nc env, true)
             | None -> (env, false)
           in
-          let texp = annot_exp assert_l (E_assert (constr_exp, checked_msg)) unit_typ (Some unit_typ) in
+          let texp = annot_exp assert_l (E_assert (constr_exp, checked_msg, checked_loc)) unit_typ (Some unit_typ) in
           let _, checked_exps = check_block' f_p env exps ret_typ in
           (* If we can prove false, then any code after the assertion
              is dead. In this inconsistent typing environment we can
@@ -3892,10 +3893,11 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
       | Some (xs, elem_typ) -> annot_exp (E_list xs) (list_typ elem_typ)
       | None -> typ_error l "Could not infer type of list literal"
     end
-  | E_assert (test, msg) ->
+  | E_assert (test, msg, loc) ->
       let checked_test = crule check_exp env test bool_typ in
       let checked_msg = crule check_exp env msg string_typ in
-      annot_exp (E_assert (checked_test, checked_msg)) unit_typ
+      let checked_loc = crule check_exp env loc string_typ in
+      annot_exp (E_assert (checked_test, checked_msg, checked_loc)) unit_typ
   | E_internal_return exp ->
       let inferred_exp = irule infer_exp env exp in
       annot_exp (E_internal_return inferred_exp) (typ_of inferred_exp)
@@ -3914,7 +3916,7 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
       (* Propagate constraint assertions on the lhs of monadic binds to the rhs *)
       let inner_env =
         match bind_exp with
-        | E_aux (E_assert (constr_exp, _), _) -> begin
+        | E_aux (E_assert (constr_exp, _, _), _) -> begin
             match assert_constraint env true constr_exp with
             | Some nc ->
                 typ_print (lazy ("Adding constraint " ^ string_of_n_constraint nc ^ " for assert"));

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -1644,7 +1644,8 @@ let doc_exp, doc_let =
                             E_aux
                               ( E_assert
                                   ( E_aux (E_lit (L_aux (L_true, _)), _),
-                                    E_aux (E_lit (L_aux (L_string "loop dummy assert", _)), _)
+                                    E_aux (E_lit (L_aux (L_string "loop dummy assert", _)), _),
+                                    E_aux (E_lit (L_aux (L_string "loop dummy location", _)), _)
                                   ),
                                 _
                               ),
@@ -2171,7 +2172,7 @@ let doc_exp, doc_let =
         let epp = liftR (separate space [string "throw"; expY e]) in
         if aexp_needed then parens (align epp) else align epp
     | E_exit e -> liftR (separate space [string "exit"; expY e])
-    | E_assert (e1, e2) ->
+    | E_assert (e1, e2, _e3) ->
         let epp = liftR (separate space [string "assert_exp"; expY e1; expY e2]) in
         if aexp_needed then parens (align epp) else align epp
     | E_var (lexp, eq_exp, in_exp) -> raise (report l __POS__ "E_vars should have been removed before pretty-printing")
@@ -2183,7 +2184,7 @@ let doc_exp, doc_let =
         let outer_env = env_of_annot (l, annot) in
         let new_ctxt = merge_new_tyvars ctxt outer_env pat (env_of e2) in
         match (pat, e1, e2) with
-        | (P_aux (P_wild, _) | P_aux (P_typ (_, P_aux (P_wild, _)), _)), E_aux (E_assert (assert_e1, assert_e2), _), _
+        | (P_aux (P_wild, _) | P_aux (P_typ (_, P_aux (P_wild, _)), _)), E_aux (E_assert (assert_e1, assert_e2, _assert_e3), _), _
           ->
             let assert_fn, mid =
               match assert_constraint outer_env true assert_e1 with

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -740,7 +740,7 @@ and doc_loop l as_monadic ctx loop_kind args =
             ( P_aux ((P_wild | P_typ (_, P_aux (P_wild, _))), _),
               E_aux
                 ( E_assert
-                    (E_aux (E_lit (L_aux (L_true, _)), _), E_aux (E_lit (L_aux (L_string "loop dummy assert", _)), _)),
+                    (E_aux (E_lit (L_aux (L_true, _)), _), E_aux (E_lit (L_aux (L_string "loop dummy assert", _)), _), E_aux (E_lit (L_aux (L_string "loop dummy location", _)), _)),
                   _
                 ),
               body'
@@ -1040,7 +1040,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
         ^^ space
         ^^ parens (string "fun the_exception => " ^^ hardline ^^ cases)
         )
-  | E_assert (e1, e2) -> string "assert " ^^ d_of_arg ctx e1 ^^ space ^^ d_of_arg ctx e2
+  | E_assert (e1, e2, e3) -> string "assert " ^^ d_of_arg ctx e1 ^^ space ^^ d_of_arg ctx e2 ^^ space ^^ d_of_arg ctx e3
   | E_list es -> brackets (separate_map comma_sp (doc_exp as_monadic ctx) es)
   | E_cons (hd_e, tl_e) -> parens (separate space [doc_exp false ctx hd_e; string "::"; doc_exp false ctx tl_e])
   | _ -> failwith ("Expression " ^ string_of_exp_con full_exp ^ " " ^ string_of_exp full_exp ^ " not translatable yet.")

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -1104,7 +1104,7 @@ let doc_exp_lem, doc_let_lem =
         else raise (Reporting.err_todo l "Warning: try-block around pure expression")
     | E_throw e -> align (liftR (separate space [string "throw"; expY e]))
     | E_exit e -> liftR (separate space [string "exit"; expY e])
-    | E_assert (e1, e2) -> align (liftR (separate space [string "assert_exp"; expY e1; expY e2]))
+    | E_assert (e1, e2, e3) -> align (liftR (separate space [string "assert_exp"; expY e1; expY e2; expY e3]))
     | E_var (lexp, eq_exp, in_exp) -> raise (report l __POS__ "E_vars should have been removed before pretty-printing")
     | E_internal_plet (pat, e1, e2) ->
         let bind, bind_unit = if ctxt.monadic then (">>=", ">>") else (">>$=", ">>$") in

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -261,7 +261,7 @@ let rec ocaml_exp ctx (E_aux (exp_aux, (l, _)) as exp) =
         end
     end
   | E_return exp -> separate space [string "r.return"; ocaml_atomic_exp ctx exp]
-  | E_assert (exp, _) -> separate space [string "assert"; ocaml_atomic_exp ctx exp]
+  | E_assert (exp, _, _) -> separate space [string "assert"; ocaml_atomic_exp ctx exp]
   | E_typ (_, exp) -> ocaml_exp ctx exp
   | E_block [exp] -> ocaml_exp ctx exp
   | E_block [] -> string "()"

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -898,9 +898,10 @@ module Make (Config : CONFIG) = struct
           else (
             let _, ret = svir_creturn l ctx creturn in
             match args with
-            | [cond; msg] ->
+            | [cond; msg; loc] ->
                 let* cond = Smt.smt_cval cond in
                 let* msg = Smt.smt_cval msg in
+                let* loc = Smt.smt_cval loc in
                 (* If the assert is only reachable under some path-condition, then the assert should pass
                    whenever the path-condition is not true. *)
                 let cond =
@@ -909,7 +910,10 @@ module Make (Config : CONFIG) = struct
                       Fn ("or", [Fn ("not", [pathcond]); Fn ("not", [Var (Name (mk_id "assert_reachable#", -1))]); cond])
                   | None -> cond
                 in
-                wrap (SVS_block [SVS_aux (SVS_assert (ngen_asrt (), cond, msg), l); SVS_aux (SVS_assign (ret, Unit), l)])
+                wrap
+                  (SVS_block
+                     [SVS_aux (SVS_assert (ngen_asrt (), cond, msg, loc), l); SVS_aux (SVS_assign (ret, Unit), l)]
+                  )
             | _ -> Reporting.unreachable l __POS__ "Invalid arguments for sail_assert"
           )
         else if Id.compare id (mk_id "sail_cons") = 0 then extern_generate l ctx creturn id "sail_cons" args
@@ -1009,10 +1013,27 @@ module Make (Config : CONFIG) = struct
     match aux with
     | SVS_comment str -> concat_map string ["/* "; str; " */"]
     | SVS_split_comb -> string "/* split comb */"
-    | SVS_assert (name, cond, msg) ->
+    | SVS_assert (name, cond, msg, loc) ->
         ( if not Config.no_assert_fatal then
             separate space
-              [string "if"; parens (pp_smt cond) ^^ semi; string "else"; string "$fatal" ^^ parens (pp_smt msg)]
+              [
+                string "if";
+                parens (pp_smt cond) ^^ semi;
+                string "else";
+                string "$fatal"
+                ^^ parens
+                     (separate (comma ^^ space)
+                        [
+                          (* The 'finish_number' parameter. 1 prints the time and location. *)
+                          string "1";
+                          (* Use a couple of spaces as a separate so it doesn't look so weird
+                  if the assertion string is empty. *)
+                          string "Assertion failed at %s  %s";
+                          pp_smt loc;
+                          pp_smt msg;
+                        ]
+                     );
+              ]
             ^^ terminator
           else empty
         )
@@ -2057,7 +2078,7 @@ module Make (Config : CONFIG) = struct
 
       method! vstatement s =
         match s with
-        | SVS_aux (SVS_assert (name, _, _), _) ->
+        | SVS_aux (SVS_assert (name, _, _, _), _) ->
             names := name :: !names;
             DoChildren
         | _ -> DoChildren

--- a/src/sail_sv_backend/sv_ir.ml
+++ b/src/sail_sv_backend/sv_ir.ml
@@ -136,7 +136,7 @@ and sv_statement_aux =
   | SVS_case of { head_exp : smt_exp; cases : (smt_exp * sv_statement) list; fallthrough : sv_statement option }
   | SVS_if of smt_exp * sv_statement option * sv_statement option
   | SVS_block of sv_statement list
-  | SVS_assert of Jib.name * smt_exp * smt_exp
+  | SVS_assert of Jib.name * smt_exp * smt_exp * smt_exp
   | SVS_foreach of sv_name * smt_exp * sv_statement
   | SVS_for of sv_for * sv_statement
   | SVS_raw of string * Jib.name list * Jib.name list
@@ -285,10 +285,10 @@ let rec visit_sv_statement (vis : svir_visitor) outer_statement =
         let fallthrough' = map_no_copy_opt (visit_sv_statement vis) fallthrough in
         if head_exp == head_exp' && cases == cases' && fallthrough == fallthrough' then no_change
         else SVS_aux (SVS_case { head_exp = head_exp'; cases = cases'; fallthrough = fallthrough' }, l)
-    | SVS_assert (name, cond, msg) ->
+    | SVS_assert (name, cond, msg, loc) ->
         let cond' = visit_smt_exp vis cond in
         let msg' = visit_smt_exp vis msg in
-        if cond == cond' && msg == msg' then no_change else SVS_aux (SVS_assert (name, cond', msg'), l)
+        if cond == cond' && msg == msg' then no_change else SVS_aux (SVS_assert (name, cond', msg', loc), l)
     | SVS_foreach (i, exp, stmt) ->
         let exp' = visit_smt_exp vis exp in
         let stmt' = visit_sv_statement vis stmt in

--- a/src/sail_sv_backend/sv_ir.mli
+++ b/src/sail_sv_backend/sv_ir.mli
@@ -132,7 +132,7 @@ and sv_statement_aux =
   | SVS_case of { head_exp : smt_exp; cases : (smt_exp * sv_statement) list; fallthrough : sv_statement option }
   | SVS_if of smt_exp * sv_statement option * sv_statement option
   | SVS_block of sv_statement list
-  | SVS_assert of Jib.name * smt_exp * smt_exp
+  | SVS_assert of Jib.name * (* condition *) smt_exp * (* message *) smt_exp * (* location string *) smt_exp
   | SVS_foreach of sv_name * smt_exp * sv_statement
   | SVS_for of sv_for * sv_statement
   | SVS_raw of string * Jib.name list * Jib.name list

--- a/src/sail_sv_backend/sv_optimize.ml
+++ b/src/sail_sv_backend/sv_optimize.ml
@@ -596,7 +596,7 @@ module RemoveUnusedVariables = struct
         begin
           match else_stmt_opt with Some else_stmt -> statement_uses stack uses else_stmt | None -> ()
         end
-    | SVS_assert (name, cond, msg) ->
+    | SVS_assert (name, cond, msg, _loc) ->
         smt_uses stack uses cond;
         smt_uses stack uses msg
     | SVS_case { head_exp; cases; fallthrough } ->


### PR DESCRIPTION
Sail currently replaces empty assertion messages with their location, so `assert(false, "")` and `assert(false)` (which is equivalent to the former) will print their location, but `assert(false, "foo")` won't.

This changes the behaviour so that instead all assertions print their location.

The previous substitution was applied during type checking, but now it is done in the ANF step.

Fixes #1453