### PR TITLE
Various formatting improvements and fixes

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -52,6 +52,10 @@ let string_of_id (Id_aux (id, _)) = string_of_id_aux id
 
 let id_loc (Id_aux (_, l)) = l
 
+let exp_loc (E_aux (_, l)) = l
+
+let shrink_to_end l = match Reporting.simp_loc l with Some (_, e) -> Range (e, e) | None -> Unknown
+
 let starting_line_num l = match Reporting.simp_loc l with Some (s, _) -> Some s.pos_lnum | None -> None
 
 let starting_column_num l =
@@ -84,6 +88,7 @@ and chunk =
       typq_opt : chunks option;
       return_typ_opt : chunks option;
       funcls : (chunks * pexp_chunks) list;
+      hanging : bool;
     }
   | Val of { id : id; extern_opt : extern option; typq_opt : chunks option; typ : chunks }
   | Enum of { id : id; enum_functions : chunks list option; members : chunks list }
@@ -100,7 +105,8 @@ and chunk =
   | Pragma of string * string
   | Unary of string * chunks
   | Binary of chunks * string * chunks
-  | Ternary of chunks * string * chunks * string * chunks
+  | Vector_binary of chunks * string * chunks
+  | Assign of chunks * (string * chunks) option * string * chunks
   | Infix_sequence of infix_chunk list
   | Index of chunks * chunks
   | Delim of string
@@ -121,7 +127,7 @@ and chunk =
       body : chunks;
     }
   | While of { repeat_until : bool; termination_measure : chunks option; cond : chunks; body : chunks }
-  | Vector_updates of chunks * chunk list
+  | Vector_updates of chunks * chunks list
   | Chunks of chunks
   | Raw of string
 
@@ -311,14 +317,22 @@ let rec prerr_chunk indent = function
           Queue.iter (prerr_chunk (indent ^ "    ")) arg
         )
         [("lhs", lhs); ("rhs", rhs)]
-  | Ternary (x, op1, y, op2, z) ->
-      Printf.eprintf "%sTernary:%s %s\n" indent op1 op2;
+  | Vector_binary (lhs, op, rhs) ->
+      Printf.eprintf "%sVector_binary:%s\n" indent op;
       List.iter
         (fun (name, arg) ->
           Printf.eprintf "%s  %s:\n" indent name;
           Queue.iter (prerr_chunk (indent ^ "    ")) arg
         )
-        [("x", x); ("y", y); ("z", z)]
+        [("lhs", lhs); ("rhs", rhs)]
+  | Assign (lhs, ternary, op, rhs) ->
+      Printf.eprintf "%sAssign:%s%s\n" indent op (Option.fold ~none:"" ~some:(fun (t_op, _) -> " " ^ t_op) ternary);
+      List.iter
+        (fun (name, arg) ->
+          Printf.eprintf "%s  %s:\n" indent name;
+          Queue.iter (prerr_chunk (indent ^ "    ")) arg
+        )
+        [("lhs", lhs); ("rhs", rhs)]
   | Infix_sequence infix_chunks ->
       Printf.eprintf "%sInfix:\n" indent;
       List.iter
@@ -375,7 +389,14 @@ let rec prerr_chunk indent = function
       Queue.iter (prerr_chunk (indent ^ "    ")) exp;
       Printf.eprintf "%s  with:" indent;
       List.iter (fun exp -> Queue.iter (prerr_chunk (indent ^ "    ")) exp) exps
-  | Vector_updates (_exp, _updates) -> Printf.eprintf "%sVector_updates:\n" indent
+  | Vector_updates (_exp, updates) ->
+      Printf.eprintf "%sVector_updates:\n" indent;
+      List.iteri
+        (fun i update ->
+          Printf.eprintf "%s  %d:\n" indent i;
+          Queue.iter (prerr_chunk (indent ^ "    ")) update
+        )
+        updates
   | Index (exp, ix) ->
       Printf.eprintf "%sIndex:\n" indent;
       List.iter
@@ -412,21 +433,32 @@ let chunk_header_comments comments chunks = function
   | DEF_aux (_, l) :: _ -> pop_header_comments comments chunks l 1
 
 (* Pop comments preceeding location into the chunkstream *)
-let rec pop_comments ?(spacer = true) comments chunks l =
+let rec pop_comments ?(newline = false) ?last_comment_line ?(spacer = true) comments chunks l =
+  let extra_lines (p : Lexing.position) =
+    match last_comment_line with
+    | Some (comment_type, last) when spacer && last < p.pos_lnum ->
+        let spacing = p.pos_lnum - last - match comment_type with Comment_line -> 1 | Comment_block -> 2 in
+        for i = 0 to spacing do
+          Queue.add (Spacer (true, 1)) chunks
+        done
+    | _ -> ()
+  in
   match Stack.top_opt comments with
-  | None -> ()
+  | None -> Option.iter (fun (s, _) -> extra_lines s) (Reporting.simp_loc l)
   | Some (Lexer.Comment (comment_type, comment_s, comment_e, contents)) -> begin
       match Reporting.simp_loc l with
       | Some (s, e) when comment_e.pos_cnum <= s.pos_cnum ->
           let _ = Stack.pop comments in
+          if newline then Queue.add (Spacer (true, 1)) chunks;
+          extra_lines comment_s;
           Queue.add
             (Comment
                (comment_type, 0, comment_s.pos_cnum - comment_s.pos_bol, contents, comment_s.pos_lnum == e.pos_lnum)
             )
             chunks;
           if spacer && comment_e.pos_lnum < s.pos_lnum then Queue.add (Spacer (true, 1)) chunks;
-          pop_comments comments chunks l
-      | _ -> ()
+          pop_comments ~last_comment_line:(comment_type, comment_e.pos_lnum) comments chunks l
+      | _ -> Option.iter (fun (s, _) -> extra_lines s) (Reporting.simp_loc l)
     end
 
 let rec pop_comments_until_loc_end comments chunks l =
@@ -692,7 +724,7 @@ let rec chunk_pat comments chunks (P_aux (aux, l)) =
         Queue.add (Atom (Big_int.to_string n)) n_chunks;
         let m_chunks = Queue.create () in
         Queue.add (Atom (Big_int.to_string m)) m_chunks;
-        Queue.add (Binary (n_chunks, "..", m_chunks)) ix_chunks
+        Queue.add (Vector_binary (n_chunks, "..", m_chunks)) ix_chunks
       );
       Queue.add (Index (id_chunks, ix_chunks)) chunks
   | P_typ (typ, pat) ->
@@ -788,7 +820,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
     chunk_exp comments chunks exp;
     chunks
   in
-  match aux with
+  ( match aux with
   | E_id id -> Queue.add (Atom (string_of_id id)) chunks
   | E_ref id -> Queue.add (Atom ("ref " ^ string_of_id id)) chunks
   | E_config s -> Queue.add (Atom ("config " ^ s)) chunks
@@ -891,8 +923,10 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
             end;
 
             let next_line_num = Option.bind next (fun bexp -> block_exp_locs bexp |> fst |> starting_line_num) in
-            if have_linebreak (ending_line_num e_l) next_line_num || Option.is_none next then
-              ignore (pop_trailing_comment comments chunks (ending_line_num e_l));
+            if
+              have_linebreak (ending_line_num e_l) next_line_num
+              || (Option.is_none next && have_linebreak (ending_line_num e_l) (ending_line_num l))
+            then ignore (pop_trailing_comment comments chunks (ending_line_num e_l));
             begin
               match next with
               | Some next ->
@@ -939,11 +973,11 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
         }
       in
       let i_chunks = rec_chunk_exp i in
-      pop_comments ~spacer:false comments i_chunks keywords.then_loc;
+      pop_comments comments i_chunks keywords.then_loc;
       let t_chunks = rec_chunk_exp t in
-      ignore (pop_trailing_comment comments t_chunks (ending_line_num keywords.then_loc));
-      (match keywords.else_loc with Some l -> pop_comments comments t_chunks l | None -> ());
+      Option.iter (fun l -> pop_comments comments t_chunks l) keywords.else_loc;
       let e_chunks = rec_chunk_exp e in
+      pop_comments comments e_chunks (shrink_to_end l);
       Queue.add (If_then_else (if_format, i_chunks, t_chunks, e_chunks)) chunks
   | (E_throw exp | E_return exp | E_deref exp | E_internal_return exp) as unop ->
       let unop =
@@ -967,6 +1001,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
       Match { kind; exp = exp_chunks; aligned; cases } |> add_chunk chunks
   | E_vector_update _ | E_vector_update_subrange _ ->
       let vec_chunks, updates = chunk_vector_update comments (E_aux (aux, l)) in
+      (match updates with update :: _ -> pop_comments ~newline:true comments update (shrink_to_end l) | [] -> ());
       Queue.add (Vector_updates (vec_chunks, List.rev updates)) chunks
   | E_vector_access (exp, ix) ->
       let exp_chunks = rec_chunk_exp exp in
@@ -977,7 +1012,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
       let ix1_chunks = rec_chunk_exp ix1 in
       let ix2_chunks = rec_chunk_exp ix2 in
       let ix_chunks = Queue.create () in
-      Queue.add (Binary (ix1_chunks, "..", ix2_chunks)) ix_chunks;
+      Queue.add (Vector_binary (ix1_chunks, "..", ix2_chunks)) ix_chunks;
       Queue.add (Index (exp_chunks, ix_chunks)) chunks
   | E_for (var, from_index, to_index, step, order, body) ->
       let decreasing =
