### PR TITLE
Pattern completeness for individual bits, redundancy removal

### DIFF
--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -244,6 +244,10 @@ let row_matrix_width l (Rows rows) =
 
 let row_matrix_height (Rows rows) = List.length rows
 
+let filter_out (is : IntSet.t) l =
+  let rec aux (i, acc) elt = if IntSet.mem i is then (i + 1, acc) else (i + 1, elt :: acc) in
+  List.fold_left aux (0, []) l |> snd |> List.rev
+
 module Make (C : Config) = struct
   type bv_constraint =
     | BVC_eq of bv_constraint * bv_constraint
@@ -866,7 +870,11 @@ module Make (C : Config) = struct
             let wild_matrix = split_matrix_wild i matrix in
             begin
               match unmatched_literal col with
-              | None -> Completeness_unknown
+              | None -> begin
+                  match matrix_is_complete l ctx wild_matrix with
+                  | Complete cinfo -> Complete cinfo
+                  | Incomplete _ | Completeness_unknown -> Completeness_unknown
+                end
               | Some lit ->
                   if row_matrix_empty wild_matrix then
                     Incomplete (undefs_except 0 i (mk_lit_exp lit) (row_matrix_width l matrix))
@@ -953,7 +961,12 @@ module Make (C : Config) = struct
                       |> completeness_map (reenum (mk_counterexample member) i) (union_complete cinfo)
               )
               (mk_complete [] []) members
-        | Unknown_column -> Completeness_unknown
+        | Unknown_column -> (
+            match matrix_is_complete l ctx (split_matrix_wild i matrix) with
+            | Incomplete unmatcheds -> Completeness_unknown
+            | Complete cinfo -> Complete cinfo
+            | Completeness_unknown -> Completeness_unknown
+          )
       end
 
   (* Just highlight the match keyword and not the whole match block. *)
@@ -982,7 +995,7 @@ module Make (C : Config) = struct
     | _, (Pat_aux (Pat_when _, _) as case) :: cases -> case :: update_cases l new_pats cases
     | _, _ -> Reporting.unreachable l __POS__ "Impossible case in update_cases" [@coverage off]
 
-  let is_complete_wildcarded ?(keyword = "match") l ctx cases head_exp_typ =
+  let is_complete_wildcarded ?(keyword = "match") ?(remove_redundant = false) l ctx cases head_exp_typ =
     try
       match cases_to_pats ctx 0 ~have_guard:false ~have_mapping:false cases with
       | _, _, [] -> None
@@ -1018,7 +1031,8 @@ module Make (C : Config) = struct
                       Reporting.warn "Redundant case" idx.loc "This match case is never used"
                   )
                   (rows_to_list matrix);
-                Some (update_cases l wildcarded_pats cases)
+                let result = update_cases l wildcarded_pats cases in
+                if remove_redundant then Some (filter_out cinfo.redundant result) else Some result
             | Completeness_unknown -> None
           end
     with
@@ -1026,7 +1040,7 @@ module Make (C : Config) = struct
     | _ ->
       None
 
-  let is_complete_funcls_wildcarded ?(keyword = "match") l ctx funcls head_exp_typ =
+  let is_complete_funcls_wildcarded ?(keyword = "match") ?(remove_redundant = false) l ctx funcls head_exp_typ =
     let destruct_funcl (FCL_aux (FCL_funcl (id, pexp), annot)) = ((id, annot), pexp) in
     let cases = List.map destruct_funcl funcls in
     match is_complete_wildcarded ~keyword l ctx (List.map snd cases) head_exp_typ with

--- a/src/lib/pattern_completeness.mli
+++ b/src/lib/pattern_completeness.mli
@@ -69,8 +69,9 @@ module type Config = sig
 end
 
 module Make (C : Config) : sig
-  val is_complete_wildcarded : ?keyword:string -> Parse_ast.l -> ctx -> C.t pexp list -> typ -> C.t pexp list option
+  val is_complete_wildcarded :
+    ?keyword:string -> ?remove_redundant:bool -> Parse_ast.l -> ctx -> C.t pexp list -> typ -> C.t pexp list option
   val is_complete_funcls_wildcarded :
