### PR TITLE
Lean: compat between early return and exception

### DIFF
--- a/src/sail_lean_backend/Sail/Specialization.lean
+++ b/src/sail_lean_backend/Sail/Specialization.lean
@@ -77,35 +77,11 @@ abbrev print_bits_effect {w : Nat} (str : String) (x : BitVec w) : SailM Unit :=
 
 abbrev print_endline_effect (str : String) : SailM Unit := PreSail.print_endline_effect str
 
-abbrev SailME α := ExceptT α SailM
+def SailME.run (m : SailME α α) : SailM α := PreSail.PreSailME.run m
 
-def SailME.run (m : SailME α α) : SailM α := do
-  match (← ExceptT.run m) with
-    | .error e => pure e
-    | .ok e => pure e
-
-def _root_.ExceptT.map_error [Monad m] (e : ExceptT ε m α) (f : ε → ε') : ExceptT ε' m α :=
-  ExceptT.mk <| do
-    match ← e.run with
-    | .ok x => pure $ .ok x
-    | .error e => pure $ .error (f e)
-
-instance [∀ x, CoeT α x α'] : CoeT (SailME α β) e (SailME α' β) where
-  coe := e.map_error (fun x => x)
-
-def SailME.throw (e : α) : SailME α β := MonadExcept.throw e
-
-abbrev ExceptM α := ExceptT α Id
-
-def ExceptM.run (m : ExceptM α α) : α :=
-  match (ExceptT.run m) with
-    | .error e => e
-    | .ok e => e
+def SailME.throw (e : α) : SailME α β := PreSail.PreSailME.throw e
 
 abbrev sailTryCatchE (e : SailME β α) (h : exception → SailME β α) : SailME β α := PreSail.sailTryCatchE e h
-
-instance : Inhabited (PreSail.SequentialState RegisterType trivialChoiceSource) where
-  default := ⟨default, (), default, default, default, default⟩
 
 def unwrapValue [Inhabited α] (x : SailM α) : α :=
   match x.run default with
@@ -113,3 +89,4 @@ def unwrapValue [Inhabited α] (x : SailM α) : α :=
   | _ => default
 
 end Sail
+

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1470,8 +1470,12 @@ let doc_monad_abbrev defs (has_registers : bool) =
   in
   let excdef = find_exc_typ defs in
   let pp_register_type = string "PreSailM RegisterType trivialChoiceSource exception" in
-  let monad = separate space [string "abbrev"; string "SailM"; coloneq; pp_register_type] ^^ hardline ^^ hardline in
-  separate hardline (remove_empties [excdef; monad])
+  let pp_register_type_e = string "PreSailME RegisterType trivialChoiceSource exception" in
+  let monad = separate space [string "abbrev"; string "SailM"; coloneq; pp_register_type] in
+  let monad_e =
+    separate space [string "abbrev"; string "SailME"; coloneq; pp_register_type_e] ^^ hardline ^^ hardline
+  in
+  separate hardline (remove_empties [excdef; monad; monad_e])
 
 let doc_instantiations ctx env =
   let params = Monad_params.find_monad_parameters env in

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -447,6 +447,7 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 instance : Arch where
   va_size := 64

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -16,6 +16,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -35,6 +35,7 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -44,6 +44,7 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX
@@ -68,7 +69,7 @@ open option
 open Register
 open E
 
-/-- Type quantifiers: k_ex2332_ : Bool, k_ex2331_ : Bool -/
+/-- Type quantifiers: k_ex2346_ : Bool, k_ex2345_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -446,7 +447,7 @@ def match_early_return_loop (x : E) : SailM E := SailME.run do
   | C => writeReg r_C A
   readReg r_B
 
-/-- Type quantifiers: k_ex2648_ : Bool -/
+/-- Type quantifiers: k_ex2662_ : Bool -/
 def ite_early_return (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
@@ -457,7 +458,7 @@ def ite_early_return (x : Bool) : SailM E := SailME.run do
     else readReg r_B ) : SailME E E )
   readReg r_B
 
-/-- Type quantifiers: k_ex2650_ : Bool -/
+/-- Type quantifiers: k_ex2664_ : Bool -/
 def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
   let loop_i_lower := 0
   let loop_i_upper := 10
@@ -476,7 +477,7 @@ def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
   (pure loop_vars)
   readReg r_B
 
-/-- Type quantifiers: k_ex2654_ : Bool -/
+/-- Type quantifiers: k_ex2668_ : Bool -/
 def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
   if (x : Bool)
   then
@@ -496,7 +497,7 @@ def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
 def unit_type (x : E) : SailM Unit := do
   writeReg r_A x
 
-/-- Type quantifiers: k_ex2658_ : Bool -/
+/-- Type quantifiers: k_ex2672_ : Bool -/
 def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
@@ -506,6 +507,20 @@ def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
           (unit_type A)
           readReg r_A)
     else readReg r_B ) : SailME E E )
+  readReg r_B
+
+/-- Type quantifiers: k_ex2674_ : Bool -/
+def ite_early_return_exit (x : Bool) : SailM E := SailME.run do
+  writeReg r_A (← readReg r_C)
+  let y ← (( do
+    if (x : Bool)
+    then
+      SailME.throw (← do
+          readReg r_A)
+    else readReg r_B ) : SailME E E )
+  if (x : Bool)
+  then throw Error.Exit
+  else (pure ())
   readReg r_B
 
 def initialize_registers (_ : Unit) : SailM Unit := do

--- a/test/lean/early_return.sail
+++ b/test/lean/early_return.sail
@@ -203,3 +203,11 @@ function ite_early_return_seq(x : bool) -> E = {
   let y : E = if x then {unit_type(A); return r_A} else r_B;
   r_B
 }
+
+function ite_early_return_exit(x : bool) -> E = {
+  r_A = r_C;
+  let y : E = if x then return r_A else r_B;
+  if x then exit();
+  r_B
+}
+

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -29,6 +29,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -33,6 +33,7 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -37,6 +37,7 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -33,6 +33,7 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/map_tactics.expected.lean
+++ b/test/lean/map_tactics.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -29,6 +29,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -40,6 +40,7 @@ instance : Inhabited (RegisterRef RegisterType E) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -26,6 +26,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -97,6 +97,7 @@ instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -56,6 +56,7 @@ instance : Inhabited (RegisterRef RegisterType Nat) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -55,6 +55,7 @@ instance : Inhabited (RegisterRef RegisterType (Vector (BitVec 64) 32)) where
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/string.expected.lean
+++ b/test/lean/string.expected.lean
@@ -18,6 +18,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -43,6 +43,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -33,6 +33,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -29,6 +29,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -16,6 +16,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -16,6 +16,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -16,6 +16,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -36,6 +36,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -30,6 +30,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -18,6 +18,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -36,6 +36,7 @@ abbrev RegisterType : Register -> Type := PEmpty.elim
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
 XXXXXXXXX


### PR DESCRIPTION
Early returns are encoded using an exception monad in Lean, and it did not allow to throw exceptions. As a by-product, we move some definitions from `Specialization.lean` to `Sail.lean`.