### PR TITLE
Allow documentation comments in a few more places.

### DIFF
--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -371,6 +371,17 @@ module KindInference = struct
     type t = env
   end)
 
+  let rec mapM_field_item f = function
+    | P.Ann_doc (doc, x, l) ->
+        let* y = mapM_field_item f x in
+        return (P.Ann_doc (doc, y, l))
+    | P.Ann_attribute (attr, arg, x, l) ->
+        let* y = mapM_field_item f x in
+        return (P.Ann_attribute (attr, arg, y, l))
+    | P.Ann_item x ->
+        let* y = f x in
+        return (P.Ann_item y)
+
   let get_var v env =
     let rec go = function
       | [] -> (None, env)
@@ -774,9 +785,10 @@ module KindInference = struct
     | P.Tu_ty_anon_rec (fields, id) ->
         let* fields =
           mapM
-            (fun (atyp, field) ->
-              let* atyp = check ctx atyp (Kind (P.K_type, atyp_loc atyp)) in
-              return (atyp, field)
+            (mapM_field_item (fun (field, atyp) ->
+                 let* atyp = check ctx atyp (Kind (P.K_type, atyp_loc atyp)) in
+                 return (field, atyp)
+             )
             )
             fields
         in
@@ -1672,6 +1684,15 @@ let to_ast_reserved_type_id ctx id =
   end
   else id
 
+let rec to_ast_field f doc attrs = function
+  | P.Ann_attribute (attr, arg, x, l) -> to_ast_field f doc (attrs @ [(l, attr, arg)]) x
+  | P.Ann_doc (doc_comment, x, l) -> (
+      match doc with
+      | Some _ -> raise (Reporting.err_general l "Field has multiple documentation comments")
+      | None -> to_ast_field f (Some doc_comment) attrs x
+    )
+  | P.Ann_item x -> f doc attrs x
+
 let to_ast_record ctx id typq fields =
   let id = to_ast_reserved_type_id ctx id in
   let infer typq fields =
@@ -1679,9 +1700,10 @@ let to_ast_record ctx id typq fields =
     let* typq = infer_typquant ctx typq in
     let* fields =
       mapM
-        (fun ((P.ATyp_aux (_, l) as atyp), id) ->
-          let* atyp = check ctx atyp (Kind (P.K_type, l)) in
-          return (atyp, id)
+        (KindInference.mapM_field_item (fun (id, (P.ATyp_aux (_, l) as atyp)) ->
+             let* atyp = check ctx atyp (Kind (P.K_type, l)) in
+             return (id, atyp)
+         )
         )
         fields
     in
@@ -1689,7 +1711,11 @@ let to_ast_record ctx id typq fields =
   in
   let (typq, fields), kenv = infer typq fields KindInference.initial_env in
   let typq, typq_ctx = ConvertType.to_ast_typquant kenv ctx typq in
-  let fields = List.map (fun (atyp, id) -> (ConvertType.to_ast_typ kenv typq_ctx atyp, to_ast_id ctx id)) fields in
+  let fields =
+    List.map
+      (to_ast_field (fun _ _ (id, atyp) -> (ConvertType.to_ast_typ kenv typq_ctx atyp, to_ast_id ctx id)) None [])
+      fields
+  in
   (id, typq, fields, add_constructor id typq K_type ctx)
 
 let check_duplicate_enum_ids ids =
@@ -1789,7 +1815,9 @@ let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : untyped_
   | P.TD_bitfield (id, typ, ranges) ->
       let id = to_ast_reserved_type_id ctx id in
       let typ = to_ast_typ ctx typ in
-      let ranges = List.map (fun (id, range) -> (to_ast_id ctx id, to_ast_range ctx range)) ranges in
+      let ranges =
+        List.map (to_ast_field (fun _ _ (id, range) -> (to_ast_id ctx id, to_ast_range ctx range)) None []) ranges
+      in
       ( [DEF_aux (DEF_type (TD_aux (TD_bitfield (id, typ, ranges), (l, empty_uannot))), def_annot)],
         { ctx with type_constructors = Bindings.add id ([], P.K_type) ctx.type_constructors }
       )

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -275,8 +275,8 @@ and pragma comments pos b after_block = parse
   | eof                                 { raise (Reporting.err_lex pos "File ended before newline in directive") }
 
 and doc_line_comment pos b = parse
-  | "\n" wsc* "///"                     { Buffer.add_char b '\n'; doc_line_comment pos b lexbuf }
-  | "\n"                                { Buffer.contents b }
+  | "\n" wsc* "///"                     { Lexing.new_line lexbuf; Buffer.add_char b '\n'; doc_line_comment pos b lexbuf }
+  | "\n"                                { Lexing.new_line lexbuf; Buffer.contents b }
   | _ as c                              { Buffer.add_char b c; doc_line_comment pos b lexbuf }
   | eof                                 { raise (Reporting.err_lex pos "File ended before newline in documentation comment") }
 

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -77,6 +77,11 @@ open Attribute_data
 
 type 'a annot = l * 'a
 
+type 'a field_annot =
+  | Ann_attribute of string * attribute_data option * 'a field_annot * l
+  | Ann_doc of doc_comment * 'a field_annot * l
+  | Ann_item of 'a
+
 type extern = { pure : bool; bindings : (string * string) list }
 
 type x = text (* identifier *)
@@ -316,7 +321,7 @@ and type_union_aux =
   | Tu_attribute of string * attribute_data option * type_union
   | Tu_doc of doc_comment * type_union
   | Tu_ty_id of atyp * id
-  | Tu_ty_anon_rec of (atyp * id) list * id
+  | Tu_ty_anon_rec of (id * atyp) field_annot list * id
 
 type tannot_opt = Typ_annot_opt_aux of tannot_opt_aux * l
 
@@ -396,11 +401,11 @@ type fundef_aux =
 type type_def_aux =
   (* Type definition body *)
   | TD_abbrev of id * typquant * kind option * atyp (* type abbreviation *)
-  | TD_record of id * typquant * (atyp * id) list (* struct type definition *)
+  | TD_record of id * typquant * (id * atyp) field_annot list (* struct type definition *)
   | TD_variant of id * typquant * type_union list * bool (* union type definition *)
   | TD_enum of id * (id * atyp) list * (id * exp option) list (* enumeration type definition *)
   | TD_abstract of id * kind * string list option
-  | TD_bitfield of id * atyp * (id * index_range) list (* register mutable bitfield type definition *)
+  | TD_bitfield of id * atyp * (id * index_range) field_annot list (* register mutable bitfield type definition *)
 
 type val_spec_aux =
   (* Value type specification *)

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -958,8 +958,12 @@ atomic_index_range:
     { mk_ir (BF_range ($2, $4)) $startpos $endpos }
 
 r_id_def:
-  | id Colon index_range
-    { $1, $3 }
+  | doc = doc_comment; r = r_id_def
+    { Ann_doc (doc, r, loc $startpos(doc) $endpos(doc)) }
+  | attr = attribute; r = r_id_def
+    { Ann_attribute (fst attr, snd attr, r, loc $startpos(attr) $endpos(attr)) }
+  | n = id; Colon; r = index_range
+    { Ann_item (n, r) }
 
 r_def_body:
   | r_id_def
@@ -1055,8 +1059,12 @@ enum:
     { ($1, Some $3) :: $5 }
 
 struct_field:
-  | id Colon typ
-    { ($3, $1) }
+  | doc = doc_comment; f = struct_field
+    { Ann_doc (doc, f, loc $startpos(doc) $endpos(doc)) }
+  | attr = attribute; f = struct_field
+    { Ann_attribute (fst attr, snd attr, f, loc $startpos(attr) $endpos(attr)) }
+  | n = id; Colon; t = typ
+    { Ann_item (n, t) }
 
 struct_fields:
   | struct_field


### PR DESCRIPTION
This is just to match existing use of ///. Slightly more work is needed to thread these through to the correct annotations, and we should also allow $[attribute] syntax whenever we have documentation comment support for consistency.