### PR TITLE
Improve support for resugaring notation in pretty printer

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -88,6 +88,8 @@ let attribute_data_object = function AD_aux (AD_object kvs, _) -> Some kvs | _ -
 
 let attribute_data_bool = function AD_aux (AD_bool b, _) -> Some b | _ -> None
 
+let attribute_data_num = function AD_aux (AD_num n, _) -> Some n | _ -> None
+
 let attribute_data_string = function AD_aux (AD_string s, _) -> Some s | _ -> None
 
 let attribute_data_string_with_loc = function AD_aux (AD_string s, l) -> Some (s, l) | _ -> None

--- a/src/lib/ast_util.mli
+++ b/src/lib/ast_util.mli
@@ -78,6 +78,8 @@ val attribute_data_object : attribute_data -> (string * attribute_data) list opt
 
 val attribute_data_bool : attribute_data -> bool option
 
+val attribute_data_num : attribute_data -> Big_int.num option
+
 val attribute_data_string : attribute_data -> string option
 
 val attribute_data_string_with_loc : attribute_data -> (string * Parse_ast.l) option

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1375,120 +1375,146 @@ let rec is_config (P.E_aux (aux, _)) =
   | P.E_config root -> Some [root]
   | _ -> None
 
+let notation_attr l level strs =
+  let open P.Attribute_data in
+  let is_ascii_digit c =
+    let n = Char.code c in
+    48 <= n && n <= 57
+  in
+  let parts =
+    List.map
+      (fun str ->
+        if Util.string_for_all is_ascii_digit str then AD_aux (AD_num (Big_int.of_string str), l)
+        else AD_aux (AD_string str, l)
+      )
+      strs
+  in
+  add_attribute l "notation"
+    (Some
+       (AD_aux
+          (AD_object [("level", AD_aux (AD_num (Big_int.of_int level), l)); ("syntax", AD_aux (AD_list parts, l))], l)
+       )
+    )
+
 let rec to_ast_letbind ctx (P.LB_aux (lb, l) : P.letbind) : uannot letbind =
   LB_aux ((match lb with P.LB_val (pat, exp) -> LB_val (to_ast_pat ctx pat, to_ast_exp ctx exp)), (l, empty_uannot))
 
 and to_ast_exp ctx exp =
   let (P.E_aux (exp, l)) = parse_infix_exp ctx exp in
+  let wrap exp = E_aux (exp, (l, empty_uannot)) in
   match exp with
+  (* Will have just been removed by parse_infix_exp *)
+  | P.E_infix _ -> assert false
   | P.E_attribute (attr, arg, exp) ->
       let (E_aux (exp, (exp_l, annot))) = to_ast_exp ctx exp in
       (* The location of an E_attribute node is just the attribute itself *)
       let annot = add_attribute l attr arg annot in
       E_aux (exp, (exp_l, annot))