@@ -1046,6 +1081,8 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
       chunk_atyp comments nc_chunks nc;
       let exp_chunks = rec_chunk_exp exp in
       Queue.add (App (Id_aux (Id "internal_assume", l), [nc_chunks; exp_chunks])) chunks
+  );
+  pop_comments comments chunks (shrink_to_end l)
 
 and chunk_vector_update comments (E_aux (aux, l) as exp) =
   let rec_chunk_exp exp =
@@ -1056,15 +1093,21 @@ and chunk_vector_update comments (E_aux (aux, l) as exp) =
   match aux with
   | E_vector_update (vec, ix, exp) ->
       let vec_chunks, update = chunk_vector_update comments vec in
+      let chunks = Queue.create () in
+      pop_comments comments chunks (exp_loc ix);
       let ix = rec_chunk_exp ix in
       let exp = rec_chunk_exp exp in
-      (vec_chunks, Binary (ix, "=", exp) :: update)
+      Queue.add (Assign (ix, None, "=", exp)) chunks;
+      (vec_chunks, chunks :: update)
   | E_vector_update_subrange (vec, ix1, ix2, exp) ->
       let vec_chunks, update = chunk_vector_update comments vec in
+      let chunks = Queue.create () in
+      pop_comments comments chunks (exp_loc ix1);
       let ix1 = rec_chunk_exp ix1 in
       let ix2 = rec_chunk_exp ix2 in
       let exp = rec_chunk_exp exp in
-      (vec_chunks, Ternary (ix1, "..", ix2, "=", exp) :: update)
+      Queue.add (Assign (ix1, Some ("..", ix2), "=", exp)) chunks;
+      (vec_chunks, chunks :: update)
   | _ ->
       let exp_chunks = Queue.create () in
       chunk_exp comments exp_chunks exp;
@@ -1077,7 +1120,9 @@ and chunk_pexp ?delim comments chunks (Pat_aux (aux, l)) =
       Queue.add (Spacer (false, 1)) chunks;
       chunk_pexp ?delim comments chunks pexp
   | Pat_exp (pat, exp) ->
-      let funcl_space = match pat with P_aux (P_tuple _, _) -> false | _ -> true in
+      let funcl_space =
+        match pat with P_aux (P_lit (L_aux (L_unit, _)), _) | P_aux (P_tuple _, _) -> false | _ -> true
+      in
       let pat_chunks = Queue.create () in
       chunk_pat comments pat_chunks pat;
       let exp_chunks = Queue.create () in
@@ -1159,16 +1204,32 @@ let chunk_default_typing_spec comments chunks (DT_aux (DT_order (kind, typ), l))
   chunk_atyp comments chunks typ;
   Queue.push (Spacer (true, 1)) chunks
 
+let rec is_hanging_fundef l = function
+  | Pat_aux (Pat_exp (_, E_aux (_, exp_l)), _) | Pat_aux (Pat_when (_, _, E_aux (_, exp_l)), _) ->
+      let line = starting_line_num l in
+      Option.is_some line && line = starting_line_num exp_l
+  | Pat_aux (Pat_attribute (_, _, pexp), _) -> is_hanging_fundef l pexp
+
 let chunk_fundef comments chunks (FD_aux (FD_function (rec_opt, tannot_opt, funcls), l)) =
   pop_comments comments chunks l;
-  let fn_id =
+  let fn_id, first_pexp =
     match funcls with
-    | FCL_aux (FCL_funcl (id, _), _) :: _ -> id
+    | FCL_aux (FCL_funcl (id, pexp), _) :: _ -> (id, pexp)
     | _ -> Reporting.unreachable l __POS__ "Empty funcl list in formatter"
   in
   let typq_opt, return_typ_opt = chunk_tannot_opt comments tannot_opt in
   let funcls = List.map (chunk_funcl comments) funcls in
-  Function { id = fn_id; clause = false; rec_opt = None; typq_opt; return_typ_opt; funcls } |> add_chunk chunks
+  Function
+    {
+      id = fn_id;
+      clause = false;
+      rec_opt = None;
+      typq_opt;
+      return_typ_opt;
+      funcls;
+      hanging = is_hanging_fundef l first_pexp;
+    }
+  |> add_chunk chunks
 
 let chunk_val_spec comments chunks (VS_aux (VS_val_spec (typschm, id, extern_opt), l)) =
   pop_comments comments chunks l;
