### PR TITLE
Merge memory request structs for concurrency interface v2

### DIFF
--- a/lib/concurrency_interface/read_write_v2.sail
+++ b/lib/concurrency_interface/read_write_v2.sail
@@ -80,14 +80,14 @@ $include <concurrency_interface/common.sail>
 */
 
 
-/* This type represent a Request to read a section of memory. It requests
-   reading 'n bytes of data and 'nt capabilities tags (if CHERI is off, 'nt must
-   be 0) The actual footprint read is max('n, 'cap_size * 'nt). If 'n is smaller
+/* This type represent a Request to access a section of memory. It requests
+   accessing 'n bytes of data and 'nt capabilities tags (if CHERI is off, 'nt must
+   be 0). The actual footprint accessed is max('n, 'cap_size * 'nt). If 'n is smaller
    than this value, the extra bytes are discarded. */
-$option -lem_extern_type Mem_read_request
-$option -coq_extern_type Mem_read_request
-$option -lean_extern_type Mem_read_request
-struct Mem_read_request('n : Int, 'nt : Int, 'addr_size : Int, 'addr_space : Type,
+$option -lem_extern_type Mem_request
+$option -coq_extern_type Mem_request
+$option -lean_extern_type Mem_request
+struct Mem_request('n : Int, 'nt : Int, 'addr_size : Int, 'addr_space : Type,
     'mem_acc : Type), 'n >= 0 & 'nt >= 0 & 'addr_size > 0 = {
   access_kind : 'mem_acc,
   address : bits('addr_size),
@@ -110,7 +110,7 @@ $endif
 
 /* Requests a memory read. Return 'n bytes and 'nt tags */
 outcome sail_mem_read : forall 'n 'nt, 'n >= 0 & (if 'CHERI then 'nt >= 0 else 'nt == 0).
-  Mem_read_request('n, 'nt, 'addr_size, 'addr_space, 'mem_acc)
+  Mem_request('n, 'nt, 'addr_size, 'addr_space, 'mem_acc)
       -> result((vector('n, bits(8)), vector('nt, bool)), 'abort)
 with
   'addr_size : Int,
@@ -202,29 +202,12 @@ constraint 'addr_size > 0 & 'cap_size_log >= 0
     }
 }
 
-/* This type represent a request to write a range of memory. It requests
-   writing 'n bytes of data and 'nt capabilities tags (if CHERI is off, 'nt must
-   be 0). 'n can be 0 to write only CHERI tags */
-$option -lem_extern_type Mem_write_request
-$option -coq_extern_type Mem_write_request
-$option -lean_extern_type Mem_write_request
-struct Mem_write_request('n : Int, 'nt : Int, 'addr_size : Int, 'addr_space : Type,
-    'mem_acc : Type), 'n >= 0 & 'nt >= 0 & 'addr_size > 0 = {
-  access_kind : 'mem_acc,
-  address : bits('addr_size),
-  address_space : 'addr_space,
-  size : int('n),
-  num_tag : int('nt),
-  value : vector('n, bits(8)),
-  tags : vector('nt, bool),
-}
-
 /* Requests a memory write. If the write cannot happen due to
    atomicity/exclusive constraints, then the execution path is discarded as
    impossible (size-0 non deterministic choice). Is the responsability of the
    Sail model to do the proper non-determinitic choices beforehand */
 outcome sail_mem_write : forall 'n 'nt, 'n >= 0 & (if 'CHERI then 'nt >= 0 else 'nt == 0).
-  Mem_write_request('n, 'nt, 'addr_size, 'addr_space, 'mem_acc)
+  (Mem_request('n, 'nt, 'addr_size, 'addr_space, 'mem_acc), vector('n, bits(8)), vector('nt, bool))
       -> result(unit, 'abort)
 with
   'addr_size : Int,
@@ -246,7 +229,7 @@ constraint 'addr_size > 0 & 'cap_size_log >= 0
     val mem_acc_is_exclusive : 'mem_acc -> bool
     val mem_acc_is_atomic_rmw : 'mem_acc -> bool
 
-    impl emulator_or_isla(request) = {
+    impl emulator_or_isla(request, value, tags) = {
         let address : {'as, 'as in {32, 64}. bits('as)} =
             if length(request.address) <= 32
             then sail_zero_extend(request.address, 32)
@@ -260,7 +243,7 @@ constraint 'addr_size > 0 & 'cap_size_log >= 0
             let tag_address = address & sail_shiftleft(sail_ones(length(address)), 'cap_size_log);
             let tag_footprint = max_int(tdiv_int(request.size + cap_size - 1, cap_size), request.num_tag);
             foreach(i from 0 to (tag_footprint - 1)) {
-                let tag_val = if (i >= request.num_tag) then false else request.tags[i];
+                let tag_val = if (i >= request.num_tag) then false else tags[i];
                 if length(address) == 32 then {
                     write_tag#(32, tag_address + i * cap_size, tag_val)
                 } else {
@@ -269,18 +252,18 @@ constraint 'addr_size > 0 & 'cap_size_log >= 0
             };
         };
         if request.size > 0 then {
-            let value = from_bytes_le(request.size, request.value);
+            let value_bits = from_bytes_le(request.size, value);
             if mem_acc_is_exclusive(request.access_kind) then {
                 if length(address) == 32 then {
-                    let _ = write_mem_exclusive#(request, 32, address, request.size, value)
+                    let _ = write_mem_exclusive#(request, 32, address, request.size, value_bits)
                 } else {
-                    let _ = write_mem_exclusive#(request, 64, address, request.size, value)
+                    let _ = write_mem_exclusive#(request, 64, address, request.size, value_bits)
                 }
             } else {
                 if length(address) == 32 then {
-                    let _ = write_mem#(request, 32, address, request.size, value)
+                    let _ = write_mem#(request, 32, address, request.size, value_bits)
                 } else {
-                    let _ = write_mem#(request, 64, address, request.size, value);
+                    let _ = write_mem#(request, 64, address, request.size, value_bits);
                 }
             }
         };
@@ -288,29 +271,12 @@ constraint 'addr_size > 0 & 'cap_size_log >= 0
     }
 }
 
-/* This type represent an announcement of an address that will be read or written.
-   All the parameters must match up with the content of the later access.  We assume
-   that the access kind identifies whether the operation is a read, write, or rmw
-   operation.
- */
-$option -lem_extern_type Mem_address_announce
-$option -coq_extern_type Mem_address_announce
-$option -lean_extern_type Mem_address_announce
-struct Mem_address_announce('n : Int, 'nt : Int, 'addr_size : Int, 'addr_space : Type,
-    'mem_acc : Type), 'n >= 0 & 'nt >= 0 & 'addr_size > 0 = {
-  access_kind : 'mem_acc,
-  address : bits('addr_size),
-  address_space : 'addr_space,
-  size : int('n),
-  num_tag : int('nt),
-}
-
 /* Requests a memory write. If the write cannot happen due to
    atomicity/exclusive constraints, then the execution path is discarded as
    impossible (size-0 non deterministic choice). Is the responsability of the
    Sail model to do the proper non-determinitic choices beforehand */
 outcome sail_mem_address_announce : forall 'n 'nt, 'n >= 0 & (if 'CHERI then 'nt >= 0 else 'nt == 0).
-  Mem_address_announce('n, 'nt, 'addr_size, 'addr_space, 'mem_acc)
+  Mem_request('n, 'nt, 'addr_size, 'addr_space, 'mem_acc)
       -> unit
 with
   'addr_size : Int,

--- a/test/c/concurrency_interface_v2.sail
+++ b/test/c/concurrency_interface_v2.sail
@@ -68,56 +68,55 @@ register R2 : bits(64)
 val main : unit -> unit
 
 function main() = {
-    let w_req : Mem_write_request(8, 1, 64, unit, unit) = struct {
+    let req : Mem_request(8, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
-        num_tag = 1,
-        value = [0xAB, 0xCD, 0x12, 0x34, 0xFF, 0xFF, 0x56, 0x78],
-        tags = [true]
+        num_tag = 1
     };
-    print_bits("least significant byte = ", w_req.value[0]);
-    match sail_mem_write(w_req) {
+    let value = [0xAB, 0xCD, 0x12, 0x34, 0xFF, 0xFF, 0x56, 0x78];
+    print_bits("least significant byte = ", value[0]);
+    match sail_mem_write(req, value, [true]) {
         Ok(_) => (),
         Err(abort) => {
             print_bits("abort = ", abort)
         }
     };
-    let r_req : Mem_read_request(8, 0, 64, unit, unit) = struct {
+    let req : Mem_request(8, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
         num_tag = 0
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) => {
             print_bits("read memory (no tag read) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
-    let r_req : Mem_read_request(4, 0, 64, unit, unit) = struct {
+    let req : Mem_request(4, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 4,
         num_tag = 0
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) => {
             print_bits("read memory 4 lower bytes (no tag read) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
-    let r_req : Mem_read_request(4, 0, 64, unit, unit) = struct {
+    let req : Mem_request(4, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0004,
         address_space = (),
         size = 4,
         num_tag = 0
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) => {
             print_bits("read memory 4 higher bytes (no tag read) = ", from_bytes_le(value))
         },
@@ -125,57 +124,56 @@ function main() = {
     };
 
     sail_barrier(Barrier1);
-    let r_req : Mem_read_request(8, 1, 64, unit, unit) = struct {
+    let req : Mem_request(8, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
         num_tag = 1,
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) if v[0] => {
             print_bits("read memory (true tag) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
 
-    let w_req : Mem_write_request(2, 0, 64, unit, unit) = struct {
+    let req : Mem_request(2, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0002,
         address_space = (),
         size = 2,
-        num_tag = 0,
-        value = [0xDE, 0xAD],
-        tags = []
+        num_tag = 0
     };
-    match sail_mem_write(w_req) {
+    let value = [0xDE, 0xAD];
+    match sail_mem_write(req, value, []) {
         Ok(_) => (),
         Err(abort) => {
             print_bits("abort = ", abort)
         }
     };
-    let r_req : Mem_read_request(8, 1, 64, unit, unit) = struct {
+    let req : Mem_request(8, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
         num_tag = 1,
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) if v[0] == false => {
             print_bits("read memory (false tag) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
 
-    let r_req : Mem_read_request(2, 1, 64, unit, unit) = struct {
+    let req : Mem_request(2, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0002,
         address_space = (),
         size = 2,
         num_tag = 1,
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) if not_bool(v[0]) => {
             print_bits("read memory 2 bytes (false tag) = ", from_bytes_le(value))
         },

--- a/test/c/concurrency_interface_v2_var.sail
+++ b/test/c/concurrency_interface_v2_var.sail
@@ -62,56 +62,55 @@ register R2 : bits(64)
 val main : unit -> unit
 
 function main() = {
-    let w_req : Mem_write_request(8, 1, 64, unit, unit) = struct {
+    let req : Mem_request(8, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
-        num_tag = 1,
-        value = [0xAB, 0xCD, 0x12, 0x34, 0xFF, 0xFF, 0x56, 0x78],
-        tags = [true]
+        num_tag = 1
     };
-    print_bits("least significant byte = ", w_req.value[0]);
-    match sail_mem_write(w_req) {
+    let value = [0xAB, 0xCD, 0x12, 0x34, 0xFF, 0xFF, 0x56, 0x78];
+    print_bits("least significant byte = ", value[0]);
+    match sail_mem_write(req, value, [true]) {
         Ok(_) => (),
         Err(abort) => {
             print_bits("abort = ", abort)
         }
     };
-    let r_req : Mem_read_request(8, 0, 64, unit, unit) = struct {
+    let req : Mem_request(8, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
         num_tag = 0
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) => {
             print_bits("read memory (no tag read) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
-    let r_req : Mem_read_request(4, 0, 64, unit, unit) = struct {
+    let req : Mem_request(4, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 4,
         num_tag = 0
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) => {
             print_bits("read memory 4 lower bytes (no tag read) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
-    let r_req : Mem_read_request(4, 0, 64, unit, unit) = struct {
+    let req : Mem_request(4, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0004,
         address_space = (),
         size = 4,
         num_tag = 0
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) => {
             print_bits("read memory 4 higher bytes (no tag read) = ", from_bytes_le(value))
         },
@@ -119,57 +118,56 @@ function main() = {
     };
 
     sail_barrier(Barrier1);
-    let r_req : Mem_read_request(8, 1, 64, unit, unit) = struct {
+    let req : Mem_request(8, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
         num_tag = 1,
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) if v[0] => {
             print_bits("read memory (true tag) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
 
-    let w_req : Mem_write_request(2, 0, 64, unit, unit) = struct {
+    let req : Mem_request(2, 0, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0002,
         address_space = (),
         size = 2,
-        num_tag = 0,
-        value = [0xDE, 0xAD],
-        tags = []
+        num_tag = 0
     };
-    match sail_mem_write(w_req) {
+    let value = [0xDE, 0xAD];
+    match sail_mem_write(req, value, []) {
         Ok(_) => (),
         Err(abort) => {
             print_bits("abort = ", abort)
         }
     };
-    let r_req : Mem_read_request(8, 1, 64, unit, unit) = struct {
+    let req : Mem_request(8, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0000,
         address_space = (),
         size = 8,
         num_tag = 1,
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) if v[0] == false => {
             print_bits("read memory (false tag) = ", from_bytes_le(value))
         },
         _ => print_endline("invalid read"),
     };
 
-    let r_req : Mem_read_request(2, 1, 64, unit, unit) = struct {
+    let req : Mem_request(2, 1, 64, unit, unit) = struct {
         access_kind = (),
         address = 0x0000_0000_0060_0002,
         address_space = (),
         size = 2,
         num_tag = 1,
     };
-    match sail_mem_read(r_req) {
+    match sail_mem_read(req) {
         Ok((value, v)) if not_bool(v[0]) => {
             print_bits("read memory 2 bytes (false tag) = ", from_bytes_le(value))
         },

--- a/test/c/mk_coq_main.sh
+++ b/test/c/mk_coq_main.sh
@@ -61,14 +61,16 @@ EOF
 EOF
   else
   cat <<EOF >> "$OUT"
-  Definition write_mem (st : state) n nt (req : Interface.WriteReq.t n nt) :=
-    let base_addr := mword_to_N req.(Interface.WriteReq.address) in
+  Definition write_mem (st : state) (req : Interface.MemReq.t) (value : definitions.bv (8 * Interface.MemReq.size req)) (tags : definitions.bv (Interface.MemReq.num_tag req)) :=
+    let n := req.(Interface.MemReq.size) in
+    let nt := req.(Interface.MemReq.num_tag) in
+    let base_addr := mword_to_N req.(Interface.MemReq.address) in
     let addrs := State_monad.genlist (fun i => base_addr + N.of_nat i)%N (N.to_nat n) in
-    let write_byte i m := NMap.add (base_addr + i)%N (definitions.bv_extract (8 * i) 8 req.(Interface.WriteReq.value)) m in
+    let write_byte i m := NMap.add (base_addr + i)%N (definitions.bv_extract (8 * i) 8 value) m in
     let cap_size := N.pow 2 Arch.cap_size_log in
-    let write_tag i m := NMap.add (base_addr + i * cap_size)%N (MachineWord.MachineWord.get_bit req.(Interface.WriteReq.tags) i) m in
+    let write_tag i m := NMap.add (base_addr + i * cap_size)%N (MachineWord.MachineWord.get_bit tags i) m in
     let new_tags :=
-      if Z.of_N nt >? 0 then N.recursion st.(state_tags) write_tag nt else NMap.add (mword_to_N (definitions.bv_and req.(Interface.WriteReq.address) (definitions.bv_opp (definitions.Z_to_bv _ (Z.of_N cap_size))))) false st.(state_tags)
+      if Z.of_N nt >? 0 then N.recursion st.(state_tags) write_tag nt else NMap.add (mword_to_N (definitions.bv_and req.(Interface.MemReq.address) (definitions.bv_opp (definitions.Z_to_bv _ (Z.of_N cap_size))))) false st.(state_tags)
     in
     {| state_memory := N.recursion st.(state_memory) write_byte n;
        state_tags := new_tags;
@@ -77,8 +79,10 @@ EOF
        state_output := st.(state_output)
     |}.
   
-  Definition read_mem (st : state) n nt (req : Interface.ReadReq.t n nt) : definitions.bv (8 * n) * definitions.bv nt :=
-    let base_addr := mword_to_N req.(Interface.ReadReq.address) in
+  Definition read_mem (st : state) (req : Interface.MemReq.t) : definitions.bv (8 * (Interface.MemReq.size req)) * definitions.bv (Interface.MemReq.num_tag req) :=
+    let n := req.(Interface.MemReq.size) in
+    let nt := req.(Interface.MemReq.num_tag) in
+    let base_addr := mword_to_N req.(Interface.MemReq.address) in
     let read_byte i v := definitions.bv_or (definitions.bv_shiftl (definitions.bv_zero_extend (8 * n) (opt_def (definitions.bv_0 8) (NMap.find (base_addr + i)%N st.(state_memory)))) (definitions.Z_to_bv (8 * n)%N (Z.of_N (8 * i)))) v in
     let cap_size := N.pow 2 Arch.cap_size_log in
     let read_tag i v := MachineWord.MachineWord.set_bit v i (opt_def false (NMap.find (base_addr + i * cap_size)%N st.(state_tags))) in
@@ -118,8 +122,8 @@ EOF
 EOF
   else
   cat <<EOF >> "$OUT"
-      | Interface.MemWrite n nt req => fun k => run (k (inl None)) (write_mem st n nt req)
-      | Interface.MemRead n nt req => fun k => run (k (inl (read_mem st n nt req))) st
+      | Interface.MemWrite req v tags => fun k => run (k (inl None)) (write_mem st req v tags)
+      | Interface.MemRead req => fun k => run (k (inl (read_mem st req))) st
       | Interface.TakeException _ => fun k => run (k tt) st
       | Interface.ReturnException => fun k => run (k tt) st
 EOF


### PR DESCRIPTION
The structs describing request for memory reads, writes, or address announcements are almost identical except for the payload of memory writes, so merge the structs and move the payload to parameters of `sail_mem_write`.