-  | _ ->
-      let aux =
-        match exp with
-        | P.E_attribute _ | P.E_infix _ -> assert false
-        | P.E_block exps -> (
-            match to_ast_fexps false ctx exps with
-            | Some fexps -> E_struct (SN_anon, fexps)
-            | None -> E_block (List.map (to_ast_exp ctx) exps)
-          )
-        | P.E_id id ->
-            (* We support identifiers the same as __LOC__, __FILE__ and
-               __LINE__ in the OCaml standard library, and similar
-               constructs in C *)
-            let id_str = string_of_parse_id id in
-            if id_str = "__LOC__" then E_lit (L_aux (L_string (Reporting.short_loc_to_string l), l))
-            else if id_str = "__FILE__" then (
-              let file = match Reporting.simp_loc l with Some (p, _) -> p.pos_fname | None -> "unknown file" in
-              E_lit (L_aux (L_string file, l))
-            )
-            else if id_str = "__LINE__" then (
-              let lnum = match Reporting.simp_loc l with Some (p, _) -> p.pos_lnum | None -> -1 in
-              E_lit (L_aux (L_num (Big_int.of_int lnum), l))
-            )
-            else E_id (to_ast_id ctx id)
-        | P.E_ref id -> E_ref (to_ast_id ctx id)
-        | P.E_lit lit -> E_lit (to_ast_lit lit)
-        | P.E_typ (typ, exp) -> E_typ (to_ast_typ ctx typ, to_ast_exp ctx exp)
-        | P.E_app (f, args) -> (
-            match List.map (to_ast_exp ctx) args with
-            | [] -> E_app (to_ast_id ctx f, [])
-            | exps -> E_app (to_ast_id ctx f, exps)
-          )
-        | P.E_app_infix (left, op, right) -> E_app (to_ast_id ctx op, [to_ast_exp ctx left; to_ast_exp ctx right])
-        | P.E_tuple exps -> E_tuple (List.map (to_ast_exp ctx) exps)
-        | P.E_if (e1, e2, e3, _) -> E_if (to_ast_exp ctx e1, to_ast_exp ctx e2, to_ast_exp ctx e3)
-        | P.E_for (id, e1, e2, e3, atyp, e4) ->
-            E_for
-              ( to_ast_id ctx id,
-                to_ast_exp ctx e1,
-                to_ast_exp ctx e2,
-                to_ast_exp ctx e3,
-                to_ast_order ctx atyp,
-                to_ast_exp ctx e4
-              )
-        | P.E_loop (P.While, m, e1, e2) -> E_loop (While, to_ast_measure ctx m, to_ast_exp ctx e1, to_ast_exp ctx e2)
-        | P.E_loop (P.Until, m, e1, e2) -> E_loop (Until, to_ast_measure ctx m, to_ast_exp ctx e1, to_ast_exp ctx e2)
-        | P.E_vector exps -> E_vector (List.map (to_ast_exp ctx) exps)
-        | P.E_vector_access (vexp, exp) -> vector_access ~loc:l (to_ast_exp ctx vexp) (to_ast_exp ctx exp)
-        | P.E_vector_subrange (vex, exp1, exp2) ->
-            vector_subrange ~loc:l (to_ast_exp ctx vex) (to_ast_exp ctx exp1) (to_ast_exp ctx exp2)
-        | P.E_vector_update (vex, exp1, exp2) ->
-            vector_update ~loc:l (to_ast_exp ctx vex) (to_ast_exp ctx exp1) (to_ast_exp ctx exp2)
-        | P.E_vector_update_subrange (vex, e1, e2, e3) ->
-            vector_update_subrange ~loc:l (to_ast_exp ctx vex) (to_ast_exp ctx e1) (to_ast_exp ctx e2)
-              (to_ast_exp ctx e3)
-        | P.E_vector_append (e1, e2) -> E_vector_append (to_ast_exp ctx e1, to_ast_exp ctx e2)
-        | P.E_list exps -> E_list (List.map (to_ast_exp ctx) exps)
-        | P.E_cons (e1, e2) -> E_cons (to_ast_exp ctx e1, to_ast_exp ctx e2)
-        | P.E_struct (struct_name, fexps) -> (
-            let struct_name = match struct_name with None -> SN_anon | Some id -> SN_id (to_ast_id ctx id) in
-            match to_ast_fexps true ctx fexps with
-            | Some fexps -> E_struct (struct_name, fexps)
-            | None -> raise (Reporting.err_unreachable l __POS__ "to_ast_fexps with true returned none")
-          )
-        | P.E_struct_update (exp, fexps) -> (
-            match to_ast_fexps true ctx fexps with
-            | Some fexps ->
-                check_duplicate_fields
-                  ~error:(fun f -> Printf.sprintf "Duplicate field '%s' in struct update" f)
-                  ~field_id:(fun (FE_aux (FE_fexp (id, _), _)) -> id)
-                  fexps;
-                E_struct_update (to_ast_exp ctx exp, fexps)
-            | _ -> raise (Reporting.err_unreachable l __POS__ "to_ast_fexps with true returned none")
-          )
-        | P.E_field (exp, field) -> (
-            match is_config exp with
-            | None -> E_field (to_ast_exp ctx exp, to_ast_id ctx field)
-            | Some key -> E_config (List.rev (string_of_parse_id field :: key))
-          )
-        | P.E_match (exp, pexps) -> E_match (to_ast_exp ctx exp, List.map (to_ast_case ctx) pexps)
-        | P.E_try (exp, pexps) -> E_try (to_ast_exp ctx exp, List.map (to_ast_case ctx) pexps)
-        | P.E_let (leb, exp) -> E_let (to_ast_letbind ctx leb, to_ast_exp ctx exp)
-        | P.E_assign (lexp, exp) -> E_assign (to_ast_lexp ctx lexp, to_ast_exp ctx exp)
-        | P.E_var (lexp, exp1, exp2) -> E_var (to_ast_lexp ctx lexp, to_ast_exp ctx exp1, to_ast_exp ctx exp2)
-        | P.E_sizeof nexp -> E_sizeof (to_ast_nexp ctx nexp)
-        | P.E_constraint nc -> E_constraint (to_ast_constraint ctx nc)
-        | P.E_exit exp -> E_exit (to_ast_exp ctx exp)
-        | P.E_throw exp -> E_throw (to_ast_exp ctx exp)
-        | P.E_config key -> E_config [key]
-        | P.E_return exp -> E_return (to_ast_exp ctx exp)
-        | P.E_assert (cond, msg) -> E_assert (to_ast_exp ctx cond, to_ast_exp ctx msg)
-        | P.E_internal_plet (pat, exp1, exp2) ->
-            if !opt_magic_hash then E_internal_plet (to_ast_pat ctx pat, to_ast_exp ctx exp1, to_ast_exp ctx exp2)
-            else raise (Reporting.err_general l "Internal plet construct found without -dmagic_hash")
-        | P.E_internal_return exp ->
-            if !opt_magic_hash then E_internal_return (to_ast_exp ctx exp)
-            else raise (Reporting.err_general l "Internal return construct found without -dmagic_hash")
-        | P.E_internal_assume (nc, exp) ->
-            if !opt_magic_hash then E_internal_assume (to_ast_constraint ctx nc, to_ast_exp ctx exp)
-            else raise (Reporting.err_general l "Internal assume construct found without -dmagic_hash")
-        | P.E_deref exp -> E_app (Id_aux (Id "__deref", l), [to_ast_exp ctx exp])
-      in
-      E_aux (aux, (l, empty_uannot))
+  | P.E_block exps -> (
+      match to_ast_fexps false ctx exps with
+      | Some fexps -> wrap (E_struct (SN_anon, fexps))
+      | None -> wrap (E_block (List.map (to_ast_exp ctx) exps))
+    )
+  | P.E_id id ->
+      (* We support identifiers the same as __LOC__, __FILE__ and __LINE__ in the OCaml standard
+        library, and similar constructs in C *)
+      let id_str = string_of_parse_id id in
+      if id_str = "__LOC__" then wrap (E_lit (L_aux (L_string (Reporting.short_loc_to_string l), l)))
+      else if id_str = "__FILE__" then (
+        let file = match Reporting.simp_loc l with Some (p, _) -> p.pos_fname | None -> "unknown file" in
+        wrap (E_lit (L_aux (L_string file, l)))
+      )
+      else if id_str = "__LINE__" then (
+        let lnum = match Reporting.simp_loc l with Some (p, _) -> p.pos_lnum | None -> -1 in
+        wrap (E_lit (L_aux (L_num (Big_int.of_int lnum), l)))
+      )
+      else wrap (E_id (to_ast_id ctx id))
+  | P.E_ref id -> wrap (E_ref (to_ast_id ctx id))
+  | P.E_lit lit -> wrap (E_lit (to_ast_lit lit))
+  | P.E_typ (typ, exp) -> wrap (E_typ (to_ast_typ ctx typ, to_ast_exp ctx exp))
+  | P.E_app (f, args) -> (
+      match List.map (to_ast_exp ctx) args with
+      | [] -> wrap (E_app (to_ast_id ctx f, []))
+      | exps -> wrap (E_app (to_ast_id ctx f, exps))
+    )
+  | P.E_app_infix (left, op, right) -> wrap (E_app (to_ast_id ctx op, [to_ast_exp ctx left; to_ast_exp ctx right]))
+  | P.E_tuple exps -> wrap (E_tuple (List.map (to_ast_exp ctx) exps))
+  | P.E_if (e1, e2, e3, _) -> wrap (E_if (to_ast_exp ctx e1, to_ast_exp ctx e2, to_ast_exp ctx e3))
+  | P.E_for (id, e1, e2, e3, atyp, e4) ->
+      wrap
+        (E_for
+           ( to_ast_id ctx id,
+             to_ast_exp ctx e1,
+             to_ast_exp ctx e2,
+             to_ast_exp ctx e3,
+             to_ast_order ctx atyp,
+             to_ast_exp ctx e4
+           )
+        )
+  | P.E_loop (P.While, m, e1, e2) -> wrap (E_loop (While, to_ast_measure ctx m, to_ast_exp ctx e1, to_ast_exp ctx e2))
+  | P.E_loop (P.Until, m, e1, e2) -> wrap (E_loop (Until, to_ast_measure ctx m, to_ast_exp ctx e1, to_ast_exp ctx e2))
+  | P.E_vector exps -> wrap (E_vector (List.map (to_ast_exp ctx) exps))
+  | P.E_vector_access (vexp, exp) ->
+      let attr = notation_attr l 0 ["10"; "["; "0"; "]"] empty_uannot in
+      E_aux (vector_access ~loc:l (to_ast_exp ctx vexp) (to_ast_exp ctx exp), (l, attr))
+  | P.E_vector_subrange (vex, exp1, exp2) ->
+      let attr = notation_attr l 0 ["10"; "["; "0"; " .. "; "0"; "]"] empty_uannot in
+      E_aux (vector_subrange ~loc:l (to_ast_exp ctx vex) (to_ast_exp ctx exp1) (to_ast_exp ctx exp2), (l, attr))
+  | P.E_vector_update (vex, exp1, exp2) ->
+      let attr = notation_attr l 0 ["["; "0"; " with "; "10"; " = "; "0"; "]"] empty_uannot in
+      E_aux (vector_update ~loc:l (to_ast_exp ctx vex) (to_ast_exp ctx exp1) (to_ast_exp ctx exp2), (l, attr))
+  | P.E_vector_update_subrange (vex, e1, e2, e3) ->
+      let attr = notation_attr l 0 ["["; "0"; " with "; "10"; " .. "; "10"; " = "; "0"; "]"] empty_uannot in
+      E_aux
+        ( vector_update_subrange ~loc:l (to_ast_exp ctx vex) (to_ast_exp ctx e1) (to_ast_exp ctx e2) (to_ast_exp ctx e3),
+          (l, attr)
+        )
+  | P.E_vector_append (e1, e2) -> wrap (E_vector_append (to_ast_exp ctx e1, to_ast_exp ctx e2))
+  | P.E_list exps -> wrap (E_list (List.map (to_ast_exp ctx) exps))
+  | P.E_cons (e1, e2) -> wrap (E_cons (to_ast_exp ctx e1, to_ast_exp ctx e2))
+  | P.E_struct (struct_name, fexps) -> (
+      let struct_name = match struct_name with None -> SN_anon | Some id -> SN_id (to_ast_id ctx id) in
+      match to_ast_fexps true ctx fexps with
+      | Some fexps -> wrap (E_struct (struct_name, fexps))
+      | None -> raise (Reporting.err_unreachable l __POS__ "to_ast_fexps with true returned none")
+    )
+  | P.E_struct_update (exp, fexps) -> (
+      match to_ast_fexps true ctx fexps with
+      | Some fexps ->
+          check_duplicate_fields
+            ~error:(fun f -> Printf.sprintf "Duplicate field '%s' in struct update" f)
+            ~field_id:(fun (FE_aux (FE_fexp (id, _), _)) -> id)
+            fexps;
+          wrap (E_struct_update (to_ast_exp ctx exp, fexps))
+      | _ -> raise (Reporting.err_unreachable l __POS__ "to_ast_fexps with true returned none")
+    )
+  | P.E_field (exp, field) -> (
+      match is_config exp with
+      | None -> wrap (E_field (to_ast_exp ctx exp, to_ast_id ctx field))
+      | Some key -> wrap (E_config (List.rev (string_of_parse_id field :: key)))
+    )
+  | P.E_match (exp, pexps) -> wrap (E_match (to_ast_exp ctx exp, List.map (to_ast_case ctx) pexps))
+  | P.E_try (exp, pexps) -> wrap (E_try (to_ast_exp ctx exp, List.map (to_ast_case ctx) pexps))
+  | P.E_let (leb, exp) -> wrap (E_let (to_ast_letbind ctx leb, to_ast_exp ctx exp))
+  | P.E_assign (lexp, exp) -> wrap (E_assign (to_ast_lexp ctx lexp, to_ast_exp ctx exp))
+  | P.E_var (lexp, exp1, exp2) -> wrap (E_var (to_ast_lexp ctx lexp, to_ast_exp ctx exp1, to_ast_exp ctx exp2))
+  | P.E_sizeof nexp -> wrap (E_sizeof (to_ast_nexp ctx nexp))
+  | P.E_constraint nc -> wrap (E_constraint (to_ast_constraint ctx nc))
+  | P.E_exit exp -> wrap (E_exit (to_ast_exp ctx exp))
+  | P.E_throw exp -> wrap (E_throw (to_ast_exp ctx exp))
+  | P.E_config key -> wrap (E_config [key])
+  | P.E_return exp -> wrap (E_return (to_ast_exp ctx exp))
+  | P.E_assert (cond, msg) -> wrap (E_assert (to_ast_exp ctx cond, to_ast_exp ctx msg))
+  | P.E_internal_plet (pat, exp1, exp2) ->
+      if !opt_magic_hash then wrap (E_internal_plet (to_ast_pat ctx pat, to_ast_exp ctx exp1, to_ast_exp ctx exp2))
+      else raise (Reporting.err_general l "Internal plet construct found without --dmagic-hash")
+  | P.E_internal_return exp ->
+      if !opt_magic_hash then wrap (E_internal_return (to_ast_exp ctx exp))
+      else raise (Reporting.err_general l "Internal return construct found without --dmagic-hash")
+  | P.E_internal_assume (nc, exp) ->
+      if !opt_magic_hash then wrap (E_internal_assume (to_ast_constraint ctx nc, to_ast_exp ctx exp))
+      else raise (Reporting.err_general l "Internal assume construct found without --dmagic-hash")
+  | P.E_deref exp -> wrap (E_app (Id_aux (Id "__deref", l), [to_ast_exp ctx exp]))
 
 and to_ast_measure ctx (P.Measure_aux (m, l)) : uannot internal_loop_measure =
   let m =

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -389,17 +389,52 @@ module Printer (Config : PRINT_CONFIG) = struct
     | P_aux (P_id _, _), E_aux (E_typ (typ, exp), annot) when Config.resugar -> (P_aux (P_typ (typ, pat), annot), exp)
     | _, _ -> (pat, binding)
 
