### PR TITLE
Thread documentation and attributes on fields throughout AST

### DIFF
--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -287,7 +287,7 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
         scan_typquant (Type id) typq
     | TD_record (id, typq, fields, _) ->
         let field_nodes =
-          List.map (fun (typ, _) -> typ_ids typ) fields
+          List.map (fun ((_, typ), _) -> typ_ids typ) fields
           |> List.fold_left IdSet.union IdSet.empty |> IdSet.elements
           |> List.map (fun id -> Type id)
         in

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -346,7 +346,8 @@ type 'a scattered_def_aux =
 | SD_funcl of 'a funcl
 | SD_variant of id * typquant
 | SD_unioncl of id * type_union
-| SD_internal_unioncl_record of id * id * typquant * (typ * id) list
+| SD_internal_unioncl_record of id * id * typquant
+   * ((id * typ) * unit def_annot) list
 | SD_mapping of id * tannot_opt
 | SD_mapcl of id * 'a mapcl
 | SD_enum of id
@@ -368,11 +369,11 @@ type 'a fundef_aux =
 
 type type_def_aux =
 | TD_abbrev of id * typquant * typ_arg
-| TD_record of id * typquant * (typ * id) list * bool
+| TD_record of id * typquant * ((id * typ) * unit def_annot) list * bool
 | TD_variant of id * typquant * type_union list * bool
 | TD_enum of id * id list * bool
 | TD_abstract of id * kind * opt_abstract_config
-| TD_bitfield of id * typ * (id * index_range) list
+| TD_bitfield of id * typ * ((id * index_range) * unit def_annot) list
 
 type outcome_spec =
 | OV_aux of outcome_spec_aux * Parse_ast.l

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -346,7 +346,8 @@ type 'a scattered_def_aux =
 | SD_funcl of 'a funcl
 | SD_variant of id * typquant
 | SD_unioncl of id * type_union
-| SD_internal_unioncl_record of id * id * typquant * (typ * id) list
+| SD_internal_unioncl_record of id * id * typquant
+   * ((id * typ) * unit def_annot) list
 | SD_mapping of id * tannot_opt
 | SD_mapcl of id * 'a mapcl
 | SD_enum of id
@@ -368,11 +369,11 @@ type 'a fundef_aux =
 
 type type_def_aux =
 | TD_abbrev of id * typquant * typ_arg
-| TD_record of id * typquant * (typ * id) list * bool
+| TD_record of id * typquant * ((id * typ) * unit def_annot) list * bool
 | TD_variant of id * typquant * type_union list * bool
 | TD_enum of id * id list * bool
 | TD_abstract of id * kind * opt_abstract_config
-| TD_bitfield of id * typ * (id * index_range) list
+| TD_bitfield of id * typ * ((id * index_range) * unit def_annot) list
 
 type outcome_spec =
 | OV_aux of outcome_spec_aux * Parse_ast.l

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1713,7 +1713,13 @@ let to_ast_record ctx id typq fields =
   let typq, typq_ctx = ConvertType.to_ast_typquant kenv ctx typq in
   let fields =
     List.map
-      (to_ast_field (fun _ _ (id, atyp) -> (ConvertType.to_ast_typ kenv typq_ctx atyp, to_ast_id ctx id)) None [])
+      (to_ast_field
+         (fun doc attrs (id, atyp) ->
+           let id = to_ast_id ctx id in
+           ((id, ConvertType.to_ast_typ kenv typq_ctx atyp), mk_def_annot ?doc ~attrs (id_loc id) ())
+         )
+         None []
+      )
       fields
   in
   (id, typq, fields, add_constructor id typq K_type ctx)
@@ -1816,7 +1822,15 @@ let rec to_ast_typedef ctx def_annot (P.TD_aux (aux, l) : P.type_def) : untyped_
       let id = to_ast_reserved_type_id ctx id in
       let typ = to_ast_typ ctx typ in
       let ranges =