-    ?keyword:string -> Parse_ast.l -> ctx -> C.t funcl list -> typ -> C.t funcl list option
+    ?keyword:string -> ?remove_redundant:bool -> Parse_ast.l -> ctx -> C.t funcl list -> typ -> C.t funcl list option
   val is_complete : ?keyword:string -> Parse_ast.l -> ctx -> C.t pexp list -> typ -> bool
 end

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -3886,7 +3886,7 @@ module MakeExhaustive = struct
             in
 
             let l = Parse_ast.Generated Parse_ast.Unknown in
-            let p = P_aux (P_wild, (l, empty_tannot)) in
+            let p = P_aux (P_wild, (l, mk_tannot env (typ_of e1))) in
             let l_ann = mk_tannot env unit_typ in
             let ann' = mk_tannot env (typ_of_annot ann) in
             (* TODO: use an expression that specifically indicates a failed pattern match *)
@@ -3906,7 +3906,7 @@ module MakeExhaustive = struct
                 Reporting.print_err (fst ann) "Non-exhaustive let" ("Example: " ^ string_of_rp example)
             in
             let l = Parse_ast.Generated Parse_ast.Unknown in
-            let p = P_aux (P_wild, (l, empty_tannot)) in
+            let p = P_aux (P_wild, (l, mk_tannot env (typ_of e1))) in
             let l_ann = mk_tannot env unit_typ in
             let ann' = mk_tannot env (typ_of_annot ann) in
             (* TODO: use an expression that specifically indicates a failed pattern match *)
@@ -3939,10 +3939,11 @@ module MakeExhaustive = struct
         in
 
         let l = Parse_ast.Generated Parse_ast.Unknown in