-  type uannot_fmt = { overloaded : (string * bool) option; is_setter : bool; doc : document }
+  type 'a notation_part = Hole of int * 'a | Part of document
+
+  let parse_notation_attr (_, attr_data_opt) =
+    let open Util.Option_monad in
+    let open Parse_ast.Attribute_data in
+    let* attr_data = attr_data_opt in
+    let* obj = attribute_data_object attr_data in
+    let* level = Option.bind (List.assoc_opt "level" obj) attribute_data_num in
+    let* parts = Option.bind (List.assoc_opt "syntax" obj) attribute_data_list in
+    let parse_part = function
+      | AD_aux (AD_num n, _) -> Some (Hole (Big_int.to_int n, ()))
+      | AD_aux (AD_string str, _) -> Some (Part (separate_map space string (String.split_on_char ' ' str)))
+      | _ -> None
+    in
+    let* parts = Util.option_all (List.map parse_part parts) in
+    Some (Big_int.to_int level, parts)
+
+  let attach_to_holes exps parts =
+    let append p = function Some ps -> Some (ps @ [p]) | None -> None in
+    List.fold_left
+      (fun (exps, result) part ->
+        match part with
+        | Part d -> (exps, append (Part d) result)
+        | Hole (n, _) -> (
+            match exps with [] -> ([], None) | e :: es -> (es, append (Hole (n, e)) result)
+          )
+      )
+      (exps, Some []) parts
+    |> snd
+
+  type uannot_fmt = {
+    overloaded : (string * bool) option;
+    is_setter : bool;
+    doc : document -> document;
+    notation : (int * unit notation_part list) option;
+  }
 
   (* This function consumes the uannot attached to an expression and
      renders its printable form. To prevent bugs, this function
      should always be used to shadow the consumed expression. *)
