### PR TITLE
Multiline string

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -96,6 +96,7 @@ and chunk =
   | Intersperse of string * chunks list
   | Atom of string
   | String_literal of string
+  | Multiline_string_literal of string list
   | Pragma of string * string
   | Unary of string * chunks
   | Binary of chunks * string * chunks
@@ -139,6 +140,9 @@ let rec prerr_chunk indent = function
   | Spacer (line, w) -> Printf.eprintf "%sSpacer:%b %d\n" indent line w
   | Atom str -> Printf.eprintf "%sAtom:%s\n" indent str
   | String_literal str -> Printf.eprintf "%sString_literal:%s\n" indent str
+  | Multiline_string_literal lines ->
+      Printf.eprintf "%sMultiline_string_literal:\n" indent;
+      List.iteri (fun i line -> Printf.eprintf "%s%d>%s\n" indent i line) lines
   | App (id, args) ->
       Printf.eprintf "%sApp:%s\n" indent (string_of_id id);
       List.iteri
@@ -484,6 +488,7 @@ let chunk_of_lit (L_aux (aux, _)) =
   | L_bin b -> Atom ("0b" ^ b)
   | L_undef -> Atom "undefined"
   | L_string s -> String_literal s
+  | L_multiline_string lines -> Multiline_string_literal lines
   | L_real r -> Atom r
 
 let rec map_peek f = function
