### PR TITLE
Don't require tuples to pass equal-sized float pairs

### DIFF
--- a/lib/float/arith_internal.sail
+++ b/lib/float/arith_internal.sail
@@ -15,8 +15,8 @@ $include <float/zero.sail>
 $include <float/nan.sail>
 $include <float/rounding.sail>
 
-val      float_is_lt_internal : fp_bits_x2 -> bool
-function float_is_lt_internal ((op_0, op_1)) = {
+val      float_is_lt_internal : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> bool
+function float_is_lt_internal (op_0, op_1) = {
   let fp_0 = float_decompose (op_0);
   let fp_1 = float_decompose (op_1);
 
@@ -35,29 +35,29 @@ function float_is_lt_internal ((op_0, op_1)) = {
   is_lt;
 }
 
-val      float_is_eq_internal : fp_bits_x2 -> bool
-function float_is_eq_internal ((op_0, op_1)) = {
+val      float_is_eq_internal : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> bool
+function float_is_eq_internal (op_0, op_1) = {
   let is_zero = float_is_zero (op_0) & float_is_zero (op_1);
   let is_eq   = (op_0 == op_1) | is_zero;
 
   is_eq;
 }
 
-val      float_is_ne_internal : fp_bits_x2 -> bool
-function float_is_ne_internal ((op_0, op_1))
-  = not (float_is_eq_internal ((op_0, op_1)))
+val      float_is_ne_internal : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> bool
+function float_is_ne_internal (op_0, op_1)
+  = not (float_is_eq_internal (op_0, op_1))
 
-val      float_is_le_internal : fp_bits_x2 -> bool
-function float_is_le_internal ((op_0, op_1))
-  = float_is_eq_internal ((op_0, op_1)) | float_is_lt_internal ((op_0, op_1))
+val      float_is_le_internal : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> bool
+function float_is_le_internal (op_0, op_1)
+  = float_is_eq_internal (op_0, op_1) | float_is_lt_internal (op_0, op_1)
 
-val      float_is_gt_internal : fp_bits_x2 -> bool
-function float_is_gt_internal ((op_0, op_1))
-  = not (float_is_le_internal ((op_0, op_1)))
+val      float_is_gt_internal : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> bool
+function float_is_gt_internal (op_0, op_1)
+  = not (float_is_le_internal (op_0, op_1))
 
-val      float_is_ge_internal : fp_bits_x2 -> bool
-function float_is_ge_internal ((op_0, op_1))
-  = not (float_is_lt_internal ((op_0, op_1)))
+val      float_is_ge_internal : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> bool
+function float_is_ge_internal (op_0, op_1)
+  = not (float_is_lt_internal (op_0, op_1))
 
 val      float_propagate_nan : forall 'n, 'n in {16, 32, 64, 128}.
   (bits('n), bits('n)) -> (bits('n), fp_exception_flags)

--- a/lib/float/common.sail
+++ b/lib/float/common.sail
@@ -13,9 +13,10 @@ $define _FLOAT_COMMON
 /* Floating point types definition */
 type fp_exception_flags = bits(5) /* Floating-point exception flags. */
 type fp_rounding_modes = bits(5) /* Floating-point rounding modes. */
-type fp_bits = { 'n, 'n in {16, 32, 64, 128}. bits('n) } /* Floating-point in bits. */
-type fp_bits_x2 = { 'n, 'n in {16, 32, 64, 128}. (bits('n), bits('n)) } /* Floating point x2 tuple */
-type fp_bool_and_flags = (bool, fp_exception_flags) /* Floating point bool and exception flags tuple */
+// Floating point in bits.
+type fp_bits = {8, 16, 32, 64, 128}
+// Type alias for use in `forall`s.
+type is_fp_bits('n) -> Bool = 'n in {8, 16, 32, 64, 128}
 
 /* Floating point constants */
 let fp_eflag_none           : fp_exception_flags = 0b00000

--- a/lib/float/eq.sail
+++ b/lib/float/eq.sail
@@ -14,15 +14,15 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_eq : fp_bits_x2 -> fp_bool_and_flags
-function float_is_eq ((op_0, op_1)) = {
+val      float_is_eq : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_eq (op_0, op_1) = {
   let is_snan = float_is_snan (op_0) | float_is_snan (op_1);
   let flags   = if   is_snan
                 then fp_eflag_invalid
                 else fp_eflag_none;
 
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
-  let is_eq   = not (is_nan) & float_is_eq_internal ((op_0, op_1));
+  let is_eq   = not (is_nan) & float_is_eq_internal (op_0, op_1);
 
   (is_eq, flags);
 }

--- a/lib/float/ge.sail
+++ b/lib/float/ge.sail
@@ -14,13 +14,13 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_ge : fp_bits_x2 -> fp_bool_and_flags
-function float_is_ge ((op_0, op_1)) = {
+val      float_is_ge : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_ge (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let flags   = if   is_nan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_ge   = not (is_nan) & float_is_ge_internal ((op_0, op_1));
+  let is_ge   = not (is_nan) & float_is_ge_internal (op_0, op_1);
 
   (is_ge, flags);
 }

--- a/lib/float/ge_quiet.sail
+++ b/lib/float/ge_quiet.sail
@@ -14,14 +14,14 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_ge_quiet : fp_bits_x2 -> fp_bool_and_flags
-function float_is_ge_quiet ((op_0, op_1)) = {
+val      float_is_ge_quiet : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_ge_quiet (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let is_snan = float_is_snan (op_0) | float_is_snan (op_1);
   let flags   = if   is_snan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_ge   = not (is_nan) & float_is_ge_internal ((op_0, op_1));
+  let is_ge   = not (is_nan) & float_is_ge_internal (op_0, op_1);
 
   (is_ge, flags);
 }

--- a/lib/float/gt.sail
+++ b/lib/float/gt.sail
@@ -14,13 +14,13 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_gt : fp_bits_x2 -> fp_bool_and_flags
-function float_is_gt ((op_0, op_1)) = {
+val      float_is_gt : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_gt (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let flags   = if   is_nan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_gt   = not (is_nan) & float_is_gt_internal ((op_0, op_1));
+  let is_gt   = not (is_nan) & float_is_gt_internal (op_0, op_1);
 
   (is_gt, flags);
 }

--- a/lib/float/gt_quiet.sail
+++ b/lib/float/gt_quiet.sail
@@ -14,14 +14,14 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_gt_quiet : fp_bits_x2 -> fp_bool_and_flags
-function float_is_gt_quiet ((op_0, op_1)) = {
+val      float_is_gt_quiet : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_gt_quiet (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let is_snan = float_is_snan (op_0) | float_is_snan (op_1);
   let flags   = if   is_snan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_gt   = not (is_nan) & float_is_gt_internal ((op_0, op_1));
+  let is_gt   = not (is_nan) & float_is_gt_internal (op_0, op_1);
 
   (is_gt, flags);
 }

--- a/lib/float/le.sail
+++ b/lib/float/le.sail
@@ -14,13 +14,13 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_le : fp_bits_x2 -> fp_bool_and_flags
-function float_is_le ((op_0, op_1)) = {
+val      float_is_le : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_le (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let flags   = if   is_nan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_le   = not (is_nan) & float_is_le_internal ((op_0, op_1));
+  let is_le   = not (is_nan) & float_is_le_internal (op_0, op_1);
 
   (is_le, flags);
 }

--- a/lib/float/le_quiet.sail
+++ b/lib/float/le_quiet.sail
@@ -14,14 +14,14 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_le_quiet : fp_bits_x2 -> fp_bool_and_flags
-function float_is_le_quiet ((op_0, op_1)) = {
+val      float_is_le_quiet : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_le_quiet (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let is_snan = float_is_snan (op_0) | float_is_snan (op_1);
   let flags   = if   is_snan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_lt   = not (is_nan) & float_is_le_internal ((op_0, op_1));
+  let is_lt   = not (is_nan) & float_is_le_internal (op_0, op_1);
 
   (is_lt, flags);
 }

--- a/lib/float/lt.sail
+++ b/lib/float/lt.sail
@@ -14,13 +14,13 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_lt : fp_bits_x2 -> fp_bool_and_flags
-function float_is_lt ((op_0, op_1)) = {
+val      float_is_lt : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_lt (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let flags   = if   is_nan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_lt   = not (is_nan) & float_is_lt_internal ((op_0, op_1));
+  let is_lt   = not (is_nan) & float_is_lt_internal (op_0, op_1);
 
   (is_lt, flags);
 }

--- a/lib/float/lt_quiet.sail
+++ b/lib/float/lt_quiet.sail
@@ -14,14 +14,14 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_lt_quiet : fp_bits_x2 -> fp_bool_and_flags
-function float_is_lt_quiet ((op_0, op_1)) = {
+val      float_is_lt_quiet : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_lt_quiet (op_0, op_1) = {
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
   let is_snan = float_is_snan (op_0) | float_is_snan (op_1);
   let flags   = if   is_snan
                 then fp_eflag_invalid
                 else fp_eflag_none;
-  let is_lt   = not (is_nan) & float_is_lt_internal ((op_0, op_1));
+  let is_lt   = not (is_nan) & float_is_lt_internal (op_0, op_1);
 
   (is_lt, flags);
 }

--- a/lib/float/ne.sail
+++ b/lib/float/ne.sail
@@ -14,15 +14,15 @@ $include <float/common.sail>
 $include <float/nan.sail>
 $include <float/arith_internal.sail>
 
-val      float_is_ne : fp_bits_x2 -> fp_bool_and_flags
-function float_is_ne ((op_0, op_1)) = {
+val      float_is_ne : forall 'n, is_fp_bits('n) . (bits('n), bits('n)) -> (bool, fp_exception_flags)
+function float_is_ne (op_0, op_1) = {
   let is_snan = float_is_snan (op_0) | float_is_snan (op_1);
   let flags   = if   is_snan
                 then fp_eflag_invalid
                 else fp_eflag_none;
 
   let is_nan  = float_is_nan (op_0) | float_is_nan (op_1);
-  let is_ne   = not (is_nan) & float_is_ne_internal ((op_0, op_1));
+  let is_ne   = not (is_nan) & float_is_ne_internal (op_0, op_1);
 
   (is_ne, flags);
 }

--- a/test/float/tuple_equality.sail
+++ b/test/float/tuple_equality.sail
@@ -13,7 +13,7 @@ $define _FLOAT_TUPLE_EQUALITY
 $include <float/common.sail>
 
 /* Floating point related tuple implementations for test */
-val      bool_and_flags_eq : (fp_bool_and_flags, fp_bool_and_flags) -> bool
+val      bool_and_flags_eq : ((bool, fp_exception_flags), (bool, fp_exception_flags)) -> bool
 function bool_and_flags_eq ((bool_0, flags_0), (bool_1, flags_1)) = {
   let is_eq = (bool_0 == bool_1) & (flags_0 == flags_1);
 


### PR DESCRIPTION
Instead of using a tuple type to pass two floats into functions, just pass them as separate parameters. This is a bit nicer to use.

Also remove the `fp_bool_and_flags` type alias because it obscures the type and isn't much shorter anyway.

Fixes #1473 