### PR TITLE
Further formatting improvements

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -135,7 +135,7 @@ and chunk =
 
 and chunks = chunk Queue.t
 
-and pexp_chunks = { funcl_space : bool; pat : chunks; guard : chunks option; body : chunks }
+and pexp_chunks = { funcl_space : bool; attr : chunks option; pat : chunks; guard : chunks option; body : chunks }
 
 let add_chunk q chunk = Queue.add chunk q
 
@@ -608,7 +608,7 @@ let chunk_infix_token comments chunk_primary (infix_token, _, _) =
   | IT_prefix op -> (
       match op with
       | "__deref" -> Infix_prefix "*"
-      | "pow2" -> Infix_prefix "2 ^"
+      | "pow2" -> Infix_prefix "2 ^ "
       | "negate" -> Infix_prefix "-"
       | _ -> Infix_prefix op
     )
@@ -1201,12 +1201,13 @@ and chunk_vector_update comments (E_aux (aux, l) as exp) =
       chunk_exp comments exp_chunks exp;
       (exp_chunks, [])
 
-and chunk_pexp ?delim comments chunks (Pat_aux (aux, l)) =
+and chunk_pexp ?attr_chunks ?delim comments chunks (Pat_aux (aux, l)) =
   match aux with
   | Pat_attribute (attr, arg, pexp) ->
+      let chunks = match attr_chunks with Some chunks -> chunks | None -> Queue.create () in
       chunk_attribute comments chunks attr arg;
       Queue.add (Spacer (false, 1)) chunks;
-      chunk_pexp ?delim comments chunks pexp
+      chunk_pexp ~attr_chunks:chunks ?delim comments chunks pexp
   | Pat_exp (pat, exp) ->
       let funcl_space =
         match pat with P_aux (P_lit (L_aux (L_unit, _)), _) | P_aux (P_tuple _, _) -> false | _ -> true
@@ -1215,9 +1216,9 @@ and chunk_pexp ?delim comments chunks (Pat_aux (aux, l)) =
       chunk_pat comments pat_chunks pat;
       let exp_chunks = Queue.create () in
       chunk_exp comments exp_chunks exp;
-      (match delim with Some d -> Queue.add (Delim d) exp_chunks | _ -> ());
+      (match delim with Some d when Option.is_none attr_chunks -> Queue.add (Delim d) exp_chunks | _ -> ());
       ignore (pop_trailing_comment comments exp_chunks (ending_line_num l));
-      { funcl_space; pat = pat_chunks; guard = None; body = exp_chunks }
+      { funcl_space; attr = attr_chunks; pat = pat_chunks; guard = None; body = exp_chunks }
   | Pat_when (pat, guard, exp) ->
       let pat_chunks = Queue.create () in
       chunk_pat comments pat_chunks pat;
@@ -1225,9 +1226,9 @@ and chunk_pexp ?delim comments chunks (Pat_aux (aux, l)) =
       chunk_exp comments guard_chunks guard;
       let exp_chunks = Queue.create () in
       chunk_exp comments exp_chunks exp;
-      (match delim with Some d -> Queue.add (Delim d) exp_chunks | _ -> ());
+      (match delim with Some d when Option.is_none attr_chunks -> Queue.add (Delim d) exp_chunks | _ -> ());
       ignore (pop_trailing_comment comments exp_chunks (ending_line_num l));
-      { funcl_space = true; pat = pat_chunks; guard = Some guard_chunks; body = exp_chunks }
+      { funcl_space = true; attr = attr_chunks; pat = pat_chunks; guard = Some guard_chunks; body = exp_chunks }
 
 let chunk_funcl comments funcl =
   let chunks = Queue.create () in

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -1047,7 +1047,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
   | E_assign (lexp, exp) ->
       let lexp_chunks = rec_chunk_exp lexp in
       let exp_chunks = rec_chunk_exp exp in
-      Queue.add (Binary (lexp_chunks, "=", exp_chunks)) chunks
+      Queue.add (Assign (lexp_chunks, None, "=", exp_chunks)) chunks
   | E_if (i, t, E_aux (E_lit (L_aux (L_unit, _)), _), keywords) ->
       let then_brace = match t with E_aux (E_block _, _) -> true | _ -> false in
       let i_chunks = rec_chunk_exp i in

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -121,7 +121,7 @@ and chunk =
 
 and chunks = chunk Queue.t
 
-and pexp_chunks = { funcl_space : bool; pat : chunks; guard : chunks option; body : chunks }
+and pexp_chunks = { funcl_space : bool; attr : chunks option; pat : chunks; guard : chunks option; body : chunks }
 
 val prerr_chunk : string -> chunk -> unit
 

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -327,13 +327,24 @@ let operator_precedence = function
   | "=" -> (10, precedence 1, nonatomic, 1)
   | ":" -> (0, subatomic, subatomic, 1)
   | ".." -> (10, atomic, atomic, 1)
-  | "@" -> (6, precedence 5, precedence 6, 1)
   | _ -> (10, subatomic, subatomic, 1)
+
+let unary_operator_precedence = function
+  | "throw" -> (0, nonatomic, space)
+  | "return" -> (0, nonatomic, space)
+  | "internal_return" -> (0, nonatomic, space)
+  | "*" -> (0, atomic, empty)
+  | "-" -> (0, atomic, empty)
+  | "2^" -> (10, atomic, empty)
+  | _ -> (10, subatomic, empty)
 
 let max_precedence infix_chunks =
   List.fold_left
     (fun max_prec infix_chunk ->
       match infix_chunk with
+      | Infix_prefix op ->
+          let prec, _, _ = unary_operator_precedence op in
+          max prec max_prec
       | Infix_op op ->
           let prec, _, _, _ = operator_precedence op in
           max prec max_prec
@@ -352,15 +363,6 @@ let ternary_operator_precedence = function
   | "..", "=" -> (0, atomic, atomic, nonatomic)
   | ":", "=" -> (0, atomic, nonatomic, nonatomic)
   | _ -> (10, subatomic, subatomic, subatomic)
-
-let unary_operator_precedence = function
-  | "throw" -> (0, nonatomic, space)
-  | "return" -> (0, nonatomic, space)
-  | "internal_return" -> (0, nonatomic, space)
-  | "*" -> (10, atomic, empty)
-  | "-" -> (10, atomic, empty)
-  | "2^" -> (10, atomic, empty)
-  | _ -> (10, subatomic, empty)
 
 let can_hang chunks =
   match Queue.peek_opt chunks with
@@ -551,9 +553,7 @@ module Make (Config : CONFIG) = struct
                   let padding =
                     match infix_style with
                     | Prefix_lineup -> ifflat space (repeat (longest_op - op_w + 1) space)
-                    | Prefix ->
-                        prerr_endline "NOPAD";
-                        space
+                    | Prefix -> space
                   in
                   break 1 ^^ string op ^^ padding
               | Infix_chunks chunks ->
@@ -582,7 +582,7 @@ module Make (Config : CONFIG) = struct
     | Assign (x, ternary, op, z) -> (
         match ternary with
         | None ->
-            let x_doc = doc_chunks (atomic opts) x in
+            let x_doc = doc_chunks (nonatomic opts) x in
             let z_doc = doc_chunks (nonatomic opts) z in
             group (x_doc ^^ space ^^ char '=' ^^ nest indent (break 1 ^^ z_doc))
         | Some (t_op, y) ->
@@ -838,7 +838,12 @@ module Make (Config : CONFIG) = struct
 
   and doc_pexp_chunks opts pexp =
     let guarded_pat, body = doc_pexp_chunks_pair opts pexp in
-    separate space [guarded_pat; string "=>"; body]
+    let doc = separate space [guarded_pat; string "=>"; body] in
+    match pexp.attr with
+    | Some attr ->
+        let attr = doc_chunks opts attr in
+        attr ^^ parens doc ^^ char ','
+    | None -> doc
 
   and doc_funcl hanging typq_opt return_typ_opt opts (header, pexp) =
     let return_typ =
@@ -1002,17 +1007,27 @@ module Make (Config : CONFIG) = struct
     let formatted, lb_info = to_string (doc ^^ hardline) in
     fixup lb_info formatted |> fixup_comments ~filename |> discard_extra_trailing_newlines
 
-  let format_defs ?(debug = false) filename source comments defs =
+  let format_defs ?(debug = false) filename source comments starting_defs =
     let open Initial_check in
-    let f1 = format_defs_once ~debug filename source comments defs in
+    let open Parse_ast_diff in
+    let f1 = format_defs_once ~debug filename source comments starting_defs in
     let comments, defs = parse_file_from_string ~filename ~contents:f1 in
     let f2 = format_defs_once ~debug filename f1 comments defs in
     let comments, defs = parse_file_from_string ~filename ~contents:f2 in
     let f3 = format_defs_once ~debug filename f2 comments defs in
     if f2 <> f3 then (
-      print_endline f2;
-      print_endline f3;
+      prerr_endline f2;
+      prerr_endline f3;
       raise (Reporting.err_general Parse_ast.Unknown filename)
+    );
+    ( match diff_list ~at:Parse_ast.Unknown diff_def starting_defs defs with
+    | Some difference ->
+        prerr_endline f3;
+        raise
+          (Reporting.err_general difference
+             (Printf.sprintf "Found difference in syntax tree here after formatting %s" filename)
+          )
+    | None -> ()
     );
     f3
 end

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -47,6 +47,8 @@
 open Parse_ast
 open Chunk_ast
 
+module IntMap = Util.IntMap
+
 let id_loc (Id_aux (_, l)) = l
 
 let rec map_last f = function
@@ -99,10 +101,13 @@ let fixup_comments ~filename source =
 module PPrintWrapper = struct
   type hardline_type = Required | Desired
 
+  type lineup = Lineup_start | Lineup_point | Lineup_end
+
   type document =
     | Empty
     | Weak_space
     | Char of char
+    | Lineup_char of lineup * char
     | String of string
     | Utf8string of string
     | Group of document
@@ -116,10 +121,11 @@ module PPrintWrapper = struct
     hardlines : (int * int * hardline_type) Queue.t;
     dedents : (int * int * int) Queue.t;
     weak_spaces : (int * int) Queue.t;
+    lineups : (int * int * lineup) Queue.t;
   }
 
   let empty_linebreak_info () =
-    { hardlines = Queue.create (); dedents = Queue.create (); weak_spaces = Queue.create () }
+    { hardlines = Queue.create (); dedents = Queue.create (); weak_spaces = Queue.create (); lineups = Queue.create () }
 
   let rec to_pprint lb_info =
     let open PPrint in
@@ -127,6 +133,7 @@ module PPrintWrapper = struct
     | Empty -> empty
     | Weak_space -> range (fun (lc, _) -> Queue.add lc lb_info.weak_spaces) (char ' ')
     | Char c -> char c
+    | Lineup_char (p, c) -> range (fun ((l, c), _) -> Queue.add (l, c, p) lb_info.lineups) (char c)
     | String s -> string s
     | Utf8string s -> utf8string s
     | Group doc -> group (to_pprint lb_info doc)
@@ -175,6 +182,12 @@ module PPrintWrapper = struct
   let group doc = Group doc
 
   let space = char ' '
+
+  let lineup_start c = Lineup_char (Lineup_start, c)
+
+  let lineup_point c = Lineup_char (Lineup_point, c)
+
+  let lineup_end c = Lineup_char (Lineup_end, c)
 
   (* A weak_space is like a space, but it is empty when it appears before any non-whitespace character in a line. *)
   let weak_space = Weak_space
@@ -584,7 +597,8 @@ module Make (Config : CONFIG) = struct
         | None ->
             let x_doc = doc_chunks (nonatomic opts) x in
             let z_doc = doc_chunks (nonatomic opts) z in
-            group (x_doc ^^ space ^^ char '=' ^^ nest indent (break 1 ^^ z_doc))
+            let rhs = if can_hang_bracketed z then space ^^ z_doc else nest indent (break 1 ^^ z_doc) in
+            group (x_doc ^^ space ^^ char '=' ^^ rhs)
         | Some (t_op, y) ->
             let outer_prec, x_prec, y_prec, z_prec = ternary_operator_precedence (t_op, op) in
             let doc =
@@ -783,12 +797,13 @@ module Make (Config : CONFIG) = struct
         ^^ break 1
         ^^ doc_chunks (nonatomic opts) z
     | Match m ->
+        let opener, closer = if m.aligned then (lineup_start '{', lineup_end '}') else (char '{', char '}') in
         let kw1, kw2 = match_keywords m.kind in
         string kw1 ^^ space
         ^^ doc_chunks (nonatomic opts) m.exp
         ^^ Option.fold ~none:empty ~some:(fun k -> space ^^ string k) kw2
         ^^ space
-        ^^ surround indent 1 (char '{') (separate_map hardline (doc_pexp_chunks opts) m.cases) (char '}')
+        ^^ surround indent 1 opener (separate_map hardline (doc_pexp_chunks m.aligned opts) m.cases) closer
         |> atomic_parens opts
     | Foreach loop ->
         let to_keyword = string (if loop.decreasing then "downto" else "to") in
@@ -836,9 +851,10 @@ module Make (Config : CONFIG) = struct
     | None -> (pat, body)
     | Some guard -> (separate space [pat; string "if"; doc_chunks opts guard], body)
 
-  and doc_pexp_chunks opts pexp =
+  and doc_pexp_chunks aligned opts pexp =
     let guarded_pat, body = doc_pexp_chunks_pair opts pexp in
-    let doc = separate space [guarded_pat; string "=>"; body] in
+    let arrow = if aligned then lineup_point '=' ^^ char '>' else string "=>" in
+    let doc = separate space [guarded_pat; arrow; body] in
     match pexp.attr with
     | Some attr ->
         let attr = doc_chunks opts attr in
@@ -926,6 +942,16 @@ module Make (Config : CONFIG) = struct
        hardline. Encountering a desired hardline means the requirement
        has been satisifed so we set it to false. *)
     let require_hardline = ref false in