@@ -1197,24 +1202,23 @@ let chunk_register comments chunks (DEC_aux (DEC_reg ((ATyp_aux (_, typ_l) as ty
 let chunk_toplevel_let l comments chunks (LB_aux (LB_val (pat, exp), _)) =
   pop_comments comments chunks l;
   let def_chunks = Queue.create () in
-  Queue.push (Atom "let") def_chunks;
-  Queue.push (Spacer (false, 1)) def_chunks;
 
   let pat_chunks = Queue.create () in
   let exp_chunks = Queue.create () in
-  begin
-    match pat with
-    | P_aux (P_typ (typ, pat), pat_l) ->
-        chunk_pat comments pat_chunks pat;
-        let typ_chunks = Queue.create () in
-        chunk_atyp comments typ_chunks typ;
-        chunk_exp comments exp_chunks exp;
-        Queue.push (Ternary (pat_chunks, ":", typ_chunks, "=", exp_chunks)) def_chunks
-    | _ ->
-        chunk_pat comments pat_chunks pat;
-        chunk_exp comments exp_chunks exp;
-        Queue.push (Binary (pat_chunks, "=", exp_chunks)) def_chunks
-  end;
+  ( match pat with
+  | P_aux (P_typ (typ, pat), pat_l) ->
+      chunk_pat comments pat_chunks pat;
+      let typ_chunks = Queue.create () in
+      chunk_atyp comments typ_chunks typ;
+      chunk_exp comments exp_chunks exp;
+      let pat_typ_chunks = Queue.create () in
+      Queue.push (Binary (pat_chunks, ":", typ_chunks)) pat_typ_chunks;
+      Queue.push (Block_binder (Let_binder, pat_typ_chunks, exp_chunks)) def_chunks
+  | _ ->
+      chunk_pat comments pat_chunks pat;
+      chunk_exp comments exp_chunks exp;
+      Queue.push (Block_binder (Let_binder, pat_chunks, exp_chunks)) def_chunks
+  );
   Queue.push (Chunks def_chunks) chunks;
   if not (pop_trailing_comment ~space:1 comments exp_chunks (ending_line_num l)) then
     Queue.push (Spacer (true, 1)) chunks

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -88,7 +88,7 @@ and chunk =
   | Val of { id : id; extern_opt : extern option; typq_opt : chunks option; typ : chunks }
   | Enum of { id : id; enum_functions : chunks list option; members : chunks list }
   | Function_typ of { mapping : bool; lhs : chunks; rhs : chunks }
-  | Exists of { vars : chunks; constr : chunks; typ : chunks }
+  | Exists of { vars : chunks; constr : chunks option; typ : chunks }
   | Typ_quant of { vars : chunks; constr_opt : chunks option }
   | App of id * chunks list
   | Field of chunks * id
@@ -208,7 +208,10 @@ let rec prerr_chunk indent = function
           Queue.iter (prerr_chunk (indent ^ "    ")) funcl.body
         )
         fn.funcls
-  | Val vs -> Printf.eprintf "%sVal:%s has_extern=%b\n" indent (string_of_id vs.id) (Option.is_some vs.extern_opt)
+  | Val vs ->
+      Printf.eprintf "%sVal:%s has_extern=%b\n" indent (string_of_id vs.id) (Option.is_some vs.extern_opt);
+      Printf.eprintf "%s  typ:\n" indent;
+      Queue.iter (prerr_chunk (indent ^ "    ")) vs.typ
   | Enum e ->
       Printf.eprintf "%sEnum:%s\n" indent (string_of_id e.id);
       begin
@@ -332,11 +335,13 @@ let rec prerr_chunk indent = function
   | Exists ex ->
       Printf.eprintf "%sExists:\n" indent;
       List.iter
-        (fun (name, arg) ->
+        (fun (name, arg_opt) ->
           Printf.eprintf "%s  %s:\n" indent name;
-          Queue.iter (prerr_chunk (indent ^ "    ")) arg
+          match arg_opt with
+          | Some arg -> Queue.iter (prerr_chunk (indent ^ "    ")) arg
+          | None -> Printf.eprintf "%s    <empty>" indent
         )
-        [("vars", ex.vars); ("constr", ex.constr); ("typ", ex.typ)]
+        [("vars", Some ex.vars); ("constr", ex.constr); ("typ", Some ex.typ)]
   | Binder _ -> ()
   | Block_binder (binder, binding, exp) ->
       Printf.eprintf "%sBlock_binder:%s\n" indent (binder_keyword binder);
@@ -634,10 +639,17 @@ let rec chunk_atyp comments chunks (ATyp_aux (aux, l)) =
   | ATyp_wild -> Queue.add (Atom "_") chunks
   | ATyp_exist (vars, constr, typ) ->
       let var_chunks = Queue.create () in
-      List.iter (fun kopt -> Queue.add (chunk_of_kopt kopt) var_chunks) vars;
-      let constr_chunks = rec_chunk_atyp constr in
+      Util.iter_last
+        (fun is_last kopt ->
+          Queue.add (chunk_of_kopt kopt) var_chunks;
+          if not is_last then Queue.add (Spacer (false, 1)) var_chunks
+        )
+        vars;
+      let constr_chunks_opt =
+        match constr with ATyp_aux (ATyp_lit (L_aux (L_true, _)), _) -> None | _ -> Some (rec_chunk_atyp constr)
+      in
       let typ_chunks = rec_chunk_atyp typ in
-      Queue.add (Exists { vars = var_chunks; constr = constr_chunks; typ = typ_chunks }) chunks
+      Queue.add (Exists { vars = var_chunks; constr = constr_chunks_opt; typ = typ_chunks }) chunks
   | ATyp_set _ -> ()
 
 let rec chunk_pat comments chunks (P_aux (aux, l)) =

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -79,7 +79,7 @@ and chunk =
   | Val of { id : Parse_ast.id; extern_opt : Parse_ast.extern option; typq_opt : chunks option; typ : chunks }
   | Enum of { id : Parse_ast.id; enum_functions : chunks list option; members : chunks list }
   | Function_typ of { mapping : bool; lhs : chunks; rhs : chunks }
-  | Exists of { vars : chunks; constr : chunks; typ : chunks }
+  | Exists of { vars : chunks; constr : chunks option; typ : chunks }
   | Typ_quant of { vars : chunks; constr_opt : chunks option }
   | App of Parse_ast.id * chunks list
   | Field of chunks * Parse_ast.id

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -87,6 +87,7 @@ and chunk =
   | Intersperse of string * chunks list
   | Atom of string
   | String_literal of string
+  | Multiline_string_literal of string list
   | Pragma of string * string
   | Unary of string * chunks
   | Binary of chunks * string * chunks

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -354,6 +354,14 @@ let can_hang chunks =
     )
   | _ -> true
 
+let can_hang_bracketed chunks =
+  match Queue.peek_opt chunks with
+  | Some (Block _) -> true
+  | Some (Struct_update _) -> true
+  | Some (Match _) -> true
+  | Some (App _) -> true
+  | _ -> false
+
 let opt_delim s = ifflat empty (string s)
 
 let softline = break 0
@@ -453,6 +461,8 @@ module Make (Config : CONFIG) = struct
     | Delim s -> string s ^^ space
     | Opt_delim s -> opt_delim s
     | String_literal s -> utf8string ("\"" ^ String.escaped s ^ "\"")
+    | Multiline_string_literal lines ->
+        string "\"\"\"" ^^ hardline ^^ separate_map hardline string lines ^^ hardline ^^ string "\"\"\""
     | App (id, args) -> (
         match args with
         | [] -> doc_id id ^^ string "()"
@@ -662,12 +672,18 @@ module Make (Config : CONFIG) = struct
         let exps = List.map fst exps in
         surround_hardline always_hardline indent 1 (char '{') (separate sep exps) (char '}') |> atomic_parens opts
     | Block_binder (binder, x, y) ->
-        if can_hang y then
+        (* If the body is braced or otherwise bracketed, then the bracketing construct will take care of indentation *)
+        if can_hang_bracketed y then
           separate space
             [string (binder_keyword binder); doc_chunks (atomic opts) x; char '='; doc_chunks (nonatomic opts) y]
+        else if can_hang y then
+          nest indent
+            (separate space
+               [string (binder_keyword binder); doc_chunks (atomic opts) x; char '='; doc_chunks (nonatomic opts) y]
+            )
         else
           separate space [string (binder_keyword binder); doc_chunks (atomic opts) x; char '=']
-          ^^ nest 4 (hardline ^^ doc_chunks (nonatomic opts) y)
+          ^^ nest indent (hardline ^^ doc_chunks (nonatomic opts) y)
     | Binder (binder, x, y, z) ->
         group
           (separate space

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -556,8 +556,7 @@ module Make (Config : CONFIG) = struct
     | Exists ex ->
         let ex_doc =
           doc_chunks (atomic opts) ex.vars
-          ^^ char ',' ^^ break 1
-          ^^ doc_chunks (nonatomic opts) ex.constr
+          ^^ (match ex.constr with Some cs -> char ',' ^^ break 1 ^^ doc_chunks (nonatomic opts) cs | None -> empty)
           ^^ char '.' ^^ break 1
           ^^ doc_chunks (nonatomic opts) ex.typ
         in

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1281,6 +1281,7 @@ let to_ast_lit (P.L_aux (lit, l)) =
         )
       | P.L_real r -> L_real r
       | P.L_string s -> L_string s
+      | P.L_multiline_string lines -> L_string (String.concat "\n" (List.map Scanf.unescaped lines))
       ),
       l
     )

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -139,6 +139,31 @@ let kw_table =
 type comment =
   | Comment of comment_type * Lexing.position * Lexing.position * string
 
+let process_multiline start_delim pos end_delim str =
+  let open Lexing in
+  let open Printf in
+  let full_loc = Parse_ast.Range (start_delim, end_delim) in
+  let lines = String.split_on_char '\n' str |> List.rev in
+  match lines with
+  | [] -> assert false
+  | prefix :: lines ->
+     if not (Util.string_for_all (fun c -> c = ' ' || c = '\t') prefix) then (
+       raise (Reporting.err_syntax_loc full_loc "Final line before \"\"\" delimiter in multi-line string must only contain whitespace")
+     );
+     let chars = ref 0 in
+     List.mapi (fun n line ->
+       if Util.starts_with ~prefix line || line = "" then (
+         let len = String.length line in
+         chars := !chars + len + 1;
+         String.sub line (String.length prefix) (len - String.length prefix)
+       ) else (
+         let h = { pos with pos_cnum = pos.pos_cnum + !chars; pos_bol = pos.pos_bol + !chars; pos_lnum = pos.pos_lnum + n } in
+         let l = Parse_ast.Hint (sprintf "Line %d starting here" (n + 1), Parse_ast.Range (h, h), full_loc) in
+         let extra = "It must contain the exact sequence of whitespace characters that preceed the final \"\"\" delimiter." in
+         raise (Reporting.err_syntax_loc l (sprintf "Line %d in multi-line string literal has an invalid prefix.\n%s" (n + 1) extra))
+       )
+     ) (List.rev lines)
+
 }
 
 let wsc = [' ''\t']
@@ -239,10 +264,16 @@ rule token comments = parse
   | digit+ as i                           { Num (Big_int.of_string i) }
   | "0b" (binarydigit+ as b)              { Bin b }
   | "0x" (hexdigit+ as h)                 { Hex h }
-  | '"'                                   { let startpos = Lexing.lexeme_start_p lexbuf in
-                                            let contents = string startpos (Buffer.create 10) lexbuf in
+  | "\"\"\"" wsc* '\n'                    { let startpos = Lexing.lexeme_start_p lexbuf in
+                                            Lexing.new_line lexbuf;
+                                            let endpos = Lexing.lexeme_end_p lexbuf in
+                                            let contents = multiline_string startpos endpos (Buffer.create 256) lexbuf in
                                             lexbuf.lex_start_p <- startpos;
-                                            String(contents) }
+                                            MultilineString contents }
+  | '"'                                   { let startpos = Lexing.lexeme_start_p lexbuf in
+                                            let contents = string startpos (Buffer.create 16) lexbuf in
+                                            lexbuf.lex_start_p <- startpos;
+                                            String contents }
   | eof                                   { Eof }
   | _  as c
     { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) (Printf.sprintf "Unexpected character: %s" (Char.escaped c))) }