-  let consume_exp_uannot (E_aux (aux, (l, uannot))) =
+  let consume_exp_uannot ~atomic (E_aux (aux, (l, uannot))) =
     let uannot, overloaded =
       if Config.resugar then (
         match get_overloaded_info uannot with
         | Some overloaded -> (remove_attribute "overloaded" uannot, Some overloaded)
-        | _ -> (uannot, None)
+        | None -> (uannot, None)
       )
       else (uannot, None)
     in
@@ -407,19 +442,33 @@ module Printer (Config : PRINT_CONFIG) = struct
       if Config.resugar && Option.is_some (get_attribute "setter" uannot) then (remove_attribute "setter" uannot, true)
       else (uannot, false)
     in
+    let uannot, notation =
+      if Config.resugar then (
+        match get_attribute "notation" uannot with
+        | Some notation -> (remove_attribute "notation" uannot, parse_notation_attr notation)
+        | None -> (uannot, None)
+      )
+      else (uannot, None)
+    in
     let doc =
-      if Config.hide_attributes then empty
-      else concat_map (fun (_, attr, arg) -> doc_attr attr arg) (get_attributes uannot)
+      if Config.hide_attributes then fun d -> d
+      else (
+        match get_attributes uannot with
+        | [] -> fun d -> d
+        | attrs ->
+            let attrs_doc = concat_map (fun (_, attr, arg) -> doc_attr attr arg) (get_attributes uannot) in
+            fun d -> if atomic then parens (attrs_doc ^^ d) else attrs_doc ^^ d
+      )
     in
     (* Once we've extracted all the printing information from a
        uannot, we want to make sure we never print it again, so return
        the expression with a stripped uannot. *)
