### PR TITLE
Add line-style documentation comments

### DIFF
--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -100,7 +100,12 @@ val get_attributes : uannot -> (l * string * attribute_data option) list
 val find_attribute_opt : string -> (l * string * attribute_data option) list -> (l * attribute_data option) option
 
 val mk_def_annot :
-  ?doc:string -> ?attrs:(l * string * attribute_data option) list -> ?visibility:visibility -> l -> 'a -> 'a def_annot
+  ?doc:Parse_ast.doc_comment ->
+  ?attrs:(l * string * attribute_data option) list ->
+  ?visibility:visibility ->
+  l ->
+  'a ->
+  'a def_annot
 
 val uannot_of_def_annot : 'a def_annot -> uannot
 

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -69,13 +69,13 @@ let match_keywords = function Try_match -> ("try", Some "catch") | Match_match -
 
 let binder_keyword = function Var_binder -> "var" | Let_binder -> "let" | Internal_plet_binder -> "internal_plet"
 
-let comment_type_delimiters = function Lexer.Comment_line -> ("//", "") | Lexer.Comment_block -> ("/*", "*/")
+let comment_type_delimiters = function Comment_line -> ("//", "") | Comment_block -> ("/*", "*/")
 
 type infix_chunk = Infix_prefix of string | Infix_op of string | Infix_chunks of chunks
 
 and chunk =
