### PR TITLE
Resolve races in some C tests and clean up headers

### DIFF
--- a/test/builtins/run_tests.py
+++ b/test/builtins/run_tests.py
@@ -28,10 +28,11 @@ def test_c_builtins(name, sail_opts):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('\'{}\' -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
+                step('\'{}\' -no_warn -c {} {} -o {}'.format(sail, sail_opts, filename, basename))
                 step('gcc {}.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}'.format(basename, sail_dir, sail_dir, basename))
                 step('./{}'.format(basename))
                 step('rm {}.c'.format(basename))
+                step('rm {}.h'.format(basename))
                 step('rm {}'.format(basename))
                 print('{} {}{}{}'.format(filename, color.PASS, 'ok', color.END))
                 sys.exit()

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -70,7 +70,7 @@ def test_c(name, c_opts, sail_opts, valgrind, compiler='cc', actually_cpp=False)
                 if valgrind and not basename.startswith('fail'):
                     step("valgrind --leak-check=full --track-origins=yes --errors-for-leak-kinds=all --error-exitcode=2 ./{}.bin".format(basename),
                          expected_status = 1 if basename.startswith('fail') else 0)
-                step('rm {}.{} {}.bin {}.result'.format(basename, extension, basename, basename))
+                step('rm {}.{} {}.h {}.bin {}.result'.format(basename, extension, basename, basename, basename))
                 print_ok(filename)
                 sys.exit()
         results.collect(tests)

--- a/test/float/run_tests.py
+++ b/test/float/run_tests.py
@@ -30,12 +30,12 @@ def test_float(name, sail_opts, compiler, c_opts):
 
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('\'{}\' -no_warn -c {} {} 1> {}.c'.format(sail, sail_opts, filename, basename))
+                step('\'{}\' -no_warn -c {} {} -o {}'.format(sail, sail_opts, filename, basename))
                 step('{} {} {}.c \'{}\'/lib/*.c -lgmp -I \'{}\'/lib -o {}.bin'.format(compiler, c_opts, basename, sail_dir, sail_dir, basename))
                 step('./{}.bin > {}.result 2> {}.err_result'.format(basename, basename, basename), expected_status = 1 if basename.startswith('fail') else 0)
 
                 step('diff {}.err_result no_error && rm {}.err_result'.format(basename, basename))
-                step('rm {}.c {}.bin {}.result'.format(basename, basename, basename))
+                step('rm {}.c {}.h {}.bin {}.result'.format(basename, basename, basename, basename))
 
                 print_ok(filename)
                 sys.exit()


### PR DESCRIPTION
Some tests were still using the old "pipe stdout into a file" method. Since we made `--c-generate-header` implicit this would mean that you get three file: `<basename>.c`, `out.c` and `out.h`. Both `.c` files `#include "out.h"`. That meant since all tests were writing to `out.h` they were clobbering each other and you got random compilation failures.

I fixed it by using `-o <basename>` instead.

I also changed the tests to delete the `.h` files as well as the `.c` files.