-    (E_aux (aux, (l, empty_uannot)), { overloaded; is_setter; doc })
+    (E_aux (aux, (l, empty_uannot)), { overloaded; is_setter; doc; notation })
 
   let rec doc_exp exp =
-    let (E_aux (e_aux, (l, _)) as exp), uannot_fmt = consume_exp_uannot exp in
+    let (E_aux (e_aux, (l, _)) as exp), uannot_fmt = consume_exp_uannot ~atomic:false exp in
     uannot_fmt.doc
-    ^^
+    @@
     match e_aux with
     | E_block [] -> string "()"
     | E_block exps -> group (lbrace ^^ nest 4 (hardline ^^ doc_block exps) ^^ hardline ^^ rbrace)
@@ -514,30 +563,24 @@ module Printer (Config : PRINT_CONFIG) = struct
           )
           else Lazy.force otherwise
         in
-        match (uannot_fmt.overloaded, exps) with
-        | Some (name, true), [x; y] -> doc_exp (E_aux (E_app (mk_operator name, [x; y]), (l, empty_uannot)))
-        | Some (name, false), _ ->
-            handle_setter (mk_id name) (lazy (doc_exp (E_aux (E_app (mk_id name, exps), (l, empty_uannot)))))
-        | None, [x; y]
-          when Config.resugar && match id with Id_aux ((Operator _ | And_bool | Or_bool), _) -> true | _ -> false ->
-            doc_infix 0 exp
-        | None, [v; n]
-          when Config.resugar
-               && (Id.compare id (mk_id "vector_access") = 0 || Id.compare id (mk_id "vector_access#") == 0) ->
-            doc_atomic_exp v ^^ char '[' ^^ doc_exp n ^^ char ']'
-        | None, [v; n; m]
-          when Config.resugar
-               && (Id.compare id (mk_id "vector_subrange") = 0 || Id.compare id (mk_id "vector_subrange#") == 0) ->
-            doc_atomic_exp v ^^ char '[' ^^ doc_exp n ^^ space ^^ string ".." ^^ space ^^ doc_exp m ^^ char ']'
-        | None, _
-          when (Config.resugar && Id.compare id (mk_id "vector_update#") = 0)
-               || Id.compare id (mk_id "vector_update_subrange#") == 0 ->
-            let input, updates = get_vector_updates exp in
-            let updates_doc = separate_map (comma ^^ space) doc_vector_update updates in
-            brackets (separate space [doc_exp input; string "with"; updates_doc])
-        | _, _ -> handle_setter id (lazy (doc_atomic_exp exp))
+        match uannot_fmt.notation with
+        | Some (level, parts) -> (
+            match attach_to_holes exps parts with Some parts -> concat_map doc_part parts | None -> doc_atomic_exp exp
+          )
+        | None -> (
+            match (uannot_fmt.overloaded, exps) with
+            | Some (name, true), [x; y] -> doc_exp (E_aux (E_app (mk_operator name, [x; y]), (l, empty_uannot)))
+            | Some (name, false), _ ->
+                handle_setter (mk_id name) (lazy (doc_exp (E_aux (E_app (mk_id name, exps), (l, empty_uannot)))))
+            | None, [x; y]
+              when Config.resugar && match id with Id_aux ((Operator _ | And_bool | Or_bool), _) -> true | _ -> false ->
+                doc_infix 0 exp
+            | _, _ -> handle_setter id (lazy (doc_atomic_exp exp))
+          )
       end
     | _ -> doc_atomic_exp exp
