### PR TITLE
Add a convenience function to load a sail_project from the OCaml REPL

### DIFF
--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -48,7 +48,7 @@ open Ast
 open Ast_util
 open Ast_defs
 
-module StringMap = Map.Make (String)
+module StringMap = Util.StringMap
 
 let opt_ddump_initial_ast = ref false
 let opt_ddump_side_effect = ref false
@@ -404,6 +404,49 @@ let load_files ?target default_sail_dir options env files =
   Profile.finish "type checking" t;
 
   finalize_ast asserts_termination ctx env (concat_ast checked)
+
+let file_to_string filename =
+  let chan = open_in filename in
+  let buf = Buffer.create 4096 in
+  try
+    let rec loop () =
+      let line = input_line chan in
+      Buffer.add_string buf line;
+      Buffer.add_char buf '\n';
+      loop ()
+    in
+    loop ()
+  with End_of_file ->
+    close_in chan;
+    Buffer.contents buf
+
+let load_project ?target ?modules ?(options = []) ?(variables = []) default_sail_dir project_files =
+  let defs =
+    List.map
+      (fun project_file ->
+        let root_directory = Filename.dirname project_file in
+        let contents = file_to_string project_file in
+        Project.mk_root root_directory :: Initial_check.parse_project ~filename:project_file ~contents ()
+      )
+      project_files
+    |> List.concat
+  in
+  let variables = ref (StringMap.of_seq @@ List.to_seq @@ variables) in
+  let proj = Project.initialize_project_structure ~variables defs in
+  let mod_ids =
+    match modules with
+    | None -> Project.all_modules proj
+    | Some modules ->
+        List.map
+          (fun mod_name ->
+            match Project.get_module_id proj mod_name with
+            | Some id -> id
+            | None -> raise (Reporting.err_general Parse_ast.Unknown ("Unknown module " ^ mod_name))
+          )
+          modules
+  in
+  let env = Type_check.initial_env_with_modules proj in
+  load_modules ?target default_sail_dir options env proj mod_ids
 
 let rewrite_ast_initial effect_info env =
   Rewrites.rewrite Initial_check.initial_ctx effect_info env

--- a/src/lib/frontend.mli
+++ b/src/lib/frontend.mli
@@ -136,6 +136,18 @@ val load_files :
   string list ->
   Initial_check.ctx * Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info
 
+(** Load a list of sail_project files.
+
+    Must also be provided with a default location to use as SAIL_DIR if the environment variable is unset. *)
+val load_project :
+  ?target:Target.target ->
+  ?modules:string list ->
+  ?options:(Arg.key * Arg.spec * Arg.doc) list ->
+  ?variables:(string * Project.value) list ->
+  string ->
+  string list ->
+  Initial_check.ctx * Type_check.typed_ast * Type_check.Env.t * Effects.side_effect_info
+
 val finalize_ast :
   bool ->
   Initial_check.ctx ->

--- a/src/lib/preprocess.ml
+++ b/src/lib/preprocess.ml
@@ -210,7 +210,8 @@ let preprocess dir target opts =
             Arg.parse_argv ~current (Array.of_list ("sail" :: args)) opts file_arg ""
           with
           | Arg.Help msg -> raise (Reporting.err_general l "-help flag passed to $option directive")
-          | Arg.Bad msg -> raise (Reporting.err_general l ("Invalid flag passed to $option directive" ^ first_line msg))
+          | Arg.Bad msg ->
+              Reporting.warn "Invalid option" l ("Invalid flag passed to $option directive" ^ first_line msg)
         end;
         reset ();
         aux includes (opt_pragma :: acc) defs

--- a/test/lexing/bad_option_pragma2.expect
+++ b/test/lexing/bad_option_pragma2.expect
@@ -1,6 +1,12 @@
-[93mError[0m:
-[96mbad_option_pragma2.sail[0m:2.0-24:
+[93mWarning[0m: Invalid option [96mbad_option_pragma2.sail[0m:2.0-24:
 2[96m |[0m$option -not_a_sail_flag
  [91m |[0m[91m^----------------------^[0m
- [91m |[0m Invalid flag passed to $option directive
- [91m |[0m sail: unknown option '-not_a_sail_flag'.
+ [91m |[0m 
+Invalid flag passed to $option directive
+sail: unknown option '-not_a_sail_flag'.
+
+[93mError[0m:
+[96mbad_option_pragma2.sail[0m:5.0-13:
+5[96m |[0m$ifdef SYMBOL
+ [91m |[0m[91m^-----------^[0m
+ [91m |[0m $ifdef, $ifndef, or $iftarget never ended by $endif

--- a/test/lexing/bad_option_pragma2.sail
+++ b/test/lexing/bad_option_pragma2.sail
@@ -1,2 +1,5 @@
 
 $option -not_a_sail_flag
+
+// An unknown flag is now a warning, but we can do something really bad to test that we still get a warning
+$ifdef SYMBOL


### PR DESCRIPTION
Realised it wasn't easy to get a handle on a complete Sail AST from a `.sail_project` file in the OCaml REPL. With this it's as simple as running `dune utop --release` from the Sail directory and then (assuming sail-riscv is checked out next to Sail).

```
open Libsail;;
let ctx, ast, env, effect_info = Frontend.load_project "." ["../sail-riscv/model/riscv.sail_project"];;
```