### PR TITLE
Fix float code

### DIFF
--- a/lib/float/common.sail
+++ b/lib/float/common.sail
@@ -13,10 +13,10 @@ $define _FLOAT_COMMON
 /* Floating point types definition */
 type fp_exception_flags = bits(5) /* Floating-point exception flags. */
 type fp_rounding_modes = bits(5) /* Floating-point rounding modes. */
-// Floating point in bits.
-type fp_bits = {8, 16, 32, 64, 128}
 // Type alias for use in `forall`s.
-type is_fp_bits('n) -> Bool = 'n in {8, 16, 32, 64, 128}
+type is_fp_bits('n) -> Bool = 'n in {16, 32, 64, 128}
+// Floating point in bits.
+type fp_bits = { 'n, is_fp_bits('n) . bits('n) }
 
 /* Floating point constants */
 let fp_eflag_none           : fp_exception_flags = 0b00000
@@ -58,7 +58,7 @@ struct float_bits('n : Int) = {
 }
 
 /* The val func implementations */
-val      float_decompose : forall 'n, 'n in { 16, 32, 64, 128 }. bits('n) -> float_bits('n)
+val      float_decompose : forall 'n, is_fp_bits('n) . bits('n) -> float_bits('n)
 function float_decompose(op) = {
   match 'n {
     16 => struct {
@@ -84,10 +84,10 @@ function float_decompose(op) = {
   }
 }
 
-val      float_compose : forall 'n, 'n in { 16, 32, 64, 128 }. float_bits('n) -> bits('n)
+val      float_compose : forall 'n, is_fp_bits('n) . float_bits('n) -> bits('n)
 function float_compose(op) = op.sign @ op.exp @ op.mantissa
 
-val      float_has_max_exp : forall 'n, 'n in { 16, 32, 64, 128 }. bits('n) -> bool
+val      float_has_max_exp : forall 'n, is_fp_bits('n) . bits('n) -> bool
 function float_has_max_exp (op) = {
   let fp = float_decompose (op);
   let bitsize = length (op);

--- a/test/float/eq_test.sail
+++ b/test/float/eq_test.sail
@@ -16,60 +16,60 @@ $include "data.sail"
 
 function test_float_is_eq () -> unit = {
   /* Half floating point */
-  assert(float_is_eq((fp16_pos_denormal_0, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp16_neg_normal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp16_neg_inf, fp16_neg_inf)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp16_pos_zero, fp16_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_denormal_0, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp16_neg_inf, fp16_neg_inf) == (true, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_zero, fp16_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq((fp16_pos_denormal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp16_pos_inf, fp16_neg_inf)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp16_pos_qnan_0, fp16_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp16_pos_qnan_0, fp16_pos_qnan_1)) == (false, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_inf, fp16_neg_inf) == (false, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_qnan_0, fp16_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp16_pos_qnan_0, fp16_pos_qnan_1) == (false, fp_eflag_none));
 
-  assert(float_is_eq((fp16_pos_snan_0, fp16_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_eq((fp16_pos_snan_1, fp16_neg_zero)) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp16_pos_snan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp16_pos_snan_1, fp16_neg_zero) == (false, fp_eflag_invalid));
 
   /* Single floating point */
-  assert(float_is_eq((fp32_pos_denormal_0, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp32_neg_normal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp32_neg_inf, fp32_neg_inf)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp32_pos_zero, fp32_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_denormal_0, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp32_neg_inf, fp32_neg_inf) == (true, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_zero, fp32_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq((fp32_pos_denormal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp32_pos_inf, fp32_neg_inf)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp32_pos_qnan_0, fp32_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp32_pos_qnan_0, fp32_pos_qnan_1)) == (false, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_inf, fp32_neg_inf) == (false, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_qnan_0, fp32_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp32_pos_qnan_0, fp32_pos_qnan_1) == (false, fp_eflag_none));
 
-  assert(float_is_eq((fp32_pos_snan_0, fp32_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_eq((fp32_pos_snan_1, fp32_neg_zero)) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp32_pos_snan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp32_pos_snan_1, fp32_neg_zero) == (false, fp_eflag_invalid));
 
   /* Double floating point */
-  assert(float_is_eq((fp64_pos_denormal_0, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp64_neg_normal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp64_neg_inf, fp64_neg_inf)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp64_pos_zero, fp64_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_denormal_0, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp64_neg_inf, fp64_neg_inf) == (true, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_zero, fp64_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq((fp64_pos_denormal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp64_pos_inf, fp64_neg_inf)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp64_pos_qnan_0, fp64_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp64_pos_qnan_0, fp64_pos_qnan_1)) == (false, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_inf, fp64_neg_inf) == (false, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_qnan_0, fp64_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp64_pos_qnan_0, fp64_pos_qnan_1) == (false, fp_eflag_none));
 
-  assert(float_is_eq((fp64_pos_snan_0, fp64_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_eq((fp64_pos_snan_1, fp64_neg_zero)) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp64_pos_snan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp64_pos_snan_1, fp64_neg_zero) == (false, fp_eflag_invalid));
 
   /* Quad floating point */
-  assert(float_is_eq((fp128_pos_denormal_0, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp128_neg_normal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp128_neg_inf, fp128_neg_inf)) == (true, fp_eflag_none));
-  assert(float_is_eq((fp128_pos_zero, fp128_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_denormal_0, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_eq(fp128_neg_inf, fp128_neg_inf) == (true, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_zero, fp128_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_eq((fp128_pos_denormal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp128_pos_inf, fp128_neg_inf)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp128_pos_qnan_0, fp128_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_eq((fp128_pos_qnan_0, fp128_pos_qnan_1)) == (false, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_inf, fp128_neg_inf) == (false, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_qnan_0, fp128_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_eq(fp128_pos_qnan_0, fp128_pos_qnan_1) == (false, fp_eflag_none));
 
-  assert(float_is_eq((fp128_pos_snan_0, fp128_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_eq((fp128_pos_snan_1, fp128_neg_zero)) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp128_pos_snan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_eq(fp128_pos_snan_1, fp128_neg_zero) == (false, fp_eflag_invalid));
 }
 
 function main () -> unit = {

--- a/test/float/ge_quiet_test.sail
+++ b/test/float/ge_quiet_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_ge_quiet () -> unit = {
   /* Half floating point */
-  assert(float_is_ge_quiet((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge_quiet((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge_quiet((fp16_neg_zero, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_zero, fp16_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_zero, fp16_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp16_pos_normal_0, fp16_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_normal_1, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_pos_normal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_normal_0, fp16_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_normal_1, fp16_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_normal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_normal_1, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_normal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_normal_0, fp16_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp16_pos_denormal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp16_neg_denormal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_ge_quiet((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge_quiet((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge_quiet((fp32_neg_zero, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_zero, fp32_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_zero, fp32_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp32_pos_normal_0, fp32_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_normal_1, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_pos_normal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_normal_0, fp32_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_normal_1, fp32_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_normal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_normal_1, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_normal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_normal_0, fp32_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp32_pos_denormal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp32_neg_denormal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_ge_quiet((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge_quiet((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge_quiet((fp64_neg_zero, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_zero, fp64_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_zero, fp64_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp64_pos_normal_0, fp64_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_normal_1, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_pos_normal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_normal_0, fp64_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_normal_1, fp64_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_normal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_normal_1, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_normal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_normal_0, fp64_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp64_pos_denormal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp64_neg_denormal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_ge_quiet((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge_quiet((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge_quiet((fp128_neg_zero, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_zero, fp128_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_zero, fp128_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp128_pos_normal_0, fp128_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_normal_1, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_pos_normal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_normal_0, fp128_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_normal_1, fp128_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_normal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_normal_1, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_normal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_normal_0, fp128_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge_quiet((fp128_pos_denormal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge_quiet((fp128_neg_denormal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/ge_test.sail
+++ b/test/float/ge_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_ge () -> unit = {
   /* Half floating point */
-  assert(float_is_ge((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge((fp16_neg_zero, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_zero, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_zero, fp16_pos_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_zero, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_zero, fp16_pos_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp16_pos_normal_0, fp16_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_normal_1, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_pos_normal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_normal_0, fp16_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_normal_1, fp16_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_normal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_normal_1, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_normal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_normal_0, fp16_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp16_pos_denormal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp16_neg_denormal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_ge((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge((fp32_neg_zero, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_zero, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_zero, fp32_pos_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_zero, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_zero, fp32_pos_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp32_pos_normal_0, fp32_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_normal_1, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_pos_normal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_normal_0, fp32_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_normal_1, fp32_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_normal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_normal_1, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_normal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_normal_0, fp32_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp32_pos_denormal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp32_neg_denormal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_ge((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge((fp64_neg_zero, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_zero, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_zero, fp64_pos_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_zero, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_zero, fp64_pos_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp64_pos_normal_0, fp64_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_normal_1, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_pos_normal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_normal_0, fp64_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_normal_1, fp64_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_normal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_normal_1, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_normal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_normal_0, fp64_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp64_pos_denormal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp64_neg_denormal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_ge((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ge((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_ge(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_ge((fp128_neg_zero, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_zero, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_zero, fp128_pos_zero)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_zero, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_zero, fp128_pos_zero) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp128_pos_normal_0, fp128_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_normal_1, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_pos_normal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_normal_0, fp128_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_normal_1, fp128_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_normal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_normal_1, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_normal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_normal_0, fp128_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_ge((fp128_pos_denormal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_ge((fp128_neg_denormal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_ge(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_ge(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/gt_quiet_test.sail
+++ b/test/float/gt_quiet_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_gt_quiet () -> unit = {
   /* Half floating point */
-  assert(float_is_gt_quiet((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt_quiet((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt_quiet((fp16_neg_zero, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_zero, fp16_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_zero, fp16_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp16_pos_normal_0, fp16_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_normal_1, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_pos_normal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_normal_0, fp16_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_normal_1, fp16_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_normal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_normal_1, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_normal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_normal_0, fp16_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp16_pos_denormal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp16_neg_denormal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_gt_quiet((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt_quiet((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt_quiet((fp32_neg_zero, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_zero, fp32_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_zero, fp32_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp32_pos_normal_0, fp32_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_normal_1, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_pos_normal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_normal_0, fp32_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_normal_1, fp32_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_normal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_normal_1, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_normal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_normal_0, fp32_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp32_pos_denormal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp32_neg_denormal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_gt_quiet((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt_quiet((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt_quiet((fp64_neg_zero, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_zero, fp64_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_zero, fp64_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp64_pos_normal_0, fp64_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_normal_1, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_pos_normal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_normal_0, fp64_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_normal_1, fp64_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_normal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_normal_1, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_normal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_normal_0, fp64_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp64_pos_denormal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp64_neg_denormal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_gt_quiet((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt_quiet((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt_quiet((fp128_neg_zero, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_zero, fp128_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_zero, fp128_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp128_pos_normal_0, fp128_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_normal_1, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_pos_normal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_normal_0, fp128_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_normal_1, fp128_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_normal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_normal_1, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_normal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_normal_0, fp128_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt_quiet((fp128_pos_denormal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt_quiet((fp128_neg_denormal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/gt_test.sail
+++ b/test/float/gt_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_gt () -> unit = {
   /* Half floating point */
-  assert(float_is_gt((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt((fp16_neg_zero, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_zero, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_zero, fp16_pos_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_zero, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_zero, fp16_pos_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt((fp16_pos_normal_0, fp16_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_normal_1, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_pos_normal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_normal_0, fp16_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_normal_1, fp16_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_normal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_normal_0, fp16_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_normal_1, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_normal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_normal_0, fp16_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_normal_1, fp16_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp16_pos_denormal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp16_neg_denormal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp16_pos_denormal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp16_neg_denormal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_gt((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt((fp32_neg_zero, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_zero, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_zero, fp32_pos_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_zero, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_zero, fp32_pos_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt((fp32_pos_normal_0, fp32_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_normal_1, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_pos_normal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_normal_0, fp32_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_normal_1, fp32_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_normal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_normal_0, fp32_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_normal_1, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_normal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_normal_0, fp32_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_normal_1, fp32_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp32_pos_denormal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp32_neg_denormal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp32_pos_denormal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp32_neg_denormal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_gt((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt((fp64_neg_zero, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_zero, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_zero, fp64_pos_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_zero, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_zero, fp64_pos_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt((fp64_pos_normal_0, fp64_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_normal_1, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_pos_normal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_normal_0, fp64_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_normal_1, fp64_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_normal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_normal_0, fp64_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_normal_1, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_normal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_normal_0, fp64_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_normal_1, fp64_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp64_pos_denormal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp64_neg_denormal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp64_pos_denormal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp64_neg_denormal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_gt((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_gt((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_gt(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_gt((fp128_neg_zero, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_zero, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_zero, fp128_pos_zero)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_zero, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_zero, fp128_pos_zero) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_gt((fp128_pos_normal_0, fp128_pos_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_normal_1, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_pos_normal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_normal_0, fp128_neg_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_normal_1, fp128_neg_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_normal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_normal_0, fp128_pos_normal_1) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_normal_1, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_normal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_normal_0, fp128_neg_normal_1) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_normal_1, fp128_neg_normal_0) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_gt((fp128_pos_denormal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_gt((fp128_neg_denormal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_gt(fp128_pos_denormal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_gt(fp128_neg_denormal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/le_quiet_test.sail
+++ b/test/float/le_quiet_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_le_quiet () -> unit = {
   /* Half floating point */
-  assert(float_is_le_quiet((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le_quiet((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le_quiet((fp16_neg_zero, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_zero, fp16_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_zero, fp16_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp16_pos_normal_0, fp16_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_normal_1, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_pos_normal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_normal_0, fp16_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_normal_1, fp16_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_normal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_normal_1, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_normal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_normal_0, fp16_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp16_pos_denormal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp16_neg_denormal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_le_quiet((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le_quiet((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le_quiet((fp32_neg_zero, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_zero, fp32_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_zero, fp32_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp32_pos_normal_0, fp32_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_normal_1, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_pos_normal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_normal_0, fp32_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_normal_1, fp32_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_normal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_normal_1, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_normal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_normal_0, fp32_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp32_pos_denormal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp32_neg_denormal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_le_quiet((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le_quiet((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le_quiet((fp64_neg_zero, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_zero, fp64_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_zero, fp64_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp64_pos_normal_0, fp64_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_normal_1, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_pos_normal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_normal_0, fp64_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_normal_1, fp64_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_normal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_normal_1, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_normal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_normal_0, fp64_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp64_pos_denormal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp64_neg_denormal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_le_quiet((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le_quiet((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le_quiet((fp128_neg_zero, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_zero, fp128_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_zero, fp128_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp128_pos_normal_0, fp128_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_normal_1, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_pos_normal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_normal_0, fp128_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_normal_1, fp128_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_normal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_normal_1, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_normal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_normal_0, fp128_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le_quiet((fp128_pos_denormal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le_quiet((fp128_neg_denormal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/le_test.sail
+++ b/test/float/le_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_le () -> unit = {
   /* Half floating point */
-  assert(float_is_le((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le((fp16_neg_zero, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_pos_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_zero, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_pos_zero, fp16_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_zero, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_pos_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_zero, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_pos_zero, fp16_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_pos_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_pos_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp16_pos_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le((fp16_pos_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp16_pos_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le((fp16_pos_normal_0, fp16_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le((fp16_pos_normal_1, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_pos_normal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_normal_0, fp16_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_normal_1, fp16_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp16_neg_normal_0, fp16_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_normal_1, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_pos_normal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_normal_0, fp16_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_neg_normal_0, fp16_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp16_pos_denormal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp16_neg_denormal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_le((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le((fp32_neg_zero, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_pos_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_zero, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_pos_zero, fp32_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_zero, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_pos_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_zero, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_pos_zero, fp32_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_pos_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_pos_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp32_pos_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le((fp32_pos_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp32_pos_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le((fp32_pos_normal_0, fp32_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le((fp32_pos_normal_1, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_pos_normal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_normal_0, fp32_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_normal_1, fp32_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp32_neg_normal_0, fp32_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_normal_1, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_pos_normal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_normal_0, fp32_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_neg_normal_0, fp32_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp32_pos_denormal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp32_neg_denormal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_le((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le((fp64_neg_zero, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_pos_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_zero, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_pos_zero, fp64_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_zero, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_pos_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_zero, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_pos_zero, fp64_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_pos_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_pos_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp64_pos_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le((fp64_pos_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp64_pos_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le((fp64_pos_normal_0, fp64_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le((fp64_pos_normal_1, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_pos_normal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_normal_0, fp64_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_normal_1, fp64_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp64_neg_normal_0, fp64_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_normal_1, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_pos_normal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_normal_0, fp64_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_neg_normal_0, fp64_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp64_pos_denormal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp64_neg_denormal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_le((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_le((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_le(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_le((fp128_neg_zero, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_pos_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_zero, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_pos_zero, fp128_neg_zero)) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_zero, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_pos_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_zero, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_pos_zero, fp128_neg_zero) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_pos_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_pos_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp128_pos_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_le((fp128_pos_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp128_pos_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_le((fp128_pos_normal_0, fp128_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_le((fp128_pos_normal_1, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_pos_normal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_normal_0, fp128_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_normal_1, fp128_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_le((fp128_neg_normal_0, fp128_neg_normal_0)) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_normal_1, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_pos_normal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_normal_0, fp128_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_neg_normal_0, fp128_neg_normal_0) == (true, fp_eflag_none));
 
-  assert(float_is_le((fp128_pos_denormal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_le((fp128_neg_denormal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_le(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_le(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/lt_quiet_test.sail
+++ b/test/float/lt_quiet_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_lt_quiet () -> unit = {
   /* Half floating point */
-  assert(float_is_lt_quiet((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt_quiet((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt_quiet((fp16_neg_zero, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_zero, fp16_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_zero, fp16_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp16_pos_normal_0, fp16_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_normal_1, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_pos_normal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_normal_0, fp16_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_normal_1, fp16_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_normal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_normal_1, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_normal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_normal_0, fp16_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp16_pos_denormal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp16_neg_denormal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_lt_quiet((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt_quiet((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt_quiet((fp32_neg_zero, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_zero, fp32_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_zero, fp32_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp32_pos_normal_0, fp32_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_normal_1, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_pos_normal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_normal_0, fp32_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_normal_1, fp32_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_normal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_normal_1, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_normal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_normal_0, fp32_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp32_pos_denormal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp32_neg_denormal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_lt_quiet((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt_quiet((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt_quiet((fp64_neg_zero, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_zero, fp64_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_zero, fp64_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp64_pos_normal_0, fp64_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_normal_1, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_pos_normal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_normal_0, fp64_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_normal_1, fp64_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_normal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_normal_1, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_normal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_normal_0, fp64_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp64_pos_denormal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp64_neg_denormal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_lt_quiet((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt_quiet((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt_quiet(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt_quiet((fp128_neg_zero, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_zero, fp128_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_zero, fp128_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp128_pos_normal_0, fp128_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_normal_1, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_pos_normal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_normal_0, fp128_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_normal_1, fp128_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_normal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_normal_1, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_normal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_normal_0, fp128_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt_quiet((fp128_pos_denormal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt_quiet((fp128_neg_denormal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt_quiet(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/lt_test.sail
+++ b/test/float/lt_test.sail
@@ -16,132 +16,132 @@ $include "data.sail"
 
 function test_float_is_lt () -> unit = {
   /* Half floating point */
-  assert(float_is_lt((fp16_pos_snan_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp16_pos_qnan_0, fp16_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp16_neg_denormal_0, fp16_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp16_pos_snan_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp16_pos_qnan_0, fp16_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp16_neg_denormal_0, fp16_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt((fp16_neg_zero, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_zero, fp16_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_zero, fp16_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_zero, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_zero, fp16_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_zero, fp16_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_inf, fp16_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_inf, fp16_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_inf, fp16_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_inf, fp16_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_inf, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_inf, fp16_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_inf, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_inf, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_inf, fp16_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_inf, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_inf, fp16_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp16_pos_normal_0, fp16_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_normal_1, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_pos_normal_0, fp16_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_normal_0, fp16_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_normal_1, fp16_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_normal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_normal_0, fp16_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_normal_1, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_normal_0, fp16_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_normal_0, fp16_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_normal_1, fp16_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_normal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp16_pos_denormal_0, fp16_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp16_neg_denormal_0, fp16_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp16_pos_denormal_0, fp16_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp16_neg_denormal_0, fp16_neg_normal_0) == (false, fp_eflag_none));
 
   /* Single floating point */
-  assert(float_is_lt((fp32_pos_snan_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp32_pos_qnan_0, fp32_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp32_neg_denormal_0, fp32_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp32_pos_snan_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp32_pos_qnan_0, fp32_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp32_neg_denormal_0, fp32_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt((fp32_neg_zero, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_zero, fp32_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_zero, fp32_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_zero, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_zero, fp32_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_zero, fp32_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_inf, fp32_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_inf, fp32_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_inf, fp32_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_inf, fp32_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_inf, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_inf, fp32_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_inf, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_inf, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_inf, fp32_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_inf, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_inf, fp32_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp32_pos_normal_0, fp32_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_normal_1, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_pos_normal_0, fp32_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_normal_0, fp32_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_normal_1, fp32_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_normal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_normal_0, fp32_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_normal_1, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_normal_0, fp32_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_normal_0, fp32_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_normal_1, fp32_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_normal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp32_pos_denormal_0, fp32_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp32_neg_denormal_0, fp32_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp32_pos_denormal_0, fp32_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp32_neg_denormal_0, fp32_neg_normal_0) == (false, fp_eflag_none));
 
   /* Double floating point */
-  assert(float_is_lt((fp64_pos_snan_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp64_pos_qnan_0, fp64_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp64_neg_denormal_0, fp64_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp64_pos_snan_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp64_pos_qnan_0, fp64_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp64_neg_denormal_0, fp64_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt((fp64_neg_zero, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_zero, fp64_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_zero, fp64_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_zero, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_zero, fp64_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_zero, fp64_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_inf, fp64_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_inf, fp64_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_inf, fp64_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_inf, fp64_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_inf, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_inf, fp64_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_inf, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_inf, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_inf, fp64_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_inf, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_inf, fp64_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp64_pos_normal_0, fp64_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_normal_1, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_pos_normal_0, fp64_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_normal_0, fp64_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_normal_1, fp64_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_normal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_normal_0, fp64_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_normal_1, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_normal_0, fp64_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_normal_0, fp64_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_normal_1, fp64_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_normal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp64_pos_denormal_0, fp64_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp64_neg_denormal_0, fp64_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp64_pos_denormal_0, fp64_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp64_neg_denormal_0, fp64_neg_normal_0) == (false, fp_eflag_none));
 
   /* Quad floating point */
-  assert(float_is_lt((fp128_pos_snan_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp128_pos_qnan_0, fp128_pos_normal_0)) == (false, fp_eflag_invalid));
-  assert(float_is_lt((fp128_neg_denormal_0, fp128_neg_snan_0)) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp128_pos_snan_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp128_pos_qnan_0, fp128_pos_normal_0) == (false, fp_eflag_invalid));
+  assert(float_is_lt(fp128_neg_denormal_0, fp128_neg_snan_0) == (false, fp_eflag_invalid));
 
-  assert(float_is_lt((fp128_neg_zero, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_zero, fp128_pos_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_zero, fp128_neg_zero)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_zero, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_zero, fp128_pos_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_zero, fp128_neg_zero) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_inf, fp128_pos_inf)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_inf, fp128_neg_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_inf, fp128_neg_zero)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_inf, fp128_pos_denormal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_inf, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_inf, fp128_neg_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_inf, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_inf, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_inf, fp128_pos_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_pos_inf) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_neg_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_neg_zero) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_pos_denormal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_inf, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_neg_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_inf, fp128_pos_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp128_pos_normal_0, fp128_pos_normal_1)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_normal_1, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_pos_normal_0, fp128_pos_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_normal_0, fp128_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_normal_1, fp128_neg_normal_0)) == (false, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_normal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_normal_0, fp128_pos_normal_1) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_normal_1, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_normal_0, fp128_pos_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_normal_0, fp128_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_normal_1, fp128_neg_normal_0) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_normal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 
-  assert(float_is_lt((fp128_pos_denormal_0, fp128_pos_normal_0)) == (true, fp_eflag_none));
-  assert(float_is_lt((fp128_neg_denormal_0, fp128_neg_normal_0)) == (false, fp_eflag_none));
+  assert(float_is_lt(fp128_pos_denormal_0, fp128_pos_normal_0) == (true, fp_eflag_none));
+  assert(float_is_lt(fp128_neg_denormal_0, fp128_neg_normal_0) == (false, fp_eflag_none));
 }
 
 function main () -> unit = {

--- a/test/float/ne_test.sail
+++ b/test/float/ne_test.sail
@@ -16,60 +16,60 @@ $include "data.sail"
 
 function test_float_is_ne () -> unit = {
   /* Half floating point */
-  assert(float_is_ne((fp16_pos_denormal_0, fp16_pos_denormal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp16_neg_normal_0, fp16_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp16_pos_denormal_1, fp16_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp16_pos_inf, fp16_neg_inf)) == (true, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_denormal_0, fp16_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp16_neg_normal_0, fp16_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_denormal_1, fp16_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_inf, fp16_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne((fp16_pos_denormal_0, fp16_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp16_neg_qnan_0, fp16_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp16_pos_zero, fp16_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp16_pos_inf, fp16_pos_inf)) == (false, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_denormal_0, fp16_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp16_neg_qnan_0, fp16_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_zero, fp16_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ne(fp16_pos_inf, fp16_pos_inf) == (false, fp_eflag_none));
 
-  assert(float_is_ne((fp16_pos_snan_0, fp16_pos_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ne((fp16_pos_snan_1, fp16_pos_normal_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp16_pos_snan_0, fp16_pos_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp16_pos_snan_1, fp16_pos_normal_0) == (false, fp_eflag_invalid));
 
   /* Single floating point */
-  assert(float_is_ne((fp32_pos_denormal_0, fp32_pos_denormal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp32_neg_normal_0, fp32_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp32_pos_denormal_1, fp32_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp32_pos_inf, fp32_neg_inf)) == (true, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_denormal_0, fp32_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp32_neg_normal_0, fp32_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_denormal_1, fp32_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_inf, fp32_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne((fp32_pos_denormal_0, fp32_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp32_neg_qnan_0, fp32_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp32_pos_zero, fp32_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp32_pos_inf, fp32_pos_inf)) == (false, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_denormal_0, fp32_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp32_neg_qnan_0, fp32_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_zero, fp32_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ne(fp32_pos_inf, fp32_pos_inf) == (false, fp_eflag_none));
 
-  assert(float_is_ne((fp32_pos_snan_0, fp32_pos_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ne((fp32_pos_snan_1, fp32_pos_normal_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp32_pos_snan_0, fp32_pos_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp32_pos_snan_1, fp32_pos_normal_0) == (false, fp_eflag_invalid));
 
   /* Double floating point */
-  assert(float_is_ne((fp64_pos_denormal_0, fp64_pos_denormal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp64_neg_normal_0, fp64_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp64_pos_denormal_1, fp64_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp64_pos_inf, fp64_neg_inf)) == (true, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_denormal_0, fp64_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp64_neg_normal_0, fp64_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_denormal_1, fp64_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_inf, fp64_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne((fp64_pos_denormal_0, fp64_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp64_neg_qnan_0, fp64_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp64_pos_zero, fp64_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp64_pos_inf, fp64_pos_inf)) == (false, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_denormal_0, fp64_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp64_neg_qnan_0, fp64_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_zero, fp64_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ne(fp64_pos_inf, fp64_pos_inf) == (false, fp_eflag_none));
 
-  assert(float_is_ne((fp64_pos_snan_0, fp64_pos_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ne((fp64_pos_snan_1, fp64_pos_normal_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp64_pos_snan_0, fp64_pos_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp64_pos_snan_1, fp64_pos_normal_0) == (false, fp_eflag_invalid));
 
   /* Quad floating point */
-  assert(float_is_ne((fp128_pos_denormal_0, fp128_pos_denormal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp128_neg_normal_0, fp128_neg_normal_1)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp128_pos_denormal_1, fp128_pos_zero)) == (true, fp_eflag_none));
-  assert(float_is_ne((fp128_pos_inf, fp128_neg_inf)) == (true, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_denormal_0, fp128_pos_denormal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp128_neg_normal_0, fp128_neg_normal_1) == (true, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_denormal_1, fp128_pos_zero) == (true, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_inf, fp128_neg_inf) == (true, fp_eflag_none));
 
-  assert(float_is_ne((fp128_pos_denormal_0, fp128_pos_denormal_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp128_neg_qnan_0, fp128_neg_qnan_0)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp128_pos_zero, fp128_neg_zero)) == (false, fp_eflag_none));
-  assert(float_is_ne((fp128_pos_inf, fp128_pos_inf)) == (false, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_denormal_0, fp128_pos_denormal_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp128_neg_qnan_0, fp128_neg_qnan_0) == (false, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_zero, fp128_neg_zero) == (false, fp_eflag_none));
+  assert(float_is_ne(fp128_pos_inf, fp128_pos_inf) == (false, fp_eflag_none));
 
-  assert(float_is_ne((fp128_pos_snan_0, fp128_pos_snan_0)) == (false, fp_eflag_invalid));
-  assert(float_is_ne((fp128_pos_snan_1, fp128_pos_normal_0)) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp128_pos_snan_0, fp128_pos_snan_0) == (false, fp_eflag_invalid));
+  assert(float_is_ne(fp128_pos_snan_1, fp128_pos_normal_0) == (false, fp_eflag_invalid));
 }
 
 function main () -> unit = {

--- a/test/float/tuple_equality.sail
+++ b/test/float/tuple_equality.sail
@@ -20,7 +20,7 @@ function bool_and_flags_eq ((bool_0, flags_0), (bool_1, flags_1)) = {
   is_eq;
 }
 
-val      fp_bits_and_flags_eq : forall 'n, 'n in { 16, 32, 64, 128 }.
+val      fp_bits_and_flags_eq : forall 'n, is_fp_bits('n) .
   ((bits('n), fp_exception_flags), (bits('n), fp_exception_flags)) -> bool
 function fp_bits_and_flags_eq ((fp_0, flags_0), (fp_1, flags_1)) = {
   let is_eq = fp_0 == fp_1 & (flags_0 == flags_1);


### PR DESCRIPTION
The previous commit to this code apparently had many errors, but for some reason CI didn't catch them.

* I accidentally added 8 bits into these definitions.
* `fp_bits` was an integer but it should have been `bits()`
* I didn't update the tests.

This fixes those issues. I also used `is_fp_bits` in a few more places.