-  | Comment of Lexer.comment_type * int * int * string * bool
-  | Doc_comment of string
+  | Comment of comment_type * int * int * string * bool
+  | Doc_comment of doc_comment
   | Spacer of bool * int
   | Function of {
       id : id;
@@ -135,7 +135,7 @@ let rec prerr_chunk indent = function
   | Comment (comment_type, n, col, contents, trailing) ->
       let s, e = comment_type_delimiters comment_type in
       Printf.eprintf "%sComment: blank=%d col=%d trailing=%b %s%s%s\n" indent n col trailing s contents e
-  | Doc_comment contents -> Printf.eprintf "%sDoc_comment: /*!%s*/\n" indent contents
+  | Doc_comment { contents; _ } -> Printf.eprintf "%sDoc_comment: /*!%s*/\n" indent contents
   | Spacer (line, w) -> Printf.eprintf "%sSpacer:%b %d\n" indent line w
   | Atom str -> Printf.eprintf "%sAtom:%s\n" indent str
   | String_literal str -> Printf.eprintf "%sString_literal:%s\n" indent str
@@ -450,12 +450,11 @@ let pop_trailing_comment ?space:(n = 0) comments chunks line_num =
   | None -> false
   | Some lnum -> begin
       match Stack.top_opt comments with
-      | Some (Lexer.Comment (comment_type, s, _, contents)) when s.pos_lnum = lnum ->
+      | Some (Lexer.Comment (comment_type, s, _, contents)) when s.pos_lnum = lnum -> (
           let _ = Stack.pop comments in
           Queue.add (Comment (comment_type, n, s.pos_cnum - s.pos_bol, contents, true)) chunks;
-          begin
-            match comment_type with Lexer.Comment_line -> true | _ -> false
-          end
+          match comment_type with Comment_line -> true | _ -> false
+        )
       | _ -> false
     end
 

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -60,13 +60,13 @@ type match_kind = Try_match | Match_match
 
 val match_keywords : match_kind -> string * string option
 
-val comment_type_delimiters : Lexer.comment_type -> string * string
+val comment_type_delimiters : Parse_ast.comment_type -> string * string
 
 type infix_chunk = Infix_prefix of string | Infix_op of string | Infix_chunks of chunks
 
 and chunk =
-  | Comment of Lexer.comment_type * int * int * string * bool
-  | Doc_comment of string
+  | Comment of Parse_ast.comment_type * int * int * string * bool
+  | Doc_comment of Parse_ast.doc_comment
   | Spacer of bool * int
   | Function of {
       id : Parse_ast.id;

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -17,7 +17,7 @@ type extern = Coq_extern.record
 
 module Coq_def_annot =
  struct
-  type 'a record = { doc_comment : string option;
+  type 'a record = { doc_comment : Parse_ast.doc_comment option;
                      attrs : (Parse_ast.l * (string * attribute_data option))
                              list;
                      visibility : visibility; loc : Parse_ast.l; env : 

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -17,7 +17,7 @@ type extern = Coq_extern.record
 
 module Coq_def_annot :
  sig
-  type 'a record = { doc_comment : string option;
+  type 'a record = { doc_comment : Parse_ast.doc_comment option;
                      attrs : (Parse_ast.l * (string * attribute_data option))
                              list;
                      visibility : visibility; loc : Parse_ast.l; env : 

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -350,7 +350,7 @@ let unary_operator_precedence = function
 let can_hang chunks =
   match Queue.peek_opt chunks with
   | Some (Comment (t, _, _, contents, _)) -> (
-      match t with Lexer.Comment_block -> is_single_line_block_comment contents | _ -> false
+      match t with Comment_block -> is_single_line_block_comment contents | _ -> false
     )
   | _ -> true
 
@@ -575,8 +575,8 @@ module Make (Config : CONFIG) = struct
           (char '}')
     | Comment (comment_type, n, col, contents, _) -> begin
         match comment_type with
-        | Lexer.Comment_line -> blank n ^^ string "//" ^^ string contents ^^ require_hardline
-        | Lexer.Comment_block -> (
+        | Comment_line -> blank n ^^ string "//" ^^ string contents ^^ require_hardline
+        | Comment_block -> (
             (* Allow a linebreak after a block comment with newlines. This prevents formatting like:
                /* comment line 1
                   comment line 2 */exp
@@ -587,9 +587,15 @@ module Make (Config : CONFIG) = struct
             | ls -> blank n ^^ group (align (string "/*" ^^ separate hardline ls ^^ string "*/")) ^^ require_hardline
           )
       end
-    | Doc_comment contents ->
-        let ls = block_comment_lines 0 contents in
-        align (string "/*!" ^^ separate hardline ls ^^ string "*/") ^^ require_hardline
+    | Doc_comment { contents; comment_type } -> (
+        match comment_type with
+        | Comment_block ->
+            let ls = block_comment_lines 0 contents in
+            align (string "/*!" ^^ separate hardline ls ^^ string "*/") ^^ require_hardline
+        | Comment_line ->
+            let ls = String.split_on_char '\n' contents in
+            align (string "///" ^^ separate_map (hardline ^^ string "///") string ls) ^^ require_hardline
+      )
     | Function f ->
         let sep = hardline ^^ string "and" ^^ space in
         let clauses =

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -136,8 +136,6 @@ let kw_table =
      ("internal_assume",         (fun _ -> InternalAssume));
    ]
 
-type comment_type = Comment_block | Comment_line
-
 type comment =
   | Comment of comment_type * Lexing.position * Lexing.position * string
 
@@ -201,12 +199,20 @@ rule token comments = parse
   | "=>"                                { EqGt "=>" }
   | "/*!"
     { let startpos = Lexing.lexeme_start_p lexbuf in
-      let arg = doc_comment (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) 0 false lexbuf in
+      let arg = doc_comment startpos (Buffer.create 10) 0 false lexbuf in
       lexbuf.lex_start_p <- startpos;
-      Doc arg }
-  | "//"        { line_comment comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) lexbuf; token comments lexbuf }
-  | "/*"        { block_comment comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) 0 lexbuf; token comments lexbuf }
-  | "*/"        { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) "Unbalanced comment") }
+      DocBlock arg }
+  | "///"
+    { let startpos = Lexing.lexeme_start_p lexbuf in
+      let arg = doc_line_comment startpos (Buffer.create 10) lexbuf in
+      lexbuf.lex_start_p <- startpos;
+      DocLine arg }
+  | "//"
+    { line_comment comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) lexbuf; token comments lexbuf }
+  | "/*"
+    { block_comment comments (Lexing.lexeme_start_p lexbuf) (Buffer.create 10) 0 lexbuf; token comments lexbuf }
+  | "*/"
+    { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) "Unbalanced comment") }
   | "$[" (ident+ as i)
     { Attribute i }
   | "$" (ident+ as i) wsc* "{"
@@ -238,9 +244,8 @@ rule token comments = parse
                                             lexbuf.lex_start_p <- startpos;
                                             String(contents) }
   | eof                                   { Eof }
