### PR TITLE
Fix hrefs in generated html.

### DIFF
--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -383,6 +383,42 @@ let read_whole_file filename =
   close_in ch;
   s
 
+(** [path] is assumed to be a path to a file, not a directory (i.e. not something like "a/b/") *)
+let split_path path =
+  let rec split p acc =
+    (* "" gives a basename and dirname of "." *)
+    if p = "" then acc
+    else (
+      let base = Filename.basename p in
+      if base = p then base :: acc else split (Filename.dirname p) (base :: acc)
+    )
+  in
+  split path []
+
+let rec join_path_segments = function [] -> "" | f :: [] -> f | h :: t -> Filename.concat h (join_path_segments t)
+
+let normalize_path_segments path_segments =
+  let rec normalize p acc =
+    match (p, acc) with
+    | [], _ -> acc
+    | "." :: p', _ -> normalize p' acc
+    | ".." :: _, [] -> failwith "escaping path segment"
+    | ".." :: p', _ :: t -> normalize p' t
+    | d :: p', acc -> normalize p' (d :: acc)
+  in
+  List.rev (normalize path_segments [])
+
+let rec relativize_path_segments base_segs target_segs =
+  match (base_segs, target_segs) with
+  | [], _ -> target_segs
+  | base_hd :: base_tl, target_hd :: target_tl when base_hd = target_hd -> relativize_path_segments base_tl target_tl
+  | _, _ -> List.init (List.length base_segs) (fun _ -> "..") @ target_segs
+
+let relativize_path base target =
+  let base_segs = normalize_path_segments (split_path (Filename.dirname base)) in
+  let target_segs = normalize_path_segments (split_path target) in
+  join_path_segments (relativize_path_segments base_segs target_segs)
+
 (*String formatting *)
 let rec string_of_list sep string_of = function
   | [] -> ""

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -240,6 +240,10 @@ val same_content_files : string -> string -> bool
 (** [read_whole_file filename] reads the contents of the file and returns it as a string. *)
 val read_whole_file : string -> string
 
+(** [relativize_path base target] gives the relative path to the file at [target] from [base]. Both paths are assumed to
+    be paths of files (not directories), and from the same root. *)
+val relativize_path : string -> string -> string
+
 (** {2 Strings} *)
 
 (** [string_to_list l] translates the string [l] to the list of its characters. *)

--- a/src/sail_doc_backend/sail_plugin_doc.ml
+++ b/src/sail_doc_backend/sail_plugin_doc.ml
@@ -56,7 +56,7 @@ let opt_doc_compact = ref false
 let opt_doc_bundle = ref "doc.json"
 
 let opt_html_css = ref None
-let opt_html_link_prefix = ref "../"
+let opt_html_link_prefix = ref None
 
 let embedding_option () =
   match !opt_doc_embed with
@@ -148,7 +148,7 @@ let html_options =
       "CSS file for html output"
     );
     ( Flag.create ~prefix:["html"] ~arg:"string" "link_prefix",
-      Arg.String (fun prefix -> opt_html_link_prefix := prefix),
+      Arg.String (fun prefix -> opt_html_link_prefix := Some prefix),
       "Prefix links in HTML output with string"
     );
   ]
@@ -181,8 +181,14 @@ let html_target files out_dir_opt { ast; _ } =
                 let filename = p.Lexing.pos_fname in
                 begin
                   match List.find_opt (fun info -> info.filename = filename) !files with
-                  | Some info ->
-                      Some (Printf.sprintf "%s%s.html#L%d" !opt_html_link_prefix info.prefix p.Lexing.pos_lnum, s, e)
+                  | Some info -> (
+                      match !opt_html_link_prefix with
+                      | None ->
+                          let relpath = Util.relativize_path file_info.filename info.prefix in
+                          Some (Printf.sprintf "%s.html#L%d" relpath p.Lexing.pos_lnum, s, e)
+                      | Some html_prefix ->
+                          Some (Printf.sprintf "%s%s.html#L%d" html_prefix info.prefix p.Lexing.pos_lnum, s, e)
+                    )
                   | None -> None
                 end
             | None -> None


### PR DESCRIPTION
The hrefs were incorrect for Sail files in a directory hierarchy. There were two issues:

- the default `html_link_prefix` of "../" was correct only if all source files were in the same directory.

- the relative path of the source and target files of the hrefs was not computed.

This now uses relative hrefs if no `html_link_prefix` is specified, and absolute hrefs if it is.

This fixes #1525.