### PR TITLE
Add Env.has_val_spec to simplify some checks

### DIFF
--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -235,7 +235,7 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
             let funcalls_of_exp =
               let e_app (id, args) =
                 let arg_funcalls = List.fold_left IdSet.union IdSet.empty args in
-                if Bindings.mem id (Env.get_val_specs env) then IdSet.add id arg_funcalls else arg_funcalls
+                if Env.has_val_spec id env then IdSet.add id arg_funcalls else arg_funcalls
               in
               fold_exp { (pure_exp_alg IdSet.empty IdSet.union) with e_app }
             in

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -3783,7 +3783,7 @@ module BitvectorSizeCasts = struct
   let specs_required = ref IdSet.empty
   let check_for_spec env name =
     let id = mk_id name in
-    match Env.get_val_spec id env with _ -> () | exception _ -> specs_required := IdSet.add id !specs_required
+    if Env.has_val_spec id env then () else specs_required := IdSet.add id !specs_required
 
   (* These functions add cast functions across case splits, so that when a
      bitvector size becomes known in sail, the generated Lem code contains a

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -90,6 +90,8 @@ module Env : sig
 
   val get_val_specs : t -> (typquant * typ) Bindings.t
 
+  val has_val_spec : id -> t -> bool
+
   val get_defined_val_specs : t -> IdSet.t
 
   (** Like get_val_spec, except that the original type variables are used. Useful when processing the body of the

--- a/src/lib/type_env.ml
+++ b/src/lib/type_env.ml
@@ -1181,6 +1181,8 @@ let get_val_spec id env =
   | Some (bind, _) -> bind
   | None -> typ_raise (id_loc id) (Err_no_function_type { id; functions = get_val_specs env })
 
+let has_val_spec id env = Bindings.mem id env.global.val_specs
+
 let add_union_id ?in_module id bind env =
   if bound_global env id then already_bound_global "union constructor" id env
   else (

--- a/src/lib/type_env.mli
+++ b/src/lib/type_env.mli
@@ -119,6 +119,7 @@ val get_val_spec_opt : id -> t -> ((typquant * typ) * l) option
 val get_val_spec : id -> t -> typquant * typ
 val get_val_specs : t -> (typquant * typ) Bindings.t
 val get_val_spec_orig : id -> t -> typquant * typ
+val has_val_spec : id -> t -> bool
 
 val is_outcome : id -> t -> bool
 val add_outcome : id -> typquant * typ * typquant * id list * t -> t -> t


### PR DESCRIPTION
In particular, using this in the undefined literal special case in callgraph construction massively reduces the peak memory usage for the Arm model.