### PR TITLE
Fix issue 1458

### DIFF
--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -210,13 +210,9 @@ let fallthrough =
 
 type return_value = Semantics.return_value
 
-let is_interpreter_extern id env =
-  let open Type_check in
-  Env.is_extern id env "interpreter"
+let is_interpreter_extern id env = Type_check.Env.is_extern id env "interpreter"
 
-let get_interpreter_extern id env =
-  let open Type_check in
-  Env.get_extern id env "interpreter"
+let get_interpreter_extern id env = Type_check.Env.get_extern id env "interpreter"
 
 let complete_value = function
   | ((v1, n1), m1) :: partial_values ->

--- a/src/lib/smt_gen.ml
+++ b/src/lib/smt_gen.ml
@@ -1052,9 +1052,13 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
 
   let builtin_vector_subrange vec i j ret_ctyp =
     match (cval_ctyp vec, cval_ctyp i, cval_ctyp j, ret_ctyp) with
-    | CT_fbits n, CT_constant i, CT_constant j, CT_fbits _ ->
-        let* vec = smt_cval vec in
-        return (Extract (Big_int.to_int i, Big_int.to_int j, n, vec))
+    | CT_fbits n, CT_constant i, CT_constant j, CT_fbits m ->
+        if m <= n then
+          let* vec = smt_cval vec in
+          return (Extract (Big_int.to_int i, Big_int.to_int j, n, vec))
+        else
+          (* We need this nonsensical case due to flow typing *)
+          return (bvzero m)
     | CT_lbits, CT_constant i, CT_constant j, CT_fbits _ ->
         let* vec = smt_cval vec in
         return (Extract (Big_int.to_int i, Big_int.to_int j, lbits_size, Fn ("contents", [vec])))

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1609,8 +1609,7 @@ let get_register id env =
 
 let get_registers env = filter_items env env.global.registers
 
-let is_extern id env backend =
-  try not (Ast_util.extern_assoc backend (Bindings.find_opt id env.global.externs) = None) with Not_found -> false
+let is_extern id env backend = Option.is_some (Ast_util.extern_assoc backend (Bindings.find_opt id env.global.externs))
 
 let add_extern id ext env =
   update_global (fun global -> { global with externs = Bindings.add id ext global.externs }) env

--- a/src/sail_smt_backend/sail_plugin_smt.ml
+++ b/src/sail_smt_backend/sail_plugin_smt.ml
@@ -134,7 +134,7 @@ let smt_rewrites =
     ("properties", []);
   ]
 
-let smt_target out_file { ast; effect_info; env; _ } =
+let smt_target out_file { ast; effect_info; env = orig_env; _ } =
   let open Ast_util in
   let properties = Property.find_properties ast in
   let prop_ids = Bindings.bindings properties |> List.map fst |> IdSet.of_list in
@@ -142,10 +142,10 @@ let smt_target out_file { ast; effect_info; env; _ } =
   Specialize.add_initial_calls prop_ids;
   let ast_smt, env, effect_info =
     if !opt_smt_specialize then (
-      let ast_smt, env, effect_info = Specialize.(specialize typ_specialization env ast effect_info) in
+      let ast_smt, env, effect_info = Specialize.(specialize typ_specialization orig_env ast effect_info) in
       Specialize.(specialize_passes 2 int_specialization_with_externs env ast_smt effect_info)
     )
-    else (ast, env, effect_info)
+    else (ast, orig_env, effect_info)
   in
   let name_file =
     match out_file with Some f -> fun str -> f ^ "_" ^ str ^ ".smt2" | None -> fun str -> str ^ ".smt2"
@@ -169,8 +169,8 @@ let smt_target out_file { ast; effect_info; env; _ } =
     let unsats =
       List.map
         (fun ({ loc; file_name; function_id; args; arg_ctyps; arg_smt_names } : SMTGen.generated_smt_info) ->
-          ( Counterexample.check ~loc ~ctx ~env:ctx.tc_env ~ast ~solver:!opt_smt_auto_solver ~file_name ~function_id
-              ~args ~arg_ctyps ~arg_smt_names,
+          ( Counterexample.check ~loc ~ctx ~env:orig_env ~ast ~solver:!opt_smt_auto_solver ~file_name ~function_id ~args
+              ~arg_ctyps ~arg_smt_names,
             function_id
           )
         )


### PR DESCRIPTION
There are points where we need to generate SMT for cases that are otherwise impossible due to flow typing, and this can lead to odd situtations where we need to e.g. extract a value that is larger than the thing we are extracting from.

All such cases should be dead code, so it's safe to just return any valid value.

Really need some kind of fuzzer or exhaustive testing for the SMT primitives - they all should return something type correct even for nonsensical inputs (those which violate the type constraints in Sail), and correct values for all possible bitwidths (that do satisfy those constraints). This particular fix is mostly a band aid over one specific case.

Also fix an issue were specialisation would delete definitions required to replay counterexamples.