-        List.map (to_ast_field (fun _ _ (id, range) -> (to_ast_id ctx id, to_ast_range ctx range)) None []) ranges
+        List.map
+          (to_ast_field
+             (fun doc attrs (id, range) ->
+               let id = to_ast_id ctx id in
+               ((id, to_ast_range ctx range), mk_def_annot ?doc ~attrs (id_loc id) ())
+             )
+             None []
+          )
+          ranges
       in
       ( [DEF_aux (DEF_type (TD_aux (TD_bitfield (id, typ, ranges), (l, empty_uannot))), def_annot)],
         { ctx with type_constructors = Bindings.add id ([], P.K_type) ctx.type_constructors }
@@ -2365,7 +2379,7 @@ let generate_undefined_record id typq fields =
     mk_fundef
       [
         mk_funcl (prepend_id "undefined_" id) pat
-          (mk_exp (E_struct (SN_anon, List.map (fun (_, id) -> mk_fexp id (mk_lit_exp L_undef)) fields)));
+          (mk_exp (E_struct (SN_anon, List.map (fun ((id, _), _) -> mk_fexp id (mk_lit_exp L_undef)) fields)));
       ];
   ]
 

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -80,7 +80,7 @@ val get_uninitialized_registers : untyped_def list -> (id * typ) list
 
 val generate_undefined_record_context : typquant -> (id * typ) list
 
-val generate_undefined_record : id -> typquant -> (typ * id) list -> untyped_def list
+val generate_undefined_record : id -> typquant -> ((id * typ) * unit def_annot) list -> untyped_def list
 
 val generate_undefined_enum : id -> id list -> untyped_def list
 

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -1774,7 +1774,7 @@ module Make (C : CONFIG) = struct
         let record_ctx = { ctx with local_env = Env.add_typquant l typq ctx.local_env } in
         let ctors =
           List.fold_left
-            (fun ctors (typ, id) -> Bindings.add id (fast_int (ctyp_of_typ record_ctx typ)) ctors)
+            (fun ctors ((id, typ), _) -> Bindings.add id (fast_int (ctyp_of_typ record_ctx typ)) ctors)
             Bindings.empty ctors
         in
         let params = quant_kopts typq |> List.filter is_typ_kopt |> List.map kopt_kid in

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -4585,9 +4585,9 @@ module ToplevelNexpRewrites = struct
           let env = Env.add_typquant tq_l tyqs env in
           let nexp_map, fields' =
             List.fold_right
-              (fun (typ, id) (nexp_map, t) ->
+              (fun ((id, typ), def_annot) (nexp_map, t) ->
                 let nexp_map, typ = rewrite_typ_in_spec env nexp_map typ in
-                (nexp_map, (typ, id) :: t)
+                (nexp_map, ((id, typ), def_annot) :: t)
               )
               fields ([], [])
           in
@@ -4666,7 +4666,11 @@ module ToplevelNexpRewrites = struct
       | TD_abbrev (id, typq, typ_arg) -> TD_aux (TD_abbrev (id, typq, typ_arg), annot)
       | TD_abstract (id, kind, instantiation) -> TD_aux (TD_abstract (id, kind, instantiation), annot)
       | TD_record (id, typq, typ_ids, flag) ->
-          TD_aux (TD_record (id, typq, List.map (fun (typ, id) -> (expand_type typ, id)) typ_ids, flag), annot)
+          TD_aux
+            ( TD_record
+                (id, typq, List.map (fun ((id, typ), def_annot) -> ((id, expand_type typ), def_annot)) typ_ids, flag),
+              annot
+            )
       | TD_variant (id, typq, tus, flag) -> TD_aux (TD_variant (id, typq, List.map rw_union tus, flag), annot)
       | TD_enum (id, ids, flag) -> TD_aux (TD_enum (id, ids, flag), annot)
       | TD_bitfield _ -> assert false (* Processed before re-writing *)

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -751,7 +751,7 @@ module Printer (Config : PRINT_CONFIG) = struct
         | Some exp -> separate space [string "register"; doc_id id; colon; doc_typ typ; equals; doc_exp exp]
       )
 
