### PR TITLE
Rocq: Fix interface type definition ordering

### DIFF
--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -702,7 +702,10 @@ let partition_instantiation_definitions include_types defs =
     |> List.concat |> NS.of_list
   in
   let g = G.prune roots NS.empty g in
-  List.partition (fun def -> NS.exists (fun n -> NodeMap.mem n g) (nodes_of_def def)) defs
+  let not_type = function DEF_aux (DEF_type _, _) -> false | _ -> true in
+  List.partition
+    (fun def -> (include_types || not_type def) && NS.exists (fun n -> NodeMap.mem n g) (nodes_of_def def))
+    defs
 
 module FCG = Graph.Make (Id)
 


### PR DESCRIPTION
We didn't notice this earlier because type definitions are often expanded.