@@ -1202,7 +1263,7 @@ let chunk_register comments chunks (DEC_aux (DEC_reg ((ATyp_aux (_, typ_l) as ty
     | Some (E_aux (_, exp_l) as exp) ->
         let exp_chunks = Queue.create () in
         chunk_exp comments exp_chunks exp;
-        Queue.push (Ternary (id_chunks, ":", typ_chunks, "=", exp_chunks)) def_chunks;
+        Queue.push (Assign (id_chunks, Some (":", typ_chunks), "=", exp_chunks)) def_chunks;
         pop_trailing_comment ~space:1 comments exp_chunks (ending_line_num exp_l)
     | None ->
         Queue.push (Binary (id_chunks, ":", typ_chunks)) def_chunks;
@@ -1309,10 +1370,20 @@ let chunk_type_def comments chunks (TD_aux (aux, l)) =
 let chunk_scattered comments chunks (SD_aux (aux, l)) =
   pop_comments comments chunks l;
   match aux with
-  | SD_funcl (FCL_aux (FCL_funcl (id, _), _) as funcl) ->
+  | SD_funcl (FCL_aux (FCL_funcl (id, pexp), _) as funcl) ->
       let funcl_chunks = chunk_funcl comments funcl in
       Queue.push
-        (Function { id; clause = true; rec_opt = None; typq_opt = None; return_typ_opt = None; funcls = [funcl_chunks] })
+        (Function
+           {
+             id;
+             clause = true;
+             rec_opt = None;
+             typq_opt = None;
+             return_typ_opt = None;
+             funcls = [funcl_chunks];
+             hanging = is_hanging_fundef l pexp;
+           }
+        )
         chunks
   | SD_end id -> build_def chunks [chunk_keyword "end"; chunk_id id comments]
   | SD_function (id, _) -> build_def chunks [chunk_keyword "scattered function"; chunk_id id comments]
@@ -1332,28 +1403,49 @@ let can_handle_td (TD_aux (aux, _)) = match aux with TD_enum _ -> true | _ -> fa
 let can_handle_sd (SD_aux (aux, _)) =
   match aux with SD_funcl _ | SD_end _ | SD_function _ | SD_enum _ | SD_enumcl _ -> true | _ -> false
 
-let rec chunk_def source last_line_span comments chunks (DEF_aux (def, l)) =
+let rec chunk_def skip source last_line_span comments chunks (DEF_aux (def, l)) =
   let line_span = (starting_line_num l, ending_line_num l) in
   let spacing = def_spacer last_line_span line_span in
   if spacing > 0 then Queue.add (Spacer (true, spacing)) chunks;
   let pragma_span = ref false in
+  let raw_source () =
+    match Reporting.simp_loc l with
+    | Some (p1, p2) ->
+        pop_comments comments chunks l;
+        (* These comments are within the source we are about to include *)
+        discard_comments comments p2;
+        let source = read_source p1 p2 source in
+        Queue.add (Raw source) chunks;
+        Queue.add (Spacer (true, 1)) chunks
+    | None ->
+        Reporting.unreachable l __POS__
+          ( if skip then "Could not find location of source code for $[fmt skip] attribute"
+            else "Invalid source code location"
+          )
+  in
   match def with
   | DEF_doc (doc, def) ->
+      pop_comments comments chunks l;
       Queue.add (Doc_comment doc) chunks;
-      chunk_def source last_line_span comments chunks def
+      chunk_def skip source last_line_span comments chunks def
   | DEF_attribute (attr, arg, def) ->
+      pop_comments comments chunks l;
       Queue.add (Atom (Ast_util.string_of_attribute attr arg)) chunks;
       Queue.add (Spacer (false, 1)) chunks;
-      chunk_def source last_line_span comments chunks def
+      let skip = match (attr, arg) with "fmt", Some (AD_aux (AD_string "skip", _)) -> true | _ -> skip in
+      chunk_def skip source last_line_span comments chunks def
   | def ->
-      begin
+      if skip then raw_source ()
+      else (
         match def with
         | DEF_fundef fdef -> chunk_fundef comments chunks fdef
         | DEF_pragma (pragma, Pragma_line (arg, _)) ->
+            pop_comments comments chunks l;
             Queue.add (Pragma (pragma, arg)) chunks;
             pragma_span := true
         | DEF_pragma (pragma, Pragma_structured data) ->
             let open Parse_ast.Attribute_data in
+            pop_comments comments chunks l;
             Queue.add
               (Pragma (pragma, Ast_util.string_of_attribute_data (AD_aux (AD_object data, Parse_ast.Unknown))))
               chunks
@@ -1368,18 +1460,8 @@ let rec chunk_def source last_line_span comments chunks (DEF_aux (def, l)) =
         | DEF_val vs -> chunk_val_spec comments chunks vs
         | DEF_scattered sd when can_handle_sd sd -> chunk_scattered comments chunks sd
         | DEF_type td when can_handle_td td -> chunk_type_def comments chunks td
-        | _ -> begin
-            match Reporting.simp_loc l with
-            | Some (p1, p2) ->
-                pop_comments comments chunks l;
-                (* These comments are within the source we are about to include *)
-                discard_comments comments p2;
-                let source = read_source p1 p2 source in
-                Queue.add (Raw source) chunks;
-                Queue.add (Spacer (true, 1)) chunks
-            | None -> Reporting.unreachable l __POS__ "Could not format"
-          end
-      end;
+        | _ -> raw_source ()
+      );
       (* Adjust the line span of a pragma to a single line so the spacing works out *)
       if not !pragma_span then line_span else (fst line_span, fst line_span)
 
@@ -1387,7 +1469,9 @@ let chunk_defs source comments defs =
   let comments = Stack.of_seq (List.to_seq comments) in
   let chunks = Queue.create () in
   chunk_header_comments comments chunks defs;
-  let _ = List.fold_left (fun last_span def -> chunk_def source last_span comments chunks def) (None, Some 0) defs in
+  let _ =
+    List.fold_left (fun last_span def -> chunk_def false source last_span comments chunks def) (None, Some 0) defs
+  in
 
   (* pop remaining comments *)
   if not (Stack.is_empty comments) then Queue.add (Spacer (true, 1)) chunks;

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -75,6 +75,7 @@ and chunk =
       typq_opt : chunks option;
       return_typ_opt : chunks option;
       funcls : (chunks * pexp_chunks) list;
+      hanging : bool;
     }
   | Val of { id : Parse_ast.id; extern_opt : Parse_ast.extern option; typq_opt : chunks option; typ : chunks }
   | Enum of { id : Parse_ast.id; enum_functions : chunks list option; members : chunks list }
@@ -91,7 +92,8 @@ and chunk =
   | Pragma of string * string
   | Unary of string * chunks
   | Binary of chunks * string * chunks
-  | Ternary of chunks * string * chunks * string * chunks
+  | Vector_binary of chunks * string * chunks
+  | Assign of chunks * (string * chunks) option * string * chunks
   | Infix_sequence of infix_chunk list
   | Index of chunks * chunks
   | Delim of string
@@ -112,7 +114,7 @@ and chunk =
       body : chunks;
     }
   | While of { repeat_until : bool; termination_measure : chunks option; cond : chunks; body : chunks }
-  | Vector_updates of chunks * chunk list
+  | Vector_updates of chunks * chunks list
   | Chunks of chunks
   | Raw of string
 

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -101,6 +101,7 @@ module PPrintWrapper = struct
 
   type document =
     | Empty
+    | Weak_space
     | Char of char
     | String of string
     | Utf8string of string
@@ -111,14 +112,20 @@ module PPrintWrapper = struct
     | Hardline of hardline_type
     | Ifflat of document * document
 
-  type linebreak_info = { hardlines : (int * int * hardline_type) Queue.t; dedents : (int * int * int) Queue.t }
+  type linebreak_info = {
+    hardlines : (int * int * hardline_type) Queue.t;
+    dedents : (int * int * int) Queue.t;
+    weak_spaces : (int * int) Queue.t;
+  }
 
-  let empty_linebreak_info () = { hardlines = Queue.create (); dedents = Queue.create () }
+  let empty_linebreak_info () =
+    { hardlines = Queue.create (); dedents = Queue.create (); weak_spaces = Queue.create () }
 
   let rec to_pprint lb_info =
     let open PPrint in
     function
     | Empty -> empty
+    | Weak_space -> range (fun (lc, _) -> Queue.add lc lb_info.weak_spaces) (char ' ')
     | Char c -> char c
     | String s -> string s
     | Utf8string s -> utf8string s
@@ -168,6 +175,9 @@ module PPrintWrapper = struct
   let group doc = Group doc
 
   let space = char ' '
+
+  (* A weak_space is like a space, but it is empty when it appears before any non-whitespace character in a line. *)
+  let weak_space = Weak_space
 
   let enclose l r x = l ^^ x ^^ r
 
@@ -316,7 +326,7 @@ let statement_like opts = { opts with statement = true }
 let operator_precedence = function
   | "=" -> (10, precedence 1, nonatomic, 1)
   | ":" -> (0, subatomic, subatomic, 1)
-  | ".." -> (10, atomic, atomic, 0)
+  | ".." -> (10, atomic, atomic, 1)
   | "@" -> (6, precedence 5, precedence 6, 1)
   | _ -> (10, subatomic, subatomic, 1)
 
@@ -329,6 +339,11 @@ let max_precedence infix_chunks =
           max prec max_prec
       | _ -> max_prec
     )
+    0 infix_chunks
+
+let longest_operator infix_chunks =
+  List.fold_left
+    (fun max_len infix_chunk -> match infix_chunk with Infix_op op -> max (String.length op) max_len | _ -> max_len)
     0 infix_chunks
 
 let intersperse_operator_precedence = function "@" -> (6, precedence 5) | _ -> (10, subatomic)
@@ -362,6 +377,8 @@ let can_hang_bracketed chunks =
   | Some (App _) -> true
   | _ -> false
 
+let is_block chunks = match Queue.peek_opt chunks with Some (Block _) -> true | _ -> false
+
 let opt_delim s = ifflat empty (string s)
 
 let softline = break 0
@@ -371,13 +388,25 @@ let prefix_parens n x y =
 
 let surround_hardline h n b opening contents closing =
   let b = if h then hardline else break b in
-  group (opening ^^ nest n (b ^^ contents) ^^ b ^^ closing)
+  opening ^^ nest n (b ^^ contents) ^^ b ^^ closing
 
-type config = { indent : int; preserve_structure : bool; line_width : int; ribbon_width : float }
+type infix_style = Prefix_lineup | Prefix
 
-let default_config = { indent = 4; preserve_structure = false; line_width = 120; ribbon_width = 1. }
+let infix_style_of_string = function "prefix_lineup" -> Some Prefix_lineup | "prefix" -> Some Prefix | _ -> None
 
-let known_key k = k = "indent" || k = "preserve_structure" || k = "line_width" || k = "ribbon_width"
+type config = {
+  indent : int;
+  preserve_structure : bool;
+  line_width : int;
+  ribbon_width : float;
+  infix_style : infix_style;
+}
+
+let default_config =
+  { indent = 4; preserve_structure = false; line_width = 120; ribbon_width = 1.; infix_style = Prefix_lineup }
+
+let known_key k =
+  k = "indent" || k = "preserve_structure" || k = "line_width" || k = "ribbon_width" || k = "infix_style"
 
 let int_option k = function
   | `Int n -> Some n
@@ -407,6 +436,19 @@ let float_option k = function
         );
       None
 
+let enum_option f k = function
+  | `String s ->
+      let res = f s in
+      if Option.is_none res then
+        Reporting.simple_warn (Printf.sprintf "Argument for key %s was not a recognized setting. Using default value." k);
+      res
+  | json ->
+      Reporting.simple_warn
+        (Printf.sprintf "Argument for key %s must be a string, got %s instead. Using default value." k
+           (Yojson.Safe.to_string json)
+        );
+      None
+
 let get_option ~key:k ~keys:ks ~read ~default:d =
   List.assoc_opt k ks |> (fun opt -> Option.bind opt (read k)) |> Option.value ~default:d
 
@@ -424,6 +466,9 @@ let config_from_json (json : Yojson.Safe.t) =
           get_option ~key:"preserve_structure" ~keys ~read:bool_option ~default:default_config.preserve_structure;
         line_width = get_option ~key:"line_width" ~keys ~read:int_option ~default:default_config.line_width;
         ribbon_width = get_option ~key:"ribbon_width" ~keys ~read:float_option ~default:default_config.ribbon_width;
+        infix_style =
+          get_option ~key:"infix_style" ~keys ~read:(enum_option infix_style_of_string)
+            ~default:default_config.infix_style;
       }
   | _ -> raise (Reporting.err_general Parse_ast.Unknown "Invalid formatting configuration")
 
@@ -454,6 +499,7 @@ let rec can_chunks_list_wrap cqs =
 module Make (Config : CONFIG) = struct
   let indent = Config.config.indent
   let preserve_structure = Config.config.preserve_structure
+  let infix_style = Config.config.infix_style
 
   let rec doc_chunk ?(ungroup_tuple = false) ?(toplevel = false) opts = function
     | Atom s -> string s
@@ -491,16 +537,32 @@ module Make (Config : CONFIG) = struct
         if outer_prec > opts.precedence then parens doc else doc
     | Infix_sequence infix_chunks ->
         let outer_prec = max_precedence infix_chunks in
+        let longest_op = longest_operator infix_chunks in
         let doc =
           separate_map empty
             (function
               | Infix_prefix op -> string op
-              | Infix_op op -> space ^^ string op ^^ space
-              | Infix_chunks chunks -> doc_chunks (opts |> atomic |> expression_like) chunks
+              | Infix_op op ->
+                  let op_w = String.length op in
+                  let padding =
+                    match infix_style with
+                    | Prefix_lineup -> ifflat space (repeat (longest_op - op_w + 1) space)
+                    | Prefix ->
+                        prerr_endline "NOPAD";
+                        space
+                  in
+                  break 1 ^^ string op ^^ padding
+              | Infix_chunks chunks ->
+                  let nesting = match infix_style with Prefix_lineup -> longest_op + 1 | Prefix -> indent in
+                  nest nesting (doc_chunks (opts |> atomic |> expression_like) chunks)
               )
             infix_chunks
         in
-        if outer_prec > opts.precedence then parens doc else doc
+        let start_padding =
+          match infix_style with Prefix_lineup -> ifflat empty (repeat (longest_op + 1) space) | Prefix -> empty
+        in
+        let doc = start_padding ^^ doc in
+        group (align (if outer_prec > opts.precedence then parens doc else doc))
     | Binary (lhs, op, rhs) ->
         let outer_prec, lhs_prec, rhs_prec, spacing = operator_precedence op in
         let doc =