+    let last_newline = ref 0 in
+    let all_lineups = ref [] in
+    let current_lineup = ref None in
+    let lineup_nesting = ref 0 in
+
+    let add_newline () =
+      Buffer.add_char buf '\n';
+      last_newline := Buffer.length buf
+    in
+
     String.iter
       (fun c ->
         let rec pop_dedents () =
@@ -952,7 +978,7 @@ module Make (Config : CONFIG) = struct
                 match hardline_type with
                 | Desired ->
                     if debug then Buffer.add_string buf Util.("H" |> red |> clear);
-                    Buffer.add_char buf '\n';
+                    add_newline ();
                     pending_spaces := 0;
                     if !require_hardline then require_hardline := false;
                     after_hardline := true
@@ -981,7 +1007,7 @@ module Make (Config : CONFIG) = struct
           )
           else (
             if !require_hardline then (
-              Buffer.add_char buf '\n';
+              add_newline ();
               require_hardline := false
             );
             if !pending_spaces > 0 then Buffer.add_string buf (String.make !pending_spaces ' ');
@@ -989,10 +1015,61 @@ module Make (Config : CONFIG) = struct
             after_hardline := false;
             pending_spaces := 0
           );
+
+          ( match Queue.peek_opt lb_info.lineups with
+          | Some (l, c, lineup_type) when l = !line && c = !column ->
+              ( match lineup_type with
+              | Lineup_start -> (
+                  match !current_lineup with None -> current_lineup := Some [] | Some _ -> incr lineup_nesting
+                )
+              | Lineup_point -> (
+                  match !current_lineup with
+                  | Some lineup when !lineup_nesting = 0 ->
+                      let offset = Buffer.length buf in
+                      current_lineup := Some (lineup @ [(offset, !last_newline)])
+                  | _ -> ()
+                )
+              | Lineup_end -> (
+                  match !current_lineup with
+                  | None -> ()
+                  | Some lineup ->
+                      if !lineup_nesting = 0 then (
+                        all_lineups := !all_lineups @ [lineup];
+                        current_lineup := None
+                      )
+                      else decr lineup_nesting
+                )
+              );
+              ignore (Queue.take lb_info.lineups)
+          | _ -> ()
+          );
+
           incr column
         )
       )
       s;
+
+    let lineup_map =
+      List.map
+        (fun lineup ->
+          let indent = List.fold_left (fun m (n, ln) -> max m (n - ln)) 0 lineup in
+          List.map (fun (n, ln) -> (n, indent - (n - ln))) lineup
+        )
+        !all_lineups
+      |> List.flatten |> List.to_seq |> IntMap.of_seq
+    in
+
+    let unaligned = Buffer.contents buf in
+    let buf = Buffer.create (String.length unaligned) in
+    String.iteri
+      (fun offset c ->
+        ( match IntMap.find_opt (offset + 1) lineup_map with
+        | Some align -> Buffer.add_string buf (String.make align ' ')
+        | None -> ()
+        );
+        Buffer.add_char buf c
+      )
+      unaligned;
     Buffer.contents buf
 
   let format_defs_once ?(debug = false) filename source comments defs =

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1159,10 +1159,9 @@ let to_ast_typschm ctx (P.TypSchm_aux (P.TypSchm_ts (typq, typ), l)) =
 
 let to_ast_tannot_opt = ConvertType.to_ast_tannot_opt KindInference.initial_env
 
-let to_ast_typschm_opt ctx (P.TypSchm_opt_aux (aux, l)) : tannot_opt ctx_out =
-  match aux with
-  | P.TypSchm_opt_none -> (Typ_annot_opt_aux (Typ_annot_opt_none, l), ctx)
-  | P.TypSchm_opt_some (P.TypSchm_aux (P.TypSchm_ts (tq, typ), l)) ->
+let to_ast_typschm_opt ~at:l ctx = function
+  | None -> (Typ_annot_opt_aux (Typ_annot_opt_none, l), ctx)
+  | Some (P.TypSchm_aux (P.TypSchm_ts (tq, typ), l)) ->
       let open KindInference in
       let (tq, typ, _), kenv = check_bind ctx tq typ (Some (P.K_aux (P.K_type, l))) initial_env in
       let tq, ctx = ConvertType.to_ast_typquant kenv ctx tq in
@@ -2132,7 +2131,7 @@ let rec to_ast_mapcl doc attrs ctx (P.MCL_aux (mcl, l)) =
 let to_ast_mapdef ctx (P.MD_aux (md, l) : P.mapdef) : uannot mapdef =
   match md with
   | P.MD_mapping (id, typschm_opt, mapcls) ->
-      let tannot_opt, ctx = to_ast_typschm_opt ctx typschm_opt in
+      let tannot_opt, ctx = to_ast_typschm_opt ~at:l ctx typschm_opt in
       MD_aux (MD_mapping (to_ast_id ctx id, tannot_opt, List.map (to_ast_mapcl None [] ctx) mapcls), (l, empty_uannot))
 
 let to_ast_dec ctx (P.DEC_aux (regdec, l)) =

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -291,15 +291,6 @@ type tannot_opt_aux =
     Typ_annot_opt_none
   | Typ_annot_opt_some of typquant * atyp
 
-type typschm_opt_aux = TypSchm_opt_none | TypSchm_opt_some of typschm
-
-type typschm_opt = TypSchm_opt_aux of typschm_opt_aux * l
-
-type effect_opt_aux =
-  | (* Optional effect annotation for functions *)
-    Effect_opt_none (* sugar for empty effect set *)
-  | Effect_opt_effect of atyp
-
 type rec_opt_aux =
   | (* Optional recursive annotation for functions *)
     Rec_none (* no termination measure *)
@@ -325,8 +316,6 @@ and type_union_aux =
   | Tu_ty_anon_rec of (id * atyp) field_annot list * id
 
 type tannot_opt = Typ_annot_opt_aux of tannot_opt_aux * l
-
-type effect_opt = Effect_opt_aux of effect_opt_aux * l
 
 type rec_opt = Rec_aux of rec_opt_aux * l
 
@@ -385,7 +374,7 @@ and mapcl_aux =
 
 type mapdef_aux =
   (* mapping definition (bidirectional pattern-match function) *)
-  | MD_mapping of id * typschm_opt * mapcl list
+  | MD_mapping of id * typschm option * mapcl list
 
 type mapdef = MD_aux of mapdef_aux * l
 
@@ -477,17 +466,6 @@ type def_aux =
   | DEF_internal_mutrec of fundef list
 
 and def = DEF_aux of def_aux * l
-
-type lexp_aux =
-  (* lvalue expression, can't occur out of the parser *)
-  | LE_id of id (* identifier *)
-  | LE_mem of id * exp list
-  | LE_vector of lexp * exp (* vector element *)
-  | LE_vector_range of lexp * exp * exp (* subvector *)
-  | LE_vector_concat of lexp list
-  | LE_field of lexp * id (* struct field *)
-
-and lexp = LE_aux of lexp_aux * l
 
 type defs =
   (* Definition sequence *)

--- a/src/lib/parse_ast_diff.ml
+++ b/src/lib/parse_ast_diff.ml
@@ -1,0 +1,889 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Parse_ast
+open Parse_ast.Attribute_data
+
+module Big_int = Nat_big_num
+
+let ( &&& ) (lhs : l option) (rhs : l option Lazy.t) : l option =
+  match lhs with
+  | Some l -> Some l
+  | None -> (
+      match rhs with (lazy (Some l)) -> Some l | (lazy None) -> None
+    )
+
+let diff_list ~at:l f (xs : 'a list) (ys : 'a list) : l option =
+  let rec go xs ys = match (xs, ys) with x :: xs, y :: ys -> f x y &&& lazy (go xs ys) | _ -> None in
+  if List.compare_lengths xs ys = 0 then go xs ys else Some l
+
+let diff_kind (K_aux (k1, l)) (K_aux (k2, _)) = if k1 = k2 then None else Some l
+
+let diff_kid (Kid_aux (Var v1, l)) (Kid_aux (Var v2, _)) = if v1 = v2 then None else Some l
+
+let diff_id (Id_aux (id1, l)) (Id_aux (id2, l)) = if id1 = id2 then None else Some l
+
+let diff_lit (L_aux (lit1, l)) (L_aux (lit2, _)) = if lit1 = lit2 then None else Some l
+
+let diff_infix_token ~at:l f lhs rhs =
+  match (lhs, rhs) with IT_primary x1, IT_primary x2 -> f x1 x2 | _ -> if lhs = rhs then None else Some l
+
+let rec strip_atyp_parens = function ATyp_aux (ATyp_parens atyp, _) -> strip_atyp_parens atyp | atyp -> atyp
+
+let diff_eq ~at:l x y = if x = y then None else Some l
+
+let diff_eq_pred ~at:l pred x y = if pred x y then None else Some l
+
+let diff_option ~at:l f x y = match (x, y) with Some x, Some y -> f x y | None, None -> None | _ -> Some l
+
+let diff_kinded_id (KOpt_aux (lhs, l)) (KOpt_aux (rhs, _)) =
+  (* Final field is for kind-inference *)
+  let (KOpt_kind (kw1, vars1, opt_kind1, _)) = lhs in
+  let (KOpt_kind (kw2, vars2, opt_kind2, _)) = rhs in
+  diff_eq ~at:l kw1 kw2
+  &&& lazy (diff_list ~at:l diff_kid vars1 vars2)
+  &&& lazy (diff_option ~at:l diff_kind opt_kind1 opt_kind2)
+
+(* Note that rather than using [match (lhs, rhs) with] this is written
+   in this style so OCaml will warn us for any missing cases,
+   particularly in the future if the parse AST changes. *)
+let rec diff_atyp lhs rhs =
+  let (ATyp_aux (lhs, l)) = strip_atyp_parens lhs in
+  let (ATyp_aux (rhs, _)) = strip_atyp_parens rhs in
+  match lhs with
+  | ATyp_parens _ -> assert false
+  | ATyp_id id1 -> (
+      match rhs with ATyp_id id2 -> diff_id id1 id2 | _ -> Some l
+    )
+  | ATyp_var kid1 -> (
+      match rhs with ATyp_var kid2 -> diff_kid kid1 kid2 | _ -> Some l
+    )
+  | ATyp_lit lit1 -> (
+      match rhs with ATyp_lit lit2 -> diff_lit lit1 lit2 | _ -> Some l
+    )
+  | ATyp_nset nums1 -> (
+      match rhs with ATyp_nset nums2 -> diff_eq_pred ~at:l (List.equal Big_int.equal) nums1 nums2 | _ -> Some l
+    )
+  | ATyp_in (n1, set1) -> (
+      match rhs with ATyp_in (n2, set2) -> diff_atyp n1 n2 &&& lazy (diff_atyp set1 set2) | _ -> Some l
+    )
+  | ATyp_times (x1, y1) -> (
+      match rhs with ATyp_times (x2, y2) -> diff_atyp x1 x2 &&& lazy (diff_atyp y1 y2) | _ -> Some l
+    )
+  | ATyp_sum (x1, y1) -> (
+      match rhs with ATyp_sum (x2, y2) -> diff_atyp x1 x2 &&& lazy (diff_atyp y1 y2) | _ -> Some l
+    )
+  | ATyp_minus (x1, y1) -> (
+      match rhs with ATyp_minus (x2, y2) -> diff_atyp x1 x2 &&& lazy (diff_atyp y1 y2) | _ -> Some l
+    )
+  | ATyp_exp atyp1 -> (
+      match rhs with ATyp_exp atyp2 -> diff_atyp atyp1 atyp2 | _ -> Some l
+    )
+  | ATyp_neg atyp1 -> (
+      match rhs with ATyp_neg atyp2 -> diff_atyp atyp1 atyp2 | _ -> Some l
+    )
+  | ATyp_infix tokens1 -> (
+      match rhs with
+      | ATyp_infix tokens2 ->
+          diff_list ~at:l
+            (fun (tok1, s1, e1) (tok2, _, _) -> diff_infix_token ~at:(Range (s1, e1)) diff_atyp tok1 tok2)
+            tokens1 tokens2
+      | _ -> Some l
+    )
+  | ATyp_inc -> if rhs = ATyp_inc then None else Some l
+  | ATyp_dec -> if rhs = ATyp_dec then None else Some l
+  | ATyp_set ids1 -> (
+      match rhs with ATyp_set ids2 -> diff_list ~at:l diff_id ids1 ids2 | _ -> Some l
+    )
+  (* We ignore the effect argument on functions and bidirectional types *)
+  | ATyp_fn (dom1, codom1, _) -> (
+      match rhs with ATyp_fn (dom2, codom2, _) -> diff_atyp dom1 dom2 &&& lazy (diff_atyp codom1 codom2) | _ -> Some l
+    )
+  | ATyp_bidir (left1, right1, _) -> (
+      match rhs with
+      | ATyp_bidir (left2, right2, _) -> diff_atyp left1 left2 &&& lazy (diff_atyp right1 right2)
+      | _ -> Some l
+    )
+  | ATyp_wild -> if rhs = ATyp_wild then None else Some l
+  | ATyp_tuple atyps1 -> (
+      match rhs with ATyp_tuple atyps2 -> diff_list ~at:l diff_atyp atyps1 atyps2 | _ -> Some l
+    )
+  | ATyp_app (id1, atyps1) -> (
+      match rhs with
+      | ATyp_app (id2, atyps2) -> diff_id id1 id2 &&& lazy (diff_list ~at:l diff_atyp atyps1 atyps2)
+      | _ -> Some l
+    )
+  | ATyp_if (i1, t1, e1) -> (
+      match rhs with
+      | ATyp_if (i2, t2, e2) -> diff_atyp i1 i2 &&& lazy (diff_atyp t1 t2) &&& lazy (diff_atyp e1 e2)
+      | _ -> Some l
+    )
+  | ATyp_exist (vars1, c1, t1) -> (
+      match rhs with
+      | ATyp_exist (vars2, c2, t2) ->
+          diff_list ~at:l diff_kinded_id vars1 vars2 &&& lazy (diff_atyp c1 c2) &&& lazy (diff_atyp t1 t2)
+      | _ -> Some l
+    )
+
+let diff_quant_item (QI_aux (lhs, l)) (QI_aux (rhs, _)) =
+  match lhs with
+  | QI_id kopt1 -> (
+      match rhs with QI_id kopt2 -> diff_kinded_id kopt1 kopt2 | _ -> Some l
+    )
+  | QI_constraint c1 -> (
+      match rhs with QI_constraint c2 -> diff_atyp c1 c2 | _ -> Some l
+    )
+
+let diff_typquant (TypQ_aux (lhs, l)) (TypQ_aux (rhs, _)) =
+  match lhs with
+  | TypQ_tq items1 -> (
+      match rhs with TypQ_tq items2 -> diff_list ~at:l diff_quant_item items1 items2 | _ -> Some l
+    )
+  | TypQ_no_forall -> diff_eq ~at:l lhs rhs
+
+let diff_typschm (TypSchm_aux (lhs, l)) (TypSchm_aux (rhs, _)) =
+  let (TypSchm_ts (quant1, atyp1)) = lhs in
+  let (TypSchm_ts (quant2, atyp2)) = rhs in
+  diff_typquant quant1 quant2 &&& lazy (diff_atyp atyp1 atyp2)
+
+let rec diff_index_range (BF_aux (lhs, l)) (BF_aux (rhs, _)) =
+  match lhs with
+  | BF_single n1 -> (
+      match rhs with BF_single n2 -> diff_atyp n1 n2 | _ -> Some l
+    )
+  | BF_range (n1, m1) -> (
+      match rhs with BF_range (n2, m2) -> diff_atyp n1 n2 &&& lazy (diff_atyp m1 m2) | _ -> Some l
+    )
+  | BF_concat (left1, right1) -> (
+      match rhs with
+      | BF_concat (left2, right2) -> diff_index_range left1 left2 &&& lazy (diff_index_range right1 right2)
+      | _ -> Some l
+    )
+
+let rec diff_attribute_data (AD_aux (lhs, l)) (AD_aux (rhs, _)) =
+  match lhs with
+  | AD_object obj1 -> (
+      match rhs with
+      | AD_object obj2 ->
+          diff_list ~at:l (fun (k1, v1) (k2, v2) -> diff_eq ~at:l k1 k2 &&& lazy (diff_attribute_data v1 v2)) obj1 obj2
+      | _ -> Some l
+    )
+  | AD_list ads1 -> (
+      match rhs with AD_list ads2 -> diff_list ~at:l diff_attribute_data ads1 ads2 | _ -> Some l
+    )
+  | AD_num n -> (
+      match rhs with AD_num m -> diff_eq_pred ~at:l Big_int.equal n m | _ -> Some l
+    )
+  | AD_string _ -> diff_eq ~at:l lhs rhs
+  | AD_bool _ -> diff_eq ~at:l lhs rhs
+
+let rec diff_pat (P_aux (lhs, l)) (P_aux (rhs, _)) =
+  match lhs with
+  | P_lit lit1 -> (
+      match rhs with P_lit lit2 -> diff_lit lit1 lit2 | _ -> Some l
+    )
+  | P_wild -> diff_eq ~at:l lhs rhs
+  | P_typ (atyp1, p1) -> (
+      match rhs with P_typ (atyp2, p2) -> diff_pat p1 p2 &&& lazy (diff_atyp atyp1 atyp2) | _ -> Some l
+    )
+  | P_id id1 -> (
+      match rhs with P_id id2 -> diff_id id1 id2 | _ -> Some l
+    )
+  | P_var (p1, atyp1) -> (
+      match rhs with P_var (p2, atyp2) -> diff_pat p1 p2 &&& lazy (diff_atyp atyp1 atyp2) | _ -> Some l
+    )
+  | P_app (id1, ps1) -> (
+      match rhs with P_app (id2, ps2) -> diff_id id1 id2 &&& lazy (diff_list ~at:l diff_pat ps1 ps2) | _ -> Some l
+    )
+  | P_vector ps1 -> (
+      match rhs with P_vector ps2 -> diff_list ~at:l diff_pat ps1 ps2 | _ -> Some l
+    )
+  | P_vector_concat ps1 -> (
+      match rhs with P_vector_concat ps2 -> diff_list ~at:l diff_pat ps1 ps2 | _ -> Some l
+    )
+  | P_vector_subrange (id1, n1, m1) -> (
+      match rhs with
+      | P_vector_subrange (id2, n2, m2) -> diff_id id1 id2 &&& lazy (diff_eq ~at:l n1 n2) &&& lazy (diff_eq ~at:l m1 m2)
+      | _ -> Some l
+    )
+  | P_tuple ps1 -> (
+      match rhs with P_tuple ps2 -> diff_list ~at:l diff_pat ps1 ps2 | _ -> Some l
+    )
+  | P_list ps1 -> (
+      match rhs with P_list ps2 -> diff_list ~at:l diff_pat ps1 ps2 | _ -> Some l
+    )
+  | P_cons (hd1, tl1) -> (
+      match rhs with P_cons (hd2, tl2) -> diff_pat hd1 hd2 &&& lazy (diff_pat tl1 tl2) | _ -> Some l
+    )
+  | P_string_append ps1 -> (
+      match rhs with P_string_append ps2 -> diff_list ~at:l diff_pat ps1 ps2 | _ -> Some l
+    )
+  | P_struct (id_opt1, fps1) -> (
+      match rhs with
+      | P_struct (id_opt2, fps2) ->
+          diff_option ~at:l diff_id id_opt1 id_opt2 &&& lazy (diff_list ~at:l diff_fpat fps1 fps2)
+      | _ -> Some l
+    )
+  | P_attribute (attr1, arg1, p1) -> (
+      match rhs with
+      | P_attribute (attr2, arg2, p2) ->
+          diff_eq ~at:l attr1 attr2 &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2) &&& lazy (diff_pat p1 p2)
+      | _ -> Some l
+    )
+
+and diff_fpat (FP_aux (lhs, l)) (FP_aux (rhs, _)) =
+  match lhs with
+  | FP_field (id1, pat1) -> (
+      match rhs with FP_field (id2, pat2) -> diff_id id1 id2 &&& lazy (diff_pat pat1 pat2) | _ -> Some l
+    )
+  | FP_wild -> diff_eq ~at:l lhs rhs
+
+(* Consider [{x}] and [x] the same as we allow the formatter to insert
+   blocks around if-then-else in certain cases. *)
+let rec strip_singleton_block = function E_aux (E_block [exp], _) -> strip_singleton_block exp | exp -> exp
+
+let rec diff_exp lhs rhs =
+  let (E_aux (lhs, l)) = strip_singleton_block lhs in
+  let (E_aux (rhs, _)) = strip_singleton_block rhs in
+  match lhs with
+  | E_block exps1 -> (
+      match rhs with E_block exps2 -> diff_list ~at:l diff_exp exps1 exps2 | _ -> Some l
+    )
+  | E_id id1 -> (
+      match rhs with E_id id2 -> diff_id id1 id2 | _ -> Some l
+    )
+  | E_ref reg1 -> (
+      match rhs with E_ref reg2 -> diff_id reg1 reg2 | _ -> Some l
+    )
+  | E_deref exp1 -> (
+      match rhs with E_deref exp2 -> diff_exp exp1 exp2 | _ -> Some l
+    )
+  | E_lit lit1 -> (
+      match rhs with E_lit lit2 -> diff_lit lit1 lit2 | _ -> Some l
+    )
+  | E_typ (atyp1, exp1) -> (
+      match rhs with E_typ (atyp2, exp2) -> diff_exp exp1 exp2 &&& lazy (diff_atyp atyp1 atyp2) | _ -> Some l
+    )
+  | E_app (f1, args1) -> (
+      match rhs with E_app (f2, args2) -> diff_id f1 f2 &&& lazy (diff_list ~at:l diff_exp args1 args2) | _ -> Some l
+    )
+  | E_app_infix (left1, op1, right1) -> (
+      match rhs with
+      | E_app_infix (left2, op2, right2) ->
+          diff_id op1 op2 &&& lazy (diff_exp left1 left2) &&& lazy (diff_exp right1 right2)
+      | _ -> Some l
+    )
+  | E_infix tokens1 -> (
+      match rhs with
+      | E_infix tokens2 ->
+          diff_list ~at:l
+            (fun (tok1, s1, e1) (tok2, _, _) -> diff_infix_token ~at:(Range (s1, e1)) diff_exp tok1 tok2)
+            tokens1 tokens2
+      | _ -> Some l
+    )
+  | E_tuple exps1 -> (
+      match rhs with E_tuple exps2 -> diff_list ~at:l diff_exp exps1 exps2 | _ -> Some l
+    )
+  | E_if (i1, t1, e1, _) -> (
+      match rhs with E_if (i2, t2, e2, _) -> diff_list ~at:l diff_exp [i1; t1; e1] [i2; t2; e2] | _ -> Some l
+    )
+  | E_loop (loop_type1, measure1, cond1, body1) -> (
+      match rhs with
+      | E_loop (loop_type2, measure2, cond2, body2) ->
+          diff_eq ~at:l loop_type1 loop_type2
+          &&& lazy (diff_measure measure1 measure2)
+          &&& lazy (diff_exp cond1 cond2)
+          &&& lazy (diff_exp body1 body2)
+      | _ -> Some l
+    )
+  | E_for (v1, f1, t1, s1, ord1, body1) -> (
+      match rhs with
+      | E_for (v2, f2, t2, s2, ord2, body2) ->
+          diff_id v1 v2
+          &&& lazy (diff_list ~at:l diff_exp [f1; t1; s1; body1] [f2; t2; s2; body2])
+          &&& lazy (diff_atyp ord1 ord2)
+      | _ -> Some l
+    )
+  | E_vector exps1 -> (
+      match rhs with E_vector exps2 -> diff_list ~at:l diff_exp exps1 exps2 | _ -> Some l
+    )
+  | E_vector_access (v1, n1) -> (
+      match rhs with E_vector_access (v2, n2) -> diff_exp v1 v2 &&& lazy (diff_exp n1 n2) | _ -> Some l
+    )
+  | E_vector_subrange (v1, n1, m1) -> (
+      match rhs with
+      | E_vector_subrange (v2, n2, m2) -> diff_exp v1 v2 &&& lazy (diff_exp n1 n2) &&& lazy (diff_exp m1 m2)
+      | _ -> Some l
+    )
+  | E_vector_update (v1, n1, x1) -> (
+      match rhs with
+      | E_vector_update (v2, n2, x2) -> diff_exp v1 v2 &&& lazy (diff_exp n1 n2) &&& lazy (diff_exp x1 x2)
+      | _ -> Some l
+    )
+  | E_vector_update_subrange (v1, n1, m1, x1) -> (
+      match rhs with
+      | E_vector_update_subrange (v2, n2, m2, x2) ->
+          diff_exp v1 v2 &&& lazy (diff_exp n1 n2) &&& lazy (diff_exp m1 m2) &&& lazy (diff_exp x1 x2)
+      | _ -> Some l
+    )
+  | E_vector_append (x1, y1) -> (
+      match rhs with E_vector_append (x2, y2) -> diff_exp x1 x2 &&& lazy (diff_exp x1 x2) | _ -> Some l
+    )
+  | E_list exps1 -> (
+      match rhs with E_list exps2 -> diff_list ~at:l diff_exp exps1 exps2 | _ -> Some l
+    )
+  | E_cons (hd1, tl1) -> (
+      match rhs with E_cons (hd2, tl2) -> diff_exp hd1 hd2 &&& lazy (diff_exp tl1 tl2) | _ -> Some l
+    )
+  | E_struct (id_opt1, exps1) -> (
+      match rhs with
+      | E_struct (id_opt2, exps2) ->
+          diff_option ~at:l diff_id id_opt1 id_opt2 &&& lazy (diff_list ~at:l diff_exp exps1 exps2)
+      | _ -> Some l
+    )
+  | E_struct_update (s1, updates1) -> (
+      match rhs with
+      | E_struct_update (s2, updates2) -> diff_exp s1 s2 &&& lazy (diff_list ~at:l diff_exp updates1 updates2)
+      | _ -> Some l
+    )
+  | E_field (exp1, field1) -> (
+      match rhs with E_field (exp2, field2) -> diff_exp exp1 exp2 &&& lazy (diff_id field1 field2) | _ -> Some l
+    )
+  | E_match (head_exp1, arms1) -> (
+      match rhs with
+      | E_match (head_exp2, arms2) -> diff_exp head_exp1 head_exp2 &&& lazy (diff_list ~at:l diff_pexp arms1 arms2)
+      | _ -> Some l
+    )
+  | E_let (lb1, body1) -> (
+      match rhs with E_let (lb2, body2) -> diff_letbind lb1 lb2 &&& lazy (diff_exp body1 body2) | _ -> Some l
+    )
+  | E_assign (lexp1, exp1) -> (
+      match rhs with E_assign (lexp2, exp2) -> diff_exp lexp1 lexp2 &&& lazy (diff_exp exp1 exp2) | _ -> Some l
+    )
+  | E_sizeof atyp1 -> (
+      match rhs with E_sizeof atyp2 -> diff_atyp atyp1 atyp2 | _ -> Some l
+    )
+  | E_constraint atyp1 -> (
+      match rhs with E_constraint atyp2 -> diff_atyp atyp1 atyp2 | _ -> Some l
+    )
+  | E_exit exp1 -> (
+      match rhs with E_exit exp2 -> diff_exp exp1 exp2 | _ -> Some l
+    )
+  | E_config s1 -> (
+      match rhs with E_config s2 -> diff_eq ~at:l s1 s2 | _ -> Some l
+    )
+  | E_throw exp1 -> (
+      match rhs with E_throw exp2 -> diff_exp exp1 exp2 | _ -> Some l
+    )
+  | E_try (head_exp1, arms1) -> (
+      match rhs with
+      | E_try (head_exp2, arms2) -> diff_exp head_exp1 head_exp2 &&& lazy (diff_list ~at:l diff_pexp arms1 arms2)
+      | _ -> Some l
+    )
+  | E_return exp1 -> (
+      match rhs with E_return exp2 -> diff_exp exp1 exp2 | _ -> Some l
+    )
+  | E_assert (cond1, msg1) -> (
+      match rhs with E_assert (cond2, msg2) -> diff_exp cond1 cond2 &&& lazy (diff_exp msg1 msg2) | _ -> Some l
+    )
+  | E_var (lexp1, v1, body1) -> (
+      match rhs with
+      | E_var (lexp2, v2, body2) -> diff_exp lexp1 lexp2 &&& lazy (diff_exp v1 v2) &&& lazy (diff_exp body1 body2)
+      | _ -> Some l
+    )
+  | E_attribute (attr1, arg1, exp1) -> (
+      match rhs with
+      | E_attribute (attr2, arg2, exp2) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_exp exp1 exp2)
+      | _ -> Some l
+    )
+  | E_internal_plet (pat1, v1, body1) -> (
+      match rhs with
+      | E_internal_plet (pat2, v2, body2) -> diff_pat pat1 pat2 &&& lazy (diff_exp v1 v2) &&& lazy (diff_exp body1 body2)
+      | _ -> Some l
+    )
+  | E_internal_return exp1 -> (
+      match rhs with E_internal_return exp2 -> diff_exp exp1 exp2 | _ -> Some l
+    )
+  | E_internal_assume (atyp1, exp1) -> (
+      match rhs with
+      | E_internal_assume (atyp2, exp2) -> diff_atyp atyp1 atyp2 &&& lazy (diff_exp exp1 exp2)
+      | _ -> Some l
+    )
+
+and diff_measure (Measure_aux (lhs, l)) (Measure_aux (rhs, _)) =
+  match lhs with
+  | Measure_none -> diff_eq ~at:l lhs rhs
+  | Measure_some exp1 -> (
+      match rhs with Measure_some exp2 -> diff_exp exp1 exp2 | Measure_none -> Some l
+    )
+
+and diff_pexp (Pat_aux (lhs, l)) (Pat_aux (rhs, _)) =
+  match lhs with
+  | Pat_exp (pat1, exp1) -> (
+      match rhs with Pat_exp (pat2, exp2) -> diff_pat pat1 pat2 &&& lazy (diff_exp exp1 exp2) | _ -> Some l
+    )
+  | Pat_when (pat1, guard1, exp1) -> (
+      match rhs with
+      | Pat_when (pat2, guard2, exp2) ->
+          diff_pat pat1 pat2 &&& lazy (diff_exp guard1 guard2) &&& lazy (diff_exp exp1 exp2)
+      | _ -> Some l
+    )
+  | Pat_attribute (attr1, arg1, pexp1) -> (
+      match rhs with
+      | Pat_attribute (attr2, arg2, pexp2) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_pexp pexp1 pexp2)
+      | _ -> Some l
+    )
+
+and diff_letbind (LB_aux (lhs, _)) (LB_aux (rhs, _)) =
+  let (LB_val (pat1, exp1)) = lhs in
+  let (LB_val (pat2, exp2)) = rhs in
+  diff_pat pat1 pat2 &&& lazy (diff_exp exp1 exp2)
+
+let rec diff_mpat (MP_aux (lhs, l)) (MP_aux (rhs, _)) =
+  match lhs with
+  | MP_lit lit1 -> (
+      match rhs with MP_lit lit2 -> diff_lit lit1 lit2 | _ -> Some l
+    )
+  | MP_typ (p1, atyp1) -> (
+      match rhs with MP_typ (p2, atyp2) -> diff_mpat p1 p2 &&& lazy (diff_atyp atyp1 atyp2) | _ -> Some l
+    )
+  | MP_id id1 -> (
+      match rhs with MP_id id2 -> diff_id id1 id2 | _ -> Some l
+    )
+  | MP_app (id1, ps1) -> (
+      match rhs with MP_app (id2, ps2) -> diff_id id1 id2 &&& lazy (diff_list ~at:l diff_mpat ps1 ps2) | _ -> Some l
+    )
+  | MP_vector ps1 -> (
+      match rhs with MP_vector ps2 -> diff_list ~at:l diff_mpat ps1 ps2 | _ -> Some l
+    )
+  | MP_vector_concat ps1 -> (
+      match rhs with MP_vector_concat ps2 -> diff_list ~at:l diff_mpat ps1 ps2 | _ -> Some l
+    )
+  | MP_vector_subrange (id1, n1, m1) -> (
+      match rhs with
+      | MP_vector_subrange (id2, n2, m2) -> diff_id id1 id2 &&& lazy (diff_eq ~at:l n1 n2) &&& lazy (diff_eq ~at:l m1 m2)
+      | _ -> Some l
+    )
+  | MP_tuple ps1 -> (
+      match rhs with MP_tuple ps2 -> diff_list ~at:l diff_mpat ps1 ps2 | _ -> Some l
+    )
+  | MP_list ps1 -> (
+      match rhs with MP_list ps2 -> diff_list ~at:l diff_mpat ps1 ps2 | _ -> Some l
+    )
+  | MP_cons (hd1, tl1) -> (
+      match rhs with MP_cons (hd2, tl2) -> diff_mpat hd1 hd2 &&& lazy (diff_mpat tl1 tl2) | _ -> Some l
+    )
+  | MP_string_append ps1 -> (
+      match rhs with MP_string_append ps2 -> diff_list ~at:l diff_mpat ps1 ps2 | _ -> Some l
+    )
+  | MP_struct (id_opt1, fps1) -> (
+      match rhs with
+      | MP_struct (id_opt2, fps2) ->
+          diff_option ~at:l diff_id id_opt1 id_opt2
+          &&& lazy (diff_list ~at:l (fun (f1, p1) (f2, p2) -> diff_id f1 f2 &&& lazy (diff_mpat p1 p2)) fps1 fps2)
+      | _ -> Some l
+    )
+  | MP_as (p1, id1) -> (
+      match rhs with MP_as (p2, id2) -> diff_mpat p1 p2 &&& lazy (diff_id id1 id2) | _ -> Some l
+    )
+
+let diff_mpexp (MPat_aux (lhs, l)) (MPat_aux (rhs, _)) =
+  match lhs with
+  | MPat_pat p1 -> (
+      match rhs with MPat_pat p2 -> diff_mpat p1 p2 | _ -> Some l
+    )
+  | MPat_when (p1, exp1) -> (
+      match rhs with MPat_when (p2, exp2) -> diff_mpat p1 p2 &&& lazy (diff_exp exp1 exp2) | _ -> Some l
+    )
+
+let rec diff_mapcl (MCL_aux (lhs, l)) (MCL_aux (rhs, _)) =
+  match lhs with
+  | MCL_attribute (attr1, arg1, mcl1) -> (
+      match rhs with
+      | MCL_attribute (attr2, arg2, mcl2) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_mapcl mcl1 mcl2)
+      | _ -> Some l
+    )
+  | MCL_doc (comment1, mcl1) -> (
+      match rhs with
+      | MCL_doc (comment2, mcl2) -> diff_eq ~at:l comment1 comment2 &&& lazy (diff_mapcl mcl1 mcl2)
+      | _ -> Some l
+    )
+  | MCL_bidir (left_mpexp1, right_mpexp1) -> (
+      match rhs with
+      | MCL_bidir (left_mpexp2, right_mpexp2) ->
+          diff_mpexp left_mpexp1 left_mpexp2 &&& lazy (diff_mpexp right_mpexp1 right_mpexp2)
+      | _ -> Some l
+    )
+  | MCL_forwards_deprecated _ ->
+      Reporting.warn "Deprecated" l "Cannot check AST equivalence here, as a deprecated construct was found.";
+      None
+  | MCL_forwards pexp1 -> (
+      match rhs with
+      | MCL_forwards pexp2 -> diff_pexp pexp1 pexp2
+      | MCL_forwards_deprecated _ ->
+          Reporting.warn "Deprecated" l "Cannot check AST equivalence here, as a deprecated construct was found.";
+          None
+      | _ -> Some l
+    )
+  | MCL_backwards pexp1 -> (
+      match rhs with MCL_backwards pexp2 -> diff_pexp pexp1 pexp2 | _ -> Some l
+    )
+  | MCL_when (mcl1, exp1) -> (
+      match rhs with MCL_when (mcl2, exp2) -> diff_mapcl mcl1 mcl2 &&& lazy (diff_exp exp1 exp2) | _ -> Some l
+    )
+
+let diff_mapdef (MD_aux (lhs, l)) (MD_aux (rhs, _)) =
+  let (MD_mapping (id1, opt_typschm1, mcls1)) = lhs in
+  let (MD_mapping (id2, opt_typschm2, mcls2)) = rhs in
+  diff_id id1 id2
+  &&& lazy (diff_option ~at:l diff_typschm opt_typschm1 opt_typschm2)
+  &&& lazy (diff_list ~at:l diff_mapcl mcls1 mcls2)
+
+let diff_val_spec (VS_aux (lhs, l)) (VS_aux (rhs, _)) =
+  let (VS_val_spec (typschm1, id1, extern1)) = lhs in
+  let (VS_val_spec (typschm2, id2, extern2)) = rhs in
+  diff_id id1 id2 &&& lazy (diff_typschm typschm1 typschm2) &&& lazy (diff_option ~at:l (diff_eq ~at:l) extern1 extern2)
+
+let rec diff_field_annot ~at:outer_l f lhs rhs =
+  match lhs with
+  | Ann_attribute (attr1, arg1, x1, l) -> (
+      match rhs with
+      | Ann_attribute (attr2, arg2, x2, _) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_field_annot ~at:outer_l f x1 x2)
+      | _ -> Some l
+    )
+  | Ann_doc (comment1, x1, l) -> (
+      match rhs with
+      | Ann_doc (comment2, x2, _) -> diff_eq ~at:l comment1 comment2 &&& lazy (diff_field_annot ~at:outer_l f x1 x2)
+      | _ -> Some l
+    )
+  | Ann_item x1 -> (
+      match rhs with Ann_item x2 -> f x1 x2 | _ -> Some outer_l
+    )
+
+let diff_tannot_opt (Typ_annot_opt_aux (lhs, l)) (Typ_annot_opt_aux (rhs, _)) =
+  match lhs with
+  | Typ_annot_opt_none -> diff_eq ~at:l lhs rhs
+  | Typ_annot_opt_some (typq1, atyp1) -> (
+      match rhs with
+      | Typ_annot_opt_some (typq2, atyp2) -> diff_typquant typq1 typq2 &&& lazy (diff_atyp atyp1 atyp2)
+      | Typ_annot_opt_none -> Some l
+    )
+
+let diff_rec_opt (Rec_aux (lhs, l)) (Rec_aux (rhs, _)) =
+  match lhs with
+  | Rec_none -> diff_eq ~at:l lhs rhs
+  | Rec_measure (pat1, exp1) -> (
+      match rhs with Rec_measure (pat2, exp2) -> diff_pat pat1 pat2 &&& lazy (diff_exp exp1 exp2) | Rec_none -> Some l
+    )
+
+let rec diff_funcl (FCL_aux (lhs, l)) (FCL_aux (rhs, _)) =
+  match lhs with
+  | FCL_private fcl1 -> (
+      match rhs with FCL_private fcl2 -> diff_funcl fcl1 fcl2 | _ -> Some l
+    )
+  | FCL_attribute (attr1, arg1, fcl1) -> (
+      match rhs with
+      | FCL_attribute (attr2, arg2, fcl2) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_funcl fcl1 fcl2)
+      | _ -> Some l
+    )
+  | FCL_doc (comment1, fcl1) -> (
+      match rhs with
+      | FCL_doc (comment2, fcl2) -> diff_eq ~at:l comment1 comment2 &&& lazy (diff_funcl fcl1 fcl2)
+      | _ -> Some l
+    )
+  | FCL_funcl (id1, pexp1) -> (
+      match rhs with FCL_funcl (id2, pexp2) -> diff_id id1 id2 &&& lazy (diff_pexp pexp1 pexp2) | _ -> Some l
+    )
+
+let rec diff_type_union (Tu_aux (lhs, l)) (Tu_aux (rhs, _)) =
+  match lhs with
+  | Tu_private tu1 -> (
+      match rhs with Tu_private tu2 -> diff_type_union tu1 tu2 | _ -> Some l
+    )
+  | Tu_attribute (attr1, arg1, tu1) -> (
+      match rhs with
+      | Tu_attribute (attr2, arg2, tu2) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_type_union tu1 tu2)
+      | _ -> Some l
+    )
+  | Tu_doc (comment1, tu1) -> (
+      match rhs with
+      | Tu_doc (comment2, tu2) -> diff_eq ~at:l comment1 comment2 &&& lazy (diff_type_union tu1 tu2)
+      | _ -> Some l
+    )
+  | Tu_ty_id (atyp1, id1) -> (
+      match rhs with Tu_ty_id (atyp2, id2) -> diff_id id1 id2 &&& lazy (diff_atyp atyp1 atyp2) | _ -> Some l
+    )
+  | Tu_ty_anon_rec (fields1, id1) -> (
+      match rhs with
+      | Tu_ty_anon_rec (fields2, id2) ->
+          diff_id id1 id2
+          &&& lazy
+                (diff_list ~at:l
+                   (diff_field_annot ~at:l (fun (field1, atyp1) (field2, atyp2) ->
+                        diff_id field1 field2 &&& lazy (diff_atyp atyp1 atyp2)
+                    )
+                   )
+                   fields1 fields2
+                )
+      | _ -> Some l
+    )
+
+let diff_fundef (FD_aux (lhs, l)) (FD_aux (rhs, _)) =
+  let (FD_function (rec_opt1, tannot_opt1, funcls1)) = lhs in
+  let (FD_function (rec_opt2, tannot_opt2, funcls2)) = rhs in
+  diff_rec_opt rec_opt1 rec_opt2
+  &&& lazy (diff_tannot_opt tannot_opt1 tannot_opt2)
+  &&& lazy (diff_list ~at:l diff_funcl funcls1 funcls2)
+
+let diff_type_def (TD_aux (lhs, l)) (TD_aux (rhs, _)) =
+  match lhs with
+  | TD_abbrev (id1, tq1, k1, atyp1) -> (
+      match rhs with
+      | TD_abbrev (id2, tq2, k2, atyp2) ->
+          diff_id id1 id2
+          &&& lazy (diff_typquant tq1 tq2)
+          &&& lazy (diff_option ~at:l diff_kind k1 k2)
+          &&& lazy (diff_atyp atyp1 atyp2)
+      | _ -> Some l
+    )
+  | TD_record (id1, tq1, fields1) -> (
+      match rhs with
+      | TD_record (id2, tq2, fields2) ->
+          diff_id id1 id2
+          &&& lazy (diff_typquant tq1 tq2)
+          &&& lazy
+                (diff_list ~at:l
+                   (diff_field_annot ~at:l (fun (field1, atyp1) (field2, atyp2) ->
+                        diff_id field1 field2 &&& lazy (diff_atyp atyp1 atyp2)
+                    )
+                   )
+                   fields1 fields2
+                )
+      | _ -> Some l
+    )
+  | TD_variant (id1, tq1, tus1, nt1) -> (
+      match rhs with
+      | TD_variant (id2, tq2, tus2, nt2) ->
+          diff_id id1 id2
+          &&& lazy (diff_typquant tq1 tq2)
+          &&& lazy (diff_list ~at:l diff_type_union tus1 tus2)
+          &&& lazy (diff_eq ~at:l nt1 nt2)
+      | _ -> Some l
+    )
+  | TD_enum (id1, with1, members1) -> (
+      match rhs with
+      | TD_enum (id2, with2, members2) ->
+          diff_id id1 id2
+          &&& lazy
+                (diff_list ~at:l
+                   (fun (f1, atyp1) (f2, atyp2) -> diff_id f1 f2 &&& lazy (diff_atyp atyp1 atyp2))
+                   with1 with2
+                )
+          &&& lazy
+                (diff_list ~at:l
+                   (fun (member1, exp_opt1) (member2, exp_opt2) ->
+                     diff_field_annot ~at:l diff_id member1 member2
+                     &&& lazy (diff_option ~at:l diff_exp exp_opt1 exp_opt2)
+                   )
+                   members1 members2
+                )
+      | _ -> Some l
+    )
+  | TD_abstract (id1, k1, conf1) -> (
+      match rhs with
+      | TD_abstract (id2, k2, conf2) -> diff_id id1 id2 &&& lazy (diff_kind k1 k2) &&& lazy (diff_eq ~at:l conf1 conf2)
+      | _ -> Some l
+    )
+  | TD_bitfield (id1, atyp1, fields1) -> (
+      match rhs with
+      | TD_bitfield (id2, atyp2, fields2) ->
+          diff_id id1 id2
+          &&& lazy (diff_atyp atyp1 atyp2)
+          &&& lazy
+                (diff_list ~at:l
+                   (diff_field_annot ~at:l (fun (field1, range1) (field2, range2) ->
+                        diff_id field1 field2 &&& lazy (diff_index_range range1 range2)
+                    )
+                   )
+                   fields1 fields2
+                )
+      | _ -> Some l
+    )
+
+let diff_pragma ~at:l lhs rhs =
+  match lhs with
+  | Pragma_line (str1, _) -> (
+      match rhs with Pragma_line (str2, _) -> diff_eq ~at:l str1 str2 | _ -> Some l
+    )
+  | Pragma_structured obj1 -> (
+      match rhs with
+      | Pragma_structured obj2 ->
+          diff_list ~at:l
+            (fun (name1, adata1) (name2, adata2) ->
+              diff_eq ~at:l name1 name2 &&& lazy (diff_attribute_data adata1 adata2)
+            )
+            obj1 obj2
+      | _ -> Some l
+    )
+
+let diff_scattered_def (SD_aux (lhs, l)) (SD_aux (rhs, _)) =
+  match lhs with
+  | SD_function (id1, tannot_opt1) -> (
+      match rhs with
+      | SD_function (id2, tannot_opt2) -> diff_id id1 id2 &&& lazy (diff_tannot_opt tannot_opt1 tannot_opt2)
+      | _ -> Some l
+    )
+  | SD_funcl funcl1 -> (
+      match rhs with SD_funcl funcl2 -> diff_funcl funcl1 funcl2 | _ -> Some l
+    )
+  | _ -> None
+
+let diff_dec_spec (DEC_aux (lhs, l)) (DEC_aux (rhs, _)) =
+  let (DEC_reg (atyp1, id1, opt_exp1)) = lhs in
+  let (DEC_reg (atyp2, id2, opt_exp2)) = rhs in
+  diff_id id1 id2 &&& lazy (diff_atyp atyp1 atyp2) &&& lazy (diff_option ~at:l diff_exp opt_exp1 opt_exp2)
+
+let rec diff_def (DEF_aux (lhs, l)) (DEF_aux (rhs, _)) =
+  match lhs with
+  | DEF_type td1 -> (
+      match rhs with DEF_type td2 -> diff_type_def td1 td2 | _ -> Some l
+    )
+  | DEF_constraint atyp1 -> (
+      match rhs with DEF_constraint atyp2 -> diff_atyp atyp1 atyp2 | _ -> Some l
+    )
+  | DEF_fundef fdef1 -> (
+      match rhs with DEF_fundef fdef2 -> diff_fundef fdef1 fdef2 | _ -> Some l
+    )
+  | DEF_mapdef mdef1 -> (
+      match rhs with DEF_mapdef mdef2 -> diff_mapdef mdef1 mdef2 | _ -> Some l
+    )
+  | DEF_impl funcl1 -> (
+      match rhs with DEF_impl funcl2 -> diff_funcl funcl1 funcl2 | _ -> Some l
+    )
+  | DEF_let lb1 -> (
+      match rhs with DEF_let lb2 -> diff_letbind lb1 lb2 | _ -> Some l
+    )
+  | DEF_overload (id1, ids1) -> (
+      match rhs with
+      | DEF_overload (id2, ids2) -> diff_id id1 id2 &&& lazy (diff_list ~at:l diff_id ids1 ids2)
+      | _ -> Some l
+    )
+  | DEF_fixity (prec1, n1, tok1) -> (
+      match rhs with
+      | DEF_fixity (prec2, n2, tok2) ->
+          diff_eq ~at:l prec1 prec2 &&& lazy (diff_eq_pred ~at:l Big_int.equal n1 n2) &&& lazy (diff_eq ~at:l tok1 tok2)
+      | _ -> Some l
+    )
+  | DEF_val vs1 -> (
+      match rhs with DEF_val vs2 -> diff_val_spec vs1 vs2 | _ -> Some l
+    )
+  | DEF_outcome _ -> None
+  | DEF_instantiation _ -> None
+  | DEF_default _ -> None
+  | DEF_scattered sdef1 -> (
+      match rhs with DEF_scattered sdef2 -> diff_scattered_def sdef1 sdef2 | _ -> Some l
+    )
+  | DEF_measure (id1, pat1, exp1) -> (
+      match rhs with
+      | DEF_measure (id2, pat2, exp2) -> diff_id id1 id2 &&& lazy (diff_pat pat1 pat2) &&& lazy (diff_exp exp1 exp2)
+      | _ -> Some l
+    )
+  | DEF_loop_measures (id1, measures1) -> (
+      match rhs with
+      | DEF_loop_measures (id2, measures2) ->
+          diff_id id1 id2
+          &&& lazy
+                (diff_list ~at:l
+                   (fun (Loop (l1, exp1)) (Loop (l2, exp2)) -> diff_eq ~at:l l1 l2 &&& lazy (diff_exp exp1 exp2))
+                   measures1 measures2
+                )
+      | _ -> Some l
+    )
+  | DEF_register dec_spec1 -> (
+      match rhs with DEF_register dec_spec2 -> diff_dec_spec dec_spec1 dec_spec2 | _ -> Some l
+    )
+  | DEF_pragma (cmd1, arg1) -> (
+      match rhs with
+      | DEF_pragma (cmd2, arg2) -> diff_eq ~at:l cmd1 cmd2 &&& lazy (diff_pragma ~at:l arg1 arg2)
+      | _ -> Some l
+    )
+  | DEF_private def1 -> (
+      match rhs with DEF_private def2 -> diff_def def1 def2 | _ -> Some l
+    )
+  | DEF_attribute (attr1, arg1, def1) -> (
+      match rhs with
+      | DEF_attribute (attr2, arg2, def2) ->
+          diff_eq ~at:l attr1 attr2
+          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+          &&& lazy (diff_def def1 def2)
+      | _ -> Some l
+    )
+  | DEF_doc (comment1, def1) -> (
+      match rhs with
+      | DEF_doc (comment2, def2) -> diff_eq ~at:l comment1 comment2 &&& lazy (diff_def def1 def2)
+      | _ -> Some l
+    )
+  | DEF_internal_mutrec fundefs1 -> (
+      match rhs with DEF_internal_mutrec fundefs2 -> diff_list ~at:l diff_fundef fundefs1 fundefs2 | _ -> Some l
+    )

--- a/src/lib/parse_ast_diff.ml
+++ b/src/lib/parse_ast_diff.ml
@@ -105,7 +105,7 @@ let rec diff_atyp lhs rhs =
       match rhs with ATyp_lit lit2 -> diff_lit lit1 lit2 | _ -> Some l
     )
   | ATyp_nset nums1 -> (
-      match rhs with ATyp_nset nums2 -> diff_eq_pred ~at:l (List.equal Big_int.equal) nums1 nums2 | _ -> Some l
+      match rhs with ATyp_nset nums2 -> diff_eq_pred ~at:l (Util.equal_list Big_int.equal) nums1 nums2 | _ -> Some l
     )
   | ATyp_in (n1, set1) -> (
       match rhs with ATyp_in (n2, set2) -> diff_atyp n1 n2 &&& lazy (diff_atyp set1 set2) | _ -> Some l
@@ -797,12 +797,53 @@ let diff_scattered_def (SD_aux (lhs, l)) (SD_aux (rhs, _)) =
   | SD_funcl funcl1 -> (
       match rhs with SD_funcl funcl2 -> diff_funcl funcl1 funcl2 | _ -> Some l
     )
-  | _ -> None
+  | SD_enum id1 -> (
+      match rhs with SD_enum id2 -> diff_id id1 id2 | _ -> Some l
+    )
+  | SD_enumcl (id1, m1) -> (
+      match rhs with SD_enumcl (id2, m2) -> diff_id id1 id2 &&& lazy (diff_id m1 m2) | _ -> Some l
+    )
+  | SD_variant (id1, typq1) -> (
+      match rhs with SD_variant (id2, typq2) -> diff_id id1 id2 &&& lazy (diff_typquant typq1 typq2) | _ -> Some l
+    )
+  | SD_unioncl (id1, tu1) -> (
+      match rhs with SD_unioncl (id2, tu2) -> diff_id id1 id2 &&& lazy (diff_type_union tu1 tu2) | _ -> Some l
+    )
+  | SD_mapping (id1, tannot_opt1) -> (
+      match rhs with
+      | SD_mapping (id2, tannot_opt2) -> diff_id id1 id2 &&& lazy (diff_tannot_opt tannot_opt1 tannot_opt2)
+      | _ -> Some l
+    )
+  | SD_mapcl (id1, mcl1) -> (
+      match rhs with SD_mapcl (id2, mcl2) -> diff_id id1 id2 &&& lazy (diff_mapcl mcl1 mcl2) | _ -> Some l
+    )
+  | SD_end id1 -> (
+      match rhs with SD_end id2 -> diff_id id1 id2 | _ -> Some l
+    )
+
+let diff_subst (IS_aux (lhs, l)) (IS_aux (rhs, _)) =
+  match lhs with
+  | IS_id (l_id1, r_id1) -> (
+      match rhs with IS_id (l_id2, r_id2) -> diff_id l_id1 l_id2 &&& lazy (diff_id r_id1 r_id2) | _ -> Some l
+    )
+  | IS_typ (v1, atyp1) -> (
+      match rhs with IS_typ (v2, atyp2) -> diff_kid v1 v2 &&& lazy (diff_atyp atyp1 atyp2) | _ -> Some l
+    )
 
 let diff_dec_spec (DEC_aux (lhs, l)) (DEC_aux (rhs, _)) =
   let (DEC_reg (atyp1, id1, opt_exp1)) = lhs in
   let (DEC_reg (atyp2, id2, opt_exp2)) = rhs in
   diff_id id1 id2 &&& lazy (diff_atyp atyp1 atyp2) &&& lazy (diff_option ~at:l diff_exp opt_exp1 opt_exp2)
+
+let diff_outcome (OV_aux (lhs, l)) (OV_aux (rhs, _)) =
+  let (OV_outcome (id1, typschm1, typq1)) = lhs in
+  let (OV_outcome (id2, typschm2, typq2)) = rhs in
+  diff_id id1 id2 &&& lazy (diff_typschm typschm1 typschm2) &&& lazy (diff_typquant typq1 typq2)
+
+let diff_default_typing_spec (DT_aux (lhs, l)) (DT_aux (rhs, _)) =
+  let (DT_order (k1, atyp1)) = lhs in
+  let (DT_order (k2, atyp2)) = rhs in
+  diff_kind k1 k2 &&& lazy (diff_atyp atyp1 atyp2)
 
 let rec diff_def (DEF_aux (lhs, l)) (DEF_aux (rhs, _)) =
   match lhs with
@@ -838,9 +879,19 @@ let rec diff_def (DEF_aux (lhs, l)) (DEF_aux (rhs, _)) =
   | DEF_val vs1 -> (
       match rhs with DEF_val vs2 -> diff_val_spec vs1 vs2 | _ -> Some l
     )
-  | DEF_outcome _ -> None
-  | DEF_instantiation _ -> None
-  | DEF_default _ -> None
+  | DEF_outcome (o1, defs1) -> (
+      match rhs with
+      | DEF_outcome (o2, defs2) -> diff_outcome o1 o2 &&& lazy (diff_list ~at:l diff_def defs1 defs2)
+      | _ -> Some l
+    )
+  | DEF_instantiation (id1, substs1) -> (
+      match rhs with
+      | DEF_instantiation (id2, substs2) -> diff_id id1 id2 &&& lazy (diff_list ~at:l diff_subst substs1 substs2)
+      | _ -> Some l
+    )
+  | DEF_default dtspec1 -> (
+      match rhs with DEF_default dtspec2 -> diff_default_typing_spec dtspec1 dtspec2 | _ -> Some l
+    )
   | DEF_scattered sdef1 -> (
       match rhs with DEF_scattered sdef2 -> diff_scattered_def sdef1 sdef2 | _ -> Some l
     )

--- a/src/lib/parse_ast_diff.mli
+++ b/src/lib/parse_ast_diff.mli
@@ -44,32 +44,8 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type infix_style = Prefix_lineup | Prefix
+open Parse_ast
 
-type config = {
-  indent : int;  (** The default indentation depth (default 4) *)
-  preserve_structure : bool;
-      (** If true, the formatter preserves the structure of the AST as much as possible - it won't insert braces around
-          if statements and so on where there weren't any and so on. (default false) *)
-  line_width : int;  (** The desired maximum line width. (default 120) *)
-  ribbon_width : float;
-      (** The fraction (between 0.0 and 1.0) of the maximum line width that can be filled by non whitespace characters
-          before we consider breaking. (default 1.0) *)
-  infix_style : infix_style;
-}
+val diff_list : at:l -> ('a -> 'a -> l option) -> 'a list -> 'a list -> l option
 
-(** Read the config struct from a json object. Raises err_general if the json is not an object, and warns about any
-    invalid keys. *)
-val config_from_json : Yojson.Safe.t -> config
-
-val default_config : config
-
-module type CONFIG = sig
-  val config : config
-end
-
-module Make (_ : CONFIG) : sig
-  (** If debug is true, we print extra debugging information to stderr, and annotate the output with various information
-      on linebreaking decisions. *)
-  val format_defs : ?debug:bool -> string -> string -> Lexer.comment list -> Parse_ast.def list -> string
-end
+val diff_def : def -> def -> l option

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -108,15 +108,6 @@ let mk_lit l n m = L_aux (l, loc n m)
 let mk_lit_exp l n m = mk_exp (E_lit (mk_lit l n m)) n m
 let mk_typschm tq t n m = TypSchm_aux (TypSchm_ts (tq, t), loc n m)
 
-let mk_typschm_opt ts n m = TypSchm_opt_aux (
-                                  TypSchm_opt_some (
-                                      ts
-                                    ),
-                                  loc n m
-                                )
-
-let mk_typschm_opt_none = TypSchm_opt_aux (TypSchm_opt_none, Unknown)
-
 let mk_sd s n m = SD_aux (s, loc n m)
 let mk_ir r n m = BF_aux (r, loc n m)
 
@@ -737,7 +728,13 @@ case:
     { mk_pexp (Pat_exp (p, body)) $startpos $endpos }
   | p = pat; If_; guard = exp; EqGt; body = exp
     { mk_pexp (Pat_when (p, guard, body)) $startpos $endpos }
-  | a = attribute; Lparen; c = case; Rparen
+  | a = attribute; c = attr_case
+    { mk_pexp (Pat_attribute (fst a, snd a, c)) $startpos $endpos(a) }
+
+attr_case:
+  | Lparen; c = case; Rparen
+    { c }
+  | a = attribute; c = attr_case
     { mk_pexp (Pat_attribute (fst a, snd a, c)) $startpos $endpos(a) }
 
 case_list:
@@ -1248,9 +1245,9 @@ mapcl_list:
 
 map_def:
   | Mapping id Eq Lcurly mapcl_list Rcurly
-    { mk_map $2 mk_typschm_opt_none $5 $startpos $endpos }
+    { mk_map $2 None $5 $startpos $endpos }
   | Mapping id Colon typschm Eq Lcurly mapcl_list Rcurly
-    { mk_map $2 (mk_typschm_opt $4 $startpos($4) $endpos($4)) $7 $startpos $endpos }
+    { mk_map $2 (Some $4) $7 $startpos $endpos }
 
 let_def:
   | Let_ letbind

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -163,6 +163,13 @@ let rec compare_list f l1 l2 =
       let c = f x y in
       if c = 0 then compare_list f l1 l2 else c
 
+let rec equal_list f l1 l2 =
+  match (l1, l2) with
+  | [], [] -> true
+  | _, [] -> false
+  | [], _ -> false
+  | x :: l1, y :: l2 -> f x y && equal_list f l1 l2
+
 let update_first f = function [] -> [] | x :: xs -> f x :: xs
 
 let rec update_last f = function [] -> [] | [x] -> [f x] | x :: xs -> x :: update_last f xs

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -175,6 +175,8 @@ val split3 : ('a * 'b * 'c) list -> 'a list * 'b list * 'c list
 
 val compare_list : ('a -> 'b -> int) -> 'a list -> 'b list -> int
 
+val equal_list : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+
 val take : int -> 'a list -> 'a list
 val drop : int -> 'a list -> 'a list
 

--- a/test/format/default/patterns.expect
+++ b/test/format/default/patterns.expect
@@ -11,6 +11,6 @@ function foo(ys : bits(6), xs : bits(6)) -> unit = {
     };
     let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
     let _ = (xs[3 .. 1] @ xs[0 .. 0]) @ xs[5 .. 4]; // should have brackets
-    let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
+    let _ = xs[3 .. 1] @ (xs[0 .. 0] @ xs[5 .. 4]);
     ()
 }

--- a/test/format/default/pexp_attr.expect
+++ b/test/format/default/pexp_attr.expect
@@ -1,0 +1,8 @@
+
+let _ : unit = match () {
+    () => (),
+    $[attr] (_ => ()),
+    $[attr1] $[attr2] (_ => () /* comment */ ),
+    $[attr1] $[attr2] (_ => () // comment
+    ),
+}

--- a/test/format/default/rv_pow2_bug.expect
+++ b/test/format/default/rv_pow2_bug.expect
@@ -1,0 +1,17 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec
+function get_num_elem(LMUL_pow : int, SEW : sew_bitsize) -> nat1 = {
+    let LMUL_pow_reg = if LMUL_pow < 0 then { 0 } else { LMUL_pow };
+
+    // Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
+    // be handled in init_masked_result
+    let num_elem = (2 ^ LMUL_pow_reg) * vlen / SEW;
+    assert(num_elem > 0);
+    num_elem
+}

--- a/test/format/lw80_preserve/patterns.expect
+++ b/test/format/lw80_preserve/patterns.expect
@@ -11,6 +11,6 @@ function foo(ys : bits(6), xs : bits(6)) -> unit = {
   };
   let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
   let _ = (xs[3 .. 1] @ xs[0 .. 0]) @ xs[5 .. 4]; // should have brackets
-  let _ = xs[3 .. 1] @ xs[0 .. 0] @ xs[5 .. 4];
+  let _ = xs[3 .. 1] @ (xs[0 .. 0] @ xs[5 .. 4]);
   ()
 }

--- a/test/format/lw80_preserve/pexp_attr.expect
+++ b/test/format/lw80_preserve/pexp_attr.expect
@@ -1,0 +1,8 @@
+
+let _ : unit = match () {
+  () => (),
+  $[attr] (_ => ()),
+  $[attr1] $[attr2] (_ => () /* comment */ ),
+  $[attr1] $[attr2] (_ => () // comment
+  ),
+}

--- a/test/format/lw80_preserve/rv_pow2_bug.expect
+++ b/test/format/lw80_preserve/rv_pow2_bug.expect
@@ -1,0 +1,17 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec
+function get_num_elem(LMUL_pow : int, SEW : sew_bitsize) -> nat1 = {
+  let LMUL_pow_reg = if LMUL_pow < 0 then { 0 } else { LMUL_pow };
+
+  // Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
+  // be handled in init_masked_result
+  let num_elem = (2 ^ LMUL_pow_reg) * vlen / SEW;
+  assert(num_elem > 0);
+  num_elem
+}

--- a/test/format/pexp_attr.sail
+++ b/test/format/pexp_attr.sail
@@ -1,0 +1,7 @@
+
+let _ : unit = match () {
+  () => (),
+  $[attr] (_ => ()),
+  $[attr1] $[attr2] (_ => () /* comment */),
+  $[attr1] ($[attr2] (_ => ())) // comment
+}

--- a/test/format/rv_pow2_bug.sail
+++ b/test/format/rv_pow2_bug.sail
@@ -1,0 +1,17 @@
+// =======================================================================================
+// This test is derived from the sail-riscv model. See RISCV_LICENSE in the formatting
+// tests directory.
+//
+// SPDX-License-Identifier: BSD-2-Clause
+// =======================================================================================
+
+// num_elem means max(VLMAX,VLEN/SEW)) according to Section 5.4 of RVV spec
+function get_num_elem(LMUL_pow : int, SEW : sew_bitsize) -> nat1 = {
+    let LMUL_pow_reg = if LMUL_pow < 0 then { 0 } else { LMUL_pow };
+
+    // Ignore lmul < 1 so that the entire vreg is read, allowing all masking to
+    // be handled in init_masked_result
+    let num_elem = (2 ^ LMUL_pow_reg) * vlen / SEW;
+    assert(num_elem > 0);
+    num_elem
+}


### PR DESCRIPTION
This file makes two main improvements to the formatter. First and most importantly, it adds an AST diff check formatting. This means that if the syntax tree differs in any way (other than some minor permitted differences) after reformatting, this raises an error.

Secondly, we now preserve lined up match statements where possible, so in something like:
```
match x {
  0  => foo,
  32 => bar,
  _  => baz,
} 
```
The extra spaces after `0` and `_` will be preserved, allowing the `=>` to remain lined up. This happens when we detect that all the match expressions were lined up in the original source. This heuristic likely needs some tweaking to find the correct balance.