+
+  and doc_part = function Part d -> d | Hole (0, exp) -> doc_exp exp | Hole (n, exp) -> doc_infix n exp
 
   and doc_let_style keyword lhs rhs body = doc_let_style_general keyword lhs (Some rhs) body
 
@@ -554,9 +597,9 @@ module Printer (Config : PRINT_CONFIG) = struct
     match m_aux with Measure_none -> [] | Measure_some exp -> [string "termination_measure"; braces (doc_exp exp)]
 
   and doc_infix n exp =
-    let (E_aux (e_aux, (l, _)) as exp), uannot_fmt = consume_exp_uannot exp in
+    let (E_aux (e_aux, (l, _)) as exp), uannot_fmt = consume_exp_uannot ~atomic:false exp in
     uannot_fmt.doc
-    ^^
+    @@
     match e_aux with
     | E_app (id, exps) when Option.is_some uannot_fmt.overloaded ->
         let name, is_infix = Option.get uannot_fmt.overloaded in
@@ -575,6 +618,9 @@ module Printer (Config : PRINT_CONFIG) = struct
     | _ -> doc_atomic_exp exp
 
   and doc_atomic_exp (E_aux (e_aux, (_, uannot)) as exp) =
+    let (E_aux (e_aux, (l, _)) as exp), uannot_fmt = consume_exp_uannot ~atomic:true exp in
+    uannot_fmt.doc
+    @@
     match e_aux with
     | E_typ (typ, exp) -> separate space [doc_atomic_exp exp; colon; doc_typ typ]
     | E_lit lit -> doc_lit lit