-        let p = P_aux (P_wild, (l, empty_tannot)) in
-        let ann' = mk_tannot env (typ_of_tannot (snd fcl_ann)) in
+        let arg_ty, ret_ty, env' = bind_funcl_arg_typ l env (typ_of_tannot (snd fcl_ann)) in
+        let p = P_aux (P_wild, (l, mk_tannot env' arg_ty)) in
+        let ret_ann = mk_tannot env ret_ty in
         (* TODO: use an expression that specifically indicates a failed pattern match *)
-        let b = E_aux (E_exit (E_aux (E_lit (L_aux (L_unit, l)), (l, empty_tannot))), (l, ann')) in
+        let b = E_aux (E_exit (E_aux (E_lit (L_aux (L_unit, l)), (l, empty_tannot))), (l, ret_ann)) in
         let default = FCL_aux (FCL_funcl (id, Pat_aux (Pat_exp (p, b), (l, empty_tannot))), fcl_ann) in
 
         FD_aux (FD_function (r, t, fcls' @ [default]), f_ann)
@@ -3974,6 +3975,46 @@ module MakeExhaustive = struct
     in
     (ast', effect_info', env)
 end
+
+(* Remove redundant patterns because Rocq doesn't like them.  Assumes that all
+   patterns are exhaustive (e.g., by the above rewrite) so that the pattern
+   completeness checker will always work. *)
+let remove_redundant_pats _env ast =
+  let remove_redundant l env pexps typ =
+    let ctx =
+      {
+        Pattern_completeness.abstract = Env.get_abstract_typs env;
+        Pattern_completeness.variants = Env.get_variants env;
+        Pattern_completeness.structs = Env.get_records env;
+        Pattern_completeness.enums = Env.get_enums env;
+        Pattern_completeness.is_open = (fun id -> Env.is_scattered_open id env);
+        Pattern_completeness.constraints = Env.get_constraints env;
+        Pattern_completeness.is_mapping = (fun id -> Env.is_mapping id env);
+      }
+    in
+    match PC.is_complete_wildcarded ~remove_redundant:true l ctx pexps typ with
+    | Some r -> r
+    | None ->
+        Reporting.unreachable l __POS__
+          ("Redundant pattern removal failed due to incomplete patterns:\n"
+          ^ String.concat "\n" (List.map string_of_pexp pexps)
+          )
+  in
+  let rw_exp rws (E_aux (e, (l, ann)) as exp) =
+    match e with
+    | E_match (e1, pexps) ->
+        let e1 = rewrite_exp rws e1 in
+        let pexps = List.map (rewrite_pexp rws) pexps in
+        let pexps = remove_redundant l (env_of_annot (l, ann)) pexps (typ_of e1) in
+        E_aux (E_match (e1, pexps), (l, ann))
+    | E_try (e1, pexps) ->
+        let e1 = rewrite_exp rws e1 in
+        let pexps = List.map (rewrite_pexp rws) pexps in
+        let pexps = remove_redundant l (env_of_annot (l, ann)) pexps exc_typ in
+        E_aux (E_try (e1, pexps), (l, ann))
+    | _ -> exp
+  in
+  rewrite_ast_base { rewriters_base with rewrite_exp = rw_exp } ast
 
 (* Splitting a function (e.g., an execute function on an AST) can produce
    new functions that appear to be recursive but are not.  This checks to
@@ -4798,6 +4839,7 @@ let all_rewriters =
     ("remove_impossible_int_cases", basic_rewriter Constant_propagation.remove_impossible_int_cases);
     ("const_prop_mutrec", String_rewriter (fun target -> base_rewriter (Constant_propagation_mutrec.rewrite_ast target)));
     ("make_cases_exhaustive", base_rewriter MakeExhaustive.rewrite);
+    ("remove_redundant_pats", basic_rewriter remove_redundant_pats);
     ("undefined", Bool_rewriter (fun b -> basic_rewriter (rewrite_undefined_if_gen b)));
     ("vector_string_pats_to_bit_list", basic_rewriter rewrite_ast_vector_string_pats_to_bit_list);
     ("remove_not_pats", basic_rewriter rewrite_ast_not_pats);

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -376,6 +376,9 @@ val bind_pat : Env.t -> uannot pat -> typ -> tannot pat * Env.t * uannot Ast.exp
     be safe to use on patterns that have previously been type checked. *)
 val bind_pat_no_guard : Env.t -> uannot pat -> typ -> tannot pat * Env.t
 
+(** Extract the argument and return types for a function clause *)
+val bind_funcl_arg_typ : Parse_ast.l -> Env.t -> typ -> typ * typ * Env.t
+
 val tc_assume : n_constraint -> tannot exp -> tannot exp
 
 (** {2 Destructuring type annotations}

--- a/src/sail_coq_backend/sail_plugin_coq.ml
+++ b/src/sail_coq_backend/sail_plugin_coq.ml
@@ -162,6 +162,7 @@ let coq_rewrites =
        introduce new wildcard clauses *)
     ("recheck_defs", []);
     ("make_cases_exhaustive", []);
+    ("remove_redundant_pats", []);
     (* merge funcls before adding the measure argument so that it doesn't
        disappear into an internal pattern match *)
     ("merge_function_clauses", []);

--- a/test/coq/pass/redundant.sail
+++ b/test/coq/pass/redundant.sail
@@ -1,0 +1,21 @@
+default Order dec
+$include <prelude.sail>
+
+/* The current guarded pattern rewrite can produce results with redundant clauses.
+   Rocq rejects these extra clauses.  This test is structured to trigger this,
+   and check that the redundant patterns have been removed. */
+
+union t = {
+  Hello : int,
+  World : int,
+}
+
+function foo(x : t) -> int = match x { Hello(y) => y, World(y) => y }
+
+function test(x : (bool, t)) -> bool =
+  match x {
+    (_, Hello(x)) if x > 0 => true,
+    (true, y) if foo(y) > 0 => true,
+    (_, Hello(x)) => false,
+    (_, _) => false,
+  }


### PR DESCRIPTION
The redundant rows removal is used in the guarded pattern rewrite to eliminate redundant clauses that might trip up (e.g.) the Rocq backend. It's possible to use there exactly because the guards have all been removed.