@@ -322,7 +353,7 @@ and block_comment comments pos b depth = parse
   | eof                                 { raise (Reporting.err_lex pos "Unbalanced comment") }
 
 and string pos b = parse
-  | ([^'"''\n''\\']*'\n' as i)          { Lexing.new_line lexbuf;
+  | ([^'"''\n''\\']* '\n' as i)         { Lexing.new_line lexbuf;
                                           Buffer.add_string b i;
                                           string pos b lexbuf }
   | ([^'"''\n''\\']* as i)              { Buffer.add_string b i; string pos b lexbuf }
@@ -331,3 +362,14 @@ and string pos b = parse
   | '\\'                                { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) "String literal contains illegal backslash escape sequence") }
   | '"'                                 { Scanf.unescaped (Buffer.contents b) }
   | eof                                 { raise (Reporting.err_lex pos "String literal not terminated") }
+
+and multiline_string delim_pos pos b = parse
+  | "\"\"\""                            { process_multiline delim_pos pos (Lexing.lexeme_end_p lexbuf) (Buffer.contents b) }
+  | "\""                                { Buffer.add_char b '"'; multiline_string delim_pos pos b lexbuf }
+  | ([^'"''\n''\\']* '\n' as i)         { Lexing.new_line lexbuf;
+                                          Buffer.add_string b i;
+                                          multiline_string delim_pos pos b lexbuf }
+  | ([^'"''\n''\\']* as i)              { Buffer.add_string b i; multiline_string delim_pos pos b lexbuf }
+  | escape_sequence as i                { Buffer.add_string b i; multiline_string delim_pos pos b lexbuf }
+  | '\\'                                { raise (Reporting.err_lex (Lexing.lexeme_start_p lexbuf) "String literal contains illegal backslash escape sequence") }
+  | eof                                 { raise (Reporting.err_lex delim_pos "Multiline string literal not terminated") }

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -124,6 +124,7 @@ type lit_aux =
   | L_bin of string (* bit vector constant, C-style *)
   | L_undef (* undefined value *)
   | L_string of string (* string constant *)