-  let doc_field (typ, id) = separate space [doc_id id; colon; doc_typ typ]
+  let doc_field ((id, typ), def_annot) = doc_def_annot def_annot ^^ separate space [doc_id id; colon; doc_typ typ]
 
   let doc_union (Tu_aux (Tu_ty_id (typ, id), def_annot)) =
     doc_def_annot def_annot ^^ separate space [doc_id id; colon; doc_typ typ]
@@ -821,7 +821,9 @@ module Printer (Config : PRINT_CONFIG) = struct
         in
         separate space [string (if is_newtype then "newtype" else "union"); doc_id id ^^ quant_doc; equals; body]
     | TD_bitfield (id, typ, fields) ->
-        let doc_field (id, range) = separate space [doc_id id; colon; doc_index_range range] in
+        let doc_field ((id, range), def_annot) =
+          doc_def_annot def_annot ^^ separate space [doc_id id; colon; doc_index_range range]
+        in
         doc_op equals
           (separate space [string "bitfield"; doc_id id; colon; doc_typ typ])
           (surround 2 0 lbrace (separate_map (comma ^^ break 1) doc_field fields) rbrace)

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -221,7 +221,7 @@ let rewrite_ast_nexp_ids, _rewrite_typ_nexp_ids =
     | DEF_aux (DEF_type (TD_aux (TD_abbrev (id, typq, typ_arg), a)), def_annot) ->
         DEF_aux (DEF_type (TD_aux (TD_abbrev (id, typq, rewrite_typ_arg env typ_arg), a)), def_annot)
     | DEF_aux (DEF_type (TD_aux (TD_record (id, typq, fields, b), a)), def_annot) ->
