### PR TITLE
Add float_classify function to float library

### DIFF
--- a/lib/float/classify.sail
+++ b/lib/float/classify.sail
@@ -1,0 +1,40 @@
+$ifndef _FLOAT_CLASSIFY
+$define _FLOAT_CLASSIFY
+
+$include <float/common.sail>
+$include <float/nan.sail>
+$include <float/zero.sail>
+$include <float/normal.sail>
+$include <float/inf.sail>
+$include <float/sign.sail>
+
+// Classify floating point numbers into one of these classes. All floating point
+// numbers are in exactly one class.
+enum float_class = {
+  float_class_negative_inf,
+  float_class_negative_normal,
+  float_class_negative_subnormal,
+  float_class_negative_zero,
+  float_class_positive_zero,
+  float_class_positive_subnormal,
+  float_class_positive_normal,
+  float_class_positive_inf,
+  float_class_snan,
+  float_class_qnan,
+}
+
+// Classify a floating point number into exactly one of the 10 possible classes.
+function float_classify(f : fp_bits) -> float_class =
+  if      float_is_snan(f)      then float_class_snan
+  else if float_is_qnan(f)      then float_class_qnan
+  else if float_is_zero(f)      then (if float_is_positive(f) then float_class_positive_zero      else float_class_negative_zero)
+  else if float_is_subnormal(f) then (if float_is_positive(f) then float_class_positive_subnormal else float_class_negative_subnormal)
+  else if float_is_normal(f)    then (if float_is_positive(f) then float_class_positive_normal    else float_class_negative_normal)
+  else if float_is_inf(f)       then (if float_is_positive(f) then float_class_positive_inf       else float_class_negative_inf)
+  else {
+    // This is unreachable.
+    assert(false, "float_classify internal logic error");
+    undefined
+  }
+
+$endif

--- a/lib/float/interface.sail
+++ b/lib/float/interface.sail
@@ -26,5 +26,6 @@ $include <float/gt.sail>
 $include <float/gt_quiet.sail>
 $include <float/ge.sail>
 $include <float/ge_quiet.sail>
+$include <float/classify.sail>
 
 $endif

--- a/lib/float/normal.sail
+++ b/lib/float/normal.sail
@@ -20,12 +20,12 @@ function float_is_normal (op) = {
   is_normal
 }
 