@@ -509,30 +571,49 @@ module Make (Config : CONFIG) = struct
             (doc_chunks (opts |> rhs_prec |> expression_like) rhs)
         in
         if outer_prec > opts.precedence then parens doc else doc
-    | Ternary (x, op1, y, op2, z) ->
-        let outer_prec, x_prec, y_prec, z_prec = ternary_operator_precedence (op1, op2) in
-        let doc =
-          prefix indent 1
-            (doc_chunks (opts |> x_prec |> expression_like) x
-            ^^ space ^^ string op1 ^^ space
-            ^^ doc_chunks (opts |> y_prec |> expression_like) y
-            ^^ space ^^ string op2
-            )
-            (doc_chunks (opts |> z_prec |> expression_like) z)
-        in
-        if outer_prec > opts.precedence then parens doc else doc
+    | Vector_binary (lhs, op, rhs) ->
+        infix indent 1 (string op)
+          (doc_chunks (opts |> nonatomic |> expression_like) lhs)
+          (doc_chunks (opts |> nonatomic |> expression_like) rhs)
+    | Assign (x, ternary, op, z) -> (
+        match ternary with
+        | None ->
+            let x_doc = doc_chunks (atomic opts) x in
+            let z_doc = doc_chunks (nonatomic opts) z in
+            group (x_doc ^^ space ^^ char '=' ^^ nest indent (break 1 ^^ z_doc))
+        | Some (t_op, y) ->
+            let outer_prec, x_prec, y_prec, z_prec = ternary_operator_precedence (t_op, op) in
+            let doc =
+              prefix indent 1
+                (doc_chunks (opts |> x_prec |> expression_like) x
+                ^^ space ^^ string t_op ^^ space
+                ^^ doc_chunks (opts |> y_prec |> expression_like) y
+                ^^ space ^^ string op
+                )
+                (doc_chunks (opts |> z_prec |> expression_like) z)
+            in
+            if outer_prec > opts.precedence then parens doc else doc
+      )
     | If_then_else (bracing, i, t, e) ->
-        let insert_braces = opts.statement || bracing.then_brace || bracing.else_brace in
+        let have_braces = bracing.then_brace || bracing.else_brace in
+        let insert_braces = (opts.statement || have_braces) && not preserve_structure in
         let i = doc_chunks (opts |> nonatomic |> expression_like) i in
         let t =
-          if insert_braces && (not preserve_structure) && not bracing.then_brace then doc_chunk opts (Block (true, [t]))
+          if insert_braces && not bracing.then_brace then doc_chunk opts (Block (true, [t]))
           else doc_chunks (opts |> nonatomic |> expression_like) t
         in
         let e =
-          if insert_braces && (not preserve_structure) && not bracing.else_brace then doc_chunk opts (Block (true, [e]))
+          if insert_braces && not bracing.else_brace then doc_chunk opts (Block (true, [e]))
           else doc_chunks (opts |> nonatomic |> expression_like) e
         in
-        separate space [string "if"; i; string "then"; t; string "else"; e] |> atomic_parens opts
+        if not (have_braces || insert_braces) then
+          string "if" ^^ space ^^ i ^^ break 1 ^^ string "then" ^^ space ^^ t ^^ break 1 ^^ string "else" ^^ space ^^ e
+          |> atomic_parens opts |> align |> group
+        else (
+          let ite_part kw doc = string kw ^^ space ^^ doc in
+          ite_part "if" i ^^ weak_space ^^ ite_part "then" t ^^ weak_space ^^ ite_part "else" e
+          |> atomic_parens opts |> group
+        )
     | If_then (bracing, i, t) ->
         let i = doc_chunks (opts |> nonatomic |> expression_like) i in
         let t =
@@ -543,15 +624,16 @@ module Make (Config : CONFIG) = struct
     | Vector_updates (exp, updates) ->
         let opts = opts |> nonatomic |> expression_like in
         let exp_doc = doc_chunks opts exp in
-        surround indent 0
-          (char '[' ^^ exp_doc ^^ space ^^ string "with" ^^ space)
-          (group (separate_map (char ',' ^^ break 1) (doc_chunk opts) updates))
-          (char ']')
-        |> atomic_parens opts
+        align
+          (char '[' ^^ ifflat empty space ^^ exp_doc ^^ space ^^ string "with"
+          ^^ nest 2 (break 1 ^^ separate_map (char ',' ^^ break 1) (doc_chunks opts) updates)
+          ^^ break 0 ^^ char ']'
+          )
+        |> atomic_parens opts |> group
     | Index (exp, ix) ->
         let exp_doc = doc_chunks (opts |> atomic |> expression_like) exp in
         let ix_doc = doc_chunks (opts |> nonatomic |> expression_like) ix in
-        let ix_doc = surround_hardline false indent 0 (char '[') ix_doc (char ']') in
+        let ix_doc = group (surround_hardline false indent 0 (char '[') ix_doc (char ']')) in
         exp_doc ^^ ix_doc
     | Exists ex ->
         let ex_doc =
@@ -581,7 +663,7 @@ module Make (Config : CONFIG) = struct
                   )
              )
           )
-        ^^ break 1
+        ^^ space
     | Struct_update (exp, fexps) ->
         surround indent 1 (char '{')
           (doc_chunks opts exp ^^ space ^^ string "with" ^^ break 1 ^^ separate_map (break 1) (doc_chunks opts) fexps)
@@ -614,15 +696,15 @@ module Make (Config : CONFIG) = struct
         let clauses =
           match f.funcls with
           | [] -> Reporting.unreachable (id_loc f.id) __POS__ "Function with no clauses found"
-          | [funcl] -> doc_funcl f.return_typ_opt opts funcl
+          | [funcl] -> doc_funcl f.hanging f.typq_opt f.return_typ_opt opts funcl
           | funcl :: funcls ->
-              doc_funcl f.return_typ_opt opts funcl ^^ sep ^^ separate_map sep (doc_funcl None opts) f.funcls
+              doc_funcl f.hanging f.typq_opt f.return_typ_opt opts funcl
+              ^^ sep
+              ^^ separate_map sep (doc_funcl false None None opts) f.funcls
         in
         string "function"
         ^^ (if f.clause then space ^^ string "clause" else empty)
-        ^^ space ^^ doc_id f.id
-        ^^ (match f.typq_opt with Some typq -> space ^^ doc_chunks opts typq | None -> empty)
-        ^^ clauses ^^ hardline
+        ^^ space ^^ doc_id f.id ^^ clauses ^^ hardline
     | Val vs ->
         let doc_binding (target, name) =
           string target ^^ char ':' ^^ space ^^ char '"' ^^ utf8string name ^^ char '"'
@@ -723,8 +805,9 @@ module Make (Config : CONFIG) = struct
                 )
                 (char ')')
              )
-        ^^ space
-        ^^ group (doc_chunks (opts |> nonatomic |> statement_like) loop.body)
+        ^^
+        if is_block loop.body then space ^^ group (doc_chunks (opts |> nonatomic |> statement_like) loop.body)
+        else nest indent (hardline ^^ group (doc_chunks (opts |> nonatomic |> statement_like) loop.body))
     | While loop ->
         let measure =
           match loop.termination_measure with
@@ -753,21 +836,26 @@ module Make (Config : CONFIG) = struct
     let guarded_pat, body = doc_pexp_chunks_pair opts pexp in
     separate space [guarded_pat; string "=>"; body]
 
-  and doc_funcl return_typ_opt opts (header, pexp) =
+  and doc_funcl hanging typq_opt return_typ_opt opts (header, pexp) =
     let return_typ =
       match return_typ_opt with
       | Some chunks -> space ^^ prefix_parens indent (string "->") (doc_chunks opts chunks) ^^ space
       | None -> space
     in
+    let typq = match typq_opt with None -> empty | Some typq -> space ^^ doc_chunks opts typq in
+    let paren_args doc = if pexp.funcl_space then parens doc else doc in
     doc_chunks opts header
     ^^
     match pexp.guard with
     | None ->
-        (if pexp.funcl_space then space else empty)
-        ^^ group (doc_chunks ~ungroup_tuple:true opts pexp.pat ^^ return_typ)
-        ^^ string "=" ^^ space ^^ doc_chunks opts pexp.body
+        group (typq ^^ paren_args (doc_chunks ~ungroup_tuple:true opts pexp.pat) ^^ return_typ)
+        ^^ string "="
+        ^^
+        if is_block pexp.body || hanging then space ^^ doc_chunks opts pexp.body
+        else nest indent (hardline ^^ doc_chunks opts pexp.body)
     | Some guard ->
