### PR TITLE
Remove special casing for negative literals in lexer

### DIFF
--- a/src/lib/infix_parser.mly
+++ b/src/lib/infix_parser.mly
@@ -388,16 +388,19 @@ exp8:
   | exp8l Op8l exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp9 Op8r exp8r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | TwoCaret exp9 { mk_exp (E_app (mk_id "pow2" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
+  | Minus exp9 { mk_exp (E_app (mk_id "negate" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
   | exp9 { $1 }
 exp8l:
   | exp9 Op8 exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp8l Op8l exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | TwoCaret exp9 { mk_exp (E_app (mk_id "pow2" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
+  | Minus exp9 { mk_exp (E_app (mk_id "negate" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
   | exp9 { $1 }
 exp8r:
   | exp9 Op8 exp9 { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | exp9 Op8r exp8r { mk_exp (E_app_infix ($1, $2, $3)) $startpos $endpos }
   | TwoCaret exp9 { mk_exp (E_app (mk_id "pow2" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
+  | Minus exp9 { mk_exp (E_app (mk_id "negate" $startpos($1) $endpos($1), [$2])) $startpos $endpos }
   | exp9 { $1 }
 
 exp9:

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -128,6 +128,9 @@ let kw_table =
      ("termination_measure",     (fun _ -> TerminationMeasure));
      ("forwards",                (fun _ -> Forwards));
      ("backwards",               (fun _ -> Backwards));
+     ("from",                    (fun _ -> From));
+     ("to",                      (fun _ -> To));
+     ("downto",                  (fun _ -> Downto));
      ("internal_plet",           (fun _ -> InternalPLet));
      ("internal_return",         (fun _ -> InternalReturn));
      ("internal_assume",         (fun _ -> InternalAssume));
@@ -227,9 +230,7 @@ rule token comments = parse
                                             else
                                               Id i }
   | (digit+ as i1) "." (digit+ as i2)     { Real (i1 ^ "." ^ i2) }
-  | "-" (digit* as i1) "." (digit+ as i2) { Real ("-" ^ i1 ^ "." ^ i2) }
   | digit+ as i                           { Num (Big_int.of_string i) }
-  | "-" digit+ as i                       { Num (Big_int.of_string i) }
   | "0b" (binarydigit+ as i)              { Bin (Util.string_of_list "" (fun s -> s) (Util.split_on_char '_' i)) }
   | "0x" (hexdigit+ as i)                 { Hex (Util.string_of_list "" (fun s -> s) (Util.split_on_char '_' i)) }
   | '"'                                   { let startpos = Lexing.lexeme_start_p lexbuf in

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -216,6 +216,7 @@ let set_syntax_deprecated l =
 %token Repeat Until While Do Mutual Var Ref Configuration TerminationMeasure Instantiation Impl Private
 %token InternalPLet InternalReturn InternalAssume
 %token Forwards Backwards
+%token From To Downto
 
 %nonassoc Then
 %nonassoc Else
@@ -527,7 +528,7 @@ pat_list:
 atomic_pat:
   | Under
     { mk_pat (P_wild) $startpos $endpos }
-  | lit
+  | negative_lit
     { mk_pat (P_lit $1) $startpos $endpos }
   | id
     { mk_pat (P_id $1) $startpos $endpos }
@@ -589,6 +590,12 @@ lit:
   | Real
     { mk_lit (L_real $1) $startpos $endpos }
 
+negative_lit:
+  | Minus Num
+    { mk_lit (L_num (Big_int.negate $2)) $startpos $endpos }
+  | lit
+    { $1 }
+
 exp_eof:
   | exp Eof
     { $1 }
@@ -599,6 +606,36 @@ internal_loop_measure:
     { mk_measure Measure_none $startpos $endpos }
   | TerminationMeasure Lcurly exp Rcurly
     { mk_measure (Measure_some $3) $startpos $endpos }
+
+%inline to_or_downto:
+  | To
+    { "to" }
+  | Downto
+    { "downto" }
+
+loop_exp:
+  | v=id; From; f=exp; To; t=exp; By; step=exp; In; order=typ
+    { (v, f, t, step, order ) }
+  | v=id; From; f=exp; ord=to_or_downto; t=exp; By; step=exp
+    { let order =
+        if ord = "to" then
+          ATyp_aux (ATyp_inc, loc $startpos(ord) $endpos(ord))
+        else
+          ATyp_aux (ATyp_dec, loc $startpos(ord) $endpos(ord))
+      in
+      (v, f, t, step, order)
+    }
+  | v=id; From; f=exp; ord=to_or_downto; t=exp
+    {
+      let step = mk_lit_exp (L_num (Big_int.of_int 1)) $startpos $endpos in
+      let order =
+        if ord = "to" then
+          ATyp_aux (ATyp_inc, loc $startpos(ord) $endpos(ord))
+        else
+          ATyp_aux (ATyp_dec, loc $startpos(ord) $endpos(ord))
+      in
+      (v, f, t, step, order)
+    }
 
 exp:
   | exp0
@@ -633,35 +670,9 @@ exp:
     { mk_exp (E_match ($2, $4)) $startpos $endpos }
   | Try exp Catch Lcurly case_list Rcurly
     { mk_exp (E_try ($2, $5)) $startpos $endpos }
-  | Foreach Lparen id Id atomic_exp Id atomic_exp By atomic_exp In typ Rparen exp
-    { if $4 <> "from" then
-       raise (Reporting.err_syntax_loc (loc $startpos $endpos) ("Missing \"from\" in foreach loop"));
-      if $6 <> "to" then
-       raise (Reporting.err_syntax_loc (loc $startpos $endpos) ("Missing \"to\" in foreach loop"));
-      mk_exp (E_for ($3, $5, $7, $9, $11, $13)) $startpos $endpos }
-  | Foreach Lparen id Id atomic_exp Id atomic_exp By atomic_exp Rparen exp
-    { if $4 <> "from" then
-       raise (Reporting.err_syntax_loc (loc $startpos $endpos) ("Missing \"from\" in foreach loop"));
-      if $6 <> "to" && $6 <> "downto" then
-       raise (Reporting.err_syntax_loc (loc $startpos $endpos) ("Missing \"to\" or \"downto\" in foreach loop"));
-      let order =
-        if $6 = "to"
-        then ATyp_aux(ATyp_inc,loc $startpos($6) $endpos($6))
-        else ATyp_aux(ATyp_dec,loc $startpos($6) $endpos($6))
-      in
-      mk_exp (E_for ($3, $5, $7, $9, order, $11)) $startpos $endpos }
-  | Foreach Lparen id Id atomic_exp Id atomic_exp Rparen exp
-    { if $4 <> "from" then
-       raise (Reporting.err_syntax_loc (loc $startpos $endpos) ("Missing \"from\" in foreach loop"));
-      if $6 <> "to" && $6 <> "downto" then
-       raise (Reporting.err_syntax_loc (loc $startpos $endpos) ("Missing \"to\" or \"downto\" in foreach loop"));
-      let step = mk_lit_exp (L_num (Big_int.of_int 1)) $startpos $endpos in
-      let ord =
-        if $6 = "to"
-        then ATyp_aux(ATyp_inc,loc $startpos($6) $endpos($6))
-        else ATyp_aux(ATyp_dec,loc $startpos($6) $endpos($6))
-      in
-      mk_exp (E_for ($3, $5, $7, step, ord, $9)) $startpos $endpos }
+  | Foreach Lparen loop_exp Rparen exp
+    { let (v, f, t, step, order) = $3 in
+      mk_exp (E_for (v, f, t, step, order, $5)) $startpos $endpos }
   | Repeat internal_loop_measure exp Until exp
     { mk_exp (E_loop (Until, $2, $5, $3)) $startpos $endpos }
   | While internal_loop_measure exp Do exp
@@ -1114,7 +1125,7 @@ mpat_list:
     { $1 :: $3 }
 
 atomic_mpat:
-  | lit
+  | negative_lit
     { mk_mpat (MP_lit $1) $startpos $endpos }
   | id
     { mk_mpat (MP_id $1) $startpos $endpos }

--- a/src/sail_doc_backend/html_source.ml
+++ b/src/sail_doc_backend/html_source.ml
@@ -90,7 +90,7 @@ let highlights ~filename ~contents =
     | Foreach | Function_ | Mapping | Overload | Throw | Try | Catch | If_ | In | Inc | Var | Ref | Pure | Impure
     | Monadic | Register | Return | Scattered | Sizeof | Constraint | Constant | Struct | Then | Typedef | Union
     | Newtype | With | Val | Outcome | Instantiation | Impl | Private | Repeat | Until | While | Do | Mutual | Config
-    | Configuration | TerminationMeasure | Forwards | Backwards | Let_ | Bitfield | When ->
+    | Configuration | TerminationMeasure | Forwards | Backwards | Let_ | Bitfield | When | To | Downto | From ->
         mark Highlight.Keyword;
         go ()
     | StructuredPragma _ | Pragma _ | Attribute _ | Fixity _ ->

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -200,7 +200,7 @@ def extern_add (_ : Unit) : Int :=
   (5 +i 4)
 
 def extern_sub (_ : Unit) : Int :=
-  (5 -i (-4))
+  (5 -i (Neg.neg 4))
 
 def extern_sub_nat (_ : Unit) : Nat :=
   (5 -i 4)
@@ -245,7 +245,7 @@ def extern_min (_ : Unit) : Int :=
   (Min.min 5 4)
 
 def extern_abs_int_plain (_ : Unit) : Int :=
-  let x : Int := (-5)
+  let x : Int := (Neg.neg 5)
   (Sail.Int.intAbs x)
 
 def extern_eq_unit (_ : Unit) : Bool :=

--- a/test/ocaml/reg_ref/rr.sail
+++ b/test/ocaml/reg_ref/rr.sail
@@ -44,12 +44,12 @@ function slice_bits MkSlice(_, xs) = xs
 val vector_slice : forall 'n 'm 'o, 0 <= 'm <= 'o < 'n.
   (bits('n), atom('o), atom('m)) -> slice('m, 'o - ('m - 1))
 
-function vector_slice (v, to, from) = MkSlice(from, v[to .. from])
+function vector_slice (v, t, f) = MkSlice(f, v[t .. f])
 
 val slice_slice : forall 'n 'm 'o 'p, 0 <= 'p <= 'm <= 'o & 'o - 'p < 'n.
   (slice('p, 'n), atom('o), atom('m)) -> slice('m, 'o - ('m - 1))
 
-function slice_slice (MkSlice(start, v), to, from) = MkSlice(from, v[to - start .. from - start])
+function slice_slice (MkSlice(s, v), t, f) = MkSlice(f, v[t - s .. f - s])
 
 /* We can update a bitvector from another bitvector or a slice */
 val _set_slice : forall 'n 'm 'o, 0 <= 'm <= 'o < 'n.

--- a/test/smt/minmax.unsat.sail
+++ b/test/smt/minmax.unsat.sail
@@ -1,9 +1,6 @@
+default Order dec
 
-val operator == = "eq_int" : (int, int) -> bool
-
-val "max_int" : (int, int) -> int
-
-val "min_int" : (int, int) -> int
+$include <prelude.sail>
 
 $property
 function prop(a: int, b: int) -> bool = {

--- a/test/typecheck/fail/negative_bits_list.expect
+++ b/test/typecheck/fail/negative_bits_list.expect
@@ -7,4 +7,4 @@
  [91m |[0m [93mCaused by [0m[96mfail/negative_bits_list.sail[0m:8.16-20:
  [91m |[0m 8[96m |[0m    let x: list(bits(-1)) = [||];
  [91m |[0m  [91m |[0m                [91m^--^[0m
- [91m |[0m  [91m |[0m Could not prove -1 >= 0 for type constructor bits
+ [91m |[0m  [91m |[0m Could not prove - 1 >= 0 for type constructor bits

--- a/test/typecheck/fail/negative_bits_struct2.expect
+++ b/test/typecheck/fail/negative_bits_struct2.expect
@@ -14,4 +14,4 @@
  [91m |[0m  [91m |[0m [93mCaused by [0m[96mfail/negative_bits_struct2.sail[0m:6.8-12:
  [91m |[0m  [91m |[0m 6[96m |[0m    xs: bits(-3)
  [91m |[0m  [91m |[0m  [91m |[0m        [91m^--^[0m
- [91m |[0m  [91m |[0m  [91m |[0m Could not prove -3 >= 0 for type constructor bits
+ [91m |[0m  [91m |[0m  [91m |[0m Could not prove - 3 >= 0 for type constructor bits

--- a/test/typecheck/fail/negative_bits_tuple.expect
+++ b/test/typecheck/fail/negative_bits_tuple.expect
@@ -7,4 +7,4 @@
  [91m |[0m [93mCaused by [0m[96mfail/negative_bits_tuple.sail[0m:8.12-16:
  [91m |[0m 8[96m |[0m    let x: (bits(-1), int) = undefined;
  [91m |[0m  [91m |[0m            [91m^--^[0m
- [91m |[0m  [91m |[0m Could not prove -1 >= 0 for type constructor bits
+ [91m |[0m  [91m |[0m Could not prove - 1 >= 0 for type constructor bits

--- a/test/typecheck/pass/minus_no_space.sail
+++ b/test/typecheck/pass/minus_no_space.sail
@@ -1,0 +1,8 @@
+default Order dec
+$include <prelude.sail>
+
+let xlen = 32
+
+let test1 = 64-xlen
+
+let test2 = 64-32


### PR DESCRIPTION
Instead treat like a normal prefix operator. We need an extra parsing rule `negative_lit` to handle negative literals in patterns and mapping patterns, where they were previously allowed but wouldn't be with this change.