-val      float_is_denormal : fp_bits -> bool
-function float_is_denormal (op) = {
+val      float_is_subnormal : fp_bits -> bool
+function float_is_subnormal (op) = {
   let struct {_, exp, mantissa} = float_decompose(op);
-  let is_denormal               = is_all_zeros (exp) & not (is_all_zeros (mantissa));
+  let is_subnormal               = is_all_zeros (exp) & not (is_all_zeros (mantissa));
 
-  is_denormal
+  is_subnormal
 }
 
 $endif

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -194,6 +194,7 @@
   (%{workspace_root}/lib/float/ge_quiet.sail as lib/float/ge_quiet.sail)
   (%{workspace_root}/lib/float/add.sail as lib/float/add.sail)
   (%{workspace_root}/lib/float/rounding.sail as lib/float/rounding.sail)
+  (%{workspace_root}/lib/float/classify.sail as lib/float/classify.sail)
   (%{workspace_root}/lib/float/interface.sail as lib/float/interface.sail)
   (%{workspace_root}/lib/reverse_endianness.sail
    as

--- a/test/float/add_test.sail
+++ b/test/float/add_test.sail
@@ -17,10 +17,10 @@ $include "tuple_equality.sail"
 
 function test_float_add () -> unit = {
   /* Half floating point */
-  assert(float_add (fp16_pos_denormal_add_0_op_0, fp16_pos_denormal_add_0_op_1) == (fp16_pos_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp16_pos_denormal_add_1_op_0, fp16_pos_denormal_add_1_op_1) == (fp16_pos_denormal_add_1_sum, fp_eflag_none));
-  assert(float_add (fp16_neg_denormal_add_0_op_0, fp16_neg_denormal_add_0_op_1) == (fp16_neg_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp16_neg_denormal_add_1_op_0, fp16_neg_denormal_add_1_op_1) == (fp16_neg_denormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp16_pos_subnormal_add_0_op_0, fp16_pos_subnormal_add_0_op_1) == (fp16_pos_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp16_pos_subnormal_add_1_op_0, fp16_pos_subnormal_add_1_op_1) == (fp16_pos_subnormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp16_neg_subnormal_add_0_op_0, fp16_neg_subnormal_add_0_op_1) == (fp16_neg_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp16_neg_subnormal_add_1_op_0, fp16_neg_subnormal_add_1_op_1) == (fp16_neg_subnormal_add_1_sum, fp_eflag_none));
 
   assert(float_add (fp16_pos_inf, fp16_pos_inf) == (fp16_pos_inf, fp_eflag_none));
   assert(float_add (fp16_pos_inf, fp16_pos_qnan_default) == (fp16_pos_qnan_default, fp_eflag_none));
@@ -122,10 +122,10 @@ function test_float_add () -> unit = {
   assert(float_add (fp16_neg_diff_exp_add_1_op_0, fp16_neg_diff_exp_add_1_op_1) == (fp16_neg_diff_exp_add_1_sum, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_add (fp32_pos_denormal_add_0_op_0, fp32_pos_denormal_add_0_op_1) == (fp32_pos_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp32_pos_denormal_add_1_op_0, fp32_pos_denormal_add_1_op_1) == (fp32_pos_denormal_add_1_sum, fp_eflag_none));
-  assert(float_add (fp32_neg_denormal_add_0_op_0, fp32_neg_denormal_add_0_op_1) == (fp32_neg_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp32_neg_denormal_add_1_op_0, fp32_neg_denormal_add_1_op_1) == (fp32_neg_denormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp32_pos_subnormal_add_0_op_0, fp32_pos_subnormal_add_0_op_1) == (fp32_pos_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp32_pos_subnormal_add_1_op_0, fp32_pos_subnormal_add_1_op_1) == (fp32_pos_subnormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp32_neg_subnormal_add_0_op_0, fp32_neg_subnormal_add_0_op_1) == (fp32_neg_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp32_neg_subnormal_add_1_op_0, fp32_neg_subnormal_add_1_op_1) == (fp32_neg_subnormal_add_1_sum, fp_eflag_none));
 
   assert(float_add (fp32_pos_inf, fp32_pos_inf) == (fp32_pos_inf, fp_eflag_none));
   assert(float_add (fp32_pos_inf, fp32_pos_qnan_default) == (fp32_pos_qnan_default, fp_eflag_none));
@@ -227,10 +227,10 @@ function test_float_add () -> unit = {
   assert(float_add (fp32_neg_diff_exp_add_1_op_0, fp32_neg_diff_exp_add_1_op_1) == (fp32_neg_diff_exp_add_1_sum, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_add (fp64_pos_denormal_add_0_op_0, fp64_pos_denormal_add_0_op_1) == (fp64_pos_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp64_pos_denormal_add_1_op_0, fp64_pos_denormal_add_1_op_1) == (fp64_pos_denormal_add_1_sum, fp_eflag_none));
-  assert(float_add (fp64_neg_denormal_add_0_op_0, fp64_neg_denormal_add_0_op_1) == (fp64_neg_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp64_neg_denormal_add_1_op_0, fp64_neg_denormal_add_1_op_1) == (fp64_neg_denormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp64_pos_subnormal_add_0_op_0, fp64_pos_subnormal_add_0_op_1) == (fp64_pos_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp64_pos_subnormal_add_1_op_0, fp64_pos_subnormal_add_1_op_1) == (fp64_pos_subnormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp64_neg_subnormal_add_0_op_0, fp64_neg_subnormal_add_0_op_1) == (fp64_neg_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp64_neg_subnormal_add_1_op_0, fp64_neg_subnormal_add_1_op_1) == (fp64_neg_subnormal_add_1_sum, fp_eflag_none));
 
   assert(float_add (fp64_pos_inf, fp64_pos_inf) == (fp64_pos_inf, fp_eflag_none));
   assert(float_add (fp64_pos_inf, fp64_pos_qnan_default) == (fp64_pos_qnan_default, fp_eflag_none));
@@ -332,10 +332,10 @@ function test_float_add () -> unit = {
   assert(float_add (fp64_neg_diff_exp_add_1_op_0, fp64_neg_diff_exp_add_1_op_1) == (fp64_neg_diff_exp_add_1_sum, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_add (fp128_pos_denormal_add_0_op_0, fp128_pos_denormal_add_0_op_1) == (fp128_pos_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp128_pos_denormal_add_1_op_0, fp128_pos_denormal_add_1_op_1) == (fp128_pos_denormal_add_1_sum, fp_eflag_none));
-  assert(float_add (fp128_neg_denormal_add_0_op_0, fp128_neg_denormal_add_0_op_1) == (fp128_neg_denormal_add_0_sum, fp_eflag_none));
-  assert(float_add (fp128_neg_denormal_add_1_op_0, fp128_neg_denormal_add_1_op_1) == (fp128_neg_denormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp128_pos_subnormal_add_0_op_0, fp128_pos_subnormal_add_0_op_1) == (fp128_pos_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp128_pos_subnormal_add_1_op_0, fp128_pos_subnormal_add_1_op_1) == (fp128_pos_subnormal_add_1_sum, fp_eflag_none));
+  assert(float_add (fp128_neg_subnormal_add_0_op_0, fp128_neg_subnormal_add_0_op_1) == (fp128_neg_subnormal_add_0_sum, fp_eflag_none));
+  assert(float_add (fp128_neg_subnormal_add_1_op_0, fp128_neg_subnormal_add_1_op_1) == (fp128_neg_subnormal_add_1_sum, fp_eflag_none));
 
   assert(float_add (fp128_pos_inf, fp128_pos_inf) == (fp128_pos_inf, fp_eflag_none));
   assert(float_add (fp128_pos_inf, fp128_pos_qnan_default) == (fp128_pos_qnan_default, fp_eflag_none));
@@ -440,4 +440,3 @@ function test_float_add () -> unit = {
 function main () -> unit = {
   test_float_add ();
 }
-

--- a/test/float/classify_test.sail
+++ b/test/float/classify_test.sail
@@ -1,0 +1,120 @@
+default Order dec
+
+$include <prelude.sail>
+$include <generic_equality.sail>
+$include <float/classify.sail>
+$include "data.sail"
+
+function test_float_classify () -> unit = {
+  /* Half floating point */
+  assert(float_classify(fp16_pos_snan_0) == float_class_snan);
+  assert(float_classify(fp16_pos_snan_1) == float_class_snan);
+  assert(float_classify(fp16_neg_snan_0) == float_class_snan);
+  assert(float_classify(fp16_neg_snan_1) == float_class_snan);
+
+  assert(float_classify(fp16_pos_qnan_0) == float_class_qnan);
+  assert(float_classify(fp16_pos_qnan_1) == float_class_qnan);
+  assert(float_classify(fp16_neg_qnan_0) == float_class_qnan);
+  assert(float_classify(fp16_neg_qnan_1) == float_class_qnan);
+
+  assert(float_classify(fp16_pos_inf) == float_class_positive_inf);
+  assert(float_classify(fp16_neg_inf) == float_class_negative_inf);
+
+  assert(float_classify(fp16_pos_zero) == float_class_positive_zero);
+  assert(float_classify(fp16_neg_zero) == float_class_negative_zero);
+
+  assert(float_classify(fp16_pos_subnormal_0) == float_class_positive_subnormal);
+  assert(float_classify(fp16_pos_subnormal_1) == float_class_positive_subnormal);
+  assert(float_classify(fp16_neg_subnormal_0) == float_class_negative_subnormal);
+  assert(float_classify(fp16_neg_subnormal_1) == float_class_negative_subnormal);
+
+  assert(float_classify(fp16_pos_normal_0) == float_class_positive_normal);
+  assert(float_classify(fp16_pos_normal_1) == float_class_positive_normal);
+  assert(float_classify(fp16_neg_normal_0) == float_class_negative_normal);
+  assert(float_classify(fp16_neg_normal_1) == float_class_negative_normal);
+
+  /* Single floating point */
+  assert(float_classify(fp32_pos_snan_0) == float_class_snan);
+  assert(float_classify(fp32_pos_snan_1) == float_class_snan);
+  assert(float_classify(fp32_neg_snan_0) == float_class_snan);
+  assert(float_classify(fp32_neg_snan_1) == float_class_snan);
+
+  assert(float_classify(fp32_pos_qnan_0) == float_class_qnan);
+  assert(float_classify(fp32_pos_qnan_1) == float_class_qnan);
+  assert(float_classify(fp32_neg_qnan_0) == float_class_qnan);
+  assert(float_classify(fp32_neg_qnan_1) == float_class_qnan);
+
+  assert(float_classify(fp32_pos_inf) == float_class_positive_inf);
+  assert(float_classify(fp32_neg_inf) == float_class_negative_inf);
+
+  assert(float_classify(fp32_pos_zero) == float_class_positive_zero);
+  assert(float_classify(fp32_neg_zero) == float_class_negative_zero);
+
+  assert(float_classify(fp32_pos_subnormal_0) == float_class_positive_subnormal);
+  assert(float_classify(fp32_pos_subnormal_1) == float_class_positive_subnormal);
+  assert(float_classify(fp32_neg_subnormal_0) == float_class_negative_subnormal);
+  assert(float_classify(fp32_neg_subnormal_1) == float_class_negative_subnormal);
+
+  assert(float_classify(fp32_pos_normal_0) == float_class_positive_normal);
+  assert(float_classify(fp32_pos_normal_1) == float_class_positive_normal);
+  assert(float_classify(fp32_neg_normal_0) == float_class_negative_normal);
+  assert(float_classify(fp32_neg_normal_1) == float_class_negative_normal);
+
+  /* Double floating point */
+  assert(float_classify(fp64_pos_snan_0) == float_class_snan);
+  assert(float_classify(fp64_pos_snan_1) == float_class_snan);
+  assert(float_classify(fp64_neg_snan_0) == float_class_snan);
+  assert(float_classify(fp64_neg_snan_1) == float_class_snan);
+
+  assert(float_classify(fp64_pos_qnan_0) == float_class_qnan);
+  assert(float_classify(fp64_pos_qnan_1) == float_class_qnan);
+  assert(float_classify(fp64_neg_qnan_0) == float_class_qnan);
+  assert(float_classify(fp64_neg_qnan_1) == float_class_qnan);
+
+  assert(float_classify(fp64_pos_inf) == float_class_positive_inf);
+  assert(float_classify(fp64_neg_inf) == float_class_negative_inf);
+
+  assert(float_classify(fp64_pos_zero) == float_class_positive_zero);
+  assert(float_classify(fp64_neg_zero) == float_class_negative_zero);
+
+  assert(float_classify(fp64_pos_subnormal_0) == float_class_positive_subnormal);
+  assert(float_classify(fp64_pos_subnormal_1) == float_class_positive_subnormal);
+  assert(float_classify(fp64_neg_subnormal_0) == float_class_negative_subnormal);
+  assert(float_classify(fp64_neg_subnormal_1) == float_class_negative_subnormal);
+
+  assert(float_classify(fp64_pos_normal_0) == float_class_positive_normal);
+  assert(float_classify(fp64_pos_normal_1) == float_class_positive_normal);
+  assert(float_classify(fp64_neg_normal_0) == float_class_negative_normal);
+  assert(float_classify(fp64_neg_normal_1) == float_class_negative_normal);
+
+  /* Quad floating point */
+  assert(float_classify(fp128_pos_snan_0) == float_class_snan);
+  assert(float_classify(fp128_pos_snan_1) == float_class_snan);
+  assert(float_classify(fp128_neg_snan_0) == float_class_snan);
+  assert(float_classify(fp128_neg_snan_1) == float_class_snan);
+
+  assert(float_classify(fp128_pos_qnan_0) == float_class_qnan);
+  assert(float_classify(fp128_pos_qnan_1) == float_class_qnan);
+  assert(float_classify(fp128_neg_qnan_0) == float_class_qnan);
+  assert(float_classify(fp128_neg_qnan_1) == float_class_qnan);
+
+  assert(float_classify(fp128_pos_inf) == float_class_positive_inf);
+  assert(float_classify(fp128_neg_inf) == float_class_negative_inf);
+
+  assert(float_classify(fp128_pos_zero) == float_class_positive_zero);
+  assert(float_classify(fp128_neg_zero) == float_class_negative_zero);
+
+  assert(float_classify(fp128_pos_subnormal_0) == float_class_positive_subnormal);
+  assert(float_classify(fp128_pos_subnormal_1) == float_class_positive_subnormal);
+  assert(float_classify(fp128_neg_subnormal_0) == float_class_negative_subnormal);
+  assert(float_classify(fp128_neg_subnormal_1) == float_class_negative_subnormal);
+
+  assert(float_classify(fp128_pos_normal_0) == float_class_positive_normal);
+  assert(float_classify(fp128_pos_normal_1) == float_class_positive_normal);
+  assert(float_classify(fp128_neg_normal_0) == float_class_negative_normal);
+  assert(float_classify(fp128_neg_normal_1) == float_class_negative_normal);
+}
+
+function main () -> unit = {
+  test_float_classify();
+}

--- a/test/float/data.sail
+++ b/test/float/data.sail
@@ -29,10 +29,10 @@ let fp16_neg_inf         = 0xfc00
 let fp16_pos_zero        = 0x0000
 let fp16_neg_zero        = 0x8000
 
-let fp16_pos_denormal_0  = 0x0200
-let fp16_pos_denormal_1  = 0x02f0
-let fp16_neg_denormal_0  = 0x8200
-let fp16_neg_denormal_1  = 0x82f0
+let fp16_pos_subnormal_0  = 0x0200
+let fp16_pos_subnormal_1  = 0x02f0
+let fp16_neg_subnormal_0  = 0x8200
+let fp16_neg_subnormal_1  = 0x82f0
 
 let fp16_pos_normal_0    = 0x7a00
 let fp16_pos_normal_1    = 0x71ff
@@ -119,21 +119,21 @@ let fp16_neg_normal_add_13_sum_rdn  = 0xfb81
 let fp16_neg_normal_add_13_sum_rup  = 0xfb80
 let fp16_neg_normal_add_13_sum_rtz  = 0xfb80
 
-let fp16_pos_denormal_add_0_op_0 = 0x00ff
-let fp16_pos_denormal_add_0_op_1 = 0x0021
-let fp16_pos_denormal_add_0_sum  = 0x0120
+let fp16_pos_subnormal_add_0_op_0 = 0x00ff
+let fp16_pos_subnormal_add_0_op_1 = 0x0021
+let fp16_pos_subnormal_add_0_sum  = 0x0120
 
-let fp16_pos_denormal_add_1_op_0 = 0x03ff
-let fp16_pos_denormal_add_1_op_1 = 0x0002
-let fp16_pos_denormal_add_1_sum  = 0x0401
+let fp16_pos_subnormal_add_1_op_0 = 0x03ff
+let fp16_pos_subnormal_add_1_op_1 = 0x0002
+let fp16_pos_subnormal_add_1_sum  = 0x0401
 
-let fp16_neg_denormal_add_0_op_0 = 0x80ff
-let fp16_neg_denormal_add_0_op_1 = 0x8021
-let fp16_neg_denormal_add_0_sum  = 0x8120
+let fp16_neg_subnormal_add_0_op_0 = 0x80ff
+let fp16_neg_subnormal_add_0_op_1 = 0x8021
+let fp16_neg_subnormal_add_0_sum  = 0x8120
 
-let fp16_neg_denormal_add_1_op_0 = 0x83ff
-let fp16_neg_denormal_add_1_op_1 = 0x8002
-let fp16_neg_denormal_add_1_sum  = 0x8401
+let fp16_neg_subnormal_add_1_op_0 = 0x83ff
+let fp16_neg_subnormal_add_1_op_1 = 0x8002
+let fp16_neg_subnormal_add_1_sum  = 0x8401
 
 let fp16_pos_diff_exp_add_0_op_0 = 0x7b23
 let fp16_pos_diff_exp_add_0_op_1 = 0x7cf1
@@ -170,10 +170,10 @@ let fp32_neg_inf         = 0xff800000
 let fp32_pos_zero        = 0x00000000
 let fp32_neg_zero        = 0x80000000
 
-let fp32_pos_denormal_0  = 0x00700000
-let fp32_pos_denormal_1  = 0x0010ff01
-let fp32_neg_denormal_0  = 0x80700000
-let fp32_neg_denormal_1  = 0x8010ff01
+let fp32_pos_subnormal_0  = 0x00700000
+let fp32_pos_subnormal_1  = 0x0010ff01
+let fp32_neg_subnormal_0  = 0x80700000
+let fp32_neg_subnormal_1  = 0x8010ff01
 
 let fp32_pos_normal_0    = 0x1a000000
 let fp32_pos_normal_1    = 0x0100002f
@@ -260,21 +260,21 @@ let fp32_neg_normal_add_13_sum_rdn  = 0xff7ff878
 let fp32_neg_normal_add_13_sum_rup  = 0xff7ff877
 let fp32_neg_normal_add_13_sum_rtz  = 0xff7ff877
 
-let fp32_pos_denormal_add_0_op_0 = 0x000fffff
-let fp32_pos_denormal_add_0_op_1 = 0x00000021
-let fp32_pos_denormal_add_0_sum  = 0x00100020
+let fp32_pos_subnormal_add_0_op_0 = 0x000fffff
+let fp32_pos_subnormal_add_0_op_1 = 0x00000021
+let fp32_pos_subnormal_add_0_sum  = 0x00100020
 
-let fp32_pos_denormal_add_1_op_0 = 0x007fffff
-let fp32_pos_denormal_add_1_op_1 = 0x00000002
-let fp32_pos_denormal_add_1_sum  = 0x00800001
+let fp32_pos_subnormal_add_1_op_0 = 0x007fffff
+let fp32_pos_subnormal_add_1_op_1 = 0x00000002
+let fp32_pos_subnormal_add_1_sum  = 0x00800001
 
-let fp32_neg_denormal_add_0_op_0 = 0x800fffff
-let fp32_neg_denormal_add_0_op_1 = 0x80000021
-let fp32_neg_denormal_add_0_sum  = 0x80100020
+let fp32_neg_subnormal_add_0_op_0 = 0x800fffff
+let fp32_neg_subnormal_add_0_op_1 = 0x80000021
+let fp32_neg_subnormal_add_0_sum  = 0x80100020
 
-let fp32_neg_denormal_add_1_op_0 = 0x807fffff
-let fp32_neg_denormal_add_1_op_1 = 0x80000002
-let fp32_neg_denormal_add_1_sum  = 0x80800001
+let fp32_neg_subnormal_add_1_op_0 = 0x807fffff
+let fp32_neg_subnormal_add_1_op_1 = 0x80000002
+let fp32_neg_subnormal_add_1_sum  = 0x80800001
 
 let fp32_pos_diff_exp_add_0_op_0 = 0x7c01293d
 let fp32_pos_diff_exp_add_0_op_1 = 0x7f8f0001
@@ -311,10 +311,10 @@ let fp64_neg_inf         = 0xfff0000000000000
 let fp64_pos_zero        = 0x0000000000000000
 let fp64_neg_zero        = 0x8000000000000000
 
-let fp64_pos_denormal_0  = 0x000f000000000000
-let fp64_pos_denormal_1  = 0x0000000fff000000
-let fp64_neg_denormal_0  = 0x800f000000000000
-let fp64_neg_denormal_1  = 0x8000000fff000000
+let fp64_pos_subnormal_0  = 0x000f000000000000
+let fp64_pos_subnormal_1  = 0x0000000fff000000
+let fp64_neg_subnormal_0  = 0x800f000000000000
+let fp64_neg_subnormal_1  = 0x8000000fff000000
 
 let fp64_pos_normal_0    = 0x1000000000000000
 let fp64_pos_normal_1    = 0x0100001111000000
@@ -401,21 +401,21 @@ let fp64_neg_normal_add_13_sum_rdn  = 0xffe00107fffffffe
 let fp64_neg_normal_add_13_sum_rup  = 0xffe00107fffffffd
 let fp64_neg_normal_add_13_sum_rtz  = 0xffe00107fffffffd
 
-let fp64_pos_denormal_add_0_op_0 = 0x0000ffffffffffff
-let fp64_pos_denormal_add_0_op_1 = 0x0000000000000041
-let fp64_pos_denormal_add_0_sum  = 0x0001000000000040
+let fp64_pos_subnormal_add_0_op_0 = 0x0000ffffffffffff
+let fp64_pos_subnormal_add_0_op_1 = 0x0000000000000041
+let fp64_pos_subnormal_add_0_sum  = 0x0001000000000040
 
-let fp64_pos_denormal_add_1_op_0 = 0x000fffffffffffff
-let fp64_pos_denormal_add_1_op_1 = 0x0000000000000002
-let fp64_pos_denormal_add_1_sum  = 0x0010000000000001
+let fp64_pos_subnormal_add_1_op_0 = 0x000fffffffffffff
+let fp64_pos_subnormal_add_1_op_1 = 0x0000000000000002
+let fp64_pos_subnormal_add_1_sum  = 0x0010000000000001
 
-let fp64_neg_denormal_add_0_op_0 = 0x8000ffffffffffff
-let fp64_neg_denormal_add_0_op_1 = 0x8000000000000041
-let fp64_neg_denormal_add_0_sum  = 0x8001000000000040
+let fp64_neg_subnormal_add_0_op_0 = 0x8000ffffffffffff
+let fp64_neg_subnormal_add_0_op_1 = 0x8000000000000041
+let fp64_neg_subnormal_add_0_sum  = 0x8001000000000040
 
-let fp64_neg_denormal_add_1_op_0 = 0x800fffffffffffff
-let fp64_neg_denormal_add_1_op_1 = 0x8000000000000002
-let fp64_neg_denormal_add_1_sum  = 0x8010000000000001
+let fp64_neg_subnormal_add_1_op_0 = 0x800fffffffffffff
+let fp64_neg_subnormal_add_1_op_1 = 0x8000000000000002
+let fp64_neg_subnormal_add_1_sum  = 0x8010000000000001
 
 let fp64_pos_diff_exp_add_0_op_0 = 0x7c0abe312d21293d
 let fp64_pos_diff_exp_add_0_op_1 = 0x7ff7700000000001
@@ -452,10 +452,10 @@ let fp128_neg_inf        = 0xffff0000000000000000000000000000
 let fp128_pos_zero       = 0x00000000000000000000000000000000
 let fp128_neg_zero       = 0x80000000000000000000000000000000
 
-let fp128_pos_denormal_0 = 0x0000f000000000000000000000000000
-let fp128_pos_denormal_1 = 0x0000000fff0000000000000000000000
-let fp128_neg_denormal_0 = 0x8000f000000000000000000000000000
-let fp128_neg_denormal_1 = 0x8000000fff0000000000000000000000
+let fp128_pos_subnormal_0 = 0x0000f000000000000000000000000000
+let fp128_pos_subnormal_1 = 0x0000000fff0000000000000000000000
+let fp128_neg_subnormal_0 = 0x8000f000000000000000000000000000
+let fp128_neg_subnormal_1 = 0x8000000fff0000000000000000000000
 
 let fp128_pos_normal_0   = 0x10000000000000000000000000000000
 let fp128_pos_normal_1   = 0x01000011110000000000000000000000
@@ -542,21 +542,21 @@ let fp128_neg_normal_add_13_sum_rdn  = 0xfffe000000068ff892110a7feeef1d3e
 let fp128_neg_normal_add_13_sum_rup  = 0xfffe000000068ff892110a7feeef1d3d
 let fp128_neg_normal_add_13_sum_rtz  = 0xfffe000000068ff892110a7feeef1d3d
 
-let fp128_pos_denormal_add_0_op_0 = 0x00000fffffffffffffffffffffffffff
-let fp128_pos_denormal_add_0_op_1 = 0x00000000000000000000000000000091
-let fp128_pos_denormal_add_0_sum  = 0x00001000000000000000000000000090
+let fp128_pos_subnormal_add_0_op_0 = 0x00000fffffffffffffffffffffffffff
+let fp128_pos_subnormal_add_0_op_1 = 0x00000000000000000000000000000091
+let fp128_pos_subnormal_add_0_sum  = 0x00001000000000000000000000000090
 
-let fp128_pos_denormal_add_1_op_0 = 0x0000ffffffffffffffffffffffffffff
-let fp128_pos_denormal_add_1_op_1 = 0x00000000000000000000000000000003
-let fp128_pos_denormal_add_1_sum  = 0x00010000000000000000000000000002
+let fp128_pos_subnormal_add_1_op_0 = 0x0000ffffffffffffffffffffffffffff
+let fp128_pos_subnormal_add_1_op_1 = 0x00000000000000000000000000000003
+let fp128_pos_subnormal_add_1_sum  = 0x00010000000000000000000000000002
 
-let fp128_neg_denormal_add_0_op_0 = 0x80000fffffffffffffffffffffffffff
-let fp128_neg_denormal_add_0_op_1 = 0x80000000000000000000000000000091
-let fp128_neg_denormal_add_0_sum  = 0x80001000000000000000000000000090
+let fp128_neg_subnormal_add_0_op_0 = 0x80000fffffffffffffffffffffffffff
+let fp128_neg_subnormal_add_0_op_1 = 0x80000000000000000000000000000091
+let fp128_neg_subnormal_add_0_sum  = 0x80001000000000000000000000000090
 
-let fp128_neg_denormal_add_1_op_0 = 0x8000ffffffffffffffffffffffffffff
-let fp128_neg_denormal_add_1_op_1 = 0x80000000000000000000000000000003
-let fp128_neg_denormal_add_1_sum  = 0x80010000000000000000000000000002
+let fp128_neg_subnormal_add_1_op_0 = 0x8000ffffffffffffffffffffffffffff
+let fp128_neg_subnormal_add_1_op_1 = 0x80000000000000000000000000000003
+let fp128_neg_subnormal_add_1_sum  = 0x80010000000000000000000000000002
 
 let fp128_pos_diff_exp_add_0_op_0 = 0x7c0abe312282812dedacd9212d21293d
 let fp128_pos_diff_exp_add_0_op_1 = 0x7fff700000000000ddde000000000001

--- a/test/float/eq_test.sail
+++ b/test/float/eq_test.sail
@@ -16,12 +16,12 @@ $include "data.sail"
 
 function test_float_is_eq () -> unit = {
   /* Half floating point */
-  assert(float_is_eq(fp16_pos_denormal_0, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_subnormal_0, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp16_neg_inf, fp16_neg_inf) == (true, fp_eflag_none));
   assert(float_is_eq(fp16_pos_zero, fp16_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq(fp16_pos_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_subnormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp16_pos_inf, fp16_neg_inf) == (false, fp_eflag_none));
   assert(float_is_eq(fp16_pos_qnan_0, fp16_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp16_pos_qnan_0, fp16_pos_qnan_1) == (false, fp_eflag_none));
@@ -30,12 +30,12 @@ function test_float_is_eq () -> unit = {
   assert(float_is_eq(fp16_pos_snan_1, fp16_neg_zero) == (false, fp_eflag_invalid));
 
   /* Single floating point */
-  assert(float_is_eq(fp32_pos_denormal_0, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_subnormal_0, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp32_neg_inf, fp32_neg_inf) == (true, fp_eflag_none));
   assert(float_is_eq(fp32_pos_zero, fp32_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq(fp32_pos_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_subnormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp32_pos_inf, fp32_neg_inf) == (false, fp_eflag_none));
   assert(float_is_eq(fp32_pos_qnan_0, fp32_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp32_pos_qnan_0, fp32_pos_qnan_1) == (false, fp_eflag_none));
@@ -44,12 +44,12 @@ function test_float_is_eq () -> unit = {
   assert(float_is_eq(fp32_pos_snan_1, fp32_neg_zero) == (false, fp_eflag_invalid));
 
   /* Double floating point */
-  assert(float_is_eq(fp64_pos_denormal_0, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_subnormal_0, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp64_neg_inf, fp64_neg_inf) == (true, fp_eflag_none));
   assert(float_is_eq(fp64_pos_zero, fp64_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq(fp64_pos_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_subnormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp64_pos_inf, fp64_neg_inf) == (false, fp_eflag_none));
   assert(float_is_eq(fp64_pos_qnan_0, fp64_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp64_pos_qnan_0, fp64_pos_qnan_1) == (false, fp_eflag_none));
@@ -58,12 +58,12 @@ function test_float_is_eq () -> unit = {
   assert(float_is_eq(fp64_pos_snan_1, fp64_neg_zero) == (false, fp_eflag_invalid));
 
   /* Quad floating point */
-  assert(float_is_eq(fp128_pos_denormal_0, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_subnormal_0, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_eq(fp128_neg_inf, fp128_neg_inf) == (true, fp_eflag_none));
   assert(float_is_eq(fp128_pos_zero, fp128_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq(fp128_pos_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_subnormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp128_pos_inf, fp128_neg_inf) == (false, fp_eflag_none));
   assert(float_is_eq(fp128_pos_qnan_0, fp128_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_eq(fp128_pos_qnan_0, fp128_pos_qnan_1) == (false, fp_eflag_none));

--- a/test/float/ge_quiet_test.sail
+++ b/test/float/ge_quiet_test.sail
@@ -18,7 +18,7 @@ function test_float_is_ge_quiet () -> unit = {
   /* Half floating point */
   assert(float_is_ge_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge_quiet(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_ge_quiet () -> unit = {
 
   assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_ge_quiet () -> unit = {
   assert(float_is_ge_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_subnormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_subnormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_ge_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge_quiet(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_ge_quiet () -> unit = {
 
   assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_ge_quiet () -> unit = {
   assert(float_is_ge_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_subnormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_subnormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_ge_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge_quiet(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_ge_quiet () -> unit = {
 
   assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_ge_quiet () -> unit = {
   assert(float_is_ge_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_subnormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_subnormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_ge_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge_quiet(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_ge_quiet () -> unit = {
 
   assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_ge_quiet () -> unit = {
   assert(float_is_ge_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_subnormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_subnormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/ge_test.sail
+++ b/test/float/ge_test.sail
@@ -18,7 +18,7 @@ function test_float_is_ge () -> unit = {
   /* Half floating point */
   assert(float_is_ge(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_ge(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_ge () -> unit = {
 
   assert(float_is_ge(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_ge () -> unit = {
   assert(float_is_ge(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_subnormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_subnormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_ge(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_ge(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_ge () -> unit = {
 
   assert(float_is_ge(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_ge () -> unit = {
   assert(float_is_ge(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_subnormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_subnormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_ge(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_ge(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_ge () -> unit = {
 
   assert(float_is_ge(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_ge () -> unit = {
   assert(float_is_ge(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_subnormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_subnormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_ge(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_ge(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_ge(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_ge(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
   assert(float_is_ge(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_ge () -> unit = {
 
   assert(float_is_ge(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
   assert(float_is_ge(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_ge(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_ge(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_ge(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_ge(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_ge(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_ge(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_ge () -> unit = {
   assert(float_is_ge(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_ge(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_ge(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_subnormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_subnormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/gt_quiet_test.sail
+++ b/test/float/gt_quiet_test.sail
@@ -18,7 +18,7 @@ function test_float_is_gt_quiet () -> unit = {
   /* Half floating point */
   assert(float_is_gt_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt_quiet(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_gt_quiet () -> unit = {
 
   assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_gt_quiet () -> unit = {
   assert(float_is_gt_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_subnormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_subnormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_gt_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt_quiet(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_gt_quiet () -> unit = {
 
   assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_gt_quiet () -> unit = {
   assert(float_is_gt_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_subnormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_subnormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_gt_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt_quiet(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_gt_quiet () -> unit = {
 
   assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_gt_quiet () -> unit = {
   assert(float_is_gt_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_subnormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_subnormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_gt_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt_quiet(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_gt_quiet () -> unit = {
 
   assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_gt_quiet () -> unit = {
   assert(float_is_gt_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_subnormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_subnormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/gt_test.sail
+++ b/test/float/gt_test.sail
@@ -18,7 +18,7 @@ function test_float_is_gt () -> unit = {
   /* Half floating point */
   assert(float_is_gt(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_gt(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_gt () -> unit = {
 
   assert(float_is_gt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_gt () -> unit = {
   assert(float_is_gt(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_subnormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_subnormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_gt(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_gt(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_gt () -> unit = {
 
   assert(float_is_gt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_gt () -> unit = {
   assert(float_is_gt(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_subnormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_subnormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_gt(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_gt(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_gt () -> unit = {
 
   assert(float_is_gt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_gt () -> unit = {
   assert(float_is_gt(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_subnormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_subnormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_gt(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_gt(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_gt(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_gt(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
   assert(float_is_gt(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_gt () -> unit = {
 
   assert(float_is_gt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
   assert(float_is_gt(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_gt(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
   assert(float_is_gt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_gt(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_gt(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
   assert(float_is_gt(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_gt () -> unit = {
   assert(float_is_gt(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
   assert(float_is_gt(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_gt(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_subnormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_subnormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/inf_test.sail
+++ b/test/float/inf_test.sail
@@ -22,7 +22,7 @@ function test_float_is_inf () -> unit = {
   assert(float_is_inf(fp16_neg_qnan_0) == false);
   assert(float_is_inf(fp16_pos_zero) == false);
   assert(float_is_inf(fp16_neg_zero) == false);
-  assert(float_is_inf(fp16_pos_denormal_0) == false);
+  assert(float_is_inf(fp16_pos_subnormal_0) == false);
   assert(float_is_inf(fp16_neg_normal_0) == false);
 
   /* Single floating point */
@@ -33,7 +33,7 @@ function test_float_is_inf () -> unit = {
   assert(float_is_inf(fp32_neg_qnan_0) == false);
   assert(float_is_inf(fp32_pos_zero) == false);
   assert(float_is_inf(fp32_neg_zero) == false);
-  assert(float_is_inf(fp32_pos_denormal_0) == false);
+  assert(float_is_inf(fp32_pos_subnormal_0) == false);
   assert(float_is_inf(fp32_neg_normal_0) == false);
 
   /* Double floating point */
@@ -44,7 +44,7 @@ function test_float_is_inf () -> unit = {
   assert(float_is_inf(fp64_neg_qnan_0) == false);
   assert(float_is_inf(fp64_pos_zero) == false);
   assert(float_is_inf(fp64_neg_zero) == false);
-  assert(float_is_inf(fp64_pos_denormal_0) == false);
+  assert(float_is_inf(fp64_pos_subnormal_0) == false);
   assert(float_is_inf(fp64_neg_normal_0) == false);
 
     /* Quad floating point */
@@ -55,7 +55,7 @@ function test_float_is_inf () -> unit = {
   assert(float_is_inf(fp128_neg_qnan_0) == false);
   assert(float_is_inf(fp128_pos_zero) == false);
   assert(float_is_inf(fp128_neg_zero) == false);
-  assert(float_is_inf(fp128_pos_denormal_0) == false);
+  assert(float_is_inf(fp128_pos_subnormal_0) == false);
   assert(float_is_inf(fp128_neg_normal_0) == false);
 }
 

--- a/test/float/le_quiet_test.sail
+++ b/test/float/le_quiet_test.sail
@@ -18,7 +18,7 @@ function test_float_is_le_quiet () -> unit = {
   /* Half floating point */
   assert(float_is_le_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le_quiet(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_le_quiet () -> unit = {
 
   assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_le_quiet () -> unit = {
   assert(float_is_le_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_subnormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_subnormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_le_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le_quiet(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_le_quiet () -> unit = {
 
   assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_le_quiet () -> unit = {
   assert(float_is_le_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_subnormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_subnormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_le_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le_quiet(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_le_quiet () -> unit = {
 
   assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_le_quiet () -> unit = {
   assert(float_is_le_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_subnormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_subnormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_le_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le_quiet(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_le_quiet () -> unit = {
 
   assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_le_quiet () -> unit = {
   assert(float_is_le_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_subnormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_subnormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/le_test.sail
+++ b/test/float/le_test.sail
@@ -18,7 +18,7 @@ function test_float_is_le () -> unit = {
   /* Half floating point */
   assert(float_is_le(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_le(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_le () -> unit = {
 
   assert(float_is_le(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_le () -> unit = {
   assert(float_is_le(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_subnormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_subnormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_le(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_le(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_le () -> unit = {
 
   assert(float_is_le(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_le () -> unit = {
   assert(float_is_le(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_subnormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_subnormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_le(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_le(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_le () -> unit = {
 
   assert(float_is_le(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_le () -> unit = {
   assert(float_is_le(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_subnormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_subnormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_le(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_le(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_le(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_le(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
   assert(float_is_le(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_le () -> unit = {
 
   assert(float_is_le(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
   assert(float_is_le(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_le(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_le(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_le(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_le(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_le(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_le () -> unit = {
   assert(float_is_le(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_le(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_le(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_subnormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_subnormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/lt_quiet_test.sail
+++ b/test/float/lt_quiet_test.sail
@@ -18,7 +18,7 @@ function test_float_is_lt_quiet () -> unit = {
   /* Half floating point */
   assert(float_is_lt_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt_quiet(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_lt_quiet () -> unit = {
 
   assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_lt_quiet () -> unit = {
   assert(float_is_lt_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_subnormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_subnormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_lt_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt_quiet(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_lt_quiet () -> unit = {
 
   assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_lt_quiet () -> unit = {
   assert(float_is_lt_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_subnormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_subnormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_lt_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt_quiet(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_lt_quiet () -> unit = {
 
   assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_lt_quiet () -> unit = {
   assert(float_is_lt_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_subnormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_subnormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_lt_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt_quiet(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_lt_quiet () -> unit = {
 
   assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_lt_quiet () -> unit = {
   assert(float_is_lt_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_subnormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_subnormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/lt_test.sail
+++ b/test/float/lt_test.sail
@@ -18,7 +18,7 @@ function test_float_is_lt () -> unit = {
   /* Half floating point */
   assert(float_is_lt(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_lt(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp16_neg_subnormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
@@ -27,14 +27,14 @@ function test_float_is_lt () -> unit = {
 
   assert(float_is_lt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
@@ -44,13 +44,13 @@ function test_float_is_lt () -> unit = {
   assert(float_is_lt(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_subnormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_subnormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
   assert(float_is_lt(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_lt(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp32_neg_subnormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
@@ -59,14 +59,14 @@ function test_float_is_lt () -> unit = {
 
   assert(float_is_lt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
@@ -76,13 +76,13 @@ function test_float_is_lt () -> unit = {
   assert(float_is_lt(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_subnormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_subnormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
   assert(float_is_lt(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_lt(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp64_neg_subnormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
@@ -91,14 +91,14 @@ function test_float_is_lt () -> unit = {
 
   assert(float_is_lt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
@@ -108,13 +108,13 @@ function test_float_is_lt () -> unit = {
   assert(float_is_lt(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_subnormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_subnormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
   assert(float_is_lt(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
   assert(float_is_lt(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
-  assert(float_is_lt(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp128_neg_subnormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
   assert(float_is_lt(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
   assert(float_is_lt(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
@@ -123,14 +123,14 @@ function test_float_is_lt () -> unit = {
 
   assert(float_is_lt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
   assert(float_is_lt(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
-  assert(float_is_lt(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_neg_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
-  assert(float_is_lt(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_pos_subnormal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
   assert(float_is_lt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
-  assert(float_is_lt(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_neg_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
-  assert(float_is_lt(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
   assert(float_is_lt(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
@@ -140,8 +140,8 @@ function test_float_is_lt () -> unit = {
   assert(float_is_lt(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
   assert(float_is_lt(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
-  assert(float_is_lt(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_subnormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_subnormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/nan_test.sail
+++ b/test/float/nan_test.sail
@@ -27,8 +27,8 @@ function test_float_is_nan () -> unit = {
 
   assert(float_is_nan(fp16_pos_inf) == false);
   assert(float_is_nan(fp16_neg_zero) == false);
-  assert(float_is_nan(fp16_pos_denormal_0) == false);
-  assert(float_is_nan(fp16_pos_denormal_1) == false);
+  assert(float_is_nan(fp16_pos_subnormal_0) == false);
+  assert(float_is_nan(fp16_pos_subnormal_1) == false);
   assert(float_is_nan(fp16_neg_normal_0) == false);
   assert(float_is_nan(fp16_neg_normal_1) == false);
 
@@ -45,8 +45,8 @@ function test_float_is_nan () -> unit = {
 
   assert(float_is_nan(fp32_pos_inf) == false);
   assert(float_is_nan(fp32_neg_zero) == false);
-  assert(float_is_nan(fp32_pos_denormal_0) == false);
-  assert(float_is_nan(fp32_pos_denormal_1) == false);
+  assert(float_is_nan(fp32_pos_subnormal_0) == false);
+  assert(float_is_nan(fp32_pos_subnormal_1) == false);
   assert(float_is_nan(fp32_neg_normal_0) == false);
   assert(float_is_nan(fp32_neg_normal_1) == false);
 
@@ -63,8 +63,8 @@ function test_float_is_nan () -> unit = {
 
   assert(float_is_nan(fp64_pos_inf) == false);
   assert(float_is_nan(fp64_neg_zero) == false);
-  assert(float_is_nan(fp64_pos_denormal_0) == false);
-  assert(float_is_nan(fp64_pos_denormal_1) == false);
+  assert(float_is_nan(fp64_pos_subnormal_0) == false);
+  assert(float_is_nan(fp64_pos_subnormal_1) == false);
   assert(float_is_nan(fp64_neg_normal_0) == false);
   assert(float_is_nan(fp64_neg_normal_1) == false);
 
@@ -81,8 +81,8 @@ function test_float_is_nan () -> unit = {
 
   assert(float_is_nan(fp128_pos_inf) == false);
   assert(float_is_nan(fp128_neg_zero) == false);
-  assert(float_is_nan(fp128_pos_denormal_0) == false);
-  assert(float_is_nan(fp128_pos_denormal_1) == false);
+  assert(float_is_nan(fp128_pos_subnormal_0) == false);
+  assert(float_is_nan(fp128_pos_subnormal_1) == false);
   assert(float_is_nan(fp128_neg_normal_0) == false);
   assert(float_is_nan(fp128_neg_normal_1) == false);
 }
@@ -98,7 +98,7 @@ function test_float_is_snan () -> unit = {
   assert(float_is_snan(fp16_neg_zero) == false);
   assert(float_is_snan(fp16_pos_qnan_0) == false);
   assert(float_is_snan(fp16_neg_qnan_0) == false);
-  assert(float_is_snan(fp16_pos_denormal_0) == false);
+  assert(float_is_snan(fp16_pos_subnormal_0) == false);
   assert(float_is_snan(fp16_neg_normal_0) == false);
 
   /* Single floating point */
@@ -111,7 +111,7 @@ function test_float_is_snan () -> unit = {
   assert(float_is_snan(fp32_neg_zero) == false);
   assert(float_is_snan(fp32_pos_qnan_0) == false);
   assert(float_is_snan(fp32_neg_qnan_0) == false);
-  assert(float_is_snan(fp32_pos_denormal_0) == false);
+  assert(float_is_snan(fp32_pos_subnormal_0) == false);
   assert(float_is_snan(fp32_neg_normal_0) == false);
 
   /* Double floating point */
@@ -124,7 +124,7 @@ function test_float_is_snan () -> unit = {
   assert(float_is_snan(fp64_neg_zero) == false);
   assert(float_is_snan(fp64_pos_qnan_0) == false);
   assert(float_is_snan(fp64_neg_qnan_0) == false);
-  assert(float_is_snan(fp64_pos_denormal_0) == false);
+  assert(float_is_snan(fp64_pos_subnormal_0) == false);
   assert(float_is_snan(fp64_neg_normal_0) == false);
 
   /* Quad floating point */
@@ -137,7 +137,7 @@ function test_float_is_snan () -> unit = {
   assert(float_is_snan(fp128_neg_zero) == false);
   assert(float_is_snan(fp128_pos_qnan_0) == false);
   assert(float_is_snan(fp128_neg_qnan_0) == false);
-  assert(float_is_snan(fp128_pos_denormal_0) == false);
+  assert(float_is_snan(fp128_pos_subnormal_0) == false);
   assert(float_is_snan(fp128_neg_normal_0) == false);
 }
 
@@ -152,7 +152,7 @@ function test_float_is_qnan () -> unit = {
   assert(float_is_qnan(fp16_neg_zero) == false);
   assert(float_is_qnan(fp16_pos_snan_0) == false);
   assert(float_is_qnan(fp16_neg_snan_0) == false);
-  assert(float_is_qnan(fp16_pos_denormal_0) == false);
+  assert(float_is_qnan(fp16_pos_subnormal_0) == false);
   assert(float_is_qnan(fp16_neg_normal_0) == false);
 
   /* Single floating pont */
@@ -165,7 +165,7 @@ function test_float_is_qnan () -> unit = {
   assert(float_is_qnan(fp32_neg_zero) == false);
   assert(float_is_qnan(fp32_pos_snan_0) == false);
   assert(float_is_qnan(fp32_neg_snan_0) == false);
-  assert(float_is_qnan(fp32_pos_denormal_0) == false);
+  assert(float_is_qnan(fp32_pos_subnormal_0) == false);
   assert(float_is_qnan(fp32_neg_normal_0) == false);
 
   /* Double floating point */
@@ -178,7 +178,7 @@ function test_float_is_qnan () -> unit = {
   assert(float_is_qnan(fp64_neg_zero) == false);
   assert(float_is_qnan(fp64_pos_snan_0) == false);
   assert(float_is_qnan(fp64_neg_snan_0) == false);
-  assert(float_is_qnan(fp64_pos_denormal_0) == false);
+  assert(float_is_qnan(fp64_pos_subnormal_0) == false);
   assert(float_is_qnan(fp64_neg_normal_0) == false);
 
   /* Quad floating point */
@@ -191,7 +191,7 @@ function test_float_is_qnan () -> unit = {
   assert(float_is_qnan(fp128_neg_zero) == false);
   assert(float_is_qnan(fp128_pos_snan_0) == false);
   assert(float_is_qnan(fp128_neg_snan_0) == false);
-  assert(float_is_qnan(fp128_pos_denormal_0) == false);
+  assert(float_is_qnan(fp128_pos_subnormal_0) == false);
   assert(float_is_qnan(fp128_neg_normal_0) == false);
 }
 

--- a/test/float/ne_test.sail
+++ b/test/float/ne_test.sail
@@ -16,12 +16,12 @@ $include "data.sail"
 
 function test_float_is_ne () -> unit = {
   /* Half floating point */
-  assert(float_is_ne(fp16_pos_denormal_0, fp16_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_subnormal_0, fp16_pos_subnormal_1) == (true, fp_eflag_none));
   assert(float_is_ne(fp16_neg_normal_0, fp16_neg_normal_1) == (true, fp_eflag_none));
-  assert(float_is_ne(fp16_pos_denormal_1, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_subnormal_1, fp16_pos_zero) == (true, fp_eflag_none));
   assert(float_is_ne(fp16_pos_inf, fp16_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne(fp16_pos_denormal_0, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_subnormal_0, fp16_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp16_neg_qnan_0, fp16_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp16_pos_zero, fp16_neg_zero) == (false, fp_eflag_none));
   assert(float_is_ne(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
@@ -30,12 +30,12 @@ function test_float_is_ne () -> unit = {
   assert(float_is_ne(fp16_pos_snan_1, fp16_pos_normal_0) == (false, fp_eflag_invalid));
 
   /* Single floating point */
-  assert(float_is_ne(fp32_pos_denormal_0, fp32_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_subnormal_0, fp32_pos_subnormal_1) == (true, fp_eflag_none));
   assert(float_is_ne(fp32_neg_normal_0, fp32_neg_normal_1) == (true, fp_eflag_none));
-  assert(float_is_ne(fp32_pos_denormal_1, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_subnormal_1, fp32_pos_zero) == (true, fp_eflag_none));
   assert(float_is_ne(fp32_pos_inf, fp32_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne(fp32_pos_denormal_0, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_subnormal_0, fp32_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp32_neg_qnan_0, fp32_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp32_pos_zero, fp32_neg_zero) == (false, fp_eflag_none));
   assert(float_is_ne(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
@@ -44,12 +44,12 @@ function test_float_is_ne () -> unit = {
   assert(float_is_ne(fp32_pos_snan_1, fp32_pos_normal_0) == (false, fp_eflag_invalid));
 
   /* Double floating point */
-  assert(float_is_ne(fp64_pos_denormal_0, fp64_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_subnormal_0, fp64_pos_subnormal_1) == (true, fp_eflag_none));
   assert(float_is_ne(fp64_neg_normal_0, fp64_neg_normal_1) == (true, fp_eflag_none));
-  assert(float_is_ne(fp64_pos_denormal_1, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_subnormal_1, fp64_pos_zero) == (true, fp_eflag_none));
   assert(float_is_ne(fp64_pos_inf, fp64_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne(fp64_pos_denormal_0, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_subnormal_0, fp64_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp64_neg_qnan_0, fp64_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp64_pos_zero, fp64_neg_zero) == (false, fp_eflag_none));
   assert(float_is_ne(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
@@ -58,12 +58,12 @@ function test_float_is_ne () -> unit = {
   assert(float_is_ne(fp64_pos_snan_1, fp64_pos_normal_0) == (false, fp_eflag_invalid));
 
   /* Quad floating point */
-  assert(float_is_ne(fp128_pos_denormal_0, fp128_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_subnormal_0, fp128_pos_subnormal_1) == (true, fp_eflag_none));
   assert(float_is_ne(fp128_neg_normal_0, fp128_neg_normal_1) == (true, fp_eflag_none));
-  assert(float_is_ne(fp128_pos_denormal_1, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_subnormal_1, fp128_pos_zero) == (true, fp_eflag_none));
   assert(float_is_ne(fp128_pos_inf, fp128_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne(fp128_pos_denormal_0, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_subnormal_0, fp128_pos_subnormal_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp128_neg_qnan_0, fp128_neg_qnan_0) == (false, fp_eflag_none));
   assert(float_is_ne(fp128_pos_zero, fp128_neg_zero) == (false, fp_eflag_none));
   assert(float_is_ne(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));

--- a/test/float/normal_test.sail
+++ b/test/float/normal_test.sail
@@ -59,53 +59,53 @@ function test_float_is_normal () -> unit = {
   assert(float_is_normal(fp128_pos_qnan_0) == false);
 }
 
-function test_float_is_denormal () -> unit = {
+function test_float_is_subnormal () -> unit = {
   /* Half floating point */
-  assert(float_is_denormal(fp16_pos_denormal_0));
-  assert(float_is_denormal(fp16_pos_denormal_1));
-  assert(float_is_denormal(fp16_neg_denormal_0));
-  assert(float_is_denormal(fp16_neg_denormal_1));
+  assert(float_is_subnormal(fp16_pos_subnormal_0));
+  assert(float_is_subnormal(fp16_pos_subnormal_1));
+  assert(float_is_subnormal(fp16_neg_subnormal_0));
+  assert(float_is_subnormal(fp16_neg_subnormal_1));
 
-  assert(float_is_denormal(fp16_pos_inf) == false);
-  assert(float_is_denormal(fp16_neg_zero) == false);
-  assert(float_is_denormal(fp16_pos_snan_0) == false);
-  assert(float_is_denormal(fp16_pos_qnan_0) == false);
+  assert(float_is_subnormal(fp16_pos_inf) == false);
+  assert(float_is_subnormal(fp16_neg_zero) == false);
+  assert(float_is_subnormal(fp16_pos_snan_0) == false);
+  assert(float_is_subnormal(fp16_pos_qnan_0) == false);
 
   /* Single floating point */
-  assert(float_is_denormal(fp32_pos_denormal_0));
-  assert(float_is_denormal(fp32_pos_denormal_1));
-  assert(float_is_denormal(fp32_neg_denormal_0));
-  assert(float_is_denormal(fp32_neg_denormal_1));
+  assert(float_is_subnormal(fp32_pos_subnormal_0));
+  assert(float_is_subnormal(fp32_pos_subnormal_1));
+  assert(float_is_subnormal(fp32_neg_subnormal_0));
+  assert(float_is_subnormal(fp32_neg_subnormal_1));
 
-  assert(float_is_denormal(fp32_pos_inf) == false);
-  assert(float_is_denormal(fp32_neg_zero) == false);
-  assert(float_is_denormal(fp32_pos_snan_0) == false);
-  assert(float_is_denormal(fp32_pos_qnan_0) == false);
+  assert(float_is_subnormal(fp32_pos_inf) == false);
+  assert(float_is_subnormal(fp32_neg_zero) == false);
+  assert(float_is_subnormal(fp32_pos_snan_0) == false);
+  assert(float_is_subnormal(fp32_pos_qnan_0) == false);
 
   /* Double floating point */
-  assert(float_is_denormal(fp64_pos_denormal_0));
-  assert(float_is_denormal(fp64_pos_denormal_1));
-  assert(float_is_denormal(fp64_neg_denormal_0));
-  assert(float_is_denormal(fp64_neg_denormal_1));
+  assert(float_is_subnormal(fp64_pos_subnormal_0));
+  assert(float_is_subnormal(fp64_pos_subnormal_1));
+  assert(float_is_subnormal(fp64_neg_subnormal_0));
+  assert(float_is_subnormal(fp64_neg_subnormal_1));
 
-  assert(float_is_denormal(fp64_pos_inf) == false);
-  assert(float_is_denormal(fp64_neg_zero) == false);
-  assert(float_is_denormal(fp64_pos_snan_0) == false);
-  assert(float_is_denormal(fp64_pos_qnan_0) == false);
+  assert(float_is_subnormal(fp64_pos_inf) == false);
+  assert(float_is_subnormal(fp64_neg_zero) == false);
+  assert(float_is_subnormal(fp64_pos_snan_0) == false);
+  assert(float_is_subnormal(fp64_pos_qnan_0) == false);
 
     /* Quad floating point */
-  assert(float_is_denormal(fp128_pos_denormal_0));
-  assert(float_is_denormal(fp128_pos_denormal_1));
-  assert(float_is_denormal(fp128_neg_denormal_0));
-  assert(float_is_denormal(fp128_neg_denormal_1));
+  assert(float_is_subnormal(fp128_pos_subnormal_0));
+  assert(float_is_subnormal(fp128_pos_subnormal_1));
+  assert(float_is_subnormal(fp128_neg_subnormal_0));
+  assert(float_is_subnormal(fp128_neg_subnormal_1));
 
-  assert(float_is_denormal(fp128_pos_inf) == false);
-  assert(float_is_denormal(fp128_neg_zero) == false);
-  assert(float_is_denormal(fp128_pos_snan_0) == false);
-  assert(float_is_denormal(fp128_pos_qnan_0) == false);
+  assert(float_is_subnormal(fp128_pos_inf) == false);
+  assert(float_is_subnormal(fp128_neg_zero) == false);
+  assert(float_is_subnormal(fp128_pos_snan_0) == false);
+  assert(float_is_subnormal(fp128_pos_qnan_0) == false);
 }
 
 function main () -> unit = {
   test_float_is_normal();
-  test_float_is_denormal();
+  test_float_is_subnormal();
 }

--- a/test/float/sign_test.sail
+++ b/test/float/sign_test.sail
@@ -19,14 +19,14 @@ function test_float_is_positive () -> unit = {
   assert(float_is_positive(fp16_pos_qnan_0));
   assert(float_is_positive(fp16_pos_zero));
   assert(float_is_positive(fp16_pos_inf));
-  assert(float_is_positive(fp16_pos_denormal_0));
+  assert(float_is_positive(fp16_pos_subnormal_0));
   assert(float_is_positive(fp16_pos_normal_0));
 
   assert(float_is_positive(fp16_neg_snan_0) == false);
   assert(float_is_positive(fp16_neg_qnan_0) == false);
   assert(float_is_positive(fp16_neg_zero) == false);
   assert(float_is_positive(fp16_neg_inf) == false);
-  assert(float_is_positive(fp16_neg_denormal_0) == false);
+  assert(float_is_positive(fp16_neg_subnormal_0) == false);
   assert(float_is_positive(fp16_neg_normal_0) == false);
 
   /* Single floating point */
@@ -34,14 +34,14 @@ function test_float_is_positive () -> unit = {
   assert(float_is_positive(fp32_pos_qnan_0));
   assert(float_is_positive(fp32_pos_zero));
   assert(float_is_positive(fp32_pos_inf));
-  assert(float_is_positive(fp32_pos_denormal_0));
+  assert(float_is_positive(fp32_pos_subnormal_0));
   assert(float_is_positive(fp32_pos_normal_0));
 
   assert(float_is_positive(fp32_neg_snan_0) == false);
   assert(float_is_positive(fp32_neg_qnan_0) == false);
   assert(float_is_positive(fp32_neg_zero) == false);
   assert(float_is_positive(fp32_neg_inf) == false);
-  assert(float_is_positive(fp32_neg_denormal_0) == false);
+  assert(float_is_positive(fp32_neg_subnormal_0) == false);
   assert(float_is_positive(fp32_neg_normal_0) == false);
 
   /* Double floating point */
@@ -49,14 +49,14 @@ function test_float_is_positive () -> unit = {
   assert(float_is_positive(fp64_pos_qnan_0));
   assert(float_is_positive(fp64_pos_zero));
   assert(float_is_positive(fp64_pos_inf));
-  assert(float_is_positive(fp64_pos_denormal_0));
+  assert(float_is_positive(fp64_pos_subnormal_0));
   assert(float_is_positive(fp64_pos_normal_0));
 
   assert(float_is_positive(fp64_neg_snan_0) == false);
   assert(float_is_positive(fp64_neg_qnan_0) == false);
   assert(float_is_positive(fp64_neg_zero) == false);
   assert(float_is_positive(fp64_neg_inf) == false);
-  assert(float_is_positive(fp64_neg_denormal_0) == false);
+  assert(float_is_positive(fp64_neg_subnormal_0) == false);
   assert(float_is_positive(fp64_neg_normal_0) == false);
 
   /* Quad floating point */
@@ -64,14 +64,14 @@ function test_float_is_positive () -> unit = {
   assert(float_is_positive(fp128_pos_qnan_0));
   assert(float_is_positive(fp128_pos_zero));
   assert(float_is_positive(fp128_pos_inf));
-  assert(float_is_positive(fp128_pos_denormal_0));
+  assert(float_is_positive(fp128_pos_subnormal_0));
   assert(float_is_positive(fp128_pos_normal_0));
 
   assert(float_is_positive(fp128_neg_snan_0) == false);
   assert(float_is_positive(fp128_neg_qnan_0) == false);
   assert(float_is_positive(fp128_neg_zero) == false);
   assert(float_is_positive(fp128_neg_inf) == false);
-  assert(float_is_positive(fp128_neg_denormal_0) == false);
+  assert(float_is_positive(fp128_neg_subnormal_0) == false);
   assert(float_is_positive(fp128_neg_normal_0) == false);
 }
 
@@ -81,14 +81,14 @@ function test_float_is_negative () -> unit = {
   assert(float_is_negative(fp16_neg_qnan_0));
   assert(float_is_negative(fp16_neg_zero));
   assert(float_is_negative(fp16_neg_inf));
-  assert(float_is_negative(fp16_neg_denormal_0));
+  assert(float_is_negative(fp16_neg_subnormal_0));
   assert(float_is_negative(fp16_neg_normal_0));
 
   assert(float_is_negative(fp16_pos_snan_0) == false);
   assert(float_is_negative(fp16_pos_qnan_0) == false);
   assert(float_is_negative(fp16_pos_zero) == false);
   assert(float_is_negative(fp16_pos_inf) == false);
-  assert(float_is_negative(fp16_pos_denormal_0) == false);
+  assert(float_is_negative(fp16_pos_subnormal_0) == false);
   assert(float_is_negative(fp16_pos_normal_0) == false);
 
   /* Single floating point */
@@ -96,14 +96,14 @@ function test_float_is_negative () -> unit = {
   assert(float_is_negative(fp32_neg_qnan_0));
   assert(float_is_negative(fp32_neg_zero));
   assert(float_is_negative(fp32_neg_inf));
-  assert(float_is_negative(fp32_neg_denormal_0));
+  assert(float_is_negative(fp32_neg_subnormal_0));
   assert(float_is_negative(fp32_neg_normal_0));
 
   assert(float_is_negative(fp32_pos_snan_0) == false);
   assert(float_is_negative(fp32_pos_qnan_0) == false);
   assert(float_is_negative(fp32_pos_zero) == false);
   assert(float_is_negative(fp32_pos_inf) == false);
-  assert(float_is_negative(fp32_pos_denormal_0) == false);
+  assert(float_is_negative(fp32_pos_subnormal_0) == false);
   assert(float_is_negative(fp32_pos_normal_0) == false);
 
   /* Double floating point */
@@ -111,14 +111,14 @@ function test_float_is_negative () -> unit = {
   assert(float_is_negative(fp64_neg_qnan_0));
   assert(float_is_negative(fp64_neg_zero));
   assert(float_is_negative(fp64_neg_inf));
-  assert(float_is_negative(fp64_neg_denormal_0));
+  assert(float_is_negative(fp64_neg_subnormal_0));
   assert(float_is_negative(fp64_neg_normal_0));
 
   assert(float_is_negative(fp64_pos_snan_0) == false);
   assert(float_is_negative(fp64_pos_qnan_0) == false);
   assert(float_is_negative(fp64_pos_zero) == false);
   assert(float_is_negative(fp64_pos_inf) == false);
-  assert(float_is_negative(fp64_pos_denormal_0) == false);
+  assert(float_is_negative(fp64_pos_subnormal_0) == false);
   assert(float_is_negative(fp64_pos_normal_0) == false);
 
   /* Quad floating point */
@@ -126,14 +126,14 @@ function test_float_is_negative () -> unit = {
   assert(float_is_negative(fp128_neg_qnan_0));
   assert(float_is_negative(fp128_neg_zero));
   assert(float_is_negative(fp128_neg_inf));
-  assert(float_is_negative(fp128_neg_denormal_0));
+  assert(float_is_negative(fp128_neg_subnormal_0));
   assert(float_is_negative(fp128_neg_normal_0));
 
   assert(float_is_negative(fp128_pos_snan_0) == false);
   assert(float_is_negative(fp128_pos_qnan_0) == false);
   assert(float_is_negative(fp128_pos_zero) == false);
   assert(float_is_negative(fp128_pos_inf) == false);
-  assert(float_is_negative(fp128_pos_denormal_0) == false);
+  assert(float_is_negative(fp128_pos_subnormal_0) == false);
   assert(float_is_negative(fp128_pos_normal_0) == false);
 }
 

--- a/test/float/zero_test.sail
+++ b/test/float/zero_test.sail
@@ -21,7 +21,7 @@ function test_float_is_zero () -> unit = {
   assert(float_is_zero(fp16_pos_snan_0) == false);
   assert(float_is_zero(fp16_neg_qnan_0) == false);
   assert(float_is_zero(fp16_pos_inf) == false);
-  assert(float_is_zero(fp16_pos_denormal_0) == false);
+  assert(float_is_zero(fp16_pos_subnormal_0) == false);
   assert(float_is_zero(fp16_neg_normal_0) == false);
 
   /* Single floating point */
@@ -31,7 +31,7 @@ function test_float_is_zero () -> unit = {
   assert(float_is_zero(fp32_pos_snan_0) == false);
   assert(float_is_zero(fp32_neg_qnan_0) == false);
   assert(float_is_zero(fp32_pos_inf) == false);
-  assert(float_is_zero(fp32_pos_denormal_0) == false);
+  assert(float_is_zero(fp32_pos_subnormal_0) == false);
   assert(float_is_zero(fp32_neg_normal_0) == false);
 
   /* Double floating point */
@@ -41,7 +41,7 @@ function test_float_is_zero () -> unit = {
   assert(float_is_zero(fp64_pos_snan_0) == false);
   assert(float_is_zero(fp64_neg_qnan_0) == false);
   assert(float_is_zero(fp64_pos_inf) == false);
-  assert(float_is_zero(fp64_pos_denormal_0) == false);
+  assert(float_is_zero(fp64_pos_subnormal_0) == false);
   assert(float_is_zero(fp64_neg_normal_0) == false);
 
   /* Quad floating point */
@@ -51,7 +51,7 @@ function test_float_is_zero () -> unit = {
   assert(float_is_zero(fp128_pos_snan_0) == false);
   assert(float_is_zero(fp128_neg_qnan_0) == false);
   assert(float_is_zero(fp128_pos_inf) == false);
-  assert(float_is_zero(fp128_pos_denormal_0) == false);
+  assert(float_is_zero(fp128_pos_subnormal_0) == false);
   assert(float_is_zero(fp128_neg_normal_0) == false);
 }
 


### PR DESCRIPTION
This is a standard operation in IEEE 754 floats - see `class()` in the "General operations" section of the spec.

It's also implemented as the `fclass` instruction in RISC-V.