### PR TITLE
Fix uninhabited constructors from monomorphisation

### DIFF
--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -339,9 +339,13 @@ let split_src_type all_errors env id ty (TypQ_aux (q, ql)) =
             | [] -> ty
             | _ -> Typ_aux (Typ_exist (kopts, nc', ty), l)
           in
-          (inst @ inst0, ty)
+          let uninhabited =
+            let env = List.fold_left (fun env kopt -> Env.add_typ_var Parse_ast.Unknown kopt env) env kopts in
+            Type_check.prove __POS__ env (nc_not nc')
+          in
+          if uninhabited then None else Some (inst @ inst0, ty)
         in
-        let tys = List.concat (List.map (fun instty -> List.map (ty_and_inst instty) insts) tys) in
+        let tys = List.concat (List.map (fun instty -> List.filter_map (ty_and_inst instty) insts) tys) in
         let free = List.fold_left (fun vars k -> KidSet.remove (kopt_kid k) vars) vars kopts in
         (free, tys)
     | Typ_internal_unknown -> Reporting.unreachable l __POS__ "escaped Typ_internal_unknown"

--- a/test/mono/run_tests.py
+++ b/test/mono/run_tests.py
@@ -21,7 +21,8 @@ def chunks(filenames, cores):
     ys = []
     chunk = []
     for filename in filenames:
-        chunk.append(filename)
+        if not args.test or filename in args.test:
+            chunk.append(filename)
         if len(chunk) >= cores:
             ys.append(list(chunk))
             chunk = []
@@ -36,7 +37,6 @@ libml = joiner.join(['sail2_{}.ml'.format(lib) for lib in libraries])
 def test():
     banner('Monomorphisation tests')
     results = Results('mono')
-    results.expect_failure('union-exist2', 'impossible function clause')
     for filenames in chunks(os.listdir('pass'), parallel()):
         tests = {}
         for filename in filenames:


### PR DESCRIPTION
Check existential constraints when case splitting a union constructor so that we don't generate uninhabited types.