### PR TITLE
Refactor internal only flag

### DIFF
--- a/aarch64/mono/mono_rewrites.sail
+++ b/aarch64/mono/mono_rewrites.sail
@@ -1,1 +1,296 @@
-../../lib/mono_rewrites.sail
+/*==========================================================================*/
+/*     Sail                                                                 */
+/*                                                                          */
+/*  Sail and the Sail architecture models here, comprising all files and    */
+/*  directories except the ASL-derived Sail code in the aarch64 directory,  */
+/*  are subject to the BSD two-clause licence below.                        */
+/*                                                                          */
+/*  The ASL derived parts of the ARMv8.3 specification in                   */
+/*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               */
+/*                                                                          */
+/*  Copyright (c) 2013-2021                                                 */
+/*    Kathyrn Gray                                                          */
+/*    Shaked Flur                                                           */
+/*    Stephen Kell                                                          */
+/*    Gabriel Kerneis                                                       */
+/*    Robert Norton-Wright                                                  */
+/*    Christopher Pulte                                                     */
+/*    Peter Sewell                                                          */
+/*    Alasdair Armstrong                                                    */
+/*    Brian Campbell                                                        */
+/*    Thomas Bauereiss                                                      */
+/*    Anthony Fox                                                           */
+/*    Jon French                                                            */
+/*    Dominic Mulligan                                                      */
+/*    Stephen Kell                                                          */
+/*    Mark Wassell                                                          */
+/*    Alastair Reid (Arm Ltd)                                               */
+/*                                                                          */
+/*  All rights reserved.                                                    */
+/*                                                                          */
+/*  This work was partially supported by EPSRC grant EP/K008528/1 <a        */
+/*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          */
+/*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   */
+/*  KTF funding, and donations from Arm.  This project has received         */
+/*  funding from the European Research Council (ERC) under the European     */
+/*  Union’s Horizon 2020 research and innovation programme (grant           */
+/*  agreement No 789108, ELVER).                                            */
+/*                                                                          */
+/*  This software was developed by SRI International and the University of  */
+/*  Cambridge Computer Laboratory (Department of Computer Science and       */
+/*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        */
+/*  and FA8750-10-C-0237 ("CTSRD").                                         */
+/*                                                                          */
+/*  SPDX-License-Identifier: BSD-2-Clause                                   */
+/*==========================================================================*/
+
+$ifndef _MONO_REWRITES
+$define _MONO_REWRITES
+
+/* Definitions for use with the -mono_rewrites option */
+
+$include <arith.sail>
+$include <vector_dec.sail>
+
+/* External definitions not in the usual asl prelude */
+
+val extzv = pure {lem: "extz_vec"} : forall 'n 'm, 'm >= 0. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec)
+function extzv(m, v) = {
+  if m < 'n then truncate(v, m) else sail_zero_extend(v, m)
+}
+
+val extsv = pure {lem: "exts_vec"} : forall 'n 'm, 'm >= 0. (implicit('m), bitvector('n, dec)) -> bitvector('m, dec)
+function extsv(m, v) = {
+  if m < 'n then truncate(v, m) else sail_sign_extend(v, m)
+}
+
+/* This is generated internally to deal with case splits which reveal the size
+   of a bitvector */
+val bitvector_cast_in = pure "zeroExtend" : forall 'n. bits('n) -> bits('n)
+val bitvector_cast_out = pure "zeroExtend" : forall 'n. bits('n) -> bits('n)
+
+/* Builtins for the rewrites */
+val string_of_bits_subrange = pure "string_of_bits_subrange" : forall 'n. (bits('n), int, int) -> string
+
+/* Definitions for the rewrites */
+
+val is_zero_subrange : forall 'n, 'n >= 0.
+  (bits('n), int, int) -> bool
+
+function is_zero_subrange (xs, i, j) = {
+  (xs & slice_mask(j, i-j+1)) == extzv([bitzero] : bits(1))
+}
+
+val is_zeros_slice : forall 'n, 'n >= 0.
+  (bits('n), int, int) -> bool
+
+function is_zeros_slice (xs, i, l) = {
+  (xs & slice_mask(i, l)) == extzv([bitzero] : bits(1))
+}
+
+val is_ones_subrange : forall 'n, 'n >= 0.
+  (bits('n), int, int) -> bool
+
+function is_ones_subrange (xs, i, j) = {
+  let m : bits('n) = slice_mask(j,i-j+1) in
+  (xs & m) == m
+}
+
+val is_ones_slice : forall 'n, 'n >= 0.
+  (bits('n), int, int) -> bool
+
+function is_ones_slice (xs, i, j) = {
+  let m : bits('n) = slice_mask(i,j) in
+  (xs & m) == m
+}
+
+val slice_slice_concat : forall 'n 'm 'r, 'n >= 0 & 'm >= 0 & 'r >= 0.
+  (implicit('r), bits('n), int, int, bits('m), int, int) -> bits('r)
+
+function slice_slice_concat (r, xs, i, l, ys, i', l') = {
+  let xs = sail_shiftright(xs & slice_mask(i,l), i) in
+  let ys = sail_shiftright(ys & slice_mask(i',l'), i') in
+  sail_shiftleft(extzv(r, xs), l') | extzv(r, ys)
+}
+
+val slice_zeros_concat : forall 'n 'p 'q, 'n >= 0 & 'p + 'q >= 0.
+  (bits('n), int, atom('p), atom('q)) -> bits('p + 'q)
+
+function slice_zeros_concat (xs, i, l, l') = {
+  let xs = sail_shiftright(xs & slice_mask(i,l), i) in
+  sail_shiftleft(extzv(l + l', xs), l')
+}
+
+val subrange_zeros_concat : forall 'n 'hi 'lo 'q, 'n >= 0 & 'hi - 'lo + 1 + 'q >= 0.
+  (bits('n), atom('hi), atom('lo), atom('q)) -> bits('hi - 'lo + 1 + 'q)
+
+function subrange_zeros_concat (xs, hi, lo, l') =
+  slice_zeros_concat(xs, lo, hi - lo + 1, l')
+
+/* Assumes initial vectors are of equal size */
+
+val subrange_subrange_eq : forall 'n, 'n >= 0.
+  (bits('n), int, int, bits('n), int, int) -> bool
+
+function subrange_subrange_eq (xs, i, j, ys, i', j') = {
+  let xs = sail_shiftright(xs & slice_mask(j,i-j+1), j) in
+  let ys = sail_shiftright(ys & slice_mask(j',i'-j'+1), j') in
+  xs == ys
+}
+
+val subrange_subrange_concat : forall 'n 'o 'p 'm 'q 'r 's, 's >= 0 & 'n >= 0 & 'm >= 0.
+  (implicit('s), bits('n), atom('o), atom('p), bits('m), atom('q), atom('r)) -> bits('s)
+
+function subrange_subrange_concat (s, xs, i, j, ys, i', j') = {
+  let xs = sail_shiftright(xs & slice_mask(j,i-j+1), j) in
+  let ys = sail_shiftright(ys & slice_mask(j',i'-j'+1), j') in
+  sail_shiftleft(extzv(s, xs), i' - j' + 1) | extzv(s, ys)
+}
+
+val place_subrange : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int, int) -> bits('m)
+
+function place_subrange(m,xs,i,j,shift) = {
+  let xs = sail_shiftright(xs & slice_mask(j,i-j+1), j) in
+  sail_shiftleft(extzv(m, xs), shift)
+}
+
+val place_slice : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int, int) -> bits('m)
+
+function place_slice(m,xs,i,l,shift) = {
+  let xs = sail_shiftright(xs & slice_mask(i,l), i) in
+  sail_shiftleft(extzv(m, xs), shift)
+}
+
+val set_slice_zeros : forall 'n, 'n >= 0.
+  (implicit('n), bits('n), int, int) -> bits('n)
+
+function set_slice_zeros(n, xs, i, l) = {
+  let ys : bits('n) = slice_mask(n, i, l) in
+  xs & not_vec(ys)
+}
+
+val set_subrange_zeros : forall 'n, 'n >= 0.
+  (implicit('n), bits('n), int, int) -> bits('n)
+
+function set_subrange_zeros(n, xs, hi, lo) =
+  set_slice_zeros(n, xs, lo, hi - lo + 1)
+
+val zext_slice : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int) -> bits('m)
+
+function zext_slice(m,xs,i,l) = {
+  let xs = sail_shiftright(xs & slice_mask(i,l), i) in
+  extzv(m, xs)
+}
+
+val zext_subrange : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int) -> bits('m)
+
+function zext_subrange(m, xs, i, j) = zext_slice(m, xs, j, i - j + 1)
+
+val sext_slice : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int) -> bits('m)
+
+function sext_slice(m,xs,i,l) = {
+  let xs = sail_arith_shiftright(sail_shiftleft((xs & slice_mask(i,l)), ('n - i - l)), 'n - l) in
+  extsv(m, xs)
+}
+
+val sext_subrange : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int) -> bits('m)
+
+function sext_subrange(m, xs, i, j) = sext_slice(m, xs, j, i - j + 1)
+
+val place_slice_signed : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int, int) -> bits('m)
+
+function place_slice_signed(m,xs,i,l,shift) = {
+  sail_shiftleft(sext_slice(m, xs, i, l), shift)
+}
+
+val place_subrange_signed : forall 'n 'm, 'n >= 0 & 'm >= 0.
+  (implicit('m), bits('n), int, int, int) -> bits('m)
+
+function place_subrange_signed(m,xs,i,j,shift) = {
+  place_slice_signed(m, xs, j, i-j+1, shift)
+}
+
+/* This has different names in the aarch64 prelude (UInt) and the other
+   preludes (unsigned).  To avoid variable name clashes, we redeclare it
+   here with a suitably awkward name. */
+val _builtin_unsigned = pure {
+  ocaml: "uint",
+  lem: "uint",
+  interpreter: "uint",
+  c: "sail_unsigned",
+  cpp: "sail_unsigned",
+  coq: "uint",
+  lean: "BitVec.toNat"
+} : forall 'n. bits('n) -> {'m, 0 <= 'm < 2 ^ 'n. int('m)}
+
+/* There are different implementation choices for division and remainder, but
+   they agree on positive values.  We use this here to give more precise return
+   types for unsigned_slice and unsigned_subrange. */
+
+val _builtin_mod_nat = pure {
+  smt: "mod",
+  ocaml: "modulus",
+  lem: "integerMod",
+  c: "tmod_int",
+  cpp: "tmod_int",
+  coq: "Z.rem",
+  lean: "Nat.mod"
+} : forall 'n 'm, 'n >= 0 & 'm >= 0. (int('n), int('m)) -> {'r, 0 <= 'r < 'm. int('r)}
+
+/* Below we need the fact that 2 ^ 'n >= 0, so we axiomatise it in the return
+   type of pow2, as SMT solvers tend to have problems with exponentiation. */
+val _builtin_pow2 = pure "pow2" : forall 'n, 'n >= 0. int('n) -> {'m, 'm == 2 ^ 'n & 'm >= 0. int('m)}
+
+val unsigned_slice : forall 'n 'l, 'n >= 0 & 'l >= 0.
+  (bits('n), int, int('l)) -> {'m, 0 <= 'm < 2 ^ 'l. int('m)}
+
+function unsigned_slice(xs,i,l) = {
+  let xs = sail_shiftright(xs & slice_mask(i,l), i) in
+  _builtin_mod_nat(_builtin_unsigned(xs), _builtin_pow2(l))
+}
+
+val unsigned_subrange : forall 'n 'i 'j, 'n >= 0 & ('i - 'j) >= 0.
+  (bits('n), int('i), int('j)) -> {'m, 0 <= 'm < 2 ^ ('i - 'j + 1). int('m)}
+
+function unsigned_subrange(xs,i,j) = {
+  let xs = sail_shiftright(xs & slice_mask(j,i-j+1), i) in
+  _builtin_mod_nat(_builtin_unsigned(xs), _builtin_pow2(i - j + 1))
+}
+
+
+val zext_ones : forall 'n, 'n >= 0. (implicit('n), int) -> bits('n)
+
+function zext_ones(n, m) = {
+  let v : bits('n) = extsv([bitone] : bits(1)) in
+  sail_shiftright(v, n - m)
+}
+
+
+val vector_update_subrange_from_subrange : forall 'n1 's1 'e1 'n2 's2 'e2,
+    0 <= 'e1 <= 's1 < 'n1 & 0 <= 'e2 <= 's2 < 'n2 & 's1 - 'e1 == 's2 - 'e2.
+    (implicit('n1), bits('n1), int('s1), int('e1), bits('n2), int('s2), int('e2)) -> bits('n1)
+
+function vector_update_subrange_from_subrange(n,v1,s1,e1,v2,s2,e2) = {
+  let xs = sail_shiftright(v2 & slice_mask(e2,s2-e2+1), e2) in
+  let xs = sail_shiftleft(extzv(n, xs), e1) in
+  let ys = v1 & not_vec(slice_mask(e1,s1-e1+1)) in
+  xs | ys
+}
+
+val vector_update_subrange_from_integer_subrange : forall 'n1 's1 'e1 's2 'e2,
+    0 <= 'e1 <= 's1 < 'n1 & 0 <= 'e2 <= 's2 & 's1 - 'e1 == 's2 - 'e2.
+    (implicit('n1), bits('n1), int('s1), int('e1), int, int('s2), int('e2)) -> bits('n1)
+
+function vector_update_subrange_from_integer_subrange(n1, v1, s1, e1, i, s2, e2) = {
+  let v2 : bits('n1) = get_slice_int(n1, i, e2) in
+  vector_update_subrange_from_subrange(n1, v1, s1, e1, v2, s2 - e2, 0)
+}
+
+$endif

--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -277,13 +277,6 @@ plugins. These options are all prefixed with `d`.
   re-writing pass. The output from each pass is placed in a file
   starting with `prefix`.
 
-* `--dmagic-hash` Allow the `#` symbol in identifiers. It's
-  currently used as a magic symbol to separate generated identifiers
-  from those the user can write, so this option allows for the output
-  of the various other debugging options to be fed back into Sail. The
-  name comes from the GHC option with the same purpose:
-  https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/magic_hash.html
-
 === Passing options via SAIL_FLAGS
 
 The `SAIL_FLAGS` environment variable can be used to pass additional

--- a/doc/old/usage.tex
+++ b/doc/old/usage.tex
@@ -344,7 +344,7 @@ indicated by starting with the letter \verb+d+.
 
 \item \verb+-dsanity+ Perform extra sanity checks on the AST.
 
-\item \verb+-dmagic_hash+ Allow the \# symbol in identifiers. It's
+\item \verb+--dallow-internal+ Allow the \# symbol in identifiers. It's
   currently used as a magic symbol to separate generated identifiers
   from those the user can write, so this option allows for the output
   of the various other debugging options to be fed back into Sail.

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -398,7 +398,7 @@ let rec options =
         Arg.String (fun str -> Callgraph.opt_debug_callgraph := Some str),
         "<file> (debug) dump callgraph to file"
       );
-      ("-dmagic_hash", Arg.Set Initial_check.opt_magic_hash, " (debug) allow special character # in identifiers");
+      ("-dallow_internal", Arg.Set Initial_check.opt_allow_internal, " (debug) allow special character # in identifiers");
       ("-dno_error_filenames", Arg.Set Error_format.opt_debug_no_filenames, " (debug) do not print filenames in errors");
       ( "-dprofile",
         Arg.Set Profile.opt_profile,

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -55,7 +55,7 @@ module P = Parse_ast
 
 (* See mli file for details on what these flags do *)
 let opt_fast_undefined = ref false
-let opt_magic_hash = ref false
+let opt_allow_internal = ref false
 let opt_strict_bitvector = ref false
 
 module StringSet = Set.Make (String)
@@ -224,9 +224,9 @@ let to_ast_id ctx (P.Id_aux (id, l)) =
   in
   if string_contains (string_of_parse_id_aux id) '#' then begin
     match Reporting.loc_file l with
-    | Some file when !opt_magic_hash || StringSet.mem file ctx.internal_files -> to_ast_id' id
+    | Some file when !opt_allow_internal || StringSet.mem file ctx.internal_files -> to_ast_id' id
     | None -> to_ast_id' id
-    | _ -> raise (Reporting.err_general l "Identifier contains hash character and -dmagic_hash is unset")
+    | _ -> raise (Reporting.err_general l "Identifier contains hash character (internal only construct)")
   end
   else to_ast_id' id
 
@@ -1506,14 +1506,14 @@ and to_ast_exp ctx exp =
   | P.E_return exp -> wrap (E_return (to_ast_exp ctx exp))
   | P.E_assert (cond, msg) -> wrap (E_assert (to_ast_exp ctx cond, to_ast_exp ctx msg))
   | P.E_internal_plet (pat, exp1, exp2) ->
-      if !opt_magic_hash then wrap (E_internal_plet (to_ast_pat ctx pat, to_ast_exp ctx exp1, to_ast_exp ctx exp2))
-      else raise (Reporting.err_general l "Internal plet construct found without --dmagic-hash")
+      if !opt_allow_internal then wrap (E_internal_plet (to_ast_pat ctx pat, to_ast_exp ctx exp1, to_ast_exp ctx exp2))
+      else raise (Reporting.err_general l "Internal plet construct found (internal only construct)")
   | P.E_internal_return exp ->
-      if !opt_magic_hash then wrap (E_internal_return (to_ast_exp ctx exp))
-      else raise (Reporting.err_general l "Internal return construct found without --dmagic-hash")
+      if !opt_allow_internal then wrap (E_internal_return (to_ast_exp ctx exp))
+      else raise (Reporting.err_general l "Internal return construct found (internal only construct)")
   | P.E_internal_assume (nc, exp) ->
-      if !opt_magic_hash then wrap (E_internal_assume (to_ast_constraint ctx nc, to_ast_exp ctx exp))
-      else raise (Reporting.err_general l "Internal assume construct found without --dmagic-hash")
+      if !opt_allow_internal then wrap (E_internal_assume (to_ast_constraint ctx nc, to_ast_exp ctx exp))
+      else raise (Reporting.err_general l "Internal assume construct found (internal only construct)")
   | P.E_deref exp -> wrap (E_app (Id_aux (Id "__deref", l), [to_ast_exp ctx exp]))
 
 and to_ast_measure ctx (P.Measure_aux (m, l)) : uannot internal_loop_measure =
@@ -1521,8 +1521,8 @@ and to_ast_measure ctx (P.Measure_aux (m, l)) : uannot internal_loop_measure =
     match m with
     | P.Measure_none -> Measure_none
     | P.Measure_some exp ->
-        if !opt_magic_hash then Measure_some (to_ast_exp ctx exp)
-        else raise (Reporting.err_general l "Internal loop termination measure found without -dmagic_hash")
+        if !opt_allow_internal then Measure_some (to_ast_exp ctx exp)
+        else raise (Reporting.err_general l "Internal loop termination measure found (internal only construct)")
   in
   Measure_aux (m, l)
 
@@ -1803,7 +1803,7 @@ let to_ast_reserved_type_id ctx id =
   let id = to_ast_id ctx id in
   if IdSet.mem id reserved_type_ids then begin
     match Reporting.loc_file (id_loc id) with
-    | Some file when !opt_magic_hash || StringSet.mem file ctx.internal_files -> id
+    | Some file when !opt_allow_internal || StringSet.mem file ctx.internal_files -> id
     | None -> id
     | Some file -> raise (Reporting.err_general (id_loc id) (sprintf "The type name %s is reserved" (string_of_id id)))
   end
@@ -2708,8 +2708,8 @@ let ast_of_def_string_with ?inline ocaml_pos ctx f str =
   let lexbuf = Lexing.from_string str in
   lexbuf.lex_curr_p <- { pos_fname = ""; pos_lnum = 1; pos_bol = 0; pos_cnum = 0 };
   inline_lexbuf lexbuf inline;
-  let internal = !opt_magic_hash in
-  opt_magic_hash := true;
+  let internal = !opt_allow_internal in
+  opt_allow_internal := true;
   let def =
     try Parser.def_eof (Lexer.token (ref [])) lexbuf
     with Parser.Error ->
@@ -2718,7 +2718,7 @@ let ast_of_def_string_with ?inline ocaml_pos ctx f str =
       raise (Reporting.err_syntax pos ("current token: " ^ tok))
   in
   let ast, ctx = Reporting.forbid_errors ocaml_pos (fun ast -> process_ast ctx ast) (P.Defs [(None, f [def])]) in
-  opt_magic_hash := internal;
+  opt_allow_internal := internal;
   (ast, ctx)
 
 let ast_of_def_string ?inline ocaml_pos ctx str = ast_of_def_string_with ?inline ocaml_pos ctx (fun x -> x) str

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -61,8 +61,8 @@ val opt_strict_bitvector : bool ref
     the right effects, so the -no_effects flag may be needed if this is true. False by default. *)
 val opt_fast_undefined : bool ref
 
-(** Allow # in identifiers when set, much like the GHC option of the same name *)
-val opt_magic_hash : bool ref
+(** Allow parsing internal constructs that should otherwise not appear in regular code *)
+val opt_allow_internal : bool ref
 
 (** {2 Contexts} *)
 

--- a/test/format/default/struct_update.expect
+++ b/test/format/default/struct_update.expect
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 default Order dec
 

--- a/test/format/lw80_preserve/struct_update.expect
+++ b/test/format/lw80_preserve/struct_update.expect
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 default Order dec
 

--- a/test/format/struct_update.sail
+++ b/test/format/struct_update.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 default Order dec
 

--- a/test/typecheck/fail/cond_mod.sail
+++ b/test/typecheck/fail/cond_mod.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# variable b = false A {} B { requires if $b then A else [] }
 

--- a/test/typecheck/fail/duplicate_toplevel_let_mod.sail
+++ b/test/typecheck/fail/duplicate_toplevel_let_mod.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B {}
 

--- a/test/typecheck/fail/mapping_body_private.sail
+++ b/test/typecheck/fail/mapping_body_private.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/overload_member_scope.sail
+++ b/test/typecheck/fail/overload_member_scope.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 // This test demonstrates that even though bar overloads foo, we
 // cannot use bar to access foo in a module where it is not available

--- a/test/typecheck/fail/private_clause.sail
+++ b/test/typecheck/fail/private_clause.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/private_ctor.sail
+++ b/test/typecheck/fail/private_ctor.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/private_extension.sail
+++ b/test/typecheck/fail/private_extension.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/private_function.sail
+++ b/test/typecheck/fail/private_function.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/private_scattered_enum.sail
+++ b/test/typecheck/fail/private_scattered_enum.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A }
 

--- a/test/typecheck/fail/private_scattered_fn.sail
+++ b/test/typecheck/fail/private_scattered_fn.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A }
 

--- a/test/typecheck/fail/private_scattered_map.sail
+++ b/test/typecheck/fail/private_scattered_map.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A }
 

--- a/test/typecheck/fail/private_scattered_union.sail
+++ b/test/typecheck/fail/private_scattered_union.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A }
 

--- a/test/typecheck/fail/private_union.sail
+++ b/test/typecheck/fail/private_union.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/pub_val_priv_fn.sail
+++ b/test/typecheck/fail/pub_val_priv_fn.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/fail/scattered_enum_mod.sail
+++ b/test/typecheck/fail/scattered_enum_mod.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A } C { requires B }
 

--- a/test/typecheck/fail/scattered_function_mod.sail
+++ b/test/typecheck/fail/scattered_function_mod.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A } C { requires B }
 

--- a/test/typecheck/fail/scattered_map_mod.sail
+++ b/test/typecheck/fail/scattered_map_mod.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A } C { requires B }
 

--- a/test/typecheck/fail/scattered_union_mod.sail
+++ b/test/typecheck/fail/scattered_union_mod.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {} B { requires A } C { requires B }
 

--- a/test/typecheck/fail/unscope_enum.sail
+++ b/test/typecheck/fail/unscope_enum.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {}
 

--- a/test/typecheck/fail/unscope_let.sail
+++ b/test/typecheck/fail/unscope_let.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {}
 

--- a/test/typecheck/fail/unscope_register.sail
+++ b/test/typecheck/fail/unscope_register.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {}
 

--- a/test/typecheck/fail/unscope_type.sail
+++ b/test/typecheck/fail/unscope_type.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {}
 

--- a/test/typecheck/fail/unscope_val.sail
+++ b/test/typecheck/fail/unscope_val.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A {}
 

--- a/test/typecheck/pass/extension_constructor.sail
+++ b/test/typecheck/pass/extension_constructor.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A { } B { requires A } C { requires A }
 

--- a/test/typecheck/pass/extension_constructor/v1.sail
+++ b/test/typecheck/pass/extension_constructor/v1.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A { } B { requires A } C { requires A }
 

--- a/test/typecheck/pass/extension_constructor/v2.sail
+++ b/test/typecheck/pass/extension_constructor/v2.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# A { } B { requires A } C { }
 

--- a/test/typecheck/pass/mod_var.sail
+++ b/test/typecheck/pass/mod_var.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 
 $project# variable mods = [A] A {} B { requires $mods }
 

--- a/test/typecheck/pass/priv_fn_no_val.sail
+++ b/test/typecheck/pass/priv_fn_no_val.sail
@@ -1,4 +1,4 @@
-$option -dmagic_hash
+$option --dallow-internal
 default Order dec
 
 $include <prelude.sail>

--- a/test/typecheck/run_tests.py
+++ b/test/typecheck/run_tests.py
@@ -38,7 +38,7 @@ def test_pass():
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 step('\'{}\' --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast pass/{} 1> rtpass/{}'.format(sail, filename, filename))
-                step('\'{}\' --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast --dmagic-hash rtpass/{} 1> rtpass2/{}'.format(sail, filename, filename))
+                step('\'{}\' --no-memo-z3 --just-check --strict-bitvector --ddump-tc-ast --dallow-internal rtpass/{} 1> rtpass2/{}'.format(sail, filename, filename))
                 step('diff rtpass/{} rtpass2/{}'.format(filename, filename))
                 i = 0
                 variantdir = os.path.join('pass', basename);


### PR DESCRIPTION
Previously we had the `--dmagic-hash` flag which allowed parsing the hash character in `#` in identifiers. This was used to mark internal identifiers in such a way that they cannot clash with any identifiers written by the user. The primary use was to re-parse generated code (e.g. which might be produced during rewrite passes) for debugging reasons, like to type-check intermediate rewrites.

However, it was used for some other internal constructs, and worse, was actively suggested in the error message as a way to work around an error that would appear when such internal constructs appeared (which were only intended as intermediates during lowering passes).

This commit renames the flag to `--dallow-internal` to better reflect all its usages, and the error messages from these constructs now provide no indication there is any way to avoid the error.