-        parens (separate space [doc_chunks opts pexp.pat; string "if"; doc_chunks opts guard])
+        typq
+        ^^ parens (separate space [doc_chunks opts pexp.pat; string "if"; doc_chunks opts guard])
         ^^ return_typ ^^ string "=" ^^ space ^^ doc_chunks opts pexp.body
 
   (* Format an expression in a block, optionally terminating it with a
@@ -871,7 +959,17 @@ module Make (Config : CONFIG) = struct
           column := 0
         )
         else (
-          if c = ' ' then incr pending_spaces
+          if c = ' ' then (
+            match Queue.peek_opt lb_info.weak_spaces with
+            | Some (l, c) when l = !line && c = !column ->
+                ignore (Queue.take lb_info.weak_spaces);
+                if !after_hardline then (if debug then Buffer.add_string buf Util.("W" |> magenta |> bold |> clear))
+                else (
+                  if debug then Buffer.add_string buf Util.("W" |> blue |> clear);
+                  incr pending_spaces
+                )
+            | _ -> incr pending_spaces
+          )
           else (
             if !require_hardline then (
               Buffer.add_char buf '\n';

--- a/src/lib/format_sail.mli
+++ b/src/lib/format_sail.mli
@@ -44,6 +44,8 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
+type infix_style = Prefix_lineup | Prefix
+
 type config = {
   indent : int;  (** The default indentation depth (default 4) *)
   preserve_structure : bool;
@@ -53,6 +55,7 @@ type config = {
   ribbon_width : float;
       (** The fraction (between 0.0 and 1.0) of the maximum line width that can be filled by non whitespace characters
           before we consider breaking. (default 1.0) *)
+  infix_style : infix_style;
 }
 
 (** Read the config struct from a json object. Raises err_general if the json is not an object, and warns about any

--- a/test/format/RISCV_LICENSE
+++ b/test/format/RISCV_LICENSE
@@ -1,0 +1,93 @@
+RISCV Sail Model
+
+This Sail RISC-V architecture model, comprising all files and
+directories except for the third party dependencies in the
+'dependencies' directory (which include copies of their licences), is
+subject to the BSD two-clause licence below.
+
+Copyright (c) 2017-2025
+   ahadali5000
+   Alasdair Armstrong
+   Alexander Richardson
+   Aril Computer Corp., for contributions by Scott Johnson
+   Ben Marshall
+   Bicheng Yang
+   Bilal Sakhawat
+   Brian Campbell
+   Chris Casinghino
+   Christopher Pulte
+   Codasip, for contributions by Tim Hutt, Martin Berger and Ben Fletcher
+   dylux
+   eroom1966
+   Google LLC, for contributions by its employees
+   Hesham Almatary
+   Jan Henrik Weinstock
+   Jessica Clarke
+   Jon French
+   Jordan Carlin
+   Martin Berger
+   Michael Sammler
+   Microsoft, for contributions by Robert Norton-Wright and Nathaniel Wesley Filardo
+   Muhammad Bilal Sakhawat
+   Nathaniel Wesley Filardo
+   Paul A. Clarke
+   Peter Rugg
+   Peter Sewell
+   Philipp Tomsich
+   Prashanth Mundkur
+   Rafael Sene
+   Rishiyur S. Nikhil (Bluespec, Inc.)
+   Robert Norton-Wright
+   Scott Johnson (Aril Inc.)
+   Shaked Flur
+   Thibaut Pérami
+   Thomas Bauereiss
+   VRULL GmbH, for contributions by its employees
+   William McSpaddden
+   Xinlai Wan
+
+For a complete list of authors run this command:
+
+    git shortlog --summary --numbered --email
+
+All rights reserved.
+
+This software was developed by the above within the Rigorous
+Engineering of Mainstream Systems (REMS) project, partly funded by
+EPSRC grant EP/K008528/1, at the Universities of Cambridge and
+Edinburgh.
+
+This software was developed by SRI International and the University of
+Cambridge Computer Laboratory (Department of Computer Science and
+Technology) under DARPA/AFRL contract FA8650-18-C-7809 ("CIFV"), and
+under DARPA contract HR0011-18-C-0016 ("ECATS") as part of the DARPA
+SSITH research programme.
+
+This project has received funding from the European Research Council
+(ERC) under the European Union’s Horizon 2020 research and innovation
+programme (grant agreement 789108, ELVER).
+
+------------------------------------------------------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/test/format/comment_spacing.sail
+++ b/test/format/comment_spacing.sail
@@ -1,0 +1,17 @@
+
+// comment
+
+// Another comment
+
+/* a block
+   comment */
+
+// A third
+// comment
+
+
+/// Doc comment
+val foo : unit -> unit
+
+function foo () =
+  ()

--- a/test/format/default/block.expect
+++ b/test/format/default/block.expect
@@ -4,7 +4,7 @@ $include <prelude.sail>
 
 val foo : unit -> unit
 
-function foo () = {
+function foo() = {
     print_endline("string1"); // comment
     print_endline("string2");
 

--- a/test/format/default/can_hang.expect
+++ b/test/format/default/can_hang.expect
@@ -2,7 +2,7 @@ default Order dec
 
 $include <prelude.sail>
 
-function foo () = {
+function foo() = {
     let x =
         /* block
            comment */
@@ -11,7 +11,7 @@ function foo () = {
         }
 }
 
-function bar () = {
+function bar() = {
     /* block
        comment */
     let x = match unit {

--- a/test/format/default/comment_spacing.expect
+++ b/test/format/default/comment_spacing.expect
@@ -1,0 +1,17 @@
+
+// comment
+
+// Another comment
+
+/* a block
+   comment */
+
+// A third
+// comment
+
+
+/// Doc comment
+val foo : unit -> unit
+
+function foo() =
+    ()

--- a/test/format/default/comments.expect
+++ b/test/format/default/comments.expect
@@ -9,16 +9,19 @@
 /* first line comment
 
         last line comment         */
+
 /* first line comment
              indent many
            last line comment*/
+
 /* first line comment
 indent many
      last line comment*/
+
 /* first line comment
        indent many
 last line comment*/
-function a () -> int = {
+function a() -> int = {
     /*comment*/
     /*      comment          */
     /* first line comment
@@ -29,12 +32,15 @@ function a () -> int = {
     /* first line comment
 
             last line comment         */
+
     /* first line comment
                  indent many
                last line comment*/
+
     /* first line comment
     indent many
          last line comment*/
+
     /* first line comment
            indent many
     last line comment*/
@@ -49,7 +55,8 @@ function a () -> int = {
 }
 
 // comment
-function b () -> int = {
+
+function b() -> int = {
     let a = {
         1
         // comment

--- a/test/format/default/config.json
+++ b/test/format/default/config.json
@@ -1,9 +1,3 @@
 {
-    "fmt": {
-        "indent": 4,
-        "preserve_structure": false,
-        "line_width": 120,
-        "ribbon_width": 1.0
-    }
+    "fmt": {}
 }
-

--- a/test/format/default/fmt_skip.expect
+++ b/test/format/default/fmt_skip.expect
@@ -1,0 +1,10 @@
+
+$[fmt "skip"]
+let foo =
+
+
+
+       ()
+
+// A comment
+val test : unit -> unit

--- a/test/format/default/index.expect
+++ b/test/format/default/index.expect
@@ -1,4 +1,4 @@
-function rX r = {
+function rX(r) = {
     let foo = Xs[1];
     let foo = Xs[a];
     let foo = Xs[unsigned(r)];

--- a/test/format/default/multi_exist.expect
+++ b/test/format/default/multi_exist.expect
@@ -1,0 +1,4 @@
+
+type t = {'n 'm. vector('n, vector('m, int))}
+
+val some_matrix : unit -> {'n 'm. vector('n, vector('m, int))}

--- a/test/format/default/patterns.expect
+++ b/test/format/default/patterns.expect
@@ -4,13 +4,13 @@ $include <prelude.sail>
 
 function foo(ys : bits(6), xs : bits(6)) -> unit = {
     match ys {
-        xs[3..1] @ xs[0] @ xs[5..4] => (),
-        (xs[3..1] @ xs[0]) @ xs[5..4] => (), // should have brackets
-        xs[3..1] @ (xs[0] @ xs[5..4]) => (), // brackets here will also be preserved for now
+        xs[3 .. 1] @ xs[0] @ xs[5 .. 4] => (),
+        (xs[3 .. 1] @ xs[0]) @ xs[5 .. 4] => (), // should have brackets
+        xs[3 .. 1] @ (xs[0] @ xs[5 .. 4]) => (), // brackets here will also be preserved for now
         _ => (),
     };
-    let _ = xs[3..1] @ xs[0..0] @ xs[5..4];
-    let _ = (xs[3..1] @ xs[0..0]) @ xs[5..4]; // should have brackets
-    let _ = xs[3..1] @ xs[0..0] @ xs[5..4];
+    let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
+    let _ = (xs[3 .. 1] @ xs[0 .. 0]) @ xs[5 .. 4]; // should have brackets
+    let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
     ()
 }

--- a/test/format/default/rv_gfmul.expect
+++ b/test/format/default/rv_gfmul.expect
@@ -1,0 +1,30 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+      (if bit_to_bool(y[0]) then x else 0x00)
+    ^ (if bit_to_bool(y[1]) then xt2(x) else 0x00)
+    ^ (if bit_to_bool(y[2]) then xt2(xt2(x)) else 0x00)
+    ^ (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}
+
+overload operator ^^^ = operator ^
+
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+        (if bit_to_bool(y[0]) then x else 0x00)
+    ^   (if bit_to_bool(y[1]) then xt2(x) else 0x00)
+    ^^^ (if bit_to_bool(y[2]) then xt2(xt2(x)) else 0x00)
+    ^   (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}
+
+$[fmt "skip"]
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then             x    else 0x00) ^
+  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
+  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
+  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}

--- a/test/format/default/rv_legalize_misa.expect
+++ b/test/format/default/rv_legalize_misa.expect
@@ -1,0 +1,34 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
+    let v = Mk_Misa(v);
+
+    // Suppress updates to MISA if MISA is not writable or if by disabling C next PC would become misaligned or an extension vetoes
+    if not(sys_enable_writable_misa) | (v[C] == 0b0 & (nextPC[1] == bitone | ext_veto_disable_C())) then {
+        m
+    } else {
+        [ m with
+          A = if hartSupports(Ext_A) then v[A] else 0b0,
+          B = if hartSupports(Ext_B) then v[B] else 0b0,
+          C = if hartSupports(Ext_C) then v[C] else 0b0,
+          D = if hartSupports(Ext_D) & v[F] == 0b1 then v[D] else 0b0,
+          F = if hartSupports(Ext_F) then v[F] else 0b0,
+          H = if hartSupports(Ext_H) then v[H] else 0b0,
+          // TODO: Not fully supported yet
+          // Writable I is not currently supported.
+          I = bool_to_bits(not(base_E_enabled)),
+          E = bool_to_bits(base_E_enabled),
+          M = if hartSupports(Ext_M) then v[M] else 0b0,
+          // Q = if hartSupports(Ext_Q) then v[Q] else 0b0, TODO: Not supported yet
+          S = if hartSupports(Ext_S) & v[U] == 0b1 then v[S] else 0b0,
+          U = if hartSupports(Ext_U) then v[U] else 0b0,
+          V = if hartSupports(Ext_V) & v[F] == 0b1 & v[D] == 0b1 then v[V] else 0b0
+          // X = ... TODO: If custom extensions are present this should be 1
+        ]
+    }
+}

--- a/test/format/default/struct_update.expect
+++ b/test/format/default/struct_update.expect
@@ -6,14 +6,14 @@ $include <prelude.sail>
 
 val foo : unit -> unit
 
-function foo () = {
+function foo() = {
     ();
     let x = { s with foo = 0xFFFF,  bar = 0b1 }
 }
 
 val bar : unit -> int
 
-function baz () = {
+function baz() = {
     ();
     let some_long_named_variable_to_break_the_line = {
         function_modify_the_struct(struct_with_a_long_name, x) with
@@ -27,7 +27,7 @@ function baz () = {
 
 scattered function /* comment */ quux
 
-function clause quux 0b0000_0000 = ()
+function clause quux(0b0000_0000) = ()
 
 end /* comment */ quux
 
@@ -43,7 +43,7 @@ enum E with f -> very_long_type_that_will_trigger_a_linebreak,
     B,
 }
 
-function has_loops () = {
+function has_loops() = {
     foreach (n from 1 to 3) { () };
     foreach (n from 3 downto 1) { () };
     foreach (n from 0 to 4 by 2) { () };

--- a/test/format/default/test_if_comment_1.expect
+++ b/test/format/default/test_if_comment_1.expect
@@ -1,24 +1,27 @@
 
-function foo () = {
+function foo() = {
     if cond then {
-        2 /* comment */
+        2
+        /* comment */
     } else {
         3 /* comment */
     }
 }
 
-function foo () = {
+function foo() = {
     if cond then {
-        2 // comment
+        2
+        // comment
     } else {
         3 // comment
     }
 }
 
-function foo () = {
+function foo() = {
     if cond then {
         if cond2 then {
-            2 // comment
+            2
+            // comment
         } else {
             4 /* comment */
         }

--- a/test/format/default/wrap_into_oneline.expect
+++ b/test/format/default/wrap_into_oneline.expect
@@ -1,27 +1,33 @@
-function f b = if b == bitone then { bitzero } else { bitone }
-function f b = if b == bitone then { bitzero } else { bitone }
-function f b = if b == bitone then {
+function f(b) = if b == bitone then { bitzero } else { bitone }
+function f(b) = if b == bitone then { bitzero } else { bitone }
+function f(b) = if b == bitone then {
     let a = 1;
     bitzero
-} else { bitone }
+} else {
+    bitone
+}
 
-function f b = if b == bitone then { { bitzero } } else { bitone }
-function f b = if b == bitone then { { { bitzero } } } else { bitone }
-function f b = if b == bitone then {
+function f(b) = if b == bitone then { { bitzero } } else { bitone }
+function f(b) = if b == bitone then { { { bitzero } } } else { bitone }
+function f(b) = if b == bitone then {
     {
         let a = 1;
         bitzero
     }
-} else { bitone }
-function f b = if b == bitone then {
+} else {
+    bitone
+}
+function f(b) = if b == bitone then {
     {
         {
             let a = 1;
             bitzero
         }
     }
-} else { bitone }
-function f b = if b == bitone then {
+} else {
+    bitone
+}
+function f(b) = if b == bitone then {
     {
         {
             {
@@ -40,7 +46,7 @@ function f b = if b == bitone then {
         }
     }
 }
-function f b = if b == bitone then {
+function f(b) = if b == bitone then {
     {
         {
             {
@@ -49,8 +55,10 @@ function f b = if b == bitone then {
             }
         }
     }
-} else { { { bitone } } }
-function f b = if b == bitone then {
+} else {
+    { { bitone } }
+}
+function f(b) = if b == bitone then {
     {
         {
             {
@@ -67,27 +75,31 @@ function f b = if b == bitone then {
 }
 
 /* comment */
-function f /* comment */ b = if b == bitone then { bitzero } else { bitone }
-function f /* comment */ b = if b == bitone then { bitzero } else { bitone }
-function f b = /* comment */ if b == bitone then { bitzero } else { bitone }
-function f b = /* comment */ if b == bitone then { bitzero } else { bitone }
+function f( /* comment */ b) = if b == bitone then { bitzero } else { bitone }
+function f( /* comment */ b) = if b == bitone then { bitzero } else { bitone }
+function f(b) = /* comment */ if b == bitone then { bitzero } else { bitone }
+function f(b) = /* comment */ if b == bitone then { bitzero } else { bitone }
 
 // TODO function f b =/* comment */if b == bitone then bitzero else bitone
-function f b = if /* comment */ b == bitone then { bitzero } else { bitone }
-function f b = if b == /* comment */ bitone then { bitzero } else { bitone }
-function f b = if b == /* comment */ bitone then { bitzero } else { bitone }
+function f(b) = if /* comment */ b == bitone then { bitzero } else { bitone }
+function f(b) = if b == /* comment */ bitone then { bitzero } else { bitone }
+function f(b) = if b == /* comment */ bitone then { bitzero } else { bitone }
 
 // TODO function f b = if b ==/* comment */bitone then bitzero else bitone
-function f b = if b == bitone /* comment */  then { bitzero } else { bitone }
-function f b = if b == bitone then {
+function f(b) = if b == bitone /* comment */  then { bitzero } else { bitone }
+function f(b) = if b == bitone then {
     /* comment */ bitzero
-} else { bitone }
-function f b = if b == bitone then {
+} else {
+    bitone
+}
+function f(b) = if b == bitone then {
     bitzero /* comment */
-} else { bitone }
-function f b = if b == bitone then {
-    bitzero /* comment */
-} else { bitone }
-function f b = if b == bitone then {
-    bitzero /* comment */
-} else { bitone }
+} else {
+    bitone
+}
+function f(b) = if b == bitone then {
+    bitzero
+} else {
+    /* comment */ bitone
+}
+function f(b) = if b == bitone then { bitzero } else { bitone } /* comment */

--- a/test/format/fmt_skip.sail
+++ b/test/format/fmt_skip.sail
@@ -1,0 +1,11 @@
+
+$[fmt skip]
+let foo =
+
+
+
+       ()
+
+
+// A comment
+val test : unit -> unit

--- a/test/format/lw80_preserve/block.expect
+++ b/test/format/lw80_preserve/block.expect
@@ -1,0 +1,27 @@
+default Order dec
+
+$include <prelude.sail>
+
+val foo : unit -> unit
+
+function foo() = {
+  print_endline("string1"); // comment
+  print_endline("string2");
+
+  ();
+  ();
+
+  let x = call_function_with_a_long_name(
+    and_long_arguments,
+    1,
+    2,
+    3,
+    4, // foo
+    5,
+    6,
+    7,
+    /* comment */ 8,
+  );
+
+  print_endline("string3")
+}

--- a/test/format/lw80_preserve/can_hang.expect
+++ b/test/format/lw80_preserve/can_hang.expect
@@ -1,0 +1,20 @@
+default Order dec
+
+$include <prelude.sail>
+
+function foo() = {
+  let x =
+    /* block
+       comment */
+    match unit {
+      unit => (),
+    }
+}
+
+function bar() = {
+  /* block
+     comment */
+  let x = match unit {
+    unit => (),
+  }
+}

--- a/test/format/lw80_preserve/comment_spacing.expect
+++ b/test/format/lw80_preserve/comment_spacing.expect
@@ -1,0 +1,17 @@
+
+// comment
+
+// Another comment
+
+/* a block
+   comment */
+
+// A third
+// comment
+
+
+/// Doc comment
+val foo : unit -> unit
+
+function foo() =
+  ()

--- a/test/format/lw80_preserve/comments.expect
+++ b/test/format/lw80_preserve/comments.expect
@@ -1,0 +1,109 @@
+/*comment*/
+/*      comment          */
+/* first line comment
+                        */
+
+/* first line comment
+
+           */
+/* first line comment
+
+        last line comment         */
+
+/* first line comment
+             indent many
+           last line comment*/
+
+/* first line comment
+indent many
+     last line comment*/
+
+/* first line comment
+       indent many
+last line comment*/
+function a() -> int = {
+  /*comment*/
+  /*      comment          */
+  /* first line comment
+                          */
+  /* first line comment
+
+             */
+  /* first line comment
+
+          last line comment         */
+
+  /* first line comment
+               indent many
+             last line comment*/
+
+  /* first line comment
+  indent many
+       last line comment*/
+
+  /* first line comment
+         indent many
+  last line comment*/
+  *R = baz; // comment
+
+  // comment
+  1 // comment
+  // comment
+  // comment
+  /* com-
+  ment */
+}
+
+// comment
+
+function b() -> int = {
+  let a = {
+    1
+    // comment
+  };
+
+  let b = {
+    1 // comment
+  };
+
+  let c = {
+    1 // comment
+    // comment
+  };
+
+  let d = {
+    1 // comment
+    // comment
+  }; // comment
+
+  let f = {
+    let g1 = {
+      1 // comment
+    };
+
+    let g2 = {
+      1
+      // comment
+    };
+
+    let g3 = {
+      1 // comment
+      // comment
+    } // comment
+  };
+
+  1
+  // comment
+}
+
+let c = 1
+
+// comment
+let c2 = 1 // comment
+let d = {
+  1
+  // comment
+} // comment
+// comment
+// comment
+// comment

--- a/test/format/lw80_preserve/config.json
+++ b/test/format/lw80_preserve/config.json
@@ -1,0 +1,9 @@
+{
+    "fmt": {
+        "indent": 2,
+        "preserve_structure": true,
+        "line_width": 80,
+        "ribbon_width": 1.0,
+        "infix_style": "prefix"
+    }
+}

--- a/test/format/lw80_preserve/doc_comment.expect
+++ b/test/format/lw80_preserve/doc_comment.expect
@@ -1,0 +1,13 @@
+default Order dec
+
+/*! first line comment
+             indent many
+           last line comment*/
+/*! first line comment
+      indent many
+           last line comment*/
+/*! first line comment
+             indent many
+      last line comment*/
+/*! A documentation comment */
+val main : unit -> unit

--- a/test/format/lw80_preserve/enum_doc_attr.expect
+++ b/test/format/lw80_preserve/enum_doc_attr.expect
@@ -1,0 +1,20 @@
+default Order dec
+
+$include <prelude.sail>
+
+enum E = {
+  /// Documentation comment
+  /* line comment */ $[attr "Some argument"]
+  A,
+  /// Another doc comment
+  // with a regular comment
+  B,
+}
+
+scattered enum SE
+
+/// Documentation comment on clause
+$[another_attr]
+enum clause SE = /* comment */ C
+
+end SE

--- a/test/format/lw80_preserve/fmt_skip.expect
+++ b/test/format/lw80_preserve/fmt_skip.expect
@@ -1,0 +1,10 @@
+
+$[fmt "skip"]
+let foo =
+
+
+
+       ()
+
+// A comment
+val test : unit -> unit

--- a/test/format/lw80_preserve/function_quant.expect
+++ b/test/format/lw80_preserve/function_quant.expect
@@ -3,26 +3,27 @@ default Order dec
 $include <prelude.sail>
 
 function foo forall 'n 'm, 'n >= 0. (x : int('n), y : int('m)) -> unit = {
-    ()
+  ()
 }
 
 function foo /* c */ forall 'n 'm, 'n >= 0. (x : int('n), y : int('m)) -> unit = {
-    ()
+  ()
 }
 
 function foo forall /* c */ 'n 'm, 'n >= 0. (x : int('n), y : int('m)) -> unit = {
-    ()
+  ()
 }
 
 function foo forall 'n 'm, /* c */ 'n >= 0. (x : int('n), y : int('m)) -> unit = {
-    ()
+  ()
 }
 
-function foo forall 'very_long_identifier_that_will_cause_a_line_break 'm, 'n >= 0. (
-    x : int('very_long_identifier_that_will_cause_a_line_break),
-    y : int('m),
+function foo forall 'very_long_identifier_that_will_cause_a_line_break 'm,
+               'n >= 0. (
+  x : int('very_long_identifier_that_will_cause_a_line_break),
+  y : int('m),
 ) -> (
-    unit
+  unit
 ) = {
-    ()
+  ()
 }

--- a/test/format/lw80_preserve/index.expect
+++ b/test/format/lw80_preserve/index.expect
@@ -1,0 +1,12 @@
+function rX(r) = {
+  let foo = Xs[1];
+  let foo = Xs[a];
+  let foo = Xs[unsigned(r)];
+  let foo = Xs[1]; // comment
+  let foo = /* comment */ Xs[unsigned(r)];
+  let foo = Xs[let r = 1 in unsigned(r)]; // comment
+  let foo = Xs[
+      let foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo = 1 in
+      foo
+    ]
+}

--- a/test/format/lw80_preserve/mls_let_hang.expect
+++ b/test/format/lw80_preserve/mls_let_hang.expect
@@ -1,0 +1,10 @@
+
+let foo : string = """
+  some text
+  x
+   y
+    z
+      abc\n\n
+  dedent
+  more text\n
+  """

--- a/test/format/lw80_preserve/multi_exist.expect
+++ b/test/format/lw80_preserve/multi_exist.expect
@@ -1,0 +1,4 @@
+
+type t = {'n 'm. vector('n, vector('m, int))}
+
+val some_matrix : unit -> {'n 'm. vector('n, vector('m, int))}

--- a/test/format/lw80_preserve/patterns.expect
+++ b/test/format/lw80_preserve/patterns.expect
@@ -1,0 +1,16 @@
+default Order dec
+
+$include <prelude.sail>
+
+function foo(ys : bits(6), xs : bits(6)) -> unit = {
+  match ys {
+    xs[3 .. 1] @ xs[0] @ xs[5 .. 4] => (),
+    (xs[3 .. 1] @ xs[0]) @ xs[5 .. 4] => (), // should have brackets
+    xs[3 .. 1] @ (xs[0] @ xs[5 .. 4]) => (), // brackets here will also be preserved for now
+    _ => (),
+  };
+  let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
+  let _ = (xs[3 .. 1] @ xs[0 .. 0]) @ xs[5 .. 4]; // should have brackets
+  let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
+  ()
+}

--- a/test/format/lw80_preserve/rv_gfmul.expect
+++ b/test/format/lw80_preserve/rv_gfmul.expect
@@ -1,0 +1,30 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then x else 0x00)
+  ^ (if bit_to_bool(y[1]) then xt2(x) else 0x00)
+  ^ (if bit_to_bool(y[2]) then xt2(xt2(x)) else 0x00)
+  ^ (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}
+
+overload operator ^^^ = operator ^
+
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then x else 0x00)
+  ^ (if bit_to_bool(y[1]) then xt2(x) else 0x00)
+  ^^^ (if bit_to_bool(y[2]) then xt2(xt2(x)) else 0x00)
+  ^ (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}
+
+$[fmt "skip"]
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then             x    else 0x00) ^
+  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
+  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
+  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}

--- a/test/format/lw80_preserve/rv_legalize_misa.expect
+++ b/test/format/lw80_preserve/rv_legalize_misa.expect
@@ -1,0 +1,34 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
+  let v = Mk_Misa(v);
+
+  // Suppress updates to MISA if MISA is not writable or if by disabling C next PC would become misaligned or an extension vetoes
+  if not(sys_enable_writable_misa) |
+    (v[C] == 0b0 & (nextPC[1] == bitone | ext_veto_disable_C()))
+  then m
+  else [ m with
+         A = if hartSupports(Ext_A) then v[A] else 0b0,
+         B = if hartSupports(Ext_B) then v[B] else 0b0,
+         C = if hartSupports(Ext_C) then v[C] else 0b0,
+         D = if hartSupports(Ext_D) & v[F] == 0b1 then v[D] else 0b0,
+         F = if hartSupports(Ext_F) then v[F] else 0b0,
+         H = if hartSupports(Ext_H) then v[H] else 0b0,
+         // TODO: Not fully supported yet
+         // Writable I is not currently supported.
+         I = bool_to_bits(not(base_E_enabled)),
+         E = bool_to_bits(base_E_enabled),
+         M = if hartSupports(Ext_M) then v[M] else 0b0,
+         // Q = if hartSupports(Ext_Q) then v[Q] else 0b0, TODO: Not supported yet
+         S = if hartSupports(Ext_S) & v[U] == 0b1 then v[S] else 0b0,
+         U = if hartSupports(Ext_U) then v[U] else 0b0,
+         V =
+           if hartSupports(Ext_V) & v[F] == 0b1 & v[D] == 0b1 then v[V] else 0b0
+         // X = ... TODO: If custom extensions are present this should be 1
+       ]
+}

--- a/test/format/lw80_preserve/set_syntax.expect
+++ b/test/format/lw80_preserve/set_syntax.expect
@@ -5,5 +5,5 @@ $include <prelude.sail>
 val main : unit -> unit
 
 function main() = {
-    let x : {1, 2, 3} = 3
+  let x : {1, 2, 3} = 3
 }

--- a/test/format/lw80_preserve/struct_update.expect
+++ b/test/format/lw80_preserve/struct_update.expect
@@ -1,0 +1,60 @@
+$option -dmagic_hash
+
+default Order dec
+
+$include <prelude.sail>
+
+val foo : unit -> unit
+
+function foo() = {
+  ();
+  let x = { s with foo = 0xFFFF,  bar = 0b1 }
+}
+
+val bar : unit -> int
+
+function baz() = {
+  ();
+  let some_long_named_variable_to_break_the_line = {
+    function_modify_the_struct(struct_with_a_long_name, x) with
+    foo = 0xFFFF,
+    bar = 0b1,
+  };
+  *R = baz; // trailing comment
+
+  return 3 + (return 4)
+}
+
+scattered function /* comment */ quux
+
+function clause quux(0b0000_0000) = ()
+
+end /* comment */ quux
+
+end quux
+
+enum E = { A, B, C }
+enum E with f -> unit, g -> unit = { A => (), B }
+
+enum E with f -> very_long_type_that_will_trigger_a_linebreak,
+            g -> another_very_long_type_name,
+            h -> a_third_very_long_type_name, = {
+  A => (),
+  B,
+}
+
+function has_loops() = {
+  foreach (n from 1 to 3) { () };
+  foreach (n from 3 downto 1) { () };
+  foreach (n from 0 to 4 by 2) { () };
+  foreach (
+    n
+    from 10000000000000000000000000000000
+    to 444444444444444444444444444444444444444444444444444444444444
+  ) { () };
+  while true do ();
+  while true do { () };
+  repeat termination_measure { foo } () until true
+}
+
+type foo = bar

--- a/test/format/lw80_preserve/test_if_comment_1.expect
+++ b/test/format/lw80_preserve/test_if_comment_1.expect
@@ -1,0 +1,25 @@
+
+function foo() = {
+  if cond then 2 /* comment */
+  else {
+    3 /* comment */
+  }
+}
+
+function foo() = {
+  if cond then 2 // comment
+  else {
+    3 // comment
+  }
+}
+
+function foo() = {
+  if cond then {
+    if cond2 then 2 // comment
+    else {
+      4 /* comment */
+    }
+  } else {
+    3 // comment
+  }
+}

--- a/test/format/lw80_preserve/val.expect
+++ b/test/format/lw80_preserve/val.expect
@@ -1,0 +1,17 @@
+default Order dec
+$include <prelude.sail>
+
+val foo = impure { _: "foo" } : unit -> unit // foo
+val bar = impure { c: "foo_c", cpp: "foo_c", _: "foo" } : (
+    unit,
+    unit,
+    unit,
+    vector(16, dec, vector(32, dec, int)),
+    unit,
+    unit,
+    unit,
+    vector(32, dec, int),
+  ) -> unit
+
+val baz : unit -> unit // baz
+val quuz : unit -> unit

--- a/test/format/lw80_preserve/wrap_into_oneline.expect
+++ b/test/format/lw80_preserve/wrap_into_oneline.expect
@@ -1,0 +1,93 @@
+function f(b) = if b == bitone then bitzero else bitone
+function f(b) = if b == bitone then { bitzero } else { bitone }
+function f(b) = if b == bitone then {
+  let a = 1;
+  bitzero
+} else {
+  bitone
+}
+
+function f(b) = if b == bitone then { { bitzero } } else { bitone }
+function f(b) = if b == bitone then { { { bitzero } } } else { bitone }
+function f(b) = if b == bitone then {
+  {
+    let a = 1;
+    bitzero
+  }
+} else {
+  bitone
+}
+function f(b) = if b == bitone then {
+  {
+    {
+      let a = 1;
+      bitzero
+    }
+  }
+} else {
+  bitone
+}
+function f(b) = if b == bitone then {
+  {
+    {
+      {
+        let a = 1;
+        bitzero
+      }
+    }
+  }
+} else {
+  {
+    {
+      {
+        let a = 1;
+        bitone
+      }
+    }
+  }
+}
+function f(b) = if b == bitone then {
+  {
+    {
+      {
+        let a = 1;
+        bitzero
+      }
+    }
+  }
+} else {
+  { { bitone } }
+}
+function f(b) = if b == bitone then {
+  {
+    {
+      {
+        let a = 1;
+        bitzero
+      }
+    }
+  }
+} else {
+  {
+    let a = 1;
+    { bitone }
+  }
+}
+
+/* comment */
+function f( /* comment */ b) = if b == bitone then bitzero else bitone
+function f( /* comment */ b) = if b == bitone then bitzero else bitone
+function f(b) = /* comment */ if b == bitone then bitzero else bitone
+function f(b) = /* comment */ if b == bitone then bitzero else bitone
+
+// TODO function f b =/* comment */if b == bitone then bitzero else bitone
+function f(b) = if /* comment */ b == bitone then bitzero else bitone
+function f(b) = if b == /* comment */ bitone then bitzero else bitone
+function f(b) = if b == /* comment */ bitone then bitzero else bitone
+
+// TODO function f b = if b ==/* comment */bitone then bitzero else bitone
+function f(b) = if b == bitone /* comment */  then bitzero else bitone
+function f(b) = if b == bitone then /* comment */ bitzero else bitone
+function f(b) = if b == bitone then bitzero /* comment */  else bitone
+function f(b) = if b == bitone then bitzero else /* comment */ bitone
+function f(b) = if b == bitone then bitzero else bitone /* comment */

--- a/test/format/multi_exist.sail
+++ b/test/format/multi_exist.sail
@@ -1,0 +1,4 @@
+
+type t = {'n 'm. vector('n, vector('m, int))}
+
+val some_matrix : unit -> {'n 'm. vector('n, vector('m, int)) }

--- a/test/format/run_tests.py
+++ b/test/format/run_tests.py
@@ -11,6 +11,8 @@ sys.path.insert(0, os.path.realpath('..'))
 
 from sailtest import *
 
+update_expected = args.update_expected
+
 sail_dir = get_sail_dir()
 sail = get_sail()
 
@@ -18,7 +20,7 @@ print("Sail is {}".format(sail))
 print("Sail dir is {}".format(sail_dir))
 
 def test(test_dir):
-    banner('Testing {}'.format(test_dir))
+    banner(f'Testing {test_dir}')
     results = Results(test_dir)
     for filenames in chunks(os.listdir('.'), parallel()):
         tests = {}
@@ -26,10 +28,16 @@ def test(test_dir):
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('cp {} {}/{}'.format(filename, test_dir, filename))
-                step('\'{}\' --sail-config {}/config.json --fmt {}/{}'.format(sail, test_dir, test_dir, filename))
-                step('diff {}/{} {}/{}.expect'.format(test_dir, filename, test_dir, basename))
-                step('rm {}/{}'.format(test_dir, filename))
+                step(f'cp {filename} {test_dir}/{filename}')
+                step(f'\'{sail}\' --sail-config {test_dir}/config.json --fmt {test_dir}/{filename}')
+                status = step_with_status(f'diff {test_dir}/{filename} {test_dir}/{basename}.expect')
+                if status != 0:
+                    if update_expected:
+                        print(f'Overriding file {test_dir}/{basename}.expected')
+                        step(f'\'{sail}\' --sail-config {test_dir}/config.json --fmt {filename} --fmt-emit stdout > {test_dir}/{basename}.expect')
+                    else:
+                        sys.exit(1)
+                step(f'rm {test_dir}/{filename}')
                 print_ok(filename)
                 sys.exit()
         results.collect(tests)
@@ -39,6 +47,7 @@ def test(test_dir):
 xml = '<testsuites>\n'
 
 xml += test('default')
+xml += test('lw80_preserve')
 
 xml += '</testsuites>\n'
 

--- a/test/format/rv_gfmul.sail
+++ b/test/format/rv_gfmul.sail
@@ -1,0 +1,30 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then             x    else 0x00) ^
+  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
+  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
+  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}
+
+overload operator ^^^ = operator ^
+
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then             x    else 0x00) ^
+  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^^^
+  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
+  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}
+
+$[fmt skip]
+function gfmul(x : bits(8), y : bits(4)) -> bits(8) = {
+  (if bit_to_bool(y[0]) then             x    else 0x00) ^
+  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
+  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
+  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
+}

--- a/test/format/rv_legalize_misa.sail
+++ b/test/format/rv_legalize_misa.sail
@@ -1,0 +1,30 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+function legalize_misa(m : Misa, v : xlenbits) -> Misa = {
+  let v = Mk_Misa(v);
+  // Suppress updates to MISA if MISA is not writable or if by disabling C next PC would become misaligned or an extension vetoes
+  if   not(sys_enable_writable_misa) | (v[C] == 0b0 & (nextPC[1] == bitone | ext_veto_disable_C()))
+  then m
+  else [m with
+    A = if hartSupports(Ext_A) then v[A] else 0b0,
+    B = if hartSupports(Ext_B) then v[B] else 0b0,
+    C = if hartSupports(Ext_C) then v[C] else 0b0,
+    D = if hartSupports(Ext_D) & v[F] == 0b1 then v[D] else 0b0,
+    F = if hartSupports(Ext_F) then v[F] else 0b0,
+    H = if hartSupports(Ext_H) then v[H] else 0b0, // TODO: Not fully supported yet
+    // Writable I is not currently supported.
+    I = bool_to_bits(not(base_E_enabled)),
+    E = bool_to_bits(base_E_enabled),
+    M = if hartSupports(Ext_M) then v[M] else 0b0,
+    // Q = if hartSupports(Ext_Q) then v[Q] else 0b0, TODO: Not supported yet
+    S = if hartSupports(Ext_S) & v[U] == 0b1 then v[S] else 0b0,
+    U = if hartSupports(Ext_U) then v[U] else 0b0,
+    V = if hartSupports(Ext_V) & v[F] == 0b1 & v[D] == 0b1 then v[V] else 0b0,
+    // X = ... TODO: If custom extensions are present this should be 1
+  ]
+}


### PR DESCRIPTION
- Add $[fmt skip] attribute to skip formatting definition

- Sail formatting improvements, mostly based on examples of bad formatting from sail-riscv. See the `rv_*` tests in `test/format`.

- Add a second formatting config to test different options

- Add `--update-expected` to formatting `run_tests.py` script.