-  | _  as c                               { raise (Reporting.err_lex
-                                              (Lexing.lexeme_start_p lexbuf)
-                                              (Printf.sprintf "Unexpected character: %s" (Char.escaped c))) }
+  | _  as c
+    { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) (Printf.sprintf "Unexpected character: %s" (Char.escaped c))) }
 
 and attribute depth pos b = parse
   | "["                                 { Buffer.add_char b '['; attribute (depth + 1) pos b lexbuf }
@@ -269,10 +274,16 @@ and pragma comments pos b after_block = parse
                                           ) }
   | eof                                 { raise (Reporting.err_lex pos "File ended before newline in directive") }
 
+and doc_line_comment pos b = parse
+  | "\n" wsc* "///"                     { Buffer.add_char b '\n'; doc_line_comment pos b lexbuf }
+  | "\n"                                { Buffer.contents b }
+  | _ as c                              { Buffer.add_char b c; doc_line_comment pos b lexbuf }
+  | eof                                 { raise (Reporting.err_lex pos "File ended before newline in documentation comment") }
+
 and line_comment comments pos b = parse
   | "\n"                                { Lexing.new_line lexbuf;
                                           comments := Comment (Comment_line, pos, Lexing.lexeme_end_p lexbuf, Buffer.contents b) :: !comments }
-  | _ as c                              { Buffer.add_string b (String.make 1 c); line_comment comments pos b lexbuf }
+  | _ as c                              { Buffer.add_char b c; line_comment comments pos b lexbuf }
   | eof                                 { raise (Reporting.err_lex pos "File ended before newline in comment") }
 
 and doc_comment pos b depth lstart = parse

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -55,6 +55,10 @@ type l =
   | Hint of string * l * l
   | Range of Lexing.position * Lexing.position
 
