### PR TITLE
Check type synonym well-formedness earlier

### DIFF
--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5025,7 +5025,12 @@ let rec check_typedef : Env.t -> env def_annot -> uannot type_def -> typed_def l
       begin
         match typ_arg with
         | A_aux (A_typ typ, a_l) -> forbid_recursive_types l (fun () -> wf_binding a_l env (typq, typ))
-        | _ -> ()
+        | A_aux (A_nexp nexp, a_l) ->
+            let env = Env.add_typquant l typq env in
+            Env.wf_nexp ~at:a_l env nexp
+        | A_aux (A_bool nc, a_l) ->
+            let env = Env.add_typquant l typq env in
+            Env.wf_constraint ~at:a_l env nc
       end;
       ([DEF_aux (DEF_type (TD_aux (tdef, (l, empty_tannot))), def_annot)], Env.add_typ_synonym id typq typ_arg env)
   | TD_abstract (id, kind, _) -> begin

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1060,6 +1060,18 @@ let wf_typ_arg ~at:at_l env (A_aux (_, l) as arg) =
     let extra, l = match l with Parse_ast.Unknown -> (" here", at_l) | _ -> ("", l) in
     typ_raise l (err_because (Err_other ("Well-formedness check failed for type argument" ^ extra), err_l, err))
 
+let wf_nexp ~at:at_l env (Nexp_aux (_, l) as nexp) =
+  Well_formedness.wf_debug "nexp" string_of_nexp nexp Well_formedness.no_existential;
+  incr depth;
+  try
+    Well_formedness.wf_nexp Well_formedness.no_existential env nexp;
+    decr depth
+  with Type_error (err_l, err) ->
+    decr depth;
+    let extra, l = match l with Parse_ast.Unknown -> (" here", at_l) | _ -> ("", l) in
+    typ_raise l
+      (err_because (Err_other ("Well-formedness check failed for numeric type expression" ^ extra), err_l, err))
+
 let wf_constraint ~at:at_l env (NC_aux (_, l) as nc) =
   Well_formedness.wf_debug "constraint" string_of_n_constraint nc Well_formedness.no_existential;
   incr depth;

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -258,6 +258,7 @@ val is_toplevel : t -> l option
 (* Well formedness-checks *)
 val wf_typ : at:l -> t -> typ -> unit
 val wf_typ_arg : at:l -> t -> typ_arg -> unit
+val wf_nexp : at:l -> t -> nexp -> unit
 val wf_constraint : at:l -> t -> n_constraint -> unit
 
 (** Some of the code in the environment needs to use the smt solver, which is defined below. To break the circularity

--- a/test/typecheck/fail/top_not_wf_constraint_syn.expect
+++ b/test/typecheck/fail/top_not_wf_constraint_syn.expect
@@ -1,0 +1,10 @@
+[93mType error[0m:
+[96mfail/top_not_wf_constraint_syn.sail[0m:4.20-22:
+4[96m |[0mtype tyvar : Bool = 'v
+ [91m |[0m                    [91m^^[0m
+ [91m |[0m Well-formedness check failed for constraint
+ [91m |[0m 
+ [91m |[0m [93mCaused by [0m[96mfail/top_not_wf_constraint_syn.sail[0m:4.20-22:
+ [91m |[0m 4[96m |[0mtype tyvar : Bool = 'v
+ [91m |[0m  [91m |[0m                    [91m^^[0m
+ [91m |[0m  [91m |[0m No type variable 'v

--- a/test/typecheck/fail/top_not_wf_constraint_syn.sail
+++ b/test/typecheck/fail/top_not_wf_constraint_syn.sail
@@ -1,0 +1,4 @@
+default Order dec
+
+let v = true
+type tyvar : Bool = 'v

--- a/test/typecheck/fail/top_not_wf_nexp_syn.expect
+++ b/test/typecheck/fail/top_not_wf_nexp_syn.expect
@@ -1,0 +1,10 @@
+[93mType error[0m:
+[96mfail/top_not_wf_nexp_syn.sail[0m:4.19-21:
+4[96m |[0mtype tyvar : Nat = 'v
+ [91m |[0m                   [91m^^[0m
+ [91m |[0m Well-formedness check failed for numeric type expression
+ [91m |[0m 
+ [91m |[0m [93mCaused by [0m[96mfail/top_not_wf_nexp_syn.sail[0m:4.19-21:
+ [91m |[0m 4[96m |[0mtype tyvar : Nat = 'v
+ [91m |[0m  [91m |[0m                   [91m^^[0m
+ [91m |[0m  [91m |[0m No type variable 'v

--- a/test/typecheck/fail/top_not_wf_nexp_syn.sail
+++ b/test/typecheck/fail/top_not_wf_nexp_syn.sail
@@ -1,0 +1,4 @@
+default Order dec
+
+let v = 3
+type tyvar : Nat = 'v


### PR DESCRIPTION
For numeric and constraint synonyms, well-formedness wasn't being checked immediately upon definition.