### PR TITLE
Improve vector subrange errors

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -596,7 +596,33 @@ let run_sail_format (config : Yojson.Safe.t option) =
       | None -> Format_sail.default_config
   end in
   let module Formatter = Format_sail.Make (Config) in
-  let parsed_files = List.map (fun f -> (f, Initial_check.parse_file f)) !opt_free_arguments in
+  let project_files, files =
+    List.partition (fun free -> Filename.check_suffix free ".sail_project") !opt_free_arguments
+  in
+
+  (* Get all the files references by project files *)
+  let referenced_files =
+    List.map
+      (fun project_file ->
+        let root_directory = Filename.dirname project_file in
+        let contents = file_to_string project_file in
+        let defs = Project.mk_root root_directory :: Initial_check.parse_project ~filename:project_file ~contents () in
+
+        let variables = ref Util.StringMap.empty in
+        List.iter
+          (fun assignment ->
+            if not (Project.parse_assignment ~variables assignment) then
+              raise (Reporting.err_general Parse_ast.Unknown ("Could not parse assignment " ^ assignment))
+          )
+          !opt_variable_assignments;
+        let proj = Project.initialize_project_structure ~variables defs in
+        Project.all_files proj
+      )
+      project_files
+    |> List.concat |> List.map fst
+  in
+
+  let parsed_files = List.map (fun f -> (f, Initial_check.parse_file f)) (files @ referenced_files) in
   List.iter
     (fun (f, (comments, parse_ast)) ->
       let source = file_to_string f in

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -453,13 +453,17 @@ module Make (Config : CONFIG) = struct
     | Delim s -> string s ^^ space
     | Opt_delim s -> opt_delim s
     | String_literal s -> utf8string ("\"" ^ String.escaped s ^ "\"")
-    | App (id, args) ->
-        doc_id id
-        ^^ group
-             (surround indent 0 (char '(')
-                (separate_map softline (doc_chunks (opts |> nonatomic |> expression_like)) args)
-                (char ')')
-             )
+    | App (id, args) -> (
+        match args with
+        | [] -> doc_id id ^^ string "()"
+        | _ ->
+            doc_id id
+            ^^ group
+                 (surround indent 0 (char '(')
+                    (separate_map softline (doc_chunks (opts |> nonatomic |> expression_like)) args)
+                    (char ')')
+                 )
+      )
     | Tuple (l, r, spacing, args) ->
         let group_fn = if ungroup_tuple then fun x -> x else group in
         group_fn

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1753,32 +1753,41 @@ let same_bindings ~at:l ~env ~left_env ~right_env lhs rhs =
         ("Identifier " ^ string_of_id id ^ " found on right hand side of mapping, but not on left")
   | None -> ()
 
-let bitvector_typ_from_range l env n m =
+let bitvector_typ_from_vector_subrange l env n m =
   let len =
-    match Env.get_default_order env with
+    let order = Env.get_default_order env in
+    match order with
     | Ord_aux (Ord_dec, _) ->
         if Big_int.greater_equal n m then Big_int.sub (Big_int.succ n) m
-        else
-          typ_error l
+        else typ_raise l (Err_vector_subrange { n; m; order })
+    (*
             (Printf.sprintf "First index %s must be greater than or equal to second index %s (when default Order dec)"
                (Big_int.to_string n) (Big_int.to_string m)
             )
+*)
     | Ord_aux (Ord_inc, _) ->
         if Big_int.less_equal n m then Big_int.sub (Big_int.succ m) n
-        else
-          typ_error l
+        else typ_raise l (Err_vector_subrange { n; m; order })
+    (*
             (Printf.sprintf "First index %s must be less than or equal to second index %s (when default Order inc)"
                (Big_int.to_string n) (Big_int.to_string m)
             )
+*)
   in
   bitvector_typ (nconstant len)
 
-let bind_pattern_vector_subranges (P_aux (_, (l, _)) as pat) env =
+let each_pattern_vector_subranges f (P_aux (_, (l, _)) as pat) acc =
   let id_ranges = pattern_vector_subranges pat in
   Bindings.fold
-    (fun id ranges env ->
+    (fun id ranges acc ->
       match ranges with
-      | [(n, m)] -> Env.add_local id (Immutable, bitvector_typ_from_range l env n m) env
+      | [(n, m)] ->
+          if Big_int.equal m Big_int.zero then f l id n m acc
+          else
+            typ_error l
+              (Printf.sprintf "Cannot bind %s as pattern subranges do not start at bit 0 (lowest bit is %s)."
+                 (string_of_id id) (Big_int.to_string m)
+              )
       | _ :: (m, _) :: _ ->
           typ_error l
             (Printf.sprintf "Cannot bind %s as pattern subranges are non-contiguous. %s[%s] is not defined."
@@ -1787,7 +1796,14 @@ let bind_pattern_vector_subranges (P_aux (_, (l, _)) as pat) env =
             )
       | _ -> Reporting.unreachable l __POS__ "Found range pattern with no range"
     )
-    id_ranges env
+    id_ranges acc
+
+let bind_pattern_vector_subranges pat env =
+  each_pattern_vector_subranges
+    (fun l id n m -> Env.add_local id (Immutable, bitvector_typ (nconstant (Big_int.sub (Big_int.succ n) m))))
+    pat env
+
+let check_pattern_vector_subranges pat env = each_pattern_vector_subranges (fun _ _ _ _ () -> ()) pat ()
 
 let unbound_id_error ~at:l env v =
   match Bindings.find_opt v (Env.get_val_specs env) with
@@ -3071,7 +3087,7 @@ and infer_pat env (P_aux (pat_aux, (l, uannot)) as pat) =
       (annot_pat (P_vector pats) (bitvector_typ len), env, guards)
   | P_vector_concat (pat :: pats) -> bind_vector_concat_pat l env uannot pat pats None
   | P_vector_subrange (id, n, m) ->
-      let typ = bitvector_typ_from_range l env n m in
+      let typ = bitvector_typ_from_vector_subrange l env n m in
       (annot_pat (P_vector_subrange (id, n, m)) typ, env, [])
   | P_string_append pats ->
       let fold_pats (pats, env, guards) pat =
@@ -3115,7 +3131,13 @@ and bind_vector_concat_generic :
     let wrap_ok (x, y, z) = (VC_elem_ok x, y, z) in
     let inferred_pat, env, guards' =
       if Option.is_none typ_opt then wrap_ok (funcs.infer env pat)
-      else (try wrap_ok (funcs.infer env pat) with Type_error _ as exn -> (VC_elem_error (pat, exn), env, []))
+      else (
+        try wrap_ok (funcs.infer env pat) with
+        (* A vector subrange error means the whole vector concat is
+             certainly broken, so error out immediately. *)
+        | Type_error (_, Err_vector_subrange _) as exn -> raise exn
+        | Type_error _ as exn -> (VC_elem_error (pat, exn), env, [])
+      )
     in
     (inferred_pat :: pats, env, guards' @ guards)
   in
@@ -4632,9 +4654,11 @@ let check_mapcl env (MCL_aux (cl, (def_annot, _))) typ =
       | MCL_bidir (left_mpexp, right_mpexp) -> begin
           let left_mpat, _, _ = destruct_mpexp left_mpexp in
           let left_dups = check_pattern_duplicates env (pat_of_mpat left_mpat) in
+          check_pattern_vector_subranges (pat_of_mpat left_mpat) env;
           let left_env = find_types env left_mpat typ1 in
           let right_mpat, _, _ = destruct_mpexp right_mpexp in
           let right_dups = check_pattern_duplicates env (pat_of_mpat right_mpat) in
+          check_pattern_vector_subranges (pat_of_mpat right_mpat) env;
           let right_env = find_types env right_mpat typ2 in
           same_bindings ~at:def_annot.loc ~env ~left_env ~right_env left_dups right_dups;
 

--- a/src/lib/type_error.ml
+++ b/src/lib/type_error.ml
@@ -297,6 +297,21 @@ let message_of_type_error type_error =
             None
           )
         else (Line ("Identifier " ^ name ^ " is unbound" ^ hint_msg), None)
+    | Err_vector_subrange { n; m; order } -> (
+        match order with
+        | Ord_aux (Ord_dec, _) ->
+            let msg =
+              Printf.sprintf "First index %s must be greater than or equal to second index %s (when default Order dec)"
+                (Big_int.to_string n) (Big_int.to_string m)
+            in
+            (Line msg, None)
+        | Ord_aux (Ord_inc, _) ->
+            let msg =
+              Printf.sprintf "First index %s must be less than or equal to second index %s (when default Order inc)"
+                (Big_int.to_string n) (Big_int.to_string m)
+            in
+            (Line msg, None)
+      )
     | Err_no_function_type { id; functions } ->
         let name = string_of_id id in
         let closest =

--- a/src/lib/type_error.mli
+++ b/src/lib/type_error.mli
@@ -84,6 +84,7 @@ type type_error =
   | Err_unbound_id of { id : id; locals : (mut * typ) Bindings.t; have_function : bool }
       (** Takes the name of the identifier, the set of local bindings, and whether we have a function of the same name
           in scope. *)
+  | Err_vector_subrange of { n : Big_int.num; m : Big_int.num; order : order }
   | Err_hint of string  (** A short error that only appears attached to a location *)
   | Err_with_hint of string * type_error
   | Err_alternate of type_error * (string * Parse_ast.l * type_error) list

--- a/src/lib/type_internal.ml
+++ b/src/lib/type_internal.ml
@@ -93,6 +93,7 @@ type type_error =
   | Err_function_arg of Parse_ast.l * typ * type_error
   | Err_no_function_type of { id : id; functions : (typquant * typ) Bindings.t }
   | Err_unbound_id of { id : id; locals : (mut * typ) Bindings.t; have_function : bool }
+  | Err_vector_subrange of { n : Big_int.num; m : Big_int.num; order : order }
   | Err_hint of string
   | Err_with_hint of string * type_error
   | Err_alternate of type_error * (string * Parse_ast.l * type_error) list

--- a/test/typecheck/fail/jal_encdec_nc.expect
+++ b/test/typecheck/fail/jal_encdec_nc.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mfail/jal_encdec_nc.sail[0m:14.6-66:
+14[96m |[0m  <-> imm[20] @ imm[9..0] @ imm[11] @ imm[19..12] @ rd @ 0b1101111
+  [91m |[0m      [91m^----------------------------------------------------------^[0m
+  [91m |[0m Cannot bind imm as pattern subranges are non-contiguous. imm[10] is not defined.

--- a/test/typecheck/fail/jal_encdec_nc.sail
+++ b/test/typecheck/fail/jal_encdec_nc.sail
@@ -1,0 +1,14 @@
+default Order dec
+
+$include <prelude.sail>
+
+scattered union instruction
+
+val encdec : instruction <-> bits(32)
+
+scattered mapping encdec
+
+union clause instruction = JAL : (bits(21), bits(5))
+
+mapping clause encdec = JAL(imm : bits(20) @ 0b0, rd)
+  <-> imm[20] @ imm[9..0] @ imm[11] @ imm[19..12] @ rd @ 0b1101111

--- a/test/typecheck/fail/jal_encdec_nz.expect
+++ b/test/typecheck/fail/jal_encdec_nz.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mfail/jal_encdec_nz.sail[0m:14.6-67:
+14[96m |[0m  <-> imm[20] @ imm[10..1] @ imm[11] @ imm[19..12] @ rd @ 0b1101111
+  [91m |[0m      [91m^-----------------------------------------------------------^[0m
+  [91m |[0m Cannot bind imm as pattern subranges do not start at bit 0 (lowest bit is 1).

--- a/test/typecheck/fail/jal_encdec_nz.sail
+++ b/test/typecheck/fail/jal_encdec_nz.sail
@@ -1,0 +1,14 @@
+default Order dec
+
+$include <prelude.sail>
+
+scattered union instruction
+
+val encdec : instruction <-> bits(32)
+
+scattered mapping encdec
+
+union clause instruction = JAL : (bits(21), bits(5))
+
+mapping clause encdec = JAL(imm : bits(20) @ 0b0, rd)
+  <-> imm[20] @ imm[10..1] @ imm[11] @ imm[19..12] @ rd @ 0b1101111

--- a/test/typecheck/pass/jal_encdec.sail
+++ b/test/typecheck/pass/jal_encdec.sail
@@ -1,0 +1,14 @@
+default Order dec
+
+$include <prelude.sail>
+
+scattered union instruction
+
+val encdec : instruction <-> bits(32)
+
+scattered mapping encdec
+
+union clause instruction = JAL : (bits(21), bits(5))
+
+mapping clause encdec = JAL(imm : bits(20) @ 0b0, rd)
+  <-> imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] @ rd @ 0b1101111

--- a/test/typecheck/pass/vector_subrange_pattern/v3.expect
+++ b/test/typecheck/pass/vector_subrange_pattern/v3.expect
@@ -1,5 +1,5 @@
 [93mType error[0m:
-[96mpass/vector_subrange_pattern/v3.sail[0m:7.13-56:
+[96mpass/vector_subrange_pattern/v3.sail[0m:7.23-32:
 7[96m |[0mfunction foo imm[19] @ imm[9..0] @ imm[10] @ imm[18..11] = {
- [91m |[0m             [91m^-----------------------------------------^[0m
- [91m |[0m First index 19 must be less than or equal to second index 0 (when default Order inc)
+ [91m |[0m                       [91m^-------^[0m
+ [91m |[0m First index 9 must be less than or equal to second index 0 (when default Order inc)

--- a/test/typecheck/pass/vector_subrange_pattern/v4.expect
+++ b/test/typecheck/pass/vector_subrange_pattern/v4.expect
@@ -1,0 +1,5 @@
+[93mType error[0m:
+[96mpass/vector_subrange_pattern/v4.sail[0m:7.13-56:
+7[96m |[0mfunction foo imm[19] @ imm[1..9] @ imm[10] @ imm[11..18] = {
+ [91m |[0m             [91m^-----------------------------------------^[0m
+ [91m |[0m Cannot bind imm as pattern subranges do not start at bit 0 (lowest bit is 1).

--- a/test/typecheck/pass/vector_subrange_pattern/v4.sail
+++ b/test/typecheck/pass/vector_subrange_pattern/v4.sail
@@ -1,0 +1,15 @@
+default Order inc
+
+$include <prelude.sail>
+
+val foo : bits(20) -> unit
+
+function foo imm[19] @ imm[1..9] @ imm[10] @ imm[11..18] = {
+    print_bits("imm = ", imm)
+}
+
+val main : unit -> unit
+
+function main() = {
+    foo(0xABCDE)
+}


### PR DESCRIPTION
Two commits:

1. Tighten up some vector subrange errors, particularly when they occur in mappings. Actually enforce that they start at bit 0, otherwise it would just fail later during rewrites.
2. Allow `sail --fmt` to be passed a `.sail_project` file, which tells it to format all sail files referenced by that project. Also fix a bug with formatting empty argument lists.