@@ -586,17 +632,18 @@ module Printer (Config : PRINT_CONFIG) = struct
     | E_sizeof nexp -> string "sizeof" ^^ parens (doc_nexp nexp)
     (* Format a function with a unit argument as f() rather than f(()) *)
     | E_app (id, [E_aux (E_lit (L_aux (L_unit, _)), _)]) -> doc_id id ^^ string "()"
-    | E_app (id, [v; n])
-      when Config.resugar && (Id.compare id (mk_id "vector_access") = 0 || Id.compare id (mk_id "vector_access#") == 0)
-      ->
-        doc_atomic_exp v ^^ char '[' ^^ doc_exp n ^^ char ']'
-    | E_app (id, [v; n; m])
-      when Config.resugar
-           && (Id.compare id (mk_id "vector_subrange") = 0 || Id.compare id (mk_id "vector_subrange#") == 0) ->
-        doc_atomic_exp v ^^ char '[' ^^ doc_exp n ^^ space ^^ string ".." ^^ space ^^ doc_exp m ^^ char ']'
-    | E_app ((Id_aux (Id _, _) as id), exps) -> doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps)
-    | E_app (id, exps) when not Config.resugar -> doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps)
-    | E_app (id, exps) when List.length exps != 2 -> doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps)
+    | E_app (id, exps) -> (
+        let as_function () = doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps) in
+        match uannot_fmt.notation with
+        | Some (level, parts) -> (
+            match attach_to_holes exps parts with
+            | Some parts ->
+                let doc = concat_map doc_part parts in
+                if level >= 10 then doc else parens doc
+            | None -> as_function ()
+          )
+        | None -> as_function ()
+      )
     | E_constraint nc -> string "constraint" ^^ parens (doc_nc nc)
     | E_assert (exp1, E_aux (E_lit (L_aux (L_string "", _)), _)) -> string "assert" ^^ parens (doc_exp exp1)
     | E_assert (exp1, exp2) -> string "assert" ^^ parens (doc_exp exp1 ^^ comma ^^ space ^^ doc_exp exp2)

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -3776,7 +3776,7 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
     )
   | E_app (Id_aux (Id "vector_subrange#", _), [v; n; m]) ->
       infer_exp env (E_aux (E_app (mk_id "vector_subrange", [v; n; m]), (l, uannot)))