-        let fields' = List.map (fun (t, id) -> (rewrite_typ env t, id)) fields in
+        let fields' = List.map (fun ((id, t), def_annot) -> ((id, rewrite_typ env t), def_annot)) fields in
         DEF_aux (DEF_type (TD_aux (TD_record (id, typq, fields', b), a)), def_annot)
     | DEF_aux (DEF_type (TD_aux (TD_variant (id, typq, constrs, b), a)), def_annot) ->
         let constrs' =
@@ -2025,7 +2025,11 @@ let rewrite_type_def_typs rw_typ rw_typquant (TD_aux (td, annot)) =
       TD_aux (TD_abbrev (id, rw_typquant typq, A_aux (A_typ (rw_typ typ), l)), annot)
   | TD_abbrev (id, typq, typ_arg) -> TD_aux (TD_abbrev (id, rw_typquant typq, typ_arg), annot)
   | TD_record (id, typq, typ_ids, flag) ->
-      TD_aux (TD_record (id, rw_typquant typq, List.map (fun (typ, id) -> (rw_typ typ, id)) typ_ids, flag), annot)
+      TD_aux
+        ( TD_record
+            (id, rw_typquant typq, List.map (fun ((id, typ), def_annot) -> ((id, rw_typ typ), def_annot)) typ_ids, flag),
+          annot
+        )
   | TD_variant (id, typq, tus, flag) ->
       TD_aux (TD_variant (id, rw_typquant typq, List.map (rewrite_type_union_typs rw_typ) tus, flag), annot)
   | TD_enum (id, ids, flag) -> TD_aux (TD_enum (id, ids, flag), annot)
@@ -4521,7 +4525,7 @@ let rewrite_unroll_constant_loops _type_env defs =
 let remove_bitfield_records type_env =
   let rewrite_def rewriters = function
     (* Avoid using Env.get_bitfield in case the typing environment is out of date (e.g., due to nexp_ids) *)
-    | DEF_aux (DEF_type (TD_aux (TD_record (id, tq, [(typ, _)], _), t_annot)), def_annot)
+    | DEF_aux (DEF_type (TD_aux (TD_record (id, tq, [((_, typ), _)], _), t_annot)), def_annot)
       when Env.is_bitfield id type_env ->
         DEF_aux (DEF_type (TD_aux (TD_abbrev (id, tq, mk_typ_arg (A_typ typ)), t_annot)), def_annot)
     | d -> rewriters_base.rewrite_def rewriters d

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -482,7 +482,7 @@ Inductive scattered_def_aux (a : Set) : Set :=
 | SD_variant : id -> typquant -> scattered_def_aux a
 | SD_unioncl : id -> type_union -> scattered_def_aux a
 | SD_internal_unioncl_record :
-  id -> id -> typquant -> list (typ * id) -> scattered_def_aux a
+  id -> id -> typquant -> list (id * typ * def_annot unit) -> scattered_def_aux a
 | SD_mapping : id -> tannot_opt -> scattered_def_aux a
 | SD_mapcl : id -> mapcl a -> scattered_def_aux a
 | SD_enum : id -> scattered_def_aux a
@@ -504,11 +504,11 @@ Inductive fundef_aux (a : Set) : Set :=
 
 Inductive type_def_aux : Set :=
 | TD_abbrev : id -> typquant -> typ_arg -> type_def_aux
-| TD_record : id -> typquant -> list (typ * id) -> bool -> type_def_aux
+| TD_record : id -> typquant -> list (id * typ * def_annot unit) -> bool -> type_def_aux
 | TD_variant : id -> typquant -> list type_union -> bool -> type_def_aux
 | TD_enum : id -> list id -> bool -> type_def_aux
 | TD_abstract : id -> kind -> opt_abstract_config -> type_def_aux
-| TD_bitfield : id -> typ -> list (id * index_range) -> type_def_aux.
+| TD_bitfield : id -> typ -> list (id * index_range * def_annot unit) -> type_def_aux.
 
 Inductive outcome_spec : Set :=
 | OV_aux : outcome_spec_aux -> loc -> outcome_spec.

--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -131,12 +131,13 @@ let generate_regstate env registers =
         if !opt_type_grouped_regstate then (
           let type_field (typ, id, has_init) =
             let base_typ = regval_base_typ env typ in
-            (function_typ [string_typ] base_typ, regstate_field base_typ)
+            let field_name = regstate_field base_typ in
+            ((field_name, function_typ [string_typ] base_typ), mk_def_annot (id_loc field_name) ())
           in
-          let cmp_id (_, id1) (_, id2) = Id.compare id1 id2 in
+          let cmp_id ((id1, _), _) ((id2, _), _) = Id.compare id1 id2 in
           List.map type_field registers |> List.sort_uniq cmp_id
         )
-        else List.map (fun (t, i, _) -> (t, i)) registers
+        else List.map (fun (t, i, _) -> ((i, t), mk_def_annot (id_loc i) ())) registers
       in
       TD_record (mk_id "regstate", mk_typquant [], fields, false)
     )
@@ -236,7 +237,7 @@ let generate_initial_regstate ctx env ast =
             (defs', Bindings.add id init_val vals)
         | TD_record (id, tq, fields, _) ->
             let init_val args =
-              let init_field (typ, id) =
+              let init_field ((id, typ), _) =
                 let typ = typ_subst_typquant tq args typ in
                 string_of_id id ^ " = " ^ lookup_init_val vals typ
               in

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4992,14 +4992,14 @@ let check_type_union u_l non_rec_env env variant typq (Tu_aux (Tu_ty_id (arg_typ
 
 let check_record l env def_annot id typq fields =
   forbid_recursive_types l (fun () ->
-      List.iter (fun ((Typ_aux (_, l) as field), _) -> wf_binding l env (typq, field)) fields
+      List.iter (fun ((_, (Typ_aux (_, l) as field)), _) -> wf_binding l env (typq, field)) fields
   );
   let env =
     try
       match get_def_attribute "bitfield" def_annot with
       | Some _ when not (Env.is_bitfield id env) -> begin
           match fields with
-          | [(typ, Id_aux (Id "bits", _))] -> Env.add_bitfield id typ Bindings.empty env
+          | [((Id_aux (Id "bits", _), typ), _)] -> Env.add_bitfield id typ Bindings.empty env
           | _ -> typ_raise l (Err_other "bitfield record has wrong fields")
         end
       | _ -> env
@@ -5050,7 +5050,7 @@ let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> typed_def l
                 (Initial_check.generate_undefined_record_context typq)
             in
             let gen_undefined =
-              List.for_all (fun (typ, field_id) -> can_be_undefined ~at:(id_loc field_id) field_env typ) fields
+              List.for_all (fun ((field_id, typ), _) -> can_be_undefined ~at:(id_loc field_id) field_env typ) fields
             in
             if (not gen_undefined) && Option.is_none attr then (
               (* If we cannot generate an undefined value, and we weren't explicitly asked to *)
@@ -5154,9 +5154,9 @@ let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> typed_def l
               | BF_aux (BF_concat (r1, r2), l) ->
                   BF_aux (BF_concat (expand_range_synonyms r1, expand_range_synonyms r2), l)
             in
-            let record_tdef = TD_record (id, mk_typquant [], [(typ, mk_id "bits")], false) in
+            let record_tdef = TD_record (id, mk_typquant [], [((mk_id "bits", typ), mk_def_annot l ())], false) in
             let ranges =
-              List.map (fun (f, r) -> (f, expand_range_synonyms r)) ranges |> List.to_seq |> Bindings.of_seq
+              List.map (fun ((f, r), _) -> (f, expand_range_synonyms r)) ranges |> List.to_seq |> Bindings.of_seq
             in
             (* This would cause us to fail later, but with a potentially confusing error message *)
             Bindings.iter

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1460,7 +1460,7 @@ let get_records env = filter_items env env.global.records
 
 let add_record id typq fields env =
   let field_env = add_typquant (id_loc id) typq env in
-  let fields = List.map (fun (typ, id) -> (expand_synonyms field_env typ, id)) fields in
+  let fields = List.map (fun ((id, typ), _) -> (expand_synonyms field_env typ, id)) fields in
   if bound_typ_id env id then already_bound "struct" id env
   else (
     typ_print (lazy (adding ^ "struct " ^ string_of_id id)) [@coverage off];

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -156,7 +156,7 @@ val is_newtype : id -> t -> bool
 
 val is_mapping : id -> t -> bool
 
-val add_record : id -> typquant -> (typ * id) list -> t -> t
+val add_record : id -> typquant -> ((id * typ) * unit def_annot) list -> t -> t
 val is_record : id -> t -> bool
 val get_record : id -> t -> typquant * (typ * id) list
 val get_records : t -> (typquant * (typ * id) list) Bindings.t

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -2426,7 +2426,7 @@ let type_dependencies defs =
         let new_def =
           match td with
           | TD_abbrev (id, tq, arg) -> Some (id, typs_of_arg arg)
-          | TD_record (id, tq, fields, _) -> Some (id, List.map fst fields)
+          | TD_record (id, tq, fields, _) -> Some (id, List.map (fun ((_, typ), _) -> typ) fields)
           | TD_variant (id, tq, branches, _) -> Some (id, List.map (fun (Tu_aux (Tu_ty_id (typ, _), _)) -> typ) branches)
           | TD_enum (id, _, _) -> Some (id, [])
           | TD_abstract _ -> None
@@ -2528,7 +2528,7 @@ let countable_types defs =
         let new_def =
           match td with
           | TD_abbrev (id, tq, arg) -> Some (id, typs_of_arg arg)
-          | TD_record (id, tq, fields, _) -> Some (id, List.map fst fields)
+          | TD_record (id, tq, fields, _) -> Some (id, List.map (fun ((_, typ), _) -> typ) fields)
           | TD_variant (id, tq, branches, _) -> Some (id, List.map (fun (Tu_aux (Tu_ty_id (typ, _), _)) -> typ) branches)
           | TD_enum (id, _, _) -> Some (id, [])
           | TD_abstract _ -> None
@@ -2616,9 +2616,9 @@ let doc_field_updates ctxt typq record_id fields =
     let kopts, _ = quant_split typq in
     match kopts with [] -> empty | _ -> space ^^ separate_map space (fun _ -> underscore) kopts
   in
-  let doc_update_field (_, fid) =
+  let doc_update_field ((fid, _), _) =
     let idpp = doc_field_name ctxt record_id fid in
-    let pp_field bind alt i (_, fid') =
+    let pp_field bind alt i ((fid', _), _) =
       if Id.compare fid fid' == 0 then string alt
       else (
         let id = "f" ^ string_of_int i in
@@ -2649,7 +2649,7 @@ let doc_field_updates ctxt typq record_id fields =
         string "#[export] Instance eta_" ^^ type_id_pp
         ^^ separate space (empty :: typq_pps)
         ^^ string " : Settable _ := settable! " ^^ constructor ^^ string " <"
-        ^^ separate_map (string "; ") (fun (_, fid) -> doc_field_name ctxt record_id fid) fields
+        ^^ separate_map (string "; ") (fun ((fid, _), _) -> doc_field_name ctxt record_id fid) fields
         ^^ string ">."
   )
   else separate hardline (List.map doc_update_field fields)
@@ -2760,7 +2760,7 @@ let doc_typdef global generic_eq_types countable_types enum_number_defs (TD_aux 
   | TD_bitfield _ -> empty (* TODO? *)
   | TD_record (id, typq, fs, _) ->
       let fname fid = doc_field_name bare_ctxt id fid in
-      let f_pp (typ, fid) = concat [fname fid; space; colon; space; doc_typ bare_ctxt Env.empty typ; semi] in
+      let f_pp ((fid, typ), _) = concat [fname fid; space; colon; space; doc_typ bare_ctxt Env.empty typ; semi] in
       let rectyp =
         match typq with
         | TypQ_aux (TypQ_tq qs, _) ->
@@ -2828,7 +2828,7 @@ let doc_typdef global generic_eq_types countable_types enum_number_defs (TD_aux 
                         );
                       string "refine {|";
                       string "  encode x := encode ("
-                      ^^ separate_map (string ", ") (fun (_typ, fid) -> fname fid ^^ space ^^ string "x") fs
+                      ^^ separate_map (string ", ") (fun ((fid, _), _) -> fname fid ^^ space ^^ string "x") fs
                       ^^ string ");";
                       string "  decode x := '(" ^^ separate (string ", ") tmp_vars ^^ string ") ← decode x;";
                       string "              mret (Build_" ^^ full_type_pp ^^ space ^^ separate space tmp_vars
@@ -2862,7 +2862,7 @@ let doc_typdef global generic_eq_types countable_types enum_number_defs (TD_aux 
       in
       let inhabited_pp =
         let req_pps = List.filter_map doc_inhabited_req (quant_items typq) in
-        let field_pp (_, fid) = fname fid ^^ string " := inhabitant" in
+        let field_pp ((fid, _), _) = fname fid ^^ string " := inhabitant" in
         string "#[export]" ^^ hardline
         ^^ group
              (prefix 2 1
@@ -3904,7 +3904,7 @@ let doc_isla_typ global (TD_aux (td, _)) =
           string "  fun v => match v with";
           string "  | RegVal_Struct fields =>";
           separate_map hardline
-            (fun (_, f) ->
+            (fun ((f, _), _) ->
               string "    " ^^ fname f ^^ utf8string " ← get_field "
               ^^ dquotes (fname f)
               ^^ utf8string " fields ≫= from_isla;"
@@ -3914,7 +3914,7 @@ let doc_isla_typ global (TD_aux (td, _)) =
             (surround_separate_map 2 1 (string "    mret {| |}") (string "    mret {|")
                (string ";" ^^ break 1)
                (string "|}")
-               (fun (_, f) -> full_fname f ^^ string " := " ^^ fname f)
+               (fun ((f, _), _) -> full_fname f ^^ string " := " ^^ fname f)
                fs
             );
           string "  | _ => mthrow \"get_isla_" ^^ type_id_pp id ^^ string ": unexpected isla value\"";
@@ -4407,7 +4407,7 @@ end = struct
           type_map;
         string "}.";
         doc_field_updates ctxt (mk_typquant []) (mk_id "regstate")
-          (List.map (fun (typ_id, typ) -> (typ, state_field_name typ_id)) type_map);
+          (List.map (fun (typ_id, typ) -> ((state_field_name typ_id, typ), mk_def_annot (id_loc typ_id) ())) type_map);
         empty;
         (* A record literal can cause problems with record type inference (e.g., if there are no registers) *)
         string "Definition init_regstate : regstate := Build_regstate";

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -328,7 +328,7 @@ let captured_typ_var ((i, Typ_aux (t, _)) as typ) =
       Some (i, ki)
   | _ -> None
 
-let doc_typ_id ctx (typ, fid) = flow (break 1) [doc_id_ctor fid; colon; doc_typ ctx typ]
+let doc_typ_id ctx ((fid, typ), _) = flow (break 1) [doc_id_ctor fid; colon; doc_typ ctx typ]
 
 let doc_kind ctx (kid : kid) (K_aux (k, _)) =
   match k with

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -256,7 +256,7 @@ let type_parameters_to_print env defs : Util.IntSet.t Bindings.t =
     match def with
     | DEF_type (TD_aux (TD_record (id, typq, fs, _), _)) ->
         let env = Env.add_typquant Unknown typq env in
-        make_type_size_map env id typq (List.map fst fs) type_size_map
+        make_type_size_map env id typq (List.map (fun ((_, t), _) -> t) fs) type_size_map
     | DEF_type (TD_aux (TD_variant (id, typq, tus, _), _)) ->
         let env = Env.add_typquant Unknown typq env in
         make_type_size_map env id typq (List.map (fun (Tu_aux (Tu_ty_id (t, _), _)) -> t) tus) type_size_map
@@ -1270,7 +1270,7 @@ let doc_typdef_lem params_to_print env (TD_aux (td, (l, annot))) =
       ^^ hardline ^^ sorts_pp
   | TD_abbrev _ -> empty
   | TD_record (id, typq, fs, _) ->
-      let f_pp (typ, fid) =
+      let f_pp ((fid, typ), _) =
         let field_env = Env.add_typquant (id_loc id) typq env in
         concat [doc_fieldname_lem id fid; space; colon; space; doc_typ_lem params_to_print field_env typ; semi]
       in

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -697,8 +697,8 @@ let ocaml_fundef ctx (FD_aux (FD_function (_, _, funcls), _)) = ocaml_funcls ctx
 let rec ocaml_fields ctx =
   let ocaml_field typ id = separate space [zencode ctx id; colon; ocaml_typ ctx typ] in
   function
-  | [(typ, id)] -> ocaml_field typ id
-  | (typ, id) :: fields -> ocaml_field typ id ^^ semi ^/^ ocaml_fields ctx fields
+  | [((id, typ), _)] -> ocaml_field typ id
+  | ((id, typ), _) :: fields -> ocaml_field typ id ^^ semi ^/^ ocaml_fields ctx fields
   | [] -> empty
 
 let rec ocaml_cases polymorphic_variant ctx =
@@ -737,7 +737,7 @@ let ocaml_struct_type ctx id = zencode_upper ctx id ^^ dot ^^ zencode ctx id
 
 let ocaml_string_of_struct ctx struct_id typq fields =
   let arg = gensym () in
-  let ocaml_field (typ, id) =
+  let ocaml_field ((id, typ), _) =
     separate space
       [
         string (string_of_id id ^ " = \"");
@@ -890,7 +890,7 @@ let ocaml_pp_generators ctx defs orig_types required =
     | TD_abbrev (_, _, A_aux (A_typ typ, _)) -> add_req_from_typ required typ
     | TD_abbrev _ -> required
     | TD_abstract _ -> required
-    | TD_record (_, _, fields, _) -> List.fold_left (fun req (typ, _) -> add_req_from_typ req typ) required fields
+    | TD_record (_, _, fields, _) -> List.fold_left (fun req ((_, typ), _) -> add_req_from_typ req typ) required fields
     | TD_variant (_, _, variants, _) ->
         List.fold_left (fun req (Tu_aux (Tu_ty_id (typ, _), _)) -> add_req_from_typ req typ) required variants
     | TD_enum _ -> required
@@ -984,7 +984,7 @@ let ocaml_pp_generators ctx defs orig_types required =
       let build_enum_constructor id =
         separate space [bar; dquotes (string (string_of_id id)); string "->"; zencode_upper ctx id]
       in
-      let rand_field (typ, id) = zencode ctx id ^^ space ^^ equals ^^ space ^^ make_subgen typ in
+      let rand_field ((id, typ), _) = zencode ctx id ^^ space ^^ equals ^^ space ^^ make_subgen typ in
       let make_args tqs =
         string "g"
         ^^

--- a/src/sail_ocaml_backend/toFromInterp_backend.ml
+++ b/src/sail_ocaml_backend/toFromInterp_backend.ml
@@ -289,7 +289,7 @@ let frominterp_typedef (TD_aux (td_aux, (l, _))) =
       in
       fromInterpValue ^^ twice hardline
   | TD_record (record_id, typq, fields, _) ->
-      let fromInterpField (typ, id) =
+      let fromInterpField ((id, typ), _) =
         separate space
           [
             string (maybe_zencode ((if !lem_mode then string_of_id record_id ^ "_" else "") ^ string_of_id id));
@@ -519,7 +519,7 @@ let tointerp_typedef (TD_aux (td_aux, (l, _))) =
       in
       toInterpValue ^^ twice hardline
   | TD_record (record_id, typq, fields, _) ->
-      let toInterpField (typ, id) =
+      let toInterpField ((id, typ), _) =
         parens
           (separate comma_sp
              [

--- a/test/lexing/line_doc_comment.expect
+++ b/test/lexing/line_doc_comment.expect
@@ -1,0 +1,7 @@
+[93mError[0m:
+[96mline_doc_comment.sail[0m:26.2-27.0:
+26[96m |[0m  /// Second doc comment!
+  [91m |[0m  [91m^----------------------[0m
+27[96m |[0m  some_field : 31 .. 16
+  [91m |[0m[91m^[0m
+  [91m |[0m Field has multiple documentation comments

--- a/test/lexing/line_doc_comment.sail
+++ b/test/lexing/line_doc_comment.sail
@@ -1,0 +1,32 @@
+default Order dec
+
+$include <prelude.sail>
+
+/// Line documentation comment
+///
+/// Another paragraph
+val main : unit -> unit
+
+union foo = {
+  ///
+  /// A second line comment
+  ///
+  /// With multiple lines
+  Ctor : unit
+}
+
+struct bar = {
+  /// Comment
+  baz : unit
+}
+
+bitfield quux : bits(32) = {
+  /// Another doc comment
+  $[attr]
+  /// Second doc comment!
+  some_field : 31 .. 16
+}
+
+function main() = {
+  print_endline("Doc comment test")
+}


### PR DESCRIPTION
Also take this opportunity to flip this particular instance of `typ * id` to match the syntactic order `id * typ`.

Rocq makes this a little annoying because it insists `(x * y * z)` is `((x * y) * z)` in OCaml, but not much we can do about that.