### PR TITLE
Refactor bitvector literals

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -497,6 +497,14 @@ let unaux_typ (Typ_aux (typ, _)) = typ
 let unaux_kind (K_aux (k, _)) = k
 let unaux_constraint (NC_aux (nc, _)) = nc
 
+let non_empty_singleton = function [] -> [] | x :: xs -> [Non_empty (x, xs)]
+
+let non_empty_for_all p (Non_empty (x, xs)) = p x && List.for_all p xs
+
+let hex_lit_length hex = List.fold_left (fun acc (Non_empty (_, ds)) -> acc + ((List.length ds + 1) * 4)) 0 hex
+
+let bin_lit_length bin = List.fold_left (fun acc (Non_empty (_, ds)) -> acc + List.length ds + 1) 0 bin
+
 let nexp_identical nexp1 nexp2 = Nexp.compare nexp1 nexp2 = 0
 
 let rec is_nexp_constant (Nexp_aux (nexp, _)) =
@@ -1294,6 +1302,41 @@ let string_of_typquant_aux = function
 let string_of_typquant = function TypQ_aux (quant, _) -> string_of_typquant_aux quant
 
 let string_of_typschm (TypSchm_aux (TypSchm_ts (quant, typ), _)) = string_of_typquant quant ^ ". " ^ string_of_typ typ
+
+type digit_case = Lowercase | Uppercase
+
+let string_of_hex_digit ~case digit =
+  let c =
+    match digit with
+    | Hex_0 -> "0"
+    | Hex_1 -> "1"
+    | Hex_2 -> "2"
+    | Hex_3 -> "3"
+    | Hex_4 -> "4"
+    | Hex_5 -> "5"
+    | Hex_6 -> "6"
+    | Hex_7 -> "7"
+    | Hex_8 -> "8"
+    | Hex_9 -> "9"
+    | Hex_A -> "A"
+    | Hex_B -> "B"
+    | Hex_C -> "C"
+    | Hex_D -> "D"
+    | Hex_E -> "E"
+    | Hex_F -> "F"
+  in
+  match case with Uppercase -> c | Lowercase -> String.lowercase_ascii c
+
+let string_of_hex_lit ?(group_separator = "_") ~case hex =
+  List.map (function Non_empty (d, ds) -> List.map (string_of_hex_digit ~case) (d :: ds) |> String.concat "") hex
+  |> String.concat group_separator
+
+let string_of_bin_lit ?(group_separator = "_") bin =
+  List.map
+    (function Non_empty (d, ds) -> List.map (function Bin_0 -> "0" | Bin_1 -> "1") (d :: ds) |> String.concat "")
+    bin
+  |> String.concat group_separator
+
 let string_of_lit (L_aux (lit, _)) =
   match lit with
   | L_unit -> "()"
@@ -1302,8 +1345,8 @@ let string_of_lit (L_aux (lit, _)) =
   | L_true -> "true"
   | L_false -> "false"
   | L_num n -> Big_int.to_string n
-  | L_hex n -> "0x" ^ n
-  | L_bin n -> "0b" ^ n
+  | L_hex hex -> "0x" ^ string_of_hex_lit ~case:Uppercase hex
+  | L_bin bin -> "0b" ^ string_of_bin_lit bin
   | L_undef -> "undefined"
   | L_real r -> r
   | L_string str -> "\"" ^ str ^ "\""
@@ -1937,40 +1980,13 @@ let explode s =
   exp (String.length s - 1) []
 
 let vector_string_to_bit_list (L_aux (lit, l)) =
-  let hexchar_to_binlist = function
-    | '0' -> ['0'; '0'; '0'; '0']
-    | '1' -> ['0'; '0'; '0'; '1']
-    | '2' -> ['0'; '0'; '1'; '0']
-    | '3' -> ['0'; '0'; '1'; '1']
-    | '4' -> ['0'; '1'; '0'; '0']
-    | '5' -> ['0'; '1'; '0'; '1']
-    | '6' -> ['0'; '1'; '1'; '0']
-    | '7' -> ['0'; '1'; '1'; '1']
-    | '8' -> ['1'; '0'; '0'; '0']
-    | '9' -> ['1'; '0'; '0'; '1']
-    | 'A' -> ['1'; '0'; '1'; '0']
-    | 'B' -> ['1'; '0'; '1'; '1']
-    | 'C' -> ['1'; '1'; '0'; '0']
-    | 'D' -> ['1'; '1'; '0'; '1']
-    | 'E' -> ['1'; '1'; '1'; '0']
-    | 'F' -> ['1'; '1'; '1'; '1']
-    | _ -> raise (Reporting.err_unreachable l __POS__ "hexchar_to_binlist given unrecognized character")
-  in
-
   let s_bin =
     match lit with
-    | L_hex s_hex -> List.flatten (List.map hexchar_to_binlist (explode (String.uppercase_ascii s_hex)))
-    | L_bin s_bin -> explode s_bin
+    | L_hex hex -> Semantics.bitlist_of_hex_lit hex
+    | L_bin bin -> Semantics.bitlist_of_bin_lit bin
     | _ -> raise (Reporting.err_unreachable l __POS__ "s_bin given non vector literal")
   in
-
-  List.map
-    (function
-      | '0' -> L_aux (L_zero, gen_loc l)
-      | '1' -> L_aux (L_one, gen_loc l)
-      | _ -> raise (Reporting.err_unreachable (gen_loc l) __POS__ "binary had non-zero or one")
-      )
-    s_bin
+  List.map (function Value_type.B0 -> L_aux (L_zero, gen_loc l) | Value_type.B1 -> L_aux (L_one, gen_loc l)) s_bin
 
 (* Functions for working with locations *)
 

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -474,8 +474,9 @@ val def_loc : ('a, 'b) def -> Parse_ast.l
     Note: For debugging and error messages only - not guaranteed to produce parseable Sail, or even print all language
     constructs! *)
 
-val string_of_order : order -> string
+type digit_case = Lowercase | Uppercase
 
+val string_of_order : order -> string
 val string_of_id : id -> string
 val string_of_kid : kid -> string
 val string_of_kind_aux : kind_aux -> string
@@ -489,6 +490,8 @@ val string_of_kinded_id : kinded_id -> string
 val string_of_quant_item : quant_item -> string
 val string_of_typquant : typquant -> string
 val string_of_typschm : typschm -> string
+val string_of_hex_lit : ?group_separator:string -> case:digit_case -> hex_digit non_empty list -> string
+val string_of_bin_lit : ?group_separator:string -> bin_digit non_empty list -> string
 val string_of_lit : lit -> string
 val string_of_exp : 'a exp -> string
 val string_of_pexp : 'a pexp -> string
@@ -521,6 +524,12 @@ val remove_id_suffix : id -> string -> id option
 val prepend_kid : string -> kid -> kid
 
 (** {1 Misc functions} *)