-  | E_app (Id_aux (Id "vector_update#", _), [v; n; exp]) -> infer_vector_update l env v n exp
+  | E_app (Id_aux (Id "vector_update#", _), [v; n; exp]) -> infer_vector_update env v n exp l uannot
   | E_app (Id_aux (Id "vector_update_subrange#", _), [v; n; m; exp]) ->
       infer_exp env (E_aux (E_app (mk_id "vector_update_subrange", [v; n; m; exp]), (l, uannot)))
   | E_app (f, xs) -> infer_funapp l env f xs uannot None
@@ -3965,22 +3965,23 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
 
 and infer_funapp l env f xs uannot ret_ctx_typ = infer_funapp' l env f (Env.get_val_spec f env) xs uannot ret_ctx_typ
 
-and infer_vector_update l env v n exp =
+and infer_vector_update env v n exp l uannot =
   let rec nested_updates acc = function
-    | E_aux (E_app (Id_aux (Id "vector_update#", _), [v; n; exp]), (l, _)) -> nested_updates ((n, exp, l) :: acc) v
+    | E_aux (E_app (Id_aux (Id "vector_update#", _), [v; n; exp]), (l, uannot)) ->
+        nested_updates ((n, exp, l, uannot) :: acc) v
     | v -> (v, List.rev acc)
   in
-  let v, updates = nested_updates [(n, exp, l)] v in
+  let v, updates = nested_updates [(n, exp, l, uannot)] v in
   let inferred_v = infer_exp env v in
   match typ_of inferred_v with
   | Typ_aux (Typ_id id, _) when Env.is_bitfield id env ->
       let update_exp =
         List.fold_left
-          (fun v (field, exp, l) ->
+          (fun v (field, exp, l, uannot) ->
             match field with
             | E_aux (E_id field_id, (field_id_loc, _)) ->
                 let (Id_aux (update_name, _)) = (Bitfield.field_accessor_ids id field_id).update in
-                mk_exp ~loc:l (E_app (Id_aux (update_name, field_id_loc), [v; exp]))
+                E_aux (E_app (Id_aux (update_name, field_id_loc), [v; exp]), (l, uannot))
             | _ -> typ_error l "Vector update could not be interpreted as a bitfield update"
           )
           v (List.rev updates)
@@ -3989,7 +3990,7 @@ and infer_vector_update l env v n exp =
   | _ ->
       let update_exp =
         List.fold_left
-          (fun v (n, exp, l) -> mk_exp ~loc:l (E_app (mk_id "vector_update", [v; n; exp])))
+          (fun v (n, exp, l, uannot) -> E_aux (E_app (mk_id "vector_update", [v; n; exp]), (l, uannot)))
           v (List.rev updates)
       in
       infer_exp env update_exp

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -493,6 +493,11 @@ let levenshtein_distance ?(osa = false) str1 str2 =
 
   dist.(String.length str1).(String.length str2)
 
+let string_for_all p str =
+  let acc = ref true in
+  String.iter (fun c -> acc := !acc && p c) str;
+  !acc
+
 let termcode n = if !opt_colors then "\x1B[" ^ string_of_int n ^ "m" else ""
 
 let bold str = termcode 1 ^ str

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -215,6 +215,9 @@ val remove_suffix : string -> string -> string option
     the optimal string alignment distance, which is similar but allows swaps as a single action. *)
 val levenshtein_distance : ?osa:bool -> string -> string -> int
 
+(** Check if all characters in a string satisfy a predicate. String.for_all for OCaml < 4.13. *)
+val string_for_all : (char -> bool) -> string -> bool
+
 (** {2 Files} *)
 
 (** [copy_file src dst] copies file [src] to file [dst]. Only files are supported, no directories. *)


### PR DESCRIPTION
Rather than resugaring vector notation in an ad-hoc way, this commit introduces a `$[notation ...]` attribute which can be attached to any function application node.

```
$[notation { level = 0, syntax = [10, "[", 0, " .. ", 0, "]"] }]
f(<expX>, <expY>, <expZ>)

// will be printed as

<expX>[<expY> .. <expZ>]
```

The first level key indicates the precedence level where the construct can appear unbracketed, and the precedences in between the tokens in the syntax key indicated the precedence of the pretty printer as it starts printing those subexpressions.

This attribute is used internally during desugaring and probably shouldn't be used outside of that.