### PR TITLE
Rocq: drop register initialisers after generating model init function

### DIFF
--- a/src/lib/state.ml
+++ b/src/lib/state.ml
@@ -920,4 +920,11 @@ let add_register_init_function ctx env ast =
   let fundef = mk_fundef [funcl] in
   let val_spec = mk_val_spec (VS_val_spec (mk_typschm (mk_typquant []) (function_typ [unit_typ] unit_typ), id, None)) in
   let new_defs, env = Type_error.check_defs env [val_spec; fundef] in
+  let drop_init = function
+    | DEF_aux (DEF_register (DEC_aux (DEC_reg (typ, id, Some exp), an)), def_annot) ->
+        let def_annot = add_def_attribute def_annot.loc "initialized_elsewhere" None def_annot in
+        DEF_aux (DEF_register (DEC_aux (DEC_reg (typ, id, None), an)), def_annot)
+    | d -> d
+  in
+  let ast = { ast with defs = List.map drop_init ast.defs } in
   (append_ast_defs ast new_defs, ctx, env)

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5431,6 +5431,15 @@ and check_def : Env.t -> untyped_def -> typed_def list * Env.t =
   | DEF_instantiation (ispec, substs) -> check_outcome_instantiation env def_annot ispec substs
   | DEF_default default -> check_default env def_annot default
   | DEF_overload (id, ids) -> ([DEF_aux (DEF_overload (id, ids), def_annot)], Env.add_overloads def_annot.loc id ids env)
+  | DEF_register (DEC_aux (DEC_reg (typ, id, None), (l, uannot)))
+    when Option.is_some (get_def_attribute "initialized_elsewhere" def_annot) ->
+      let env = Env.add_register id typ env in
+      ( [
+          DEF_aux
+            (DEF_register (DEC_aux (DEC_reg (typ, id, None), (l, mk_expected_tannot env typ (Some typ)))), def_annot);
+        ],
+        env
+      )
   | DEF_register (DEC_aux (DEC_reg (typ, id, None), (l, uannot))) -> begin
       Env.wf_typ ~at:l env typ;
       match typ with


### PR DESCRIPTION
Prevents spurious dependency loops.  Will also be useful for other backends that use `State.add_register_init_function`.