+  | L_multiline_string of string list (* multi-line string constant *)
   | L_real of string
 
 type lit = L_aux of lit_aux * l

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -230,6 +230,7 @@ let set_syntax_deprecated l =
 %token <string> Id TyVar
 %token <Nat_big_num.num> Num
 %token <string> String Bin Hex Real
+%token <string list> MultilineString
 
 %token <string> Eq EqGt Unit Colon
 
@@ -587,6 +588,8 @@ lit:
     { mk_lit (L_hex $1) $startpos $endpos }
   | String
     { mk_lit (L_string $1) $startpos $endpos }
+  | MultilineString
+    { mk_lit (L_multiline_string $1) $startpos $endpos }
   | Real
     { mk_lit (L_real $1) $startpos $endpos }
 

--- a/src/sail_doc_backend/html_source.ml
+++ b/src/sail_doc_backend/html_source.ml
@@ -80,7 +80,7 @@ let highlights ~filename ~contents =
     | INT | NAT | BOOL | TYPE | ORDER ->
         mark Highlight.Kind;
         go ()
-    | String _ ->
+    | String _ | MultilineString _ ->
         mark Highlight.String;
         go ()
     | DocLine _ | DocBlock _ ->

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -92,13 +92,11 @@ function b () -> int = {
 let c = 1
 
 // comment
-let c2 =
-    1 // comment
-let d =
-    {
-        1
-        // comment
-    } // comment
+let c2 = 1 // comment
+let d = {
+    1
+    // comment
+} // comment
 // comment
 // comment
 // comment

--- a/test/format/default/index.expect
+++ b/test/format/default/index.expect
@@ -6,7 +6,7 @@ function rX r = {
     let foo = /* comment */ Xs[unsigned(r)];
     let foo = Xs[let r = 1 in unsigned(r)]; // comment
     let foo = Xs[
-        let foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = 1 in
-        foo
-    ]
+            let foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = 1 in
+            foo
+        ]
 }

