### PR TITLE
bump Lean version

### DIFF
--- a/src/sail_lean_backend/Sail/IntRange.lean
+++ b/src/sail_lean_backend/Sail/IntRange.lean
@@ -16,7 +16,7 @@ instance : DecidableRel (fun (i : Int) (r : IntRange) => i ∈ r) := fun i r => 
   infer_instance
 
 theorem toNat_le {n : Nat} : Int.toNat m ≤ n ↔ m ≤ n := by
-  rw [Int.ofNat_le.symm, Int.toNat_eq_max, Int.max_le]; exact and_iff_left (Int.ofNat_zero_le _)
+  rw [Int.ofNat_le.symm, Int.toNat_eq_max, Int.max_le]; exact and_iff_left (Int.natCast_nonneg _)
 
 theorem lt_toNat {m : Nat} : m < Int.toNat n ↔ (m : Int) < n := by rw [← Int.not_le, ← Nat.not_le, toNat_le]
 

--- a/src/sail_lean_backend/Sail/Sail.lean
+++ b/src/sail_lean_backend/Sail/Sail.lean
@@ -97,7 +97,7 @@ def update (x : BitVec m) (n : Nat) (b : BitVec 1) := updateSubrange' x n _ b
 def updateBE (x : BitVec m) (n : Nat) (b : BitVec 1) := updateSubrange' x (m - n - 1) _ b
 
 def toBin {w : Nat} (x : BitVec w) : String :=
-  List.asString (List.map (fun c => if c then '1' else '0') (List.ofFn (BitVec.getMsb x)))
+  String.ofList (List.map (fun c => if c then '1' else '0') (List.ofFn (BitVec.getMsb x)))
 
 def toFormatted {w : Nat} (x : BitVec w) : String :=
   if (length x % 4) == 0 then
@@ -127,7 +127,7 @@ def parse_hex_bits_digits (n : Nat) (str : String) : BitVec n :=
   let len := str.length
   if h : n < 4 || len = 0 then BitVec.zero n else
     let bv := parse_hex_bits_digits (n-4) (str.take (len-1))
-    let c := str.get! ⟨len-1⟩ |> charToHex
+    let c := String.Pos.Raw.get! str ⟨len-1⟩ |> charToHex
     BitVec.append bv c |>.cast (by simp_all)
 decreasing_by simp_all <;> omega
 
@@ -137,7 +137,7 @@ where
   -- TODO: when there are lemmas about `String.take`, replace with WF induction
   go (fuel : Nat) (str : String) :=
     if fuel = 0 then 0 else
-      let lsd := str.get! ⟨str.length - 1⟩
+      let lsd := String.Pos.Raw.get! str ⟨str.length - 1⟩
       let rest := str.take (str.length - 1)
       (charToHex lsd).setWidth n + 10#n * go (fuel-1) rest
 

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -87,8 +87,8 @@ let opt_lean_executable : bool ref = ref false
 let opt_enable_matchbv : bool ref = ref false
 let opt_disable_matchbv : bool ref = ref true
 
-let lean_version : string = "lean4:nightly-2025-08-02"
-let mathlib_version : string = "nightly-testing-2025-08-02"
+let lean_version : string = "lean4:nightly-2025-11-18"
+let mathlib_version : string = "nightly-testing-2025-11-18"
 
 let lean_options =
   [


### PR DESCRIPTION
This nightly version includes performance improvements that help with some code generated by SAIL.

Namely:
- https://github.com/leanprover/lean4/pull/11196
- https://github.com/leanprover/lean4/pull/11200

I'm not sure what the process is for bumping Lean versions, so please let me know if I should be doing something else!