+type comment_type = Comment_block | Comment_line
+
+type doc_comment = { contents : string; comment_type : comment_type }
+
 (** We put the attribute data type in it's own module, so other modules can import it unqualified. The parse AST and the
     main AST share this type, so modules that wouldn't normally import this module will want to use it. *)
 module Attribute_data = struct
@@ -301,7 +305,7 @@ and funcl_aux =
   (* Function clause *)
   | FCL_private of funcl
   | FCL_attribute of string * attribute_data option * funcl
-  | FCL_doc of string * funcl
+  | FCL_doc of doc_comment * funcl
   | FCL_funcl of id * pexp
 
 type type_union = Tu_aux of type_union_aux * l
@@ -310,7 +314,7 @@ and type_union_aux =
   (* Type union constructors *)
   | Tu_private of type_union
   | Tu_attribute of string * attribute_data option * type_union
-  | Tu_doc of string * type_union
+  | Tu_doc of doc_comment * type_union
   | Tu_ty_id of atyp * id
   | Tu_ty_anon_rec of (atyp * id) list * id
 
@@ -366,7 +370,7 @@ type mapcl = MCL_aux of mapcl_aux * l
 and mapcl_aux =
   (* mapping clause (bidirectional pattern-match) *)
   | MCL_attribute of string * attribute_data option * mapcl
-  | MCL_doc of string * mapcl
+  | MCL_doc of doc_comment * mapcl
   | MCL_bidir of mpexp * mpexp
   | MCL_forwards_deprecated of mpexp * exp
   | MCL_forwards of pexp
@@ -463,7 +467,7 @@ type def_aux =
   | DEF_pragma of string * pragma
   | DEF_private of def
   | DEF_attribute of string * attribute_data option * def
-  | DEF_doc of string * def
+  | DEF_doc of doc_comment * def
   | DEF_internal_mutrec of fundef list
 
 and def = DEF_aux of def_aux * l

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -233,7 +233,7 @@ let set_syntax_deprecated l =
 
 %token <string> Eq EqGt Unit Colon
 
-%token <string> Doc
+%token <string> DocBlock DocLine
 
 %token <string> OpId
 
@@ -875,12 +875,18 @@ attribute_data_eof:
   | d = attribute_data; Eof
     { d }
 
+doc_comment:
+  | str = DocBlock
+    { { contents = str; comment_type = Comment_block } }
+  | str = DocLine
+    { { contents = str; comment_type = Comment_line } }
+
 funcl_annotation:
   | visibility = Private
     { (fun funcl -> FCL_aux (FCL_private funcl, loc $startpos(visibility) $endpos(visibility))) }
   | attr = attribute
     { (fun funcl -> FCL_aux (FCL_attribute (fst attr, snd attr, funcl), loc $startpos(attr) $endpos(attr))) }
-  | doc = Doc
+  | doc = doc_comment
     { (fun funcl -> FCL_aux (FCL_doc (doc, funcl), loc $startpos(doc) $endpos(doc))) }
 
 funcl_patexp:
@@ -1065,7 +1071,7 @@ type_union:
     { Tu_aux (Tu_private tu, loc $startpos(visibility) $endpos(visibility)) }
   | attr = attribute; tu = type_union
     { Tu_aux (Tu_attribute (fst attr, snd attr, tu), loc $startpos(attr) $endpos(attr)) }
-  | doc = Doc; tu = type_union
+  | doc = doc_comment; tu = type_union
     { Tu_aux (Tu_doc (doc, tu), loc $startpos(doc) $endpos(doc)) }
   | id Colon typ
     { Tu_aux (Tu_ty_id ($3, $1), loc $startpos $endpos) }
@@ -1167,7 +1173,7 @@ fmpat:
 mapcl:
   | attr = attribute; mcl = mapcl
     { MCL_aux (MCL_attribute (fst attr, snd attr, mcl), loc $startpos(attr) $endpos(attr)) }
-  | doc = Doc; mcl = mapcl
+  | doc = doc_comment; mcl = mapcl
     { MCL_aux (MCL_doc (doc, mcl), loc $startpos(doc) $endpos(doc)) }
   | mcl = mapcl0
     { mcl }
@@ -1381,7 +1387,7 @@ def(AUX):
     { DEF_aux (DEF_private def, loc $startpos(visibility) $endpos(visibility)) }
   | attr = attribute; def = def(AUX)
     { DEF_aux (DEF_attribute (fst attr, snd attr, def), loc $startpos(attr) $endpos(attr)) }
-  | doc = Doc; def = def(AUX)
+  | doc = doc_comment; def = def(AUX)
     { DEF_aux (DEF_doc (doc, def), loc $startpos(doc) $endpos(doc)) }
   | d = AUX
     { DEF_aux (d, loc $startpos(d) $endpos(d)) }

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -70,7 +70,13 @@ module Printer (Config : PRINT_CONFIG) = struct
 
   let doc_def_annot def_annot =
     ( match def_annot.Coq_def_annot.doc_comment with
-    | Some str -> string "/*!" ^^ string str ^^ string "*/" ^^ hardline
+    | Some { contents; comment_type } -> (
+        match comment_type with
+        | Comment_block -> string "/*!" ^^ string contents ^^ string "*/" ^^ hardline
+        | Comment_line ->
+            let ls = String.split_on_char '\n' contents in
+            string "///" ^^ separate_map (hardline ^^ string "///") string ls ^^ hardline
+      )
     | _ -> empty
     )
     ^^ ( match def_annot.attrs with

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -14,6 +14,10 @@ Definition l := loc.
 
 Extract Inlined Constant loc => "Parse_ast.l".
 
+Parameter ext_doc_comment : Set.
+
+Extract Inlined Constant ext_doc_comment => "Parse_ast.doc_comment".
+
 Parameter ext_attribute_data : Set.
 
 Extract Inlined Constant ext_attribute_data => "Parse_ast.Attribute_data.attribute_data".
@@ -38,7 +42,7 @@ Definition extern := extern.record.
 
 Module def_annot.
   Record record {a : Set} : Set := Build {
-    doc_comment : option string;
+    doc_comment : option ext_doc_comment;
     attrs : list (loc * (string * option attribute_data));
     visibility : visibility;
     loc : loc;

--- a/src/sail_doc_backend/docinfo.ml
+++ b/src/sail_doc_backend/docinfo.ml
@@ -243,7 +243,7 @@ type 'a function_clause_doc = {
   guard_source : location_or_raw option;
   body_source : location_or_raw;
   module_path : string list option;
-  comment : string option;
+  comment : Parse_ast.doc_comment option;
   splits : location_or_raw Bindings.t option;
   attributes : (string * attribute_data option) list;
 }
@@ -256,7 +256,7 @@ let json_of_function_clause_doc docinfo =
        ("pattern", json_of_pat docinfo.pat);
      ]
     @ (match docinfo.wavedrom with Some w -> [("wavedrom", `String w)] | None -> [])
-    @ (match docinfo.comment with Some s -> [("comment", `String s)] | None -> [])
+    @ (match docinfo.comment with Some { contents; _ } -> [("comment", `String contents)] | None -> [])
     @ (match docinfo.guard_source with Some s -> [("guard", json_of_location_or_raw s)] | None -> [])
     @ [("body", json_of_location_or_raw docinfo.body_source)]
     @ (match docinfo.module_path with Some mods -> [("path", `List (List.map (fun m -> `String m) mods))] | None -> [])
@@ -338,12 +338,12 @@ let json_of_let_doc docinfo =
     @ json_of_attributes docinfo.attributes
     )
 
-type anchor_doc = { source : location_or_raw; comment : string option }
+type anchor_doc = { source : location_or_raw; comment : Parse_ast.doc_comment option }
 
 let json_of_anchor_doc docinfo =
   `Assoc
     ([("source", json_of_location_or_raw docinfo.source)]
-    @ match docinfo.comment with Some c -> [("comment", `String c)] | None -> []
+    @ match docinfo.comment with Some { contents; _ } -> [("comment", `String contents)] | None -> []
     )
 
 type 'a linkable = { doc : 'a; links : hyperlink list; module_path : string list option }
@@ -442,9 +442,9 @@ module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) = struct
 
   let get_doc_comment def_annot =
     Option.map
-      (fun comment ->
+      (fun ({ contents; comment_type } : Parse_ast.doc_comment) ->
         let conf = Converter.default_config ~loc:def_annot.loc in
-        Converter.convert conf comment
+        ({ contents = encode (Converter.convert conf contents); comment_type } : Parse_ast.doc_comment)
       )
       def_annot.doc_comment
 
@@ -559,7 +559,7 @@ module Generator (Converter : Markdown.CONVERTER) (Config : CONFIG) = struct
       guard_source;
       body_source;
       module_path;
-      comment = Option.map encode comment;
+      comment;
       splits;
       attributes = List.map (fun (_, attr, data) -> (attr, data)) attrs;
     }

--- a/src/sail_doc_backend/html_source.ml
+++ b/src/sail_doc_backend/html_source.ml
@@ -83,7 +83,7 @@ let highlights ~filename ~contents =
     | String _ ->
         mark Highlight.String;
         go ()
-    | Doc _ ->
+    | DocLine _ | DocBlock _ ->
         mark Highlight.Comment;
         go ()
     | And | As | Assert | By | Match | Clause | Dec | Op | Default | Effect | End | Enum | Else | Exit | Cast | Forall

--- a/src/sail_latex_backend/latex.ml
+++ b/src/sail_latex_backend/latex.ml
@@ -392,7 +392,7 @@ let latex_command ~docstring cat id no_loc l =
   end
 
 let latex_docstring (def_annot : 'a Ast.def_annot) =
-  match def_annot.doc_comment with Some contents -> string (latex_of_markdown contents) | None -> empty
+  match def_annot.doc_comment with Some { contents; _ } -> string (latex_of_markdown contents) | None -> empty
 
 let latex_funcls def =
   let module StringMap = Map.Make (String) in


### PR DESCRIPTION
Support Rust-style single line documentation comments, i.e. rather than
```
/*! Documentation comment */
```
you can now write
```
/// Documentation comment
```

These comments can span multiple lines, provided each line is prefixed by `///`.
```
/// Multiple line documentation comment.
///
/// With a second paragraph.
<Some definition>
```

Currently fully blank lines are not allowed, so
```
/// Comment 1

/// Comment 2
```
is treated by the lexer and parser as two separate documentation comments.

In various places in the AST annotations where comments were just represented as strings, they are now represented using the `doc_comment` struct, which contains a `comment_type` field along with the contents.