+
+val non_empty_singleton : 'a list -> 'a non_empty list
+val non_empty_for_all : ('a -> bool) -> 'a non_empty -> bool
+
+val hex_lit_length : hex_digit non_empty list -> int
+val bin_lit_length : bin_digit non_empty list -> int
 
 val nexp_identical : nexp -> nexp -> bool
 val is_nexp_constant : nexp -> bool

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -502,13 +502,13 @@ let find_json ~at:l full_parts json =
   go full_parts json
 
 let json_bit ~at:l = function
-  | `Bool true -> '1'
-  | `Bool false -> '0'
+  | `Bool true -> Bin_1
+  | `Bool false -> Bin_0
   | json -> raise (Reporting.err_general l (Printf.sprintf "Failed to interpret %s as a bit" (J.to_string json)))
 
 let json_to_string = function `String s -> Some s | _ -> None
 
-let valid_bin_char c = match c with '_' -> None | ('0' | '1') as c -> Some (Some c) | _ -> Some None
+let valid_bin_char c = match c with '_' -> None | '0' -> Some (Some Bin_0) | '1' -> Some (Some Bin_1) | _ -> Some None
 
 let valid_dec_char c =
   match c with
@@ -517,53 +517,48 @@ let valid_dec_char c =
   | _ -> Some None
 
 let valid_hex_char c =
-  match Char.uppercase_ascii c with
-  | '_' -> None
-  | ('0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F') as c -> Some (Some c)
-  | _ -> Some None
+  if c = '_' then None
+  else (match Initial_check.hex_digit_of_char c with Some (digit, _) -> Some (Some digit) | None -> Some None)
 
-let hex_char_to_bits c =
-  match Sail2_values.nibble_of_char c with Some (b1, b2, b3, b4) -> [b1; b2; b3; b4] | None -> []
-
-let bin_char_to_bit c = match c with '0' -> Sail2_values.B0 | '1' -> Sail2_values.B1 | _ -> Sail2_values.BU
+let bin_digit_to_bit = function Bin_0 -> Value_type.B0 | Bin_1 -> Value_type.B1
 
 let fix_length ~at:l ~len bitlist =
-  let d = len - List.length bitlist in
-  if d = 0 then bitlist
-  else if d > 0 then Sail2_operators_bitlists.zero_extend bitlist (Big_int.of_int len)
-  else (
-    Reporting.warn ~force_show:true "Configuration" l "Forced to truncate configuration bitvector literal";
-    Util.drop (abs d) bitlist
-  )
+  let open Value_type in
+  let coerce_bit = function V_bit b -> b | _ -> assert false in
+  match Primops.zero_extend (V_vector (List.map (fun b -> V_bit b) bitlist)) (V_int (Big_int.of_int len)) with
+  | Some (V_vector bitlist) -> List.map coerce_bit bitlist
+  | _ ->
+      Reporting.warn ~force_show:true "Configuration" l "Forced to truncate configuration bitvector literal";
+      let d = len - List.length bitlist in
+      Util.drop (abs d) bitlist
 
-let bitlist_to_string bitlist = List.map Sail2_values.bitU_char bitlist |> List.to_seq |> String.of_seq
+let bitlist_to_literal bitlist =
+  non_empty_singleton (List.map (function Value_type.B0 -> Bin_0 | Value_type.B1 -> Bin_1) bitlist)
 
 let parse_json_string_to_bits ~at:l ~len str =
   let open Util.Option_monad in
-  let open Sail2_operators_bitlists in
   let str_len = String.length str in
   let chars = str |> String.to_seq |> List.of_seq in
   let* bitlist =
     if str_len > 2 && String.sub str 0 2 = "0b" then
-      let* bin_chars = Util.drop 2 chars |> List.filter_map valid_bin_char |> Util.option_all in
-      Some (List.map bin_char_to_bit bin_chars |> fix_length ~at:l ~len)
+      let* bin_digits = Util.drop 2 chars |> List.filter_map valid_bin_char |> Util.option_all in
+      Some (List.map bin_digit_to_bit bin_digits |> fix_length ~at:l ~len)
     else if str_len > 2 && String.sub str 0 2 = "0x" then
-      let* hex_chars = Util.drop 2 chars |> List.filter_map valid_hex_char |> Util.option_all in
-      Some (List.map hex_char_to_bits hex_chars |> List.concat |> fix_length ~at:l ~len)
+      let* hex_digits = Util.drop 2 chars |> List.filter_map valid_hex_char |> Util.option_all in
+      Some (List.map Semantics.bitlist_of_hex_digit hex_digits |> List.concat |> fix_length ~at:l ~len)
     else
       let* dec_chars = List.filter_map valid_dec_char chars |> Util.option_all in
       let n = List.to_seq dec_chars |> String.of_seq |> Big_int.of_string in
-      Some (get_slice_int (Big_int.of_int len) n Big_int.zero)
+      Some (Sail_lib.get_slice_int (Big_int.of_int len, n, Big_int.zero))
   in
-  Some (mk_lit_exp ~loc:l (L_bin (bitlist_to_string bitlist)))
+  Some (mk_lit_exp ~loc:l (L_bin (bitlist_to_literal bitlist)))
 
 let parse_json_string_to_abstract_bits ~at:l ~len str =
   let open Util.Option_monad in
-  let open Sail2_operators_bitlists in
   let str_len = String.length str in
   let chars = str |> String.to_seq |> List.of_seq in
   let mask bitlist =
-    mk_exp (E_app (mk_id "sail_mask", [mk_exp (E_sizeof (nid len)); mk_lit_exp (L_bin (bitlist_to_string bitlist))]))
+    mk_exp (E_app (mk_id "sail_mask", [mk_exp (E_sizeof (nid len)); mk_lit_exp (L_bin (bitlist_to_literal bitlist))]))
     |> locate (fun _ -> l)
   in
   let slice_int n =
@@ -574,11 +569,11 @@ let parse_json_string_to_abstract_bits ~at:l ~len str =
     |> locate (fun _ -> l)
   in
   if str_len > 2 && String.sub str 0 2 = "0b" then
-    let* bin_chars = Util.drop 2 chars |> List.filter_map valid_bin_char |> Util.option_all in
-    Some (List.map bin_char_to_bit bin_chars |> mask)
+    let* bin_digits = Util.drop 2 chars |> List.filter_map valid_bin_char |> Util.option_all in
+    Some (List.map bin_digit_to_bit bin_digits |> mask)
   else if str_len > 2 && String.sub str 0 2 = "0x" then
-    let* hex_chars = Util.drop 2 chars |> List.filter_map valid_hex_char |> Util.option_all in
-    Some (List.map hex_char_to_bits hex_chars |> List.concat |> mask)
+    let* hex_digits = Util.drop 2 chars |> List.filter_map valid_hex_char |> Util.option_all in
+    Some (List.map Semantics.bitlist_of_hex_digit hex_digits |> List.concat |> mask)
   else
     let* dec_chars = List.filter_map valid_dec_char chars |> Util.option_all in
     let n = List.to_seq dec_chars |> String.of_seq |> Big_int.of_string in
@@ -609,8 +604,7 @@ let rec sail_exp_from_json ~at:l env typ =
       match base_typ with
       | Typ_aux (Typ_app (id, args), _) -> (
           match (string_of_id id, args) with
-          | "bitvector", _ ->
-              L_bin (List.map (json_bit ~at:l) jsons |> List.to_seq |> String.of_seq) |> mk_lit_exp ~loc:l
+          | "bitvector", _ -> L_bin (non_empty_singleton (List.map (json_bit ~at:l) jsons)) |> mk_lit_exp ~loc:l
           | "vector", [_; A_aux (A_typ item_typ, _)] ->
               let items = List.map (sail_exp_from_json ~at:l env item_typ) jsons in
               mk_exp ~loc:l (E_vector items)

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -218,8 +218,9 @@ let rec drop_casts = function E_aux (E_typ (_, e), _) -> drop_casts e | exp -> e
 
 let construct_lit_vector args =
   let rec aux l = function
-    | [] -> Some (L_aux (L_bin (String.concat "" (List.rev l)), Unknown))
-    | E_aux (E_lit (L_aux (((L_zero | L_one) as lit), _)), _) :: t -> aux ((if lit = L_zero then "0" else "1") :: l) t
+    | [] -> Some (L_aux (L_bin (non_empty_singleton (List.rev l)), Unknown))
+    | E_aux (E_lit (L_aux (((L_zero | L_one) as lit), _)), _) :: t ->
+        aux ((if lit = L_zero then Bin_0 else Bin_1) :: l) t
     | _ -> None
   in
   aux [] args

--- a/src/lib/constraint.ml
+++ b/src/lib/constraint.ml
@@ -542,8 +542,8 @@ let call_smt_solve_bitvector l smt_file smt_vars =
           let prefix = Str.matched_group 1 smt_output in
           let result = Str.matched_group 2 smt_output in
           match prefix with
-          | "#b" -> Some (smt_var, mk_lit (L_bin result))
-          | "#x" -> Some (smt_var, mk_lit (L_hex result))
+          | "#b" -> Some (smt_var, mk_lit (L_bin (Option.get @@ Initial_check.parse_bin_lit result)))
+          | "#x" -> Some (smt_var, mk_lit (L_hex (Option.get @@ Initial_check.parse_hex_lit result)))
           | _ -> raise (Reporting.err_general l "Could not parse bitvector value from SMT solver")
         )
       with Not_found -> None

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -24,6 +24,9 @@ module Coq_def_annot =
                      'a }
  end
 
+type 'a non_empty =
+| Non_empty of 'a * 'a list
+
 type 'a def_annot = 'a Coq_def_annot.record
 
 type 'a clause_annot = unit def_annot * 'a
@@ -33,6 +36,28 @@ type 'a annot = Parse_ast.l * 'a
 type loop =
 | While
 | Until
+
+type hex_digit =
+| Hex_0
+| Hex_1
+| Hex_2
+| Hex_3
+| Hex_4
+| Hex_5
+| Hex_6
+| Hex_7
+| Hex_8
+| Hex_9
+| Hex_A
+| Hex_B
+| Hex_C
+| Hex_D
+| Hex_E
+| Hex_F
+
+type bin_digit =
+| Bin_0
+| Bin_1
 
 type kind_aux =
 | K_type
@@ -70,8 +95,8 @@ type lit_aux =
 | L_true
 | L_false
 | L_num of Big_int_Z.big_int
-| L_hex of string
-| L_bin of string
+| L_hex of hex_digit non_empty list
+| L_bin of bin_digit non_empty list
 | L_string of string
 | L_undef
 | L_real of string

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -24,6 +24,9 @@ module Coq_def_annot :
                      'a }
  end
 
+type 'a non_empty =
+| Non_empty of 'a * 'a list
+
 type 'a def_annot = 'a Coq_def_annot.record
 
 type 'a clause_annot = unit def_annot * 'a
@@ -33,6 +36,28 @@ type 'a annot = Parse_ast.l * 'a
 type loop =
 | While
 | Until
+
+type hex_digit =
+| Hex_0
+| Hex_1
+| Hex_2
+| Hex_3
+| Hex_4
+| Hex_5
+| Hex_6
+| Hex_7
+| Hex_8
+| Hex_9
+| Hex_A
+| Hex_B
+| Hex_C
+| Hex_D
+| Hex_E
+| Hex_F
+
+type bin_digit =
+| Bin_0
+| Bin_1
 
 type kind_aux =
 | K_type
@@ -70,8 +95,8 @@ type lit_aux =
 | L_true
 | L_false
 | L_num of Big_int_Z.big_int
-| L_hex of string
-| L_bin of string
+| L_hex of hex_digit non_empty list
+| L_bin of bin_digit non_empty list
 | L_string of string
 | L_undef
 | L_real of string

--- a/src/lib/extraction/BinInt.ml
+++ b/src/lib/extraction/BinInt.ml
@@ -103,6 +103,26 @@ module Z =
     | Lt -> true
     | _ -> false
 
+  (** val to_nat : Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let to_nat z =
+    (fun fO fp fn z -> let s = Big_int_Z.sign_big_int z in
+  if s = 0 then fO () else if s > 0 then fp z
+  else fn (Big_int_Z.minus_big_int z))
+      (fun _ -> Big_int_Z.zero_big_int)
+      (fun p -> Pos.to_nat p)
+      (fun _ -> Big_int_Z.zero_big_int)
+      z
+
+  (** val of_nat : Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let of_nat n =
+    (fun fO fS n -> if Big_int_Z.sign_big_int n <= 0 then fO ()
+  else fS (Big_int_Z.pred_big_int n))
+      (fun _ -> Big_int_Z.zero_big_int)
+      (fun n0 -> (Pos.of_succ_nat n0))
+      n
+
   (** val gtb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool **)
 
   let gtb x y =

--- a/src/lib/extraction/BinInt.mli
+++ b/src/lib/extraction/BinInt.mli
@@ -21,5 +21,9 @@ module Z :
 
   val ltb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
 
+  val to_nat : Big_int_Z.big_int -> Big_int_Z.big_int
+
+  val of_nat : Big_int_Z.big_int -> Big_int_Z.big_int
+
   val gtb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
  end

--- a/src/lib/extraction/ListDef.ml
+++ b/src/lib/extraction/ListDef.ml
@@ -4,3 +4,12 @@
 let rec map f = function
 | [] -> []
 | a :: l0 -> (f a) :: (map f l0)
+
+(** val repeat : 'a1 -> Big_int_Z.big_int -> 'a1 list **)
+
+let rec repeat x n =
+  (fun fO fS n -> if Big_int_Z.sign_big_int n <= 0 then fO ()
+  else fS (Big_int_Z.pred_big_int n))
+    (fun _ -> [])
+    (fun k -> x :: (repeat x k))
+    n

--- a/src/lib/extraction/ListDef.mli
+++ b/src/lib/extraction/ListDef.mli
@@ -1,2 +1,4 @@
 
 val map : ('a1 -> 'a2) -> 'a1 list -> 'a2 list
+
+val repeat : 'a1 -> Big_int_Z.big_int -> 'a1 list

--- a/src/lib/extraction/Nat0.ml
+++ b/src/lib/extraction/Nat0.ml
@@ -1,0 +1,9 @@
+
+(** val add : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+let rec add = Big_int_Z.add_big_int
+
+(** val sub : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+let rec sub = (fun n m -> Big_int_Z.max_big_int Big_int_Z.zero_big_int
+  (Big_int_Z.sub_big_int n m))

--- a/src/lib/extraction/Nat0.mli
+++ b/src/lib/extraction/Nat0.mli
@@ -1,0 +1,4 @@
+
+val add : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int
+
+val sub : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int

--- a/src/lib/extraction/PosDef.ml
+++ b/src/lib/extraction/PosDef.ml
@@ -1,4 +1,5 @@
 open Datatypes
+open Nat0
 
 module Pos =
  struct
@@ -164,4 +165,30 @@ module Pos =
 
   let compare =
     compare_cont Eq
+
+  (** val iter_op : ('a1 -> 'a1 -> 'a1) -> Big_int_Z.big_int -> 'a1 -> 'a1 **)
+
+  let rec iter_op op p a =
+    (fun f2p1 f2p f1 p ->
+  if Big_int_Z.le_big_int p Big_int_Z.unit_big_int then f1 () else
+  let (q,r) = Big_int_Z.quomod_big_int p (Big_int_Z.big_int_of_int 2) in
+  if Big_int_Z.eq_big_int r Big_int_Z.zero_big_int then f2p q else f2p1 q)
+      (fun p0 -> op a (iter_op op p0 (op a a)))
+      (fun p0 -> iter_op op p0 (op a a))
+      (fun _ -> a)
+      p
+
+  (** val to_nat : Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let to_nat x =
+    iter_op Nat0.add x (Big_int_Z.succ_big_int Big_int_Z.zero_big_int)
+
+  (** val of_succ_nat : Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let rec of_succ_nat n =
+    (fun fO fS n -> if Big_int_Z.sign_big_int n <= 0 then fO ()
+  else fS (Big_int_Z.pred_big_int n))
+      (fun _ -> Big_int_Z.unit_big_int)
+      (fun x -> succ (of_succ_nat x))
+      n
  end

--- a/src/lib/extraction/PosDef.mli
+++ b/src/lib/extraction/PosDef.mli
@@ -1,4 +1,5 @@
 open Datatypes
+open Nat0
 
 module Pos :
  sig
@@ -14,4 +15,10 @@ module Pos :
     comparison -> Big_int_Z.big_int -> Big_int_Z.big_int -> comparison
 
   val compare : Big_int_Z.big_int -> Big_int_Z.big_int -> comparison
+
+  val iter_op : ('a1 -> 'a1 -> 'a1) -> Big_int_Z.big_int -> 'a1 -> 'a1
+
+  val to_nat : Big_int_Z.big_int -> Big_int_Z.big_int
+
+  val of_succ_nat : Big_int_Z.big_int -> Big_int_Z.big_int
  end

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -299,6 +299,108 @@ let left_to_right3 x y z =
       | _ -> LTR3_1 (v1, y, z))
    | _ -> LTR3_0 (x, y, z))
 
+(** val bitlist_of_hex_digit : hex_digit -> bit list **)
+
+let bitlist_of_hex_digit = function
+| Hex_0 -> B0 :: (B0 :: (B0 :: (B0 :: [])))
+| Hex_1 -> B0 :: (B0 :: (B0 :: (B1 :: [])))
+| Hex_2 -> B0 :: (B0 :: (B1 :: (B0 :: [])))
+| Hex_3 -> B0 :: (B0 :: (B1 :: (B1 :: [])))
+| Hex_4 -> B0 :: (B1 :: (B0 :: (B0 :: [])))
+| Hex_5 -> B0 :: (B1 :: (B0 :: (B1 :: [])))
+| Hex_6 -> B0 :: (B1 :: (B1 :: (B0 :: [])))
+| Hex_7 -> B0 :: (B1 :: (B1 :: (B1 :: [])))
+| Hex_8 -> B1 :: (B0 :: (B0 :: (B0 :: [])))
+| Hex_9 -> B1 :: (B0 :: (B0 :: (B1 :: [])))
+| Hex_A -> B1 :: (B0 :: (B1 :: (B0 :: [])))
+| Hex_B -> B1 :: (B0 :: (B1 :: (B1 :: [])))
+| Hex_C -> B1 :: (B1 :: (B0 :: (B0 :: [])))
+| Hex_D -> B1 :: (B1 :: (B0 :: (B1 :: [])))
+| Hex_E -> B1 :: (B1 :: (B1 :: (B0 :: [])))
+| Hex_F -> B1 :: (B1 :: (B1 :: (B1 :: [])))
+
+(** val hex_digit_of_nibble : bit -> bit -> bit -> bit -> hex_digit **)
+
+let hex_digit_of_nibble b1 b2 b3 b4 =
+  let p = ((b1, b2), b3) in
+  let (p0, b0) = p in
+  let (b5, b6) = p0 in
+  (match b5 with
+   | B0 ->
+     (match b6 with
+      | B0 ->
+        (match b0 with
+         | B0 -> (match b4 with
+                  | B0 -> Hex_0
+                  | B1 -> Hex_1)
+         | B1 -> (match b4 with
+                  | B0 -> Hex_2
+                  | B1 -> Hex_3))
+      | B1 ->
+        (match b0 with
+         | B0 -> (match b4 with
+                  | B0 -> Hex_4
+                  | B1 -> Hex_5)
+         | B1 -> (match b4 with
+                  | B0 -> Hex_6
+                  | B1 -> Hex_7)))
+   | B1 ->
+     (match b6 with
+      | B0 ->
+        (match b0 with
+         | B0 -> (match b4 with
+                  | B0 -> Hex_8
+                  | B1 -> Hex_9)
+         | B1 -> (match b4 with
+                  | B0 -> Hex_A
+                  | B1 -> Hex_B))
+      | B1 ->
+        (match b0 with
+         | B0 -> (match b4 with
+                  | B0 -> Hex_C
+                  | B1 -> Hex_D)
+         | B1 -> (match b4 with
+                  | B0 -> Hex_E
+                  | B1 -> Hex_F))))
+
+(** val hex_digits_of_bitlist : bit list -> hex_digit list option **)
+
+let rec hex_digits_of_bitlist = function
+| [] -> Some []
+| b1 :: l ->
+  (match l with
+   | [] -> None
+   | b2 :: l0 ->
+     (match l0 with
+      | [] -> None
+      | b3 :: l1 ->
+        (match l1 with
+         | [] -> None
+         | b4 :: rest ->
+           let digit = hex_digit_of_nibble b1 b2 b3 b4 in
+           (match hex_digits_of_bitlist rest with
+            | Some digits -> Some (digit :: digits)
+            | None -> None))))
+
+(** val non_empty_to_list : 'a1 non_empty -> 'a1 list **)
+
+let non_empty_to_list = function
+| Non_empty (y, ys) -> y :: ys
+
+(** val bitlist_of_hex_lit : hex_digit non_empty list -> bit list **)
+
+let bitlist_of_hex_lit hex =
+  let digits = concat (map non_empty_to_list hex) in
+  concat (map bitlist_of_hex_digit digits)
+
+(** val bitlist_of_bin_lit : bin_digit non_empty list -> bit list **)
+
+let bitlist_of_bin_lit bin =
+  let digits = concat (map non_empty_to_list bin) in
+  map (fun b -> match b with
+                | Bin_0 -> B0
+                | Bin_1 -> B1) digits
+
 module type SemanticExt =
  sig
   type tannot
@@ -316,10 +418,6 @@ module type SemanticExt =
   val id_equal_string : id -> string -> bool
 
   val string_of_id : id -> string
-
-  val bits_of_hex_string : string -> bit list
-
-  val bits_of_bin_string : string -> bit list
 
   val rational_of_string : string -> Rational.t
 
@@ -474,9 +572,9 @@ module Make =
      | L_false -> Monad.pure (V_bool false)
      | L_num n -> Monad.pure (V_int n)
      | L_hex h ->
-       Monad.pure (V_vector (map (fun x -> V_bit x) (T.bits_of_hex_string h)))
+       Monad.pure (V_vector (map (fun x -> V_bit x) (bitlist_of_hex_lit h)))
      | L_bin b ->
-       Monad.pure (V_vector (map (fun x -> V_bit x) (T.bits_of_bin_string b)))
+       Monad.pure (V_vector (map (fun x -> V_bit x) (bitlist_of_bin_lit b)))
      | L_string s -> Monad.pure (V_string s)
      | L_undef -> Monad.get_undefined typ0
      | L_real r -> Monad.pure (V_real (T.rational_of_string r)))
@@ -537,11 +635,11 @@ module Make =
                    | _ -> false)
      | L_hex s ->
        (match v with
-        | V_vector vs -> same_bits (T.bits_of_hex_string s) vs
+        | V_vector vs -> same_bits (bitlist_of_hex_lit s) vs
         | _ -> false)
      | L_bin s ->
        (match v with
-        | V_vector vs -> same_bits (T.bits_of_bin_string s) vs
+        | V_vector vs -> same_bits (bitlist_of_bin_lit s) vs
         | _ -> false)
      | L_string s1 -> (match v with
                        | V_string s2 -> (=) s1 s2

--- a/src/lib/extraction/Semantics.mli
+++ b/src/lib/extraction/Semantics.mli
@@ -120,6 +120,18 @@ type 'a ltr3 =
 
 val left_to_right3 : 'a1 exp -> 'a1 exp -> 'a1 exp -> 'a1 ltr3
 
+val bitlist_of_hex_digit : hex_digit -> bit list
+
+val hex_digit_of_nibble : bit -> bit -> bit -> bit -> hex_digit
+
+val hex_digits_of_bitlist : bit list -> hex_digit list option
+
+val non_empty_to_list : 'a1 non_empty -> 'a1 list
+
+val bitlist_of_hex_lit : hex_digit non_empty list -> bit list
+
+val bitlist_of_bin_lit : bin_digit non_empty list -> bit list
+
 module type SemanticExt =
  sig
   type tannot
@@ -137,10 +149,6 @@ module type SemanticExt =
   val id_equal_string : id -> string -> bool
 
   val string_of_id : id -> string
-
-  val bits_of_hex_string : string -> bit list
-
-  val bits_of_bin_string : string -> bit list
 
   val rational_of_string : string -> Rational.t
 

--- a/src/lib/extraction/Value_type.ml
+++ b/src/lib/extraction/Value_type.ml
@@ -1,4 +1,7 @@
 open BinInt
+open Datatypes
+open ListDef
+open Nat0
 
 type bit =
 | B0
@@ -59,6 +62,21 @@ module Primops =
     | V_int v3 ->
       (match v2 with
        | V_int v4 -> Some (V_int (Z.sub v3 v4))
+       | _ -> None)
+    | _ -> None
+
+  (** val zero_extend : value -> value -> value option **)
+
+  let zero_extend bits n =
+    match bits with
+    | V_vector bitlist ->
+      (match n with
+       | V_int n0 ->
+         let len = length bitlist in
+         if Z.ltb n0 (Z.of_nat len)
+         then None
+         else let extend = sub (Z.to_nat n0) len in
+              Some (V_vector (app (repeat (V_bit B0) extend) bitlist))
        | _ -> None)
     | _ -> None
  end

--- a/src/lib/extraction/Value_type.mli
+++ b/src/lib/extraction/Value_type.mli
@@ -1,4 +1,7 @@
 open BinInt
+open Datatypes
+open ListDef
+open Nat0
 
 type bit =
 | B0
@@ -29,4 +32,6 @@ module Primops :
   val add_int : value -> value -> value option
 
   val sub_int : value -> value -> value option
+
+  val zero_extend : value -> value -> value option
  end

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1168,6 +1168,97 @@ let to_ast_typschm_opt ctx (P.TypSchm_opt_aux (aux, l)) : tannot_opt ctx_out =
       let tq, ctx = ConvertType.to_ast_typquant kenv ctx tq in
       (Typ_annot_opt_aux (Typ_annot_opt_some (tq, ConvertType.to_ast_typ kenv ctx typ), l), ctx)
 
+let hex_digit_of_char c =
+  let open Util.Option_monad in
+  let* digit =
+    match c with
+    | '0' -> Some Hex_0
+    | '1' -> Some Hex_1
+    | '2' -> Some Hex_2
+    | '3' -> Some Hex_3
+    | '4' -> Some Hex_4
+    | '5' -> Some Hex_5
+    | '6' -> Some Hex_6
+    | '7' -> Some Hex_7
+    | '8' -> Some Hex_8
+    | '9' -> Some Hex_9
+    | 'a' | 'A' -> Some Hex_A
+    | 'b' | 'B' -> Some Hex_B
+    | 'c' | 'C' -> Some Hex_C
+    | 'd' | 'D' -> Some Hex_D
+    | 'e' | 'E' -> Some Hex_E
+    | 'f' | 'F' -> Some Hex_F
+    | _ -> None
+  in
+  let n = Char.code c in
+  let case = if 65 <= n && n <= 70 then Some Uppercase else if 97 <= n && n <= 102 then Some Lowercase else None in
+  Some (digit, case)
+
+let rec filter_non_empty = function
+  | [] -> []
+  | [] :: xs -> filter_non_empty xs
+  | (y :: ys) :: xs -> Non_empty (y, ys) :: filter_non_empty xs
+
+let parse_hex_lit ?warn_inconsistent_case str =
+  let groups = String.split_on_char '_' str in
+  let failed = ref false in
+  let seen_case = ref None in
+  let check_consistent_case = function
+    | None -> ()
+    | Some case -> (
+        match !seen_case with
+        | None -> seen_case := Some case
+        | Some previous ->
+            if case = previous then ()
+            else (
+              match warn_inconsistent_case with
+              | None -> ()
+              | Some l ->
+                  Reporting.warn "Inconsistent hexadecimal casing" l
+                    "This hexadecimal bitvector literal contains both lowercase and uppercase digits."
+            )
+      )
+  in
+  let hex =
+    List.map
+      (fun group ->
+        String.to_seq group
+        |> Seq.map (fun c ->
+               match hex_digit_of_char c with
+               | Some (digit, case) ->
+                   check_consistent_case case;
+                   digit
+               | None ->
+                   failed := true;
+                   Hex_0
+           )
+        |> List.of_seq
+      )
+      groups
+  in
+  if not !failed then Some (filter_non_empty hex) else None
+
+let parse_bin_lit str =
+  let groups = String.split_on_char '_' str in
+  let failed = ref false in
+  let bin =
+    List.map
+      (fun group ->
+        String.to_seq group
+        |> Seq.map (fun c ->
+               match c with
+               | '0' -> Bin_0
+               | '1' -> Bin_1
+               | _ ->
+                   failed := true;
+                   Bin_0
+           )
+        |> List.of_seq
+      )
+      groups
+  in
+  if not !failed then Some (filter_non_empty bin) else None
+
 let to_ast_lit (P.L_aux (lit, l)) =
   L_aux
     ( ( match lit with
@@ -1178,8 +1269,16 @@ let to_ast_lit (P.L_aux (lit, l)) =
       | P.L_false -> L_false
       | P.L_undef -> L_undef
       | P.L_num i -> L_num i
-      | P.L_hex h -> L_hex h
-      | P.L_bin b -> L_bin b
+      | P.L_hex h -> (
+          match parse_hex_lit ~warn_inconsistent_case:l h with
+          | Some h -> L_hex h
+          | None -> raise (Reporting.err_syntax_loc l "Failed to parse hexadecimal bitvector literal")
+        )
+      | P.L_bin b -> (
+          match parse_bin_lit b with
+          | Some b -> L_bin b
+          | None -> raise (Reporting.err_syntax_loc l "Failed to parse binary bitvector literal")
+        )
       | P.L_real r -> L_real r
       | P.L_string s -> L_string s
       ),

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -100,6 +100,11 @@ val process_ast : ctx -> Parse_ast.defs -> untyped_ast * ctx
 
 (** {2 Parsing expressions and definitions from strings} *)
 
+val hex_digit_of_char : char -> (hex_digit * digit_case option) option
+
+val parse_hex_lit : ?warn_inconsistent_case:Parse_ast.l -> string -> hex_digit non_empty list option
+val parse_bin_lit : string -> bin_digit non_empty list option
+
 val extern_of_string : ?pure:bool -> id -> string -> untyped_def
 
 val val_spec_of_string : id -> string -> untyped_def

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -237,8 +237,8 @@ rule token comments = parse
                                               Id i }
   | (digit+ as i1) "." (digit+ as i2)     { Real (i1 ^ "." ^ i2) }
   | digit+ as i                           { Num (Big_int.of_string i) }
-  | "0b" (binarydigit+ as i)              { Bin (Util.string_of_list "" (fun s -> s) (Util.split_on_char '_' i)) }
-  | "0x" (hexdigit+ as i)                 { Hex (Util.string_of_list "" (fun s -> s) (Util.split_on_char '_' i)) }
+  | "0b" (binarydigit+ as b)              { Bin b }
+  | "0x" (hexdigit+ as h)                 { Hex h }
   | '"'                                   { let startpos = Lexing.lexeme_start_p lexbuf in
                                             let contents = string startpos (Buffer.create 10) lexbuf in
                                             lexbuf.lex_start_p <- startpos;

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -137,11 +137,11 @@ let ids_in_exp exp =
 
 let make_vector_lit sz i =
   let f j =
-    if Big_int.equal (Big_int.modulus (Big_int.shift_right i (sz - j - 1)) (Big_int.of_int 2)) Big_int.zero then '0'
-    else '1'
+    if Big_int.equal (Big_int.modulus (Big_int.shift_right i (sz - j - 1)) (Big_int.of_int 2)) Big_int.zero then Bin_0
+    else Bin_1
   in
-  let s = String.init sz f in
-  L_aux (L_bin s, Generated Unknown)
+  let s = List.init sz f in
+  L_aux (L_bin (non_empty_singleton s), Generated Unknown)
 
 let tabulate f n =
   let rec aux acc n =
@@ -3034,12 +3034,7 @@ module MonoRewrites = struct
     let is_slice = is_id env (Id "slice") in
     let is_zeros id = is_zeros env id in
     let is_ones id = is_id env (Id "Ones") id || is_id env (Id "ones") id || is_id env (Id "sail_ones") id in
-    let is_ones_lit str =
-      (* String.for_all requires a newer version of OCaml than our current minimum *)
-      let rec aux i = if str.[i] = '1' then if i = 0 then true else aux (i - 1) else false in
-      let len = String.length str in
-      if len = 0 then false else aux (len - 1)
-    in
+    let is_ones_lit = function [] -> false | bin -> List.for_all (non_empty_for_all (fun b -> b = Bin_1)) bin in
     let is_zero_extend = is_zero_extend env id in
     let is_sign_extend =
       is_id env (Id "SignExtend") id || is_id env (Id "sign_extend") id || is_id env (Id "sail_sign_extend") id
@@ -3051,7 +3046,8 @@ module MonoRewrites = struct
     let rec is_zeros_exp e =
       match unaux_exp e with
       | E_app (zeros, [_]) when is_zeros zeros -> true
-      | E_lit (L_aux ((L_bin s | L_hex s), _)) -> List.for_all (fun c -> c = '0') (Util.string_to_list s)
+      | E_lit (L_aux (L_bin bin, _)) -> List.for_all (non_empty_for_all (fun b -> b = Bin_0)) bin
+      | E_lit (L_aux (L_hex hex, _)) -> List.for_all (non_empty_for_all (fun n -> n = Hex_0)) hex
       | E_typ (_, e) -> is_zeros_exp e
       | _ -> false
     in
@@ -3198,7 +3194,7 @@ module MonoRewrites = struct
           | Some zlen ->
               (* Give the length explicitly rather than relying on the context;
                  it might not be sufficiently constrained. *)
-              let len1 = mk_exp (E_lit (L_aux (L_num (Nat_big_num.of_int (String.length lit)), Unknown))) in
+              let len1 = mk_exp (E_lit (L_aux (L_num (Nat_big_num.of_int (bin_lit_length lit)), Unknown))) in
               let total = mk_infix_exp zlen (mk_operator "+") len1 in
               try_cast_to_typ (mk_exp (E_app (mk_id "slice_mask", [total; zlen; len1])))
           | None -> E_app (id, args)
@@ -3222,7 +3218,7 @@ module MonoRewrites = struct
           | Some zlen ->
               (* Give the length explicitly rather than relying on the context;
                  it might not be sufficiently constrained. *)
-              let len2 = mk_exp (E_lit (L_aux (L_num (Nat_big_num.of_int (String.length lit)), Unknown))) in
+              let len2 = mk_exp (E_lit (L_aux (L_num (Nat_big_num.of_int (bin_lit_length lit)), Unknown))) in
               let total = mk_infix_exp zlen (mk_operator "+") len2 in
               let zero = mk_exp (E_lit (mk_lit (L_num Nat_big_num.zero))) in
               try_cast_to_typ (mk_exp (E_app (mk_id "slice_mask", [total; zero; len2])))
@@ -3523,7 +3519,7 @@ module MonoRewrites = struct
           try_cast_to_typ (rewrap (E_app (mk_id "zext_subrange", length_arg @ [vector1; hi1; lo1])))
       | [E_aux (E_app (ones, [len1]), _)] when is_ones ones ->
           try_cast_to_typ (rewrap (E_app (mk_id "zext_ones", length_arg @ [len1])))
-      | [E_aux (E_app (replicate_bits, [E_aux (E_lit (L_aux (L_bin "1", _)), _); len1]), _)]
+      | [E_aux (E_app (replicate_bits, [E_aux (E_lit (L_aux (L_bin [Non_empty (Bin_1, [])], _)), _); len1]), _)]
         when is_id env (Id "replicate_bits") replicate_bits ->
           let start1 = mk_exp (E_lit (mk_lit (L_num Big_int.zero))) in
           try_cast_to_typ (rewrap (E_app (mk_id "slice_mask", length_arg @ [start1; len1])))
@@ -3608,8 +3604,8 @@ module MonoRewrites = struct
     else if is_id env (Id "Replicate") id then (
       let length_arg = List.filter (fun arg -> is_number (typ_of arg)) args in
       match List.filter (fun arg -> not (is_number (typ_of arg))) args with
-      | [E_aux (E_lit (L_aux (L_bin "0", _)), _)] -> E_app (mk_id "sail_zeros", length_arg)
-      | [E_aux (E_lit (L_aux (L_bin "1", _)), _)] -> E_app (mk_id "sail_ones", length_arg)
+      | [E_aux (E_lit (L_aux (L_bin [Non_empty (Bin_0, [])], _)), _)] -> E_app (mk_id "sail_zeros", length_arg)
+      | [E_aux (E_lit (L_aux (L_bin [Non_empty (Bin_1, [])], _)), _)] -> E_app (mk_id "sail_ones", length_arg)
       | _ -> E_app (id, args)
       (* Turn constant-length subranges into slices, making the constant length more explicit,
          e.g. turning x[i+1 .. i] into slice(x, i, 2) *)

--- a/src/lib/nl_flow.ml
+++ b/src/lib/nl_flow.ml
@@ -61,8 +61,8 @@ let is_bitvector_literal (L_aux (aux, _)) = match aux with L_bin _ | L_hex _ -> 
 let bitvector_unsigned (L_aux (aux, _)) =
   let open Sail_lib in
   match aux with
-  | L_bin str -> uint (List.map bin_char (Util.string_to_list str))
-  | L_hex str -> uint (bits_of_string str)
+  | L_bin bin -> uint (Semantics.bitlist_of_bin_lit bin)
+  | L_hex hex -> uint (Semantics.bitlist_of_hex_lit hex)
   | _ -> assert false
 
 let rec pat_id (P_aux (aux, _)) =

--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -354,8 +354,14 @@ module Make (C : Config) = struct
         (* Unit pattern always matches on unit, so generalize to wildcard *)
         GP_wild
     | P_lit (L_aux (L_hex hex, _)) ->
-        GP_bitvector (pnum, String.length hex * 4, fun x -> BVC_eq (x, BVC_lit ("#x" ^ hex)))
-    | P_lit (L_aux (L_bin bin, _)) -> GP_bitvector (pnum, String.length bin, fun x -> BVC_eq (x, BVC_lit ("#b" ^ bin)))
+        GP_bitvector
+          ( pnum,
+            hex_lit_length hex,
+            fun x -> BVC_eq (x, BVC_lit ("#x" ^ string_of_hex_lit ~group_separator:"" ~case:Uppercase hex))
+          )
+    | P_lit (L_aux (L_bin bin, _)) ->
+        GP_bitvector
+          (pnum, bin_lit_length bin, fun x -> BVC_eq (x, BVC_lit ("#b" ^ string_of_bin_lit ~group_separator:"" bin)))
     | P_vector pats when is_bitvector_typ typ ->
         let mask, bits =
           List.fold_left

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -284,8 +284,8 @@ module Printer (Config : PRINT_CONFIG) = struct
       | L_true -> "true"
       | L_false -> "false"
       | L_num i -> Big_int.to_string i
-      | L_hex n -> "0x" ^ n
-      | L_bin n -> "0b" ^ n
+      | L_hex hex -> "0x" ^ string_of_hex_lit ~case:Uppercase hex
+      | L_bin bin -> "0b" ^ string_of_bin_lit bin
       | L_real r -> r
       | L_undef -> "undefined"
       | L_string s -> "\"" ^ String.escaped s ^ "\""

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -1419,14 +1419,16 @@ let rewrite_ast_vector_string_pats_to_bit_list env =
 let rewrite_bit_lists_to_lits env =
   (* TODO Make all rewriting passes support bitvector literals instead of
      converting back and forth *)
-  let open Sail2_values in
-  let bit_of_lit = function L_aux (L_zero, _) -> Some B0 | L_aux (L_one, _) -> Some B1 | _ -> None in
+  let bit_of_lit = function
+    | L_aux (L_zero, _) -> Some Value_type.B0
+    | L_aux (L_one, _) -> Some Value_type.B1
+    | _ -> None
+  in
   let bit_of_exp = function E_aux (E_lit lit, _) -> bit_of_lit lit | _ -> None in
-  let string_of_chars cs = String.concat "" (List.map (String.make 1) cs) in
   let lit_of_bits bits =
-    match hexstring_of_bits bits with
-    | Some h -> L_hex (string_of_chars h)
-    | None -> L_bin (string_of_chars (List.map bitU_char bits))
+    match Semantics.hex_digits_of_bitlist bits with
+    | Some h -> L_hex (non_empty_singleton h)
+    | None -> L_bin (non_empty_singleton (List.map (function Value_type.B0 -> Bin_0 | Value_type.B1 -> Bin_1) bits))
   in
   let e_aux (e, (l, annot)) =
     let rewrap e = E_aux (e, (l, annot)) in
@@ -1435,7 +1437,7 @@ let rewrite_bit_lists_to_lits env =
       let typ = typ_of_annot (l, annot) in
       match e with
       | E_vector es when is_bitvector_typ typ -> (
-          match just_list (List.map bit_of_exp es) with
+          match Util.option_all (List.map bit_of_exp es) with
           | Some bits -> check_exp env (mk_exp (E_typ (typ, mk_lit_exp (lit_of_bits bits)))) typ
           | None -> rewrap e
         )
@@ -4385,10 +4387,12 @@ let rewrite_truncate_hex_literals _type_env defs =
         ( Id_aux (Id "truncate", _),
           [E_aux (E_lit (L_aux (L_hex hex, l_ann)), _); E_aux (E_lit (L_aux (L_num len, _)), _)]
         ) ->
-        let bin = hex_to_bin hex in
+        let bin =
+          Semantics.bitlist_of_hex_lit hex |> List.map (function Value_type.B0 -> Bin_0 | Value_type.B1 -> Bin_1)
+        in
         let len = Nat_big_num.to_int len in
-        let truncation = String.sub bin (String.length bin - len) len in
-        E_aux (E_lit (L_aux (L_bin truncation, l_ann)), annot)
+        let truncation = Util.drop (List.length bin - len) bin in
+        E_aux (E_lit (L_aux (L_bin (non_empty_singleton truncation), l_ann)), annot)
     | _ -> E_aux (e, annot)
   in
   rewrite_ast_base

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -61,6 +61,11 @@ Module def_annot.
     Build t_a r.(doc_comment) r.(attrs) r.(visibility) r.(loc) env.
 End def_annot.
 
+Inductive non_empty (a : Set) : Set :=
+| Non_empty : a -> list a -> non_empty a.
+
+Arguments Non_empty {_}.
+
 Definition def_annot := def_annot.record.
 
 Definition clause_annot (a : Set) : Set := def_annot unit * a.
@@ -70,6 +75,28 @@ Definition annot (a : Set) : Set := loc * a.
 Inductive loop : Set :=
 | While : loop
 | Until : loop.
+
+Inductive hex_digit : Set :=
+| Hex_0 : hex_digit
+| Hex_1 : hex_digit
+| Hex_2 : hex_digit
+| Hex_3 : hex_digit
+| Hex_4 : hex_digit
+| Hex_5 : hex_digit
+| Hex_6 : hex_digit
+| Hex_7 : hex_digit
+| Hex_8 : hex_digit
+| Hex_9 : hex_digit
+| Hex_A : hex_digit
+| Hex_B : hex_digit
+| Hex_C : hex_digit
+| Hex_D : hex_digit
+| Hex_E : hex_digit
+| Hex_F : hex_digit.
+
+Inductive bin_digit : Set :=
+| Bin_0
+| Bin_1.
 
 Inductive kind_aux : Set :=
 | K_type : kind_aux
@@ -107,8 +134,8 @@ Inductive lit_aux : Set :=
 | L_true : lit_aux
 | L_false : lit_aux
 | L_num : Z -> lit_aux
-| L_hex : string -> lit_aux
-| L_bin : string -> lit_aux
+| L_hex : list (non_empty hex_digit) -> lit_aux
+| L_bin : list (non_empty bin_digit) -> lit_aux
 | L_string : string -> lit_aux
 | L_undef : lit_aux
 | L_real : string -> lit_aux.

--- a/src/lib/rocq/theories/Semantics.v
+++ b/src/lib/rocq/theories/Semantics.v
@@ -410,6 +410,81 @@ Proof.
     lia.
 Qed.
 
+Definition bitlist_of_hex_digit (h : hex_digit) : list bit :=
+  match h with
+  | Hex_0 => [B0; B0; B0; B0]
+  | Hex_1 => [B0; B0; B0; B1]
+  | Hex_2 => [B0; B0; B1; B0]
+  | Hex_3 => [B0; B0; B1; B1]
+  | Hex_4 => [B0; B1; B0; B0]
+  | Hex_5 => [B0; B1; B0; B1]
+  | Hex_6 => [B0; B1; B1; B0]
+  | Hex_7 => [B0; B1; B1; B1]
+  | Hex_8 => [B1; B0; B0; B0]
+  | Hex_9 => [B1; B0; B0; B1]
+  | Hex_A => [B1; B0; B1; B0]
+  | Hex_B => [B1; B0; B1; B1]
+  | Hex_C => [B1; B1; B0; B0]
+  | Hex_D => [B1; B1; B0; B1]
+  | Hex_E => [B1; B1; B1; B0]
+  | Hex_F => [B1; B1; B1; B1]
+  end.
+
+Definition hex_digit_of_nibble (b1 b2 b3 b4 : bit) : hex_digit :=
+  match (b1, b2, b3, b4) with
+  | (B0, B0, B0, B0) => Hex_0
+  | (B0, B0, B0, B1) => Hex_1
+  | (B0, B0, B1, B0) => Hex_2
+  | (B0, B0, B1, B1) => Hex_3
+  | (B0, B1, B0, B0) => Hex_4
+  | (B0, B1, B0, B1) => Hex_5
+  | (B0, B1, B1, B0) => Hex_6
+  | (B0, B1, B1, B1) => Hex_7
+  | (B1, B0, B0, B0) => Hex_8
+  | (B1, B0, B0, B1) => Hex_9
+  | (B1, B0, B1, B0) => Hex_A
+  | (B1, B0, B1, B1) => Hex_B
+  | (B1, B1, B0, B0) => Hex_C
+  | (B1, B1, B0, B1) => Hex_D
+  | (B1, B1, B1, B0) => Hex_E
+  | (B1, B1, B1, B1) => Hex_F
+  end.
+
+Fixpoint hex_digits_of_bitlist (bits : list bit) : option (list hex_digit) :=
+  match bits with
+  | b1 :: b2 :: b3 :: b4 :: rest =>
+      let digit := hex_digit_of_nibble b1 b2 b3 b4 in
+      match hex_digits_of_bitlist rest with
+      | None => None
+      | Some digits => Some (digit :: digits)
+      end
+  | [] => Some []
+  | _ => None
+  end.
+
+Definition non_empty_to_list {A : Set} (xs : non_empty A) : list A :=
+  let 'Non_empty y ys := xs in y :: ys.
+
+Definition bitlist_of_hex_lit (hex : list (non_empty hex_digit)) : list bit :=
+  let digits := List.concat (List.map non_empty_to_list hex) in
+  List.concat (List.map bitlist_of_hex_digit digits).
+
+Lemma hex_lit_bitlist_rt : forall (d : hex_digit), hex_digits_of_bitlist (bitlist_of_hex_lit [Non_empty d []]) = Some [d].
+Proof.
+  induction d.
+  all: cbn.
+  all: reflexivity.
+Qed.
+
+Definition bitlist_of_bin_lit (bin : list (non_empty bin_digit)) : list bit :=
+  let digits := List.concat (List.map non_empty_to_list bin) in
+  List.map (fun b =>
+      match b with
+      | Bin_0 => B0
+      | Bin_1 => B1
+      end
+    ) digits.
+
 (** Sail annotates terms with custom type annotation data, which we
     don't have access to here. Instead use a functor parameterised by
     the following SemanticExt signature, which can provide the methods we
@@ -430,10 +505,6 @@ Module Type SemanticExt.
   Parameter id_equal_string : id -> string -> bool.
 
   Parameter string_of_id : id -> string.
-
-  Parameter bits_of_hex_string : string -> list bit.
-
-  Parameter bits_of_bin_string : string -> list bit.
 
   Parameter rational_of_string : string -> rational.
 
@@ -559,9 +630,8 @@ Module Make (T : SemanticExt).
     | L_true => pure (V_bool true)
     | L_false => pure (V_bool false)
     | L_num n => pure (V_int n)
-    (* Fix the representation of these internally, so they work nicely... *)
-    | L_hex h => pure (V_vector (map V_bit (T.bits_of_hex_string h)))
-    | L_bin b => pure (V_vector (map V_bit (T.bits_of_bin_string b)))
+    | L_hex h => pure (V_vector (map V_bit (bitlist_of_hex_lit h)))
+    | L_bin b => pure (V_vector (map V_bit (bitlist_of_bin_lit b)))
     | L_real r => pure (V_real (T.rational_of_string r))
     | L_string s => pure (V_string s)
     | L_undef => get_undefined typ
@@ -617,8 +687,8 @@ Module Make (T : SemanticExt).
     | (L_true, V_bool true) => true
     | (L_false, V_bool false) => true
     | (L_num n, V_int m) => T.num_equal n m
-    | (L_hex s, V_vector vs) => same_bits (T.bits_of_hex_string s) vs
-    | (L_bin s, V_vector vs) => same_bits (T.bits_of_bin_string s) vs
+    | (L_hex s, V_vector vs) => same_bits (bitlist_of_hex_lit s) vs
+    | (L_bin s, V_vector vs) => same_bits (bitlist_of_bin_lit s) vs
     | (L_string s1, V_string s2) => String.eqb s1 s2
     | (L_real r1, V_real r2) => T.rational_equal (T.rational_of_string r1) r2
     | _ => false
@@ -1561,6 +1631,6 @@ Module Make (T : SemanticExt).
   Defined.
 End Make.
 
-Extraction Blacklist List String.
+Extraction Blacklist Nat List String.
 
-Separate Extraction l attribute_data def impldef opt_default Make IdMap.
+Separate Extraction Primops l attribute_data hex_digits_of_bitlist def impldef opt_default Make IdMap.

--- a/src/lib/rocq/theories/Value_type.v
+++ b/src/lib/rocq/theories/Value_type.v
@@ -61,4 +61,16 @@ Module Primops.
     | (V_int v1, V_int v2) => Some (V_int (Z.sub v1 v2))
     | _ => None
     end.
+
+  Definition zero_extend (bits : value) (n : value) : option value :=
+    match (bits, n) with
+    | (V_vector bitlist, V_int n) =>
+      let len := List.length bitlist in
+      if Z.ltb n (Z.of_nat len) then
+        None
+      else
+        let extend := (Z.to_nat n) - len in
+        Some (V_vector (List.repeat (V_bit B0) extend ++ bitlist))
+    | _ => None
+    end.
 End Primops.

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1383,8 +1383,8 @@ let infer_lit (L_aux (lit_aux, l)) =
   | L_string _ when !Type_env.opt_string_literal_type -> string_literal_typ
   | L_string _ -> string_typ
   | L_real _ -> real_typ
-  | L_bin str -> bitvector_typ (nint (String.length str))
-  | L_hex str -> bitvector_typ (nint (String.length str * 4))
+  | L_bin bin -> bitvector_typ (nint (bin_lit_length bin))
+  | L_hex hex -> bitvector_typ (nint (hex_lit_length hex))
   | L_undef -> typ_error l "Cannot infer the type of undefined"
 
 let instantiate_simple_equations =

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -142,11 +142,16 @@ let literal_to_fragment (L_aux (l_aux, _)) =
   match l_aux with
   | L_num n when Big_int.less_equal (min_int 64) n && Big_int.less_equal n (max_int 64) ->
       Some (V_lit (VL_int n, CT_fint 64))
-  | L_hex str when String.length str <= 16 ->
-      let padding = 16 - String.length str in
-      let padding = Util.list_init padding (fun _ -> Sail2_values.B0) in
-      let content = Util.string_to_list str |> List.map hex_char |> List.concat in
-      Some (V_lit (VL_bits (padding @ content), CT_fbits (String.length str * 4)))
+  | L_hex hex ->
+      let len = hex_lit_length hex in
+      if len <= 64 then (
+        let content =
+          Semantics.bitlist_of_hex_lit hex
+          |> List.map (function Value_type.B0 -> Sail2_values.B0 | Value_type.B1 -> Sail2_values.B1)
+        in
+        Some (V_lit (VL_bits content, CT_fbits len))
+      )
+      else None
   | L_unit -> Some (V_lit (VL_unit, CT_unit))
   | L_true -> Some (V_lit (VL_bool true, CT_bool))
   | L_false -> Some (V_lit (VL_bool false, CT_bool))

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -847,8 +847,8 @@ let doc_lit (L_aux (lit, l)) =
       if Big_int.less i Big_int.zero then parens ipp else ipp
   (* Not a typo, the bbv hex notation uses the letter O *)
   (* These need parens because of the 'sz 'b "..."' variants :( *)
-  | L_hex n -> utf8string ("(Ox\"" ^ n ^ "\")")
-  | L_bin n -> utf8string ("('b\"" ^ n ^ "\")")
+  | L_hex hex -> utf8string ("(Ox\"" ^ string_of_hex_lit ~group_separator:"" ~case:Uppercase hex ^ "\")")
+  | L_bin bin -> utf8string ("('b\"" ^ string_of_bin_lit ~group_separator:"" bin ^ "\")")
   | L_undef -> utf8string "(Fail \"undefined value of unsupported type\")"
   | L_string s -> utf8string ("\"" ^ coq_escape_string s ^ "\"")
   | L_real s ->

--- a/src/sail_doc_backend/wavedrom.ml
+++ b/src/sail_doc_backend/wavedrom.ml
@@ -70,8 +70,9 @@ let wavedrom_label size = function
   | None -> Printf.sprintf ", attr: '%d'" size
   | Some label -> Printf.sprintf ", attr: ['%d', '%s']" size label
 
-let binary_to_hex str =
+let binary_to_hex bin =
   let open Sail2_values in
+  let str = string_of_bin_lit ~group_separator:"" bin in
   let padded = match String.length str mod 4 with 0 -> str | 1 -> "000" ^ str | 2 -> "00" ^ str | _ -> "0" ^ str in
   Util.string_to_list padded
   |> List.map (function '0' -> B0 | _ -> B1)
@@ -88,7 +89,8 @@ let rec wavedrom_elem_string size label (P_aux (aux, _)) =
   | P_lit (L_aux (L_bin bin, _)) ->
       Printf.sprintf "    { bits: %d, name: 0x%s%s, type: 8 }" size (binary_to_hex bin) (wavedrom_label size label)
   | P_lit (L_aux (L_hex hex, _)) ->
-      Printf.sprintf "    { bits: %d, name: 0x%s%s, type: 8 }" size hex (wavedrom_label size label)
+      let hexstr = string_of_hex_lit ~group_separator:"" ~case:Uppercase hex in
+      Printf.sprintf "    { bits: %d, name: 0x%s%s, type: 8 }" size hexstr (wavedrom_label size label)
   | P_vector_subrange (_, n, m) when Big_int.equal n m ->
       Printf.sprintf "    { bits: %d, name: '[%s]'%s, type: 3 }" size (Big_int.to_string n) (wavedrom_label size label)
   | P_vector_subrange (id, n, m) ->

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -379,9 +379,9 @@ let doc_lit (L_aux (lit, l)) =
   | L_false -> string "false"
   | L_true -> string "true"
   | L_num i -> doc_big_int i
-  | L_hex "" | L_bin "" -> string "BitVec.nil"
-  | L_hex n -> utf8string ("0x" ^ n)
-  | L_bin n -> utf8string ("0b" ^ n)
+  | L_hex [] | L_bin [] -> string "BitVec.nil"
+  | L_hex hex -> utf8string ("0x" ^ string_of_hex_lit ~group_separator:"" ~case:Uppercase hex)
+  | L_bin bin -> utf8string ("0b" ^ string_of_bin_lit ~group_separator:"" bin)
   | L_undef -> utf8string "(Fail \"undefined value of unsupported type\")"
   | L_string s -> utf8string ("\"" ^ lean_escape_string s ^ "\"")
   | L_real s -> utf8string s (* TODO test if this is really working *)

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -511,8 +511,9 @@ let rec doc_lit_lem (L_aux (lit, l)) =
   | L_num i ->
       let ipp = Big_int.to_string i in
       utf8string (if Big_int.less i Big_int.zero then "((0" ^ ipp ^ "):ii)" else "(" ^ ipp ^ ":ii)")
-  | L_hex n when !Monomorphise.opt_mwords -> utf8string ("0x" ^ n)
-  | L_bin n when !Monomorphise.opt_mwords -> utf8string ("0b" ^ n)
+  | L_hex hex when !Monomorphise.opt_mwords ->
+      utf8string ("0x" ^ string_of_hex_lit ~group_separator:"" ~case:Uppercase hex)
+  | L_bin bin when !Monomorphise.opt_mwords -> utf8string ("0b" ^ string_of_bin_lit ~group_separator:"" bin)
   | L_hex _ | L_bin _ ->
       vector_string_to_bit_list (L_aux (lit, l)) |> flow_map (semi ^^ break 0) doc_lit_lem |> group |> align |> brackets
   | L_undef -> utf8string "(return (failwith \"undefined value of unsupported type\"))"

--- a/src/sail_smt_backend/jib_smt.ml
+++ b/src/sail_smt_backend/jib_smt.ml
@@ -1150,33 +1150,19 @@ end) : Jib_compile.CONFIG = struct
     | Typ_var kid -> CT_poly kid
     | _ -> raise (Reporting.err_unreachable l __POS__ ("No SMT type for type " ^ string_of_typ typ))
 
-  let hex_char =
-    let open Sail2_values in
-    function
-    | '0' -> [B0; B0; B0; B0]
-    | '1' -> [B0; B0; B0; B1]
-    | '2' -> [B0; B0; B1; B0]
-    | '3' -> [B0; B0; B1; B1]
-    | '4' -> [B0; B1; B0; B0]
-    | '5' -> [B0; B1; B0; B1]
-    | '6' -> [B0; B1; B1; B0]
-    | '7' -> [B0; B1; B1; B1]
-    | '8' -> [B1; B0; B0; B0]
-    | '9' -> [B1; B0; B0; B1]
-    | 'A' | 'a' -> [B1; B0; B1; B0]
-    | 'B' | 'b' -> [B1; B0; B1; B1]
-    | 'C' | 'c' -> [B1; B1; B0; B0]
-    | 'D' | 'd' -> [B1; B1; B0; B1]
-    | 'E' | 'e' -> [B1; B1; B1; B0]
-    | 'F' | 'f' -> [B1; B1; B1; B1]
-    | _ -> failwith "Invalid hex character"
-
   let literal_to_cval (L_aux (l_aux, _) as lit) =
     match l_aux with
     | L_num n -> Some (V_lit (VL_int n, CT_constant n))
-    | L_hex str when String.length str <= 16 ->
-        let content = Util.string_to_list str |> List.map hex_char |> List.concat in
-        Some (V_lit (VL_bits content, CT_fbits (String.length str * 4)))
+    | L_hex hex ->
+        let len = hex_lit_length hex in
+        if len <= 64 then (
+          let content =
+            Semantics.bitlist_of_hex_lit hex
+            |> List.map (function Value_type.B0 -> Sail2_values.B0 | Value_type.B1 -> Sail2_values.B1)
+          in
+          Some (V_lit (VL_bits content, CT_fbits len))
+        )
+        else None
     | L_unit -> Some (V_lit (VL_unit, CT_unit))
     | L_true -> Some (V_lit (VL_bool true, CT_bool))
     | L_false -> Some (V_lit (VL_bool false, CT_bool))

--- a/test/format/default/struct_update.expect
+++ b/test/format/default/struct_update.expect
@@ -27,7 +27,7 @@ function baz () = {
 
 scattered function /* comment */ quux
 
-function clause quux 0b00000000 = ()
+function clause quux 0b0000_0000 = ()
 
 end /* comment */ quux
 


### PR DESCRIPTION
Previously (binary and hexadecimal) bitvector literals were stored as strings in the AST. This was simple enough, but for the Rocq semantics it causes us to need to hook in some OCaml parsing code into the step function via the SemanticsExt module. This felt a bit ugly.

Another problem is the lexer would immediately strip all '\_' group separators, which meant code inside Sail didn't have to worry about wayward '\_' characters changing the lengths of bitvector literals, and could do something simple like `String.length h * 4` to determine the length of a hexadecimal literal. The problem is that `sail --fmt` had no idea how the user intended to group the bits, and just printed every bitvector without separators.

Change: The AST now has two types `hex_digit` and `bin_digit` representing hexadecimal and binary digits respectively. Literals are all
```
<digit> list list
```
The outer list represents the groups, so
```
0xAB_CD
```
is
```
[[Hex_A; Hex_B]; [Hex_C; Hex_D]]
```

Note that the `bin_digit` type has two constructors `Bin_0` and `Bin_1`. It is currently intentionally different to the semantic `bit` type. The reason is
```
bin_digit list OR bin_digit list list
```
represents the order the digits appear syntactically in the source, whereas in
```
bit list
```
the position of each bit represents its significance.