--- a/test/format/default/mls_let_hang.expect
+++ b/test/format/default/mls_let_hang.expect
@@ -1,0 +1,10 @@
+
+let foo : string = """
+    some text
+    x
+     y
+      z
+        abc\n\n
+    dedent
+    more text\n
+    """

--- a/test/format/mls_let_hang.sail
+++ b/test/format/mls_let_hang.sail
@@ -1,0 +1,12 @@
+
+let foo
+  : string =
+                     """
+some text
+x
+ y
+  z
+    abc\n\n
+dedent
+more text\n
+"""

--- a/test/lexing/mls_dedent.expect
+++ b/test/lexing/mls_dedent.expect
@@ -1,0 +1,11 @@
+[93mSyntax error[0m:
+[96mmls_dedent.sail[0m:8.0-0:
+8[96m |[0m  dedent
+ [92m |[0m[92m^[0m [92mLine 6 starting here[0m
+[96mmls_dedent.sail[0m:2.19-10.7:
+2 [96m |[0mlet foo : string = """
+  [91m |[0m                   [91m^--[0m
+10[96m |[0m    """
+  [91m |[0m[91m------^[0m
+  [91m |[0m Line 6 in multi-line string literal has an invalid prefix.
+  [91m |[0m It must contain the exact sequence of whitespace characters that preceed the final """ delimiter.

--- a/test/lexing/mls_dedent.sail
+++ b/test/lexing/mls_dedent.sail
@@ -1,0 +1,10 @@
+
+let foo : string = """
+    some text
+    x
+    y
+    z
+      abc
+  dedent
+    more text
+    """


### PR DESCRIPTION
This commit introduces multi-line strings delimited by `"""`.

Rationale:

These are primarily intended to make writing longer strings in Sail attributes simpler, so one can do:
```sail
$[attr {
  some_key = """
    A multi-line
      string
    value
    """
}]
```
A second reason to add these is that the auto-formatter can make a mess of multi-line strings made by repeatedly appending using `^`, whereas these format in a straightforward way.

The rules are similar to C#.

- The opening `"""` must be followed by a newline. This newline is ignored.

- The closing `"""` must be on its own line, it can be preceded by whitespace (tab or space) characters. This whitespace controls the indentation of the string. Each line after the opening `"""` line must be prefixed by exactly this sequence of whitespace characters.

  - The one exception to this prefixing rule is that lines may also be empty.

  - The final newline before the closing `"""` line is also ignored.

- Escape characters are handled on a per-line basis, as per the rules for ordinary Sail strings. This is a point of divergence from C# multi-line strings, as these are not also raw strings. This means that if a trailing newline is wanted, one can just do:
  ```sail
  """
  a multi-
  line string\n
  """
  ```

- Unlike regular strings `"` can appear unescaped.

- The trailing newline of any line within the multi-line string cannot be escaped, so
  ```sail
  """
  escape\
  newline
  """
  ```
  is not permitted.

If we consider the first example in this commit message, it would produce the regular string:
```sail
"A multi-line\n  string\nvalue"
```