### PR TITLE
Lean: fix miscompilations

### DIFF
--- a/src/sail_lean_backend/Sail/Specialization.lean
+++ b/src/sail_lean_backend/Sail/Specialization.lean
@@ -104,4 +104,12 @@ def ExceptM.run (m : ExceptM α α) : α :=
 
 abbrev sailTryCatchE (e : SailME β α) (h : exception → SailME β α) : SailME β α := PreSail.sailTryCatchE e h
 
+instance : Inhabited (PreSail.SequentialState RegisterType trivialChoiceSource) where
+  default := ⟨default, (), default, default, default, default⟩
+
+def unwrapValue [Inhabited α] (x : SailM α) : α :=
+  match x.run default with
+  | .ok x _ => x
+  | _ => default
+
 end Sail

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -111,7 +111,7 @@ let doc_id_ctor (Id_aux (i, _)) =
 let doc_kid ctx (Kid_aux (Var x, _) as ki) =
   match KBindings.find_opt ki ctx.kid_id_renames with
   | Some (Some i) -> doc_id_ctor i
-  | _ -> string ("k_" ^ String.sub x 1 (String.length x - 1))
+  | _ -> "k_" ^ String.sub x 1 (String.length x - 1) |> fix_id |> string
 
 (* TODO do a proper renaming and keep track of it *)
 
@@ -1127,7 +1127,7 @@ let doc_funcl_init global (FCL_aux (FCL_funcl (id, pexp), annot)) =
   let typ_quant_comment = doc_typ_quant_in_comment ctx tq_all in
   (* Use auto-implicits for type quanitifiers for now and see if this works *)
   let doc_ret_typ_orig = doc_typ ctx ret_typ in
-  let is_monadic = effectful (effect_of exp) in
+  let is_monadic = not (Effects.function_is_pure id ctx.global.effect_info) in
   let early_return = has_early_return exp in
   let has_loop = has_loop exp in
   (* Add monad for stateful functions *)
@@ -1180,7 +1180,7 @@ let doc_funcl_body fixup_binders ctx (FCL_aux (FCL_funcl (id, pexp), annot)) =
   (* If an argument was [x : (Int, Int)], which is transformed to [(arg0: Int) (arg1: Int)],
      this adds a let binding at the beginning of the function, of the form [let x := (arg0, arg1)] *)
   let exp = fixup_binders exp in
-  let is_monadic = has_effect exp in
+  let is_monadic = has_effect exp || not (Effects.function_is_pure id ctx.global.effect_info) in
   if untranslatable_mapping id exp then string "throw Error.Exit" else doc_exp is_monadic (context_with_env ctx env) exp
 
 let doc_termination ctx fnpat (Rec_aux (meas, _)) =
@@ -1264,6 +1264,8 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let vars = List.map parens vars in
       let vars = separate space vars in
       nest 2 (flow (break 1) (remove_empties [string "abbrev"; doc_id_ctor id; vars; coloneq; doc_typ ctx t]))
+  | TD_abbrev (id, tq, A_aux (A_typ t, _)) when string_of_id id = "fp_bits" ->
+      string (Printf.sprintf "-- Abbreviation %s skipped" (string_of_id id)) (* FIXME *)
   | TD_abbrev (id, tq, A_aux (A_typ t, _)) ->
       let vars = doc_typ_quant_only_vars ctx tq in
       let vars = separate space vars in
@@ -1317,7 +1319,9 @@ let doc_val ctx pat exp =
   in
   let typpp = match pat_typ with None -> empty | Some typ -> space ^^ colon ^^ space ^^ doc_typ ctx typ in
   let idpp = doc_id_ctor id in
-  let base_pp = doc_exp false ctx exp in
+  let base_pp =
+    if has_effect exp then string "unwrapValue" ^^ space ^^ parens (doc_exp true ctx exp) else doc_exp false ctx exp
+  in
   (global, nest 2 (group (string "def" ^^ space ^^ idpp ^^ typpp ^^ space ^^ coloneq ^/^ base_pp)))
 
 let should_print_function_def def =

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -509,7 +509,7 @@ open CacheOp
 open Barrier
 open AccessType
 
-/-- Type quantifiers: k_ex6037# : Bool, k_ex6036# : Bool -/
+/-- Type quantifiers: k_ex6037_ : Bool, k_ex6036_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex708# : Bool, k_ex707# : Bool -/
+/-- Type quantifiers: k_ex708_ : Bool, k_ex707_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -56,7 +56,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex709# : Bool, k_ex708# : Bool -/
+/-- Type quantifiers: k_ex709_ : Bool, k_ex708_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex827# : Bool, k_ex826# : Bool -/
+/-- Type quantifiers: k_ex827_ : Bool, k_ex826_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -66,7 +66,7 @@ open option
 open Register
 open E
 
-/-- Type quantifiers: k_ex2332# : Bool, k_ex2331# : Bool -/
+/-- Type quantifiers: k_ex2332_ : Bool, k_ex2331_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -444,7 +444,7 @@ def match_early_return_loop (x : E) : SailM E := SailME.run do
   | C => writeReg r_C A
   readReg r_B
 
-/-- Type quantifiers: k_ex2648# : Bool -/
+/-- Type quantifiers: k_ex2648_ : Bool -/
 def ite_early_return (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
@@ -455,7 +455,7 @@ def ite_early_return (x : Bool) : SailM E := SailME.run do
     else readReg r_B ) : SailME E E )
   readReg r_B
 
-/-- Type quantifiers: k_ex2650# : Bool -/
+/-- Type quantifiers: k_ex2650_ : Bool -/
 def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
   let loop_i_lower := 0
   let loop_i_upper := 10
@@ -474,7 +474,7 @@ def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
   (pure loop_vars)
   readReg r_B
 
-/-- Type quantifiers: k_ex2654# : Bool -/
+/-- Type quantifiers: k_ex2654_ : Bool -/
 def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
   if (x : Bool)
   then
@@ -494,7 +494,7 @@ def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
 def unit_type (x : E) : SailM Unit := do
   writeReg r_A x
 
-/-- Type quantifiers: k_ex2658# : Bool -/
+/-- Type quantifiers: k_ex2658_ : Bool -/
 def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -50,7 +50,7 @@ namespace Out.Functions
 open option
 open E
 
-/-- Type quantifiers: k_ex726# : Bool, k_ex725# : Bool -/
+/-- Type quantifiers: k_ex726_ : Bool, k_ex725_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -54,7 +54,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex736# : Bool, k_ex735# : Bool -/
+/-- Type quantifiers: k_ex736_ : Bool, k_ex735_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -147,13 +147,13 @@ def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
 def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
-/-- Type quantifiers: k_ex833# : Bool -/
+/-- Type quantifiers: k_ex833_ : Bool -/
 def test_exit (b : Bool) : SailM Unit := do
   if (b : Bool)
   then throw Error.Exit
   else (pure ())
 
-/-- Type quantifiers: k_ex835# : Bool -/
+/-- Type quantifiers: k_ex835_ : Bool -/
 def test_assert (b : Bool) : SailM (BitVec 1) := do
   assert b "b is false"
   (pure 1#1)

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex1170# : Bool, k_ex1169# : Bool -/
+/-- Type quantifiers: k_ex1170_ : Bool, k_ex1169_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex738# : Bool, k_ex737# : Bool -/
+/-- Type quantifiers: k_ex738_ : Bool, k_ex737_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex795# : Bool, k_ex794# : Bool -/
+/-- Type quantifiers: k_ex795_ : Bool, k_ex794_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -146,7 +146,7 @@ def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
 def foo (x : (BitVec 8)) : (BitVec 16) :=
   (EXTZ (m := 16) x)
 
-/-- Type quantifiers: k_ex892# : Bool, n : Nat, n ≥ 0 -/
+/-- Type quantifiers: k_ex892_ : Bool, n : Nat, n ≥ 0 -/
 def slice_mask2 {n : _} (i : (BitVec n)) (l : (BitVec n)) (b : Bool) : (BitVec n) :=
   if (b : Bool)
   then i

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -58,7 +58,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex811# : Bool, k_ex810# : Bool -/
+/-- Type quantifiers: k_ex811_ : Bool, k_ex810_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex778# : Bool, k_ex777# : Bool -/
+/-- Type quantifiers: k_ex857_ : Bool, k_ex856_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -150,6 +150,23 @@ def bar (_ : Unit) : (BitVec 16) :=
 def baz (_ : Unit) : SailM (BitVec 16) := do
   (print_effect "baz")
   (pure (0x0000 : (BitVec 16)))
+
+/-- Type quantifiers: x : Int -/
+def f (x : Int) : SailM Int := do
+  assert (x >b 4) "..."
+  (pure x)
+
+def a_constant : Int := unwrapValue ((f 22))
+
+def g (_ : Unit) : SailM Int := do
+  (pure (a_constant +i 3))
+
+def h (_ : Unit) : SailM Int := do
+  (print_effect "hi there")
+  (pure (a_constant +i (← (g ()))))
+
+def i (_ : Unit) : SailM Int := do
+  (pure (a_constant +i (← (g ()))))
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/let.sail
+++ b/test/lean/let.sail
@@ -19,3 +19,22 @@ function baz() -> bits(16) = {
   0x0000
 }
 
+function f(x : int) -> int = {
+  assert (x > 4, "...");
+  x
+}
+
+let a_constant : int = f(22)
+
+function g() -> int = {
+  a_constant + 3
+}
+
+function h() -> int = {
+  print_str ("hi there");
+  a_constant + g()
+}
+
+function i() -> int = {
+  a_constant + g()
+}

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -54,7 +54,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex2414# : Bool, k_ex2413# : Bool -/
+/-- Type quantifiers: k_ex2414_ : Bool, k_ex2413_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/map_tactics.expected.lean
+++ b/test/lean/map_tactics.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex1883# : Bool, k_ex1882# : Bool -/
+/-- Type quantifiers: k_ex1883_ : Bool, k_ex1882_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -175,7 +175,7 @@ def hex_bits_1_backwards (arg_ : String) : (BitVec 1) :=
   match arg_ with
   | s => (hex_bits_backwards (1, s))
 
-def hex_bits_1_forwards_matches (arg_ : (BitVec 1)) : Bool :=
+def hex_bits_1_forwards_matches (arg_ : (BitVec 1)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -183,10 +183,10 @@ def hex_bits_1_forwards_matches (arg_ : (BitVec 1)) : Bool :=
     | (1, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_1_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -211,7 +211,7 @@ def hex_bits_2_backwards (arg_ : String) : (BitVec 2) :=
   match arg_ with
   | s => (hex_bits_backwards (2, s))
 
-def hex_bits_2_forwards_matches (arg_ : (BitVec 2)) : Bool :=
+def hex_bits_2_forwards_matches (arg_ : (BitVec 2)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -219,10 +219,10 @@ def hex_bits_2_forwards_matches (arg_ : (BitVec 2)) : Bool :=
     | (2, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_2_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -247,7 +247,7 @@ def hex_bits_3_backwards (arg_ : String) : (BitVec 3) :=
   match arg_ with
   | s => (hex_bits_backwards (3, s))
 
-def hex_bits_3_forwards_matches (arg_ : (BitVec 3)) : Bool :=
+def hex_bits_3_forwards_matches (arg_ : (BitVec 3)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -255,10 +255,10 @@ def hex_bits_3_forwards_matches (arg_ : (BitVec 3)) : Bool :=
     | (3, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_3_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -283,7 +283,7 @@ def hex_bits_4_backwards (arg_ : String) : (BitVec 4) :=
   match arg_ with
   | s => (hex_bits_backwards (4, s))
 
-def hex_bits_4_forwards_matches (arg_ : (BitVec 4)) : Bool :=
+def hex_bits_4_forwards_matches (arg_ : (BitVec 4)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -291,10 +291,10 @@ def hex_bits_4_forwards_matches (arg_ : (BitVec 4)) : Bool :=
     | (4, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_4_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -319,7 +319,7 @@ def hex_bits_5_backwards (arg_ : String) : (BitVec 5) :=
   match arg_ with
   | s => (hex_bits_backwards (5, s))
 
-def hex_bits_5_forwards_matches (arg_ : (BitVec 5)) : Bool :=
+def hex_bits_5_forwards_matches (arg_ : (BitVec 5)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -327,10 +327,10 @@ def hex_bits_5_forwards_matches (arg_ : (BitVec 5)) : Bool :=
     | (5, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_5_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -355,7 +355,7 @@ def hex_bits_6_backwards (arg_ : String) : (BitVec 6) :=
   match arg_ with
   | s => (hex_bits_backwards (6, s))
 
-def hex_bits_6_forwards_matches (arg_ : (BitVec 6)) : Bool :=
+def hex_bits_6_forwards_matches (arg_ : (BitVec 6)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -363,10 +363,10 @@ def hex_bits_6_forwards_matches (arg_ : (BitVec 6)) : Bool :=
     | (6, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_6_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -391,7 +391,7 @@ def hex_bits_7_backwards (arg_ : String) : (BitVec 7) :=
   match arg_ with
   | s => (hex_bits_backwards (7, s))
 
-def hex_bits_7_forwards_matches (arg_ : (BitVec 7)) : Bool :=
+def hex_bits_7_forwards_matches (arg_ : (BitVec 7)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -399,10 +399,10 @@ def hex_bits_7_forwards_matches (arg_ : (BitVec 7)) : Bool :=
     | (7, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_7_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -427,7 +427,7 @@ def hex_bits_8_backwards (arg_ : String) : (BitVec 8) :=
   match arg_ with
   | s => (hex_bits_backwards (8, s))
 
-def hex_bits_8_forwards_matches (arg_ : (BitVec 8)) : Bool :=
+def hex_bits_8_forwards_matches (arg_ : (BitVec 8)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -435,10 +435,10 @@ def hex_bits_8_forwards_matches (arg_ : (BitVec 8)) : Bool :=
     | (8, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_8_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -463,7 +463,7 @@ def hex_bits_9_backwards (arg_ : String) : (BitVec 9) :=
   match arg_ with
   | s => (hex_bits_backwards (9, s))
 
-def hex_bits_9_forwards_matches (arg_ : (BitVec 9)) : Bool :=
+def hex_bits_9_forwards_matches (arg_ : (BitVec 9)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -471,10 +471,10 @@ def hex_bits_9_forwards_matches (arg_ : (BitVec 9)) : Bool :=
     | (9, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_9_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -499,7 +499,7 @@ def hex_bits_10_backwards (arg_ : String) : (BitVec 10) :=
   match arg_ with
   | s => (hex_bits_backwards (10, s))
 
-def hex_bits_10_forwards_matches (arg_ : (BitVec 10)) : Bool :=
+def hex_bits_10_forwards_matches (arg_ : (BitVec 10)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -507,10 +507,10 @@ def hex_bits_10_forwards_matches (arg_ : (BitVec 10)) : Bool :=
     | (10, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_10_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -535,7 +535,7 @@ def hex_bits_11_backwards (arg_ : String) : (BitVec 11) :=
   match arg_ with
   | s => (hex_bits_backwards (11, s))
 
-def hex_bits_11_forwards_matches (arg_ : (BitVec 11)) : Bool :=
+def hex_bits_11_forwards_matches (arg_ : (BitVec 11)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -543,10 +543,10 @@ def hex_bits_11_forwards_matches (arg_ : (BitVec 11)) : Bool :=
     | (11, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_11_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -571,7 +571,7 @@ def hex_bits_12_backwards (arg_ : String) : (BitVec 12) :=
   match arg_ with
   | s => (hex_bits_backwards (12, s))
 
-def hex_bits_12_forwards_matches (arg_ : (BitVec 12)) : Bool :=
+def hex_bits_12_forwards_matches (arg_ : (BitVec 12)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -579,10 +579,10 @@ def hex_bits_12_forwards_matches (arg_ : (BitVec 12)) : Bool :=
     | (12, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_12_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -607,7 +607,7 @@ def hex_bits_13_backwards (arg_ : String) : (BitVec 13) :=
   match arg_ with
   | s => (hex_bits_backwards (13, s))
 
-def hex_bits_13_forwards_matches (arg_ : (BitVec 13)) : Bool :=
+def hex_bits_13_forwards_matches (arg_ : (BitVec 13)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -615,10 +615,10 @@ def hex_bits_13_forwards_matches (arg_ : (BitVec 13)) : Bool :=
     | (13, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_13_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -643,7 +643,7 @@ def hex_bits_14_backwards (arg_ : String) : (BitVec 14) :=
   match arg_ with
   | s => (hex_bits_backwards (14, s))
 
-def hex_bits_14_forwards_matches (arg_ : (BitVec 14)) : Bool :=
+def hex_bits_14_forwards_matches (arg_ : (BitVec 14)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -651,10 +651,10 @@ def hex_bits_14_forwards_matches (arg_ : (BitVec 14)) : Bool :=
     | (14, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_14_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -679,7 +679,7 @@ def hex_bits_15_backwards (arg_ : String) : (BitVec 15) :=
   match arg_ with
   | s => (hex_bits_backwards (15, s))
 
-def hex_bits_15_forwards_matches (arg_ : (BitVec 15)) : Bool :=
+def hex_bits_15_forwards_matches (arg_ : (BitVec 15)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -687,10 +687,10 @@ def hex_bits_15_forwards_matches (arg_ : (BitVec 15)) : Bool :=
     | (15, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_15_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -715,7 +715,7 @@ def hex_bits_16_backwards (arg_ : String) : (BitVec 16) :=
   match arg_ with
   | s => (hex_bits_backwards (16, s))
 
-def hex_bits_16_forwards_matches (arg_ : (BitVec 16)) : Bool :=
+def hex_bits_16_forwards_matches (arg_ : (BitVec 16)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -723,10 +723,10 @@ def hex_bits_16_forwards_matches (arg_ : (BitVec 16)) : Bool :=
     | (16, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_16_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -751,7 +751,7 @@ def hex_bits_17_backwards (arg_ : String) : (BitVec 17) :=
   match arg_ with
   | s => (hex_bits_backwards (17, s))
 
-def hex_bits_17_forwards_matches (arg_ : (BitVec 17)) : Bool :=
+def hex_bits_17_forwards_matches (arg_ : (BitVec 17)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -759,10 +759,10 @@ def hex_bits_17_forwards_matches (arg_ : (BitVec 17)) : Bool :=
     | (17, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_17_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -787,7 +787,7 @@ def hex_bits_18_backwards (arg_ : String) : (BitVec 18) :=
   match arg_ with
   | s => (hex_bits_backwards (18, s))
 
-def hex_bits_18_forwards_matches (arg_ : (BitVec 18)) : Bool :=
+def hex_bits_18_forwards_matches (arg_ : (BitVec 18)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -795,10 +795,10 @@ def hex_bits_18_forwards_matches (arg_ : (BitVec 18)) : Bool :=
     | (18, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_18_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -823,7 +823,7 @@ def hex_bits_19_backwards (arg_ : String) : (BitVec 19) :=
   match arg_ with
   | s => (hex_bits_backwards (19, s))
 
-def hex_bits_19_forwards_matches (arg_ : (BitVec 19)) : Bool :=
+def hex_bits_19_forwards_matches (arg_ : (BitVec 19)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -831,10 +831,10 @@ def hex_bits_19_forwards_matches (arg_ : (BitVec 19)) : Bool :=
     | (19, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_19_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -859,7 +859,7 @@ def hex_bits_20_backwards (arg_ : String) : (BitVec 20) :=
   match arg_ with
   | s => (hex_bits_backwards (20, s))
 
-def hex_bits_20_forwards_matches (arg_ : (BitVec 20)) : Bool :=
+def hex_bits_20_forwards_matches (arg_ : (BitVec 20)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -867,10 +867,10 @@ def hex_bits_20_forwards_matches (arg_ : (BitVec 20)) : Bool :=
     | (20, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_20_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -895,7 +895,7 @@ def hex_bits_21_backwards (arg_ : String) : (BitVec 21) :=
   match arg_ with
   | s => (hex_bits_backwards (21, s))
 
-def hex_bits_21_forwards_matches (arg_ : (BitVec 21)) : Bool :=
+def hex_bits_21_forwards_matches (arg_ : (BitVec 21)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -903,10 +903,10 @@ def hex_bits_21_forwards_matches (arg_ : (BitVec 21)) : Bool :=
     | (21, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_21_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -931,7 +931,7 @@ def hex_bits_22_backwards (arg_ : String) : (BitVec 22) :=
   match arg_ with
   | s => (hex_bits_backwards (22, s))
 
-def hex_bits_22_forwards_matches (arg_ : (BitVec 22)) : Bool :=
+def hex_bits_22_forwards_matches (arg_ : (BitVec 22)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -939,10 +939,10 @@ def hex_bits_22_forwards_matches (arg_ : (BitVec 22)) : Bool :=
     | (22, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_22_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -967,7 +967,7 @@ def hex_bits_23_backwards (arg_ : String) : (BitVec 23) :=
   match arg_ with
   | s => (hex_bits_backwards (23, s))
 
-def hex_bits_23_forwards_matches (arg_ : (BitVec 23)) : Bool :=
+def hex_bits_23_forwards_matches (arg_ : (BitVec 23)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -975,10 +975,10 @@ def hex_bits_23_forwards_matches (arg_ : (BitVec 23)) : Bool :=
     | (23, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_23_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1003,7 +1003,7 @@ def hex_bits_24_backwards (arg_ : String) : (BitVec 24) :=
   match arg_ with
   | s => (hex_bits_backwards (24, s))
 
-def hex_bits_24_forwards_matches (arg_ : (BitVec 24)) : Bool :=
+def hex_bits_24_forwards_matches (arg_ : (BitVec 24)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1011,10 +1011,10 @@ def hex_bits_24_forwards_matches (arg_ : (BitVec 24)) : Bool :=
     | (24, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_24_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1039,7 +1039,7 @@ def hex_bits_25_backwards (arg_ : String) : (BitVec 25) :=
   match arg_ with
   | s => (hex_bits_backwards (25, s))
 
-def hex_bits_25_forwards_matches (arg_ : (BitVec 25)) : Bool :=
+def hex_bits_25_forwards_matches (arg_ : (BitVec 25)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1047,10 +1047,10 @@ def hex_bits_25_forwards_matches (arg_ : (BitVec 25)) : Bool :=
     | (25, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_25_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1075,7 +1075,7 @@ def hex_bits_26_backwards (arg_ : String) : (BitVec 26) :=
   match arg_ with
   | s => (hex_bits_backwards (26, s))
 
-def hex_bits_26_forwards_matches (arg_ : (BitVec 26)) : Bool :=
+def hex_bits_26_forwards_matches (arg_ : (BitVec 26)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1083,10 +1083,10 @@ def hex_bits_26_forwards_matches (arg_ : (BitVec 26)) : Bool :=
     | (26, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_26_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1111,7 +1111,7 @@ def hex_bits_27_backwards (arg_ : String) : (BitVec 27) :=
   match arg_ with
   | s => (hex_bits_backwards (27, s))
 
-def hex_bits_27_forwards_matches (arg_ : (BitVec 27)) : Bool :=
+def hex_bits_27_forwards_matches (arg_ : (BitVec 27)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1119,10 +1119,10 @@ def hex_bits_27_forwards_matches (arg_ : (BitVec 27)) : Bool :=
     | (27, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_27_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1147,7 +1147,7 @@ def hex_bits_28_backwards (arg_ : String) : (BitVec 28) :=
   match arg_ with
   | s => (hex_bits_backwards (28, s))
 
-def hex_bits_28_forwards_matches (arg_ : (BitVec 28)) : Bool :=
+def hex_bits_28_forwards_matches (arg_ : (BitVec 28)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1155,10 +1155,10 @@ def hex_bits_28_forwards_matches (arg_ : (BitVec 28)) : Bool :=
     | (28, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_28_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1183,7 +1183,7 @@ def hex_bits_29_backwards (arg_ : String) : (BitVec 29) :=
   match arg_ with
   | s => (hex_bits_backwards (29, s))
 
-def hex_bits_29_forwards_matches (arg_ : (BitVec 29)) : Bool :=
+def hex_bits_29_forwards_matches (arg_ : (BitVec 29)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1191,10 +1191,10 @@ def hex_bits_29_forwards_matches (arg_ : (BitVec 29)) : Bool :=
     | (29, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_29_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1219,7 +1219,7 @@ def hex_bits_30_backwards (arg_ : String) : (BitVec 30) :=
   match arg_ with
   | s => (hex_bits_backwards (30, s))
 
-def hex_bits_30_forwards_matches (arg_ : (BitVec 30)) : Bool :=
+def hex_bits_30_forwards_matches (arg_ : (BitVec 30)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1227,10 +1227,10 @@ def hex_bits_30_forwards_matches (arg_ : (BitVec 30)) : Bool :=
     | (30, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_30_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1255,7 +1255,7 @@ def hex_bits_31_backwards (arg_ : String) : (BitVec 31) :=
   match arg_ with
   | s => (hex_bits_backwards (31, s))
 
-def hex_bits_31_forwards_matches (arg_ : (BitVec 31)) : Bool :=
+def hex_bits_31_forwards_matches (arg_ : (BitVec 31)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1263,10 +1263,10 @@ def hex_bits_31_forwards_matches (arg_ : (BitVec 31)) : Bool :=
     | (31, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_31_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1291,7 +1291,7 @@ def hex_bits_32_backwards (arg_ : String) : (BitVec 32) :=
   match arg_ with
   | s => (hex_bits_backwards (32, s))
 
-def hex_bits_32_forwards_matches (arg_ : (BitVec 32)) : Bool :=
+def hex_bits_32_forwards_matches (arg_ : (BitVec 32)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1299,10 +1299,10 @@ def hex_bits_32_forwards_matches (arg_ : (BitVec 32)) : Bool :=
     | (32, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_32_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1327,7 +1327,7 @@ def hex_bits_33_backwards (arg_ : String) : (BitVec 33) :=
   match arg_ with
   | s => (hex_bits_backwards (33, s))
 
-def hex_bits_33_forwards_matches (arg_ : (BitVec 33)) : Bool :=
+def hex_bits_33_forwards_matches (arg_ : (BitVec 33)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1335,10 +1335,10 @@ def hex_bits_33_forwards_matches (arg_ : (BitVec 33)) : Bool :=
     | (33, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_33_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1363,7 +1363,7 @@ def hex_bits_34_backwards (arg_ : String) : (BitVec 34) :=
   match arg_ with
   | s => (hex_bits_backwards (34, s))
 
-def hex_bits_34_forwards_matches (arg_ : (BitVec 34)) : Bool :=
+def hex_bits_34_forwards_matches (arg_ : (BitVec 34)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1371,10 +1371,10 @@ def hex_bits_34_forwards_matches (arg_ : (BitVec 34)) : Bool :=
     | (34, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_34_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1399,7 +1399,7 @@ def hex_bits_35_backwards (arg_ : String) : (BitVec 35) :=
   match arg_ with
   | s => (hex_bits_backwards (35, s))
 
-def hex_bits_35_forwards_matches (arg_ : (BitVec 35)) : Bool :=
+def hex_bits_35_forwards_matches (arg_ : (BitVec 35)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1407,10 +1407,10 @@ def hex_bits_35_forwards_matches (arg_ : (BitVec 35)) : Bool :=
     | (35, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_35_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1435,7 +1435,7 @@ def hex_bits_36_backwards (arg_ : String) : (BitVec 36) :=
   match arg_ with
   | s => (hex_bits_backwards (36, s))
 
-def hex_bits_36_forwards_matches (arg_ : (BitVec 36)) : Bool :=
+def hex_bits_36_forwards_matches (arg_ : (BitVec 36)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1443,10 +1443,10 @@ def hex_bits_36_forwards_matches (arg_ : (BitVec 36)) : Bool :=
     | (36, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_36_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1471,7 +1471,7 @@ def hex_bits_37_backwards (arg_ : String) : (BitVec 37) :=
   match arg_ with
   | s => (hex_bits_backwards (37, s))
 
-def hex_bits_37_forwards_matches (arg_ : (BitVec 37)) : Bool :=
+def hex_bits_37_forwards_matches (arg_ : (BitVec 37)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1479,10 +1479,10 @@ def hex_bits_37_forwards_matches (arg_ : (BitVec 37)) : Bool :=
     | (37, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_37_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1507,7 +1507,7 @@ def hex_bits_38_backwards (arg_ : String) : (BitVec 38) :=
   match arg_ with
   | s => (hex_bits_backwards (38, s))
 
-def hex_bits_38_forwards_matches (arg_ : (BitVec 38)) : Bool :=
+def hex_bits_38_forwards_matches (arg_ : (BitVec 38)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1515,10 +1515,10 @@ def hex_bits_38_forwards_matches (arg_ : (BitVec 38)) : Bool :=
     | (38, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_38_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1543,7 +1543,7 @@ def hex_bits_39_backwards (arg_ : String) : (BitVec 39) :=
   match arg_ with
   | s => (hex_bits_backwards (39, s))
 
-def hex_bits_39_forwards_matches (arg_ : (BitVec 39)) : Bool :=
+def hex_bits_39_forwards_matches (arg_ : (BitVec 39)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1551,10 +1551,10 @@ def hex_bits_39_forwards_matches (arg_ : (BitVec 39)) : Bool :=
     | (39, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_39_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1579,7 +1579,7 @@ def hex_bits_40_backwards (arg_ : String) : (BitVec 40) :=
   match arg_ with
   | s => (hex_bits_backwards (40, s))
 
-def hex_bits_40_forwards_matches (arg_ : (BitVec 40)) : Bool :=
+def hex_bits_40_forwards_matches (arg_ : (BitVec 40)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1587,10 +1587,10 @@ def hex_bits_40_forwards_matches (arg_ : (BitVec 40)) : Bool :=
     | (40, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_40_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1615,7 +1615,7 @@ def hex_bits_41_backwards (arg_ : String) : (BitVec 41) :=
   match arg_ with
   | s => (hex_bits_backwards (41, s))
 
-def hex_bits_41_forwards_matches (arg_ : (BitVec 41)) : Bool :=
+def hex_bits_41_forwards_matches (arg_ : (BitVec 41)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1623,10 +1623,10 @@ def hex_bits_41_forwards_matches (arg_ : (BitVec 41)) : Bool :=
     | (41, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_41_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1651,7 +1651,7 @@ def hex_bits_42_backwards (arg_ : String) : (BitVec 42) :=
   match arg_ with
   | s => (hex_bits_backwards (42, s))
 
-def hex_bits_42_forwards_matches (arg_ : (BitVec 42)) : Bool :=
+def hex_bits_42_forwards_matches (arg_ : (BitVec 42)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1659,10 +1659,10 @@ def hex_bits_42_forwards_matches (arg_ : (BitVec 42)) : Bool :=
     | (42, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_42_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1687,7 +1687,7 @@ def hex_bits_43_backwards (arg_ : String) : (BitVec 43) :=
   match arg_ with
   | s => (hex_bits_backwards (43, s))
 
-def hex_bits_43_forwards_matches (arg_ : (BitVec 43)) : Bool :=
+def hex_bits_43_forwards_matches (arg_ : (BitVec 43)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1695,10 +1695,10 @@ def hex_bits_43_forwards_matches (arg_ : (BitVec 43)) : Bool :=
     | (43, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_43_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1723,7 +1723,7 @@ def hex_bits_44_backwards (arg_ : String) : (BitVec 44) :=
   match arg_ with
   | s => (hex_bits_backwards (44, s))
 
-def hex_bits_44_forwards_matches (arg_ : (BitVec 44)) : Bool :=
+def hex_bits_44_forwards_matches (arg_ : (BitVec 44)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1731,10 +1731,10 @@ def hex_bits_44_forwards_matches (arg_ : (BitVec 44)) : Bool :=
     | (44, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_44_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1759,7 +1759,7 @@ def hex_bits_45_backwards (arg_ : String) : (BitVec 45) :=
   match arg_ with
   | s => (hex_bits_backwards (45, s))
 
-def hex_bits_45_forwards_matches (arg_ : (BitVec 45)) : Bool :=
+def hex_bits_45_forwards_matches (arg_ : (BitVec 45)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1767,10 +1767,10 @@ def hex_bits_45_forwards_matches (arg_ : (BitVec 45)) : Bool :=
     | (45, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_45_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1795,7 +1795,7 @@ def hex_bits_46_backwards (arg_ : String) : (BitVec 46) :=
   match arg_ with
   | s => (hex_bits_backwards (46, s))
 
-def hex_bits_46_forwards_matches (arg_ : (BitVec 46)) : Bool :=
+def hex_bits_46_forwards_matches (arg_ : (BitVec 46)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1803,10 +1803,10 @@ def hex_bits_46_forwards_matches (arg_ : (BitVec 46)) : Bool :=
     | (46, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_46_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1831,7 +1831,7 @@ def hex_bits_47_backwards (arg_ : String) : (BitVec 47) :=
   match arg_ with
   | s => (hex_bits_backwards (47, s))
 
-def hex_bits_47_forwards_matches (arg_ : (BitVec 47)) : Bool :=
+def hex_bits_47_forwards_matches (arg_ : (BitVec 47)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1839,10 +1839,10 @@ def hex_bits_47_forwards_matches (arg_ : (BitVec 47)) : Bool :=
     | (47, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_47_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1867,7 +1867,7 @@ def hex_bits_48_backwards (arg_ : String) : (BitVec 48) :=
   match arg_ with
   | s => (hex_bits_backwards (48, s))
 
-def hex_bits_48_forwards_matches (arg_ : (BitVec 48)) : Bool :=
+def hex_bits_48_forwards_matches (arg_ : (BitVec 48)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1875,10 +1875,10 @@ def hex_bits_48_forwards_matches (arg_ : (BitVec 48)) : Bool :=
     | (48, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_48_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1903,7 +1903,7 @@ def hex_bits_49_backwards (arg_ : String) : (BitVec 49) :=
   match arg_ with
   | s => (hex_bits_backwards (49, s))
 
-def hex_bits_49_forwards_matches (arg_ : (BitVec 49)) : Bool :=
+def hex_bits_49_forwards_matches (arg_ : (BitVec 49)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1911,10 +1911,10 @@ def hex_bits_49_forwards_matches (arg_ : (BitVec 49)) : Bool :=
     | (49, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_49_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1939,7 +1939,7 @@ def hex_bits_50_backwards (arg_ : String) : (BitVec 50) :=
   match arg_ with
   | s => (hex_bits_backwards (50, s))
 
-def hex_bits_50_forwards_matches (arg_ : (BitVec 50)) : Bool :=
+def hex_bits_50_forwards_matches (arg_ : (BitVec 50)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1947,10 +1947,10 @@ def hex_bits_50_forwards_matches (arg_ : (BitVec 50)) : Bool :=
     | (50, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_50_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -1975,7 +1975,7 @@ def hex_bits_51_backwards (arg_ : String) : (BitVec 51) :=
   match arg_ with
   | s => (hex_bits_backwards (51, s))
 
-def hex_bits_51_forwards_matches (arg_ : (BitVec 51)) : Bool :=
+def hex_bits_51_forwards_matches (arg_ : (BitVec 51)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -1983,10 +1983,10 @@ def hex_bits_51_forwards_matches (arg_ : (BitVec 51)) : Bool :=
     | (51, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_51_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2011,7 +2011,7 @@ def hex_bits_52_backwards (arg_ : String) : (BitVec 52) :=
   match arg_ with
   | s => (hex_bits_backwards (52, s))
 
-def hex_bits_52_forwards_matches (arg_ : (BitVec 52)) : Bool :=
+def hex_bits_52_forwards_matches (arg_ : (BitVec 52)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2019,10 +2019,10 @@ def hex_bits_52_forwards_matches (arg_ : (BitVec 52)) : Bool :=
     | (52, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_52_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2047,7 +2047,7 @@ def hex_bits_53_backwards (arg_ : String) : (BitVec 53) :=
   match arg_ with
   | s => (hex_bits_backwards (53, s))
 
-def hex_bits_53_forwards_matches (arg_ : (BitVec 53)) : Bool :=
+def hex_bits_53_forwards_matches (arg_ : (BitVec 53)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2055,10 +2055,10 @@ def hex_bits_53_forwards_matches (arg_ : (BitVec 53)) : Bool :=
     | (53, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_53_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2083,7 +2083,7 @@ def hex_bits_54_backwards (arg_ : String) : (BitVec 54) :=
   match arg_ with
   | s => (hex_bits_backwards (54, s))
 
-def hex_bits_54_forwards_matches (arg_ : (BitVec 54)) : Bool :=
+def hex_bits_54_forwards_matches (arg_ : (BitVec 54)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2091,10 +2091,10 @@ def hex_bits_54_forwards_matches (arg_ : (BitVec 54)) : Bool :=
     | (54, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_54_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2119,7 +2119,7 @@ def hex_bits_55_backwards (arg_ : String) : (BitVec 55) :=
   match arg_ with
   | s => (hex_bits_backwards (55, s))
 
-def hex_bits_55_forwards_matches (arg_ : (BitVec 55)) : Bool :=
+def hex_bits_55_forwards_matches (arg_ : (BitVec 55)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2127,10 +2127,10 @@ def hex_bits_55_forwards_matches (arg_ : (BitVec 55)) : Bool :=
     | (55, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_55_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2155,7 +2155,7 @@ def hex_bits_56_backwards (arg_ : String) : (BitVec 56) :=
   match arg_ with
   | s => (hex_bits_backwards (56, s))
 
-def hex_bits_56_forwards_matches (arg_ : (BitVec 56)) : Bool :=
+def hex_bits_56_forwards_matches (arg_ : (BitVec 56)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2163,10 +2163,10 @@ def hex_bits_56_forwards_matches (arg_ : (BitVec 56)) : Bool :=
     | (56, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_56_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2191,7 +2191,7 @@ def hex_bits_57_backwards (arg_ : String) : (BitVec 57) :=
   match arg_ with
   | s => (hex_bits_backwards (57, s))
 
-def hex_bits_57_forwards_matches (arg_ : (BitVec 57)) : Bool :=
+def hex_bits_57_forwards_matches (arg_ : (BitVec 57)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2199,10 +2199,10 @@ def hex_bits_57_forwards_matches (arg_ : (BitVec 57)) : Bool :=
     | (57, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_57_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2227,7 +2227,7 @@ def hex_bits_58_backwards (arg_ : String) : (BitVec 58) :=
   match arg_ with
   | s => (hex_bits_backwards (58, s))
 
-def hex_bits_58_forwards_matches (arg_ : (BitVec 58)) : Bool :=
+def hex_bits_58_forwards_matches (arg_ : (BitVec 58)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2235,10 +2235,10 @@ def hex_bits_58_forwards_matches (arg_ : (BitVec 58)) : Bool :=
     | (58, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_58_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2263,7 +2263,7 @@ def hex_bits_59_backwards (arg_ : String) : (BitVec 59) :=
   match arg_ with
   | s => (hex_bits_backwards (59, s))
 
-def hex_bits_59_forwards_matches (arg_ : (BitVec 59)) : Bool :=
+def hex_bits_59_forwards_matches (arg_ : (BitVec 59)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2271,10 +2271,10 @@ def hex_bits_59_forwards_matches (arg_ : (BitVec 59)) : Bool :=
     | (59, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_59_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2299,7 +2299,7 @@ def hex_bits_60_backwards (arg_ : String) : (BitVec 60) :=
   match arg_ with
   | s => (hex_bits_backwards (60, s))
 
-def hex_bits_60_forwards_matches (arg_ : (BitVec 60)) : Bool :=
+def hex_bits_60_forwards_matches (arg_ : (BitVec 60)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2307,10 +2307,10 @@ def hex_bits_60_forwards_matches (arg_ : (BitVec 60)) : Bool :=
     | (60, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_60_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2335,7 +2335,7 @@ def hex_bits_61_backwards (arg_ : String) : (BitVec 61) :=
   match arg_ with
   | s => (hex_bits_backwards (61, s))
 
-def hex_bits_61_forwards_matches (arg_ : (BitVec 61)) : Bool :=
+def hex_bits_61_forwards_matches (arg_ : (BitVec 61)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2343,10 +2343,10 @@ def hex_bits_61_forwards_matches (arg_ : (BitVec 61)) : Bool :=
     | (61, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_61_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2371,7 +2371,7 @@ def hex_bits_62_backwards (arg_ : String) : (BitVec 62) :=
   match arg_ with
   | s => (hex_bits_backwards (62, s))
 
-def hex_bits_62_forwards_matches (arg_ : (BitVec 62)) : Bool :=
+def hex_bits_62_forwards_matches (arg_ : (BitVec 62)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2379,10 +2379,10 @@ def hex_bits_62_forwards_matches (arg_ : (BitVec 62)) : Bool :=
     | (62, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_62_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2407,7 +2407,7 @@ def hex_bits_63_backwards (arg_ : String) : (BitVec 63) :=
   match arg_ with
   | s => (hex_bits_backwards (63, s))
 
-def hex_bits_63_forwards_matches (arg_ : (BitVec 63)) : Bool :=
+def hex_bits_63_forwards_matches (arg_ : (BitVec 63)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2415,10 +2415,10 @@ def hex_bits_63_forwards_matches (arg_ : (BitVec 63)) : Bool :=
     | (63, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_63_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -2443,7 +2443,7 @@ def hex_bits_64_backwards (arg_ : String) : (BitVec 64) :=
   match arg_ with
   | s => (hex_bits_backwards (64, s))
 
-def hex_bits_64_forwards_matches (arg_ : (BitVec 64)) : Bool :=
+def hex_bits_64_forwards_matches (arg_ : (BitVec 64)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -2451,10 +2451,10 @@ def hex_bits_64_forwards_matches (arg_ : (BitVec 64)) : Bool :=
     | (64, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_64_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -3300,7 +3300,7 @@ def csr_name_map_forwards_matches (arg_ : (BitVec 12)) : Bool :=
   | reg => true
   | _ => false
 
-def csr_name_map_backwards_matches (arg_ : String) : Bool :=
+def csr_name_map_backwards_matches (arg_ : String) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | "stimecmp" => (some true)
@@ -3562,10 +3562,10 @@ def csr_name_map_backwards_matches (arg_ : String) : Bool :=
       | reg => (some true)
       | _ => none)
     else none)) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -50,7 +50,7 @@ namespace Out.Functions
 open word_width
 open option
 
-/-- Type quantifiers: k_ex921# : Bool, k_ex920# : Bool -/
+/-- Type quantifiers: k_ex921_ : Bool, k_ex920_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -313,7 +313,7 @@ def hex_bits_2_backwards (arg_ : String) : (BitVec 2) :=
   match arg_ with
   | s => (hex_bits_backwards (2, s))
 
-def hex_bits_2_forwards_matches (arg_ : (BitVec 2)) : Bool :=
+def hex_bits_2_forwards_matches (arg_ : (BitVec 2)) : SailM Bool := do
   let head_exp_ := arg_
   match (match head_exp_ with
   | mapping0_ =>
@@ -321,10 +321,10 @@ def hex_bits_2_forwards_matches (arg_ : (BitVec 2)) : Bool :=
     | (2, s) => (some true)
     | _ => none)
   | _ => none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def hex_bits_2_backwards_matches (arg_ : String) : Bool :=
   match arg_ with
@@ -371,7 +371,7 @@ def vtype_assembly2_backwards (arg_ : ((BitVec 1) × (BitVec 1))) : SailM String
   match arg_ with
   | (ta, sew) => (hex_bits_2_forwards ((ta : (BitVec 1)) ++ (sew : (BitVec 1))))
 
-def vtype_assembly2_forwards_matches (arg_ : String) : Bool :=
+def vtype_assembly2_forwards_matches (arg_ : String) : SailM Bool := do
   let head_exp_ := arg_
   match (let mapping0_ := head_exp_
   if ((hex_bits_2_backwards_matches mapping0_) : Bool)
@@ -380,10 +380,10 @@ def vtype_assembly2_forwards_matches (arg_ : String) : Bool :=
     | [ta:1,sew:1] => (some true)
     | _ => none)
   else none) with
-  | .some result => result
+  | .some result => (pure result)
   | none =>
     (match head_exp_ with
-    | _ => false)
+    | _ => (pure false))
 
 def vtype_assembly2_backwards_matches (arg_ : ((BitVec 1) × (BitVec 1))) : Bool :=
   match arg_ with

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -62,7 +62,7 @@ open option
 open Register
 open E
 
-/-- Type quantifiers: k_ex823# : Bool, k_ex822# : Bool -/
+/-- Type quantifiers: k_ex823_ : Bool, k_ex822_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex1275# : Bool, k_ex1274# : Bool -/
+/-- Type quantifiers: k_ex1275_ : Bool, k_ex1274_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex708# : Bool, k_ex707# : Bool -/
+/-- Type quantifiers: k_ex708_ : Bool, k_ex707_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -46,7 +46,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex768# : Bool, k_ex767# : Bool -/
+/-- Type quantifiers: k_ex768_ : Bool, k_ex767_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -118,7 +118,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex2436# : Bool, k_ex2435# : Bool -/
+/-- Type quantifiers: k_ex2436_ : Bool, k_ex2435_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -77,7 +77,7 @@ namespace Out.Functions
 open option
 open Register
 
-/-- Type quantifiers: k_ex948# : Bool, k_ex947# : Bool -/
+/-- Type quantifiers: k_ex948_ : Bool, k_ex947_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -178,7 +178,7 @@ def undefined_My_struct (_ : Unit) : SailM My_struct := do
   (pure { field1 := (← (undefined_int ()))
           field2 := (← (undefined_bit ())) })
 
-/-- Type quantifiers: k_ex1058# : Bool -/
+/-- Type quantifiers: k_ex1058_ : Bool -/
 def test_reg_if_struct (x : My_struct) (b : Bool) : SailM My_struct := do
   let y ← do
     (pure { x with field1 := (← if (b : Bool)

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -78,7 +78,7 @@ open iop
 open ast
 open Register
 
-/-- Type quantifiers: k_ex869# : Bool, k_ex868# : Bool -/
+/-- Type quantifiers: k_ex869_ : Bool, k_ex868_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/string.expected.lean
+++ b/test/lean/string.expected.lean
@@ -36,7 +36,7 @@ open Sail
 
 namespace Out.Functions
 
-/-- Type quantifiers: k_ex448# : Bool, k_ex447# : Bool -/
+/-- Type quantifiers: k_ex448_ : Bool, k_ex447_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -63,7 +63,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex769# : Bool, k_ex768# : Bool -/
+/-- Type quantifiers: k_ex769_ : Bool, k_ex768_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -54,7 +54,7 @@ namespace Out.Functions
 open option
 open e_test
 
-/-- Type quantifiers: k_ex714# : Bool, k_ex713# : Bool -/
+/-- Type quantifiers: k_ex714_ : Bool, k_ex713_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -50,7 +50,7 @@ namespace Out.Functions
 open option
 open E
 
-/-- Type quantifiers: k_ex792# : Bool, k_ex791# : Bool -/
+/-- Type quantifiers: k_ex792_ : Bool, k_ex791_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -178,7 +178,7 @@ def measure2 (x : E) : Int :=
   | B => 5
   | C => 1
 
-/-- Type quantifiers: k_ex900# : Bool -/
+/-- Type quantifiers: k_ex900_ : Bool -/
 def enabled2 (b : Bool) (e : E) : Bool :=
   match e with
   | A => (enabled2 b B)

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -56,7 +56,7 @@ namespace Out.Functions
 
 open option
 
-/-- Type quantifiers: k_ex724# : Bool, k_ex723# : Bool -/
+/-- Type quantifiers: k_ex724_ : Bool, k_ex723_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -51,7 +51,7 @@ namespace Out.Functions
 open virtaddr
 open option
 
-/-- Type quantifiers: k_ex769# : Bool, k_ex768# : Bool -/
+/-- Type quantifiers: k_ex769_ : Bool, k_ex768_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 


### PR DESCRIPTION
Issues fixed:
1. We did not escape # in some type variables
2. We did not handle constants defined using effectful functions
3. We mistranslated `fp_bits` from the standard library, for now we just skip it.

