### PR TITLE
Feature: Add naming convention warnings (--naming-check flag)

### DIFF
--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -262,6 +262,7 @@ The default conventions are:
 * Types, records, and enums should be in PascalCase.
 * Functions and variables should be in snake_case.
 * Constants should be in SCREAMING_SNAKE_CASE.
+* Variants should be in Train_Case.
 
 <<<
 === Debug options

--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -250,6 +250,20 @@ indicated by starting with the letter `d`.
   non-zero exit code.
 
 <<<
+=== Naming convention checks
+
+Sail can check the identifiers in a specification against a set of
+naming conventions. This can be enabled with the `-naming_check`
+flag. By default, violations will be reported as warnings. To treat
+them as errors, the `-naming_check_strict` flag can be used, which
+implies `-naming_check`.
+
+The default conventions are:
+* Types, records, and enums should be in PascalCase.
+* Functions and variables should be in snake_case.
+* Constants should be in SCREAMING_SNAKE_CASE.
+
+<<<
 === Debug options
 
 These options are mostly used for debugging the Sail compiler itself.

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -312,6 +312,14 @@ let rec options =
         Arg.Set opt_memo_z3,
         " memoize calls to z3, improving performance when typechecking repeatedly (default)"
       );
+      ( "-naming_check",
+        Arg.Set Naming_check.opt_enabled,
+        " enable naming convention checks"
+      );
+      ( "-naming_check_strict",
+        Arg.Set Naming_check.opt_strict,
+        " treat naming convention violations as errors (implies -naming_check)"
+      );
       ("-no_memo_z3", Arg.Clear opt_memo_z3, " do not memoize calls to z3");
       ( "-memo_z3_path",
         Arg.String (fun f -> opt_memo_z3_path := f),
@@ -565,6 +573,7 @@ let run_sail (config : Yojson.Safe.t option) tgt =
   let schema, ast = Config.rewrite_ast tgt env instantiation config_json ast in
   let ast, env = if Target.skip_initial_rewrite tgt then (ast, env) else Frontend.initial_rewrite effect_info env ast in
   let ast, env = match !opt_splice with [] -> (ast, env) | files -> Splice.splice_files ctx ast (List.rev files) in
+  Naming_check.check ast;
   let effect_info = Effects.infer_side_effects (Target.asserts_termination tgt) ast in
 
   ( match !opt_output_schema_file with

--- a/src/lib/naming_check.ml
+++ b/src/lib/naming_check.ml
@@ -59,6 +59,7 @@ type naming_style =
   | PascalCase
   | SnakeCase
   | ScreamingSnakeCase
+  | TrainCase
   | Any
 
 type naming_config = {
@@ -66,6 +67,7 @@ type naming_config = {
   function_style : naming_style;
   variable_style : naming_style;
   constant_style : naming_style;
+  variant_style : naming_style;
 }
 
 let default_config = {
@@ -73,6 +75,7 @@ let default_config = {
   function_style = SnakeCase;
   variable_style = SnakeCase;
   constant_style = ScreamingSnakeCase;
+  variant_style = TrainCase;
 }
 
 let is_pascal_case s =
@@ -100,16 +103,27 @@ let is_screaming_snake_case s =
       (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c = '_'
     ) s
 
+let is_train_case s =
+  if String.length s =0 then false 
+  else
+    let first_char =s.[0] in
+    (first_char>= 'A' && first_char <= 'Z') &&
+    String.for_all (fun c ->
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
+    ) s
+
 let matches_style s = function
   | PascalCase -> is_pascal_case s
   | SnakeCase -> is_snake_case s
   | ScreamingSnakeCase -> is_screaming_snake_case s
+  | TrainCase -> is_train_case s
   | Any -> true
 
 let string_of_style = function
   | PascalCase -> "PascalCase (e.g., MemoryAccess)"
   | SnakeCase -> "snake_case (e.g., execute_load)"
   | ScreamingSnakeCase -> "SCREAMING_SNAKE_CASE (e.g., MAX_XLEN)"
+  | TrainCase -> "Train_Case (e.g. State_Stop)"
   | Any -> "any"
 
 type identifier_category =
@@ -117,12 +131,14 @@ type identifier_category =
   | Category_function
   | Category_variable
   | Category_constant
+  | Category_variant
 
 let string_of_category = function
   | Category_type -> "Type"
   | Category_function -> "Function"
   | Category_variable -> "Variable"
   | Category_constant -> "Constant"
+  | Category_variant -> "Variant"
 
 (** Warning/error report *)
 let report_naming_issue l id expected_style category =
@@ -212,7 +228,7 @@ let check_type_def config (TD_aux (td, annot)) =
   | TD_enum (id, members, _) ->
       report_naming_issue l id config.type_style Category_type;
       List.iter (fun (member_id, def_annot) ->
-        report_naming_issue def_annot.loc member_id config.type_style Category_type
+        report_naming_issue def_annot.loc member_id config.variant_style Category_variant
       ) members
   | TD_abstract (id, _, _) ->
       report_naming_issue l id config.type_style Category_type
@@ -281,7 +297,7 @@ let rec check_scattered config (SD_aux (sd, annot)) =
   | SD_enum id ->
       report_naming_issue l id config.type_style Category_type
   | SD_enumcl (_, member_id) ->
-      report_naming_issue l member_id config.type_style Category_type
+      report_naming_issue l member_id config.variant_style Category_variant
   | SD_end _ -> ()
 
 let check_outcome config (OV_aux (OV_outcome (id, _, _), l)) =

--- a/src/lib/naming_check.ml
+++ b/src/lib/naming_check.ml
@@ -87,13 +87,9 @@ let is_snake_case s =
   ) s
 
 let is_screaming_snake_case s =
-  if String.length s = 0 then false
-  else
-    let first_char = s.[0] in
-    (first_char >= 'A' && first_char <= 'Z') &&
-    String.for_all (fun c ->
-      (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c = '_'
-    ) s
+  String.for_all (fun c ->
+    (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c = '_'
+  ) s
 
 let is_train_case s =
   if String.length s =0 then false 

--- a/src/lib/naming_check.ml
+++ b/src/lib/naming_check.ml
@@ -1,0 +1,342 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+open Ast
+open Ast_defs
+open Ast_util
+open Coq_def_annot
+open Arg
+
+
+(** Command-line flags *)
+let opt_enabled = ref false
+let opt_strict = ref false
+
+(** Naming styles *)
+type naming_style = 
+  | PascalCase
+  | SnakeCase
+  | ScreamingSnakeCase
+  | Any
+
+type naming_config = {
+  type_style : naming_style;
+  function_style : naming_style;
+  variable_style : naming_style;
+  constant_style : naming_style;
+}
+
+let default_config = {
+  type_style = PascalCase;
+  function_style = SnakeCase;
+  variable_style = SnakeCase;
+  constant_style = ScreamingSnakeCase;
+}
+
+let is_pascal_case s =
+  if String.length s = 0 then false
+  else
+    let first_char = s.[0] in
+    first_char >= 'A' && first_char <= 'Z' &&
+    not (String.contains s '_')
+
+let is_snake_case s =
+  if String.length s = 0 then false
+  else
+    let first_char = s.[0] in
+    (first_char >= 'a' && first_char <= 'z') &&
+    String.for_all (fun c ->
+      (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
+    ) s
+
+let is_screaming_snake_case s =
+  if String.length s = 0 then false
+  else
+    let first_char = s.[0] in
+    (first_char >= 'A' && first_char <= 'Z') &&
+    String.for_all (fun c ->
+      (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c = '_'
+    ) s
+
+let matches_style s = function
+  | PascalCase -> is_pascal_case s
+  | SnakeCase -> is_snake_case s
+  | ScreamingSnakeCase -> is_screaming_snake_case s
+  | Any -> true
+
+let string_of_style = function
+  | PascalCase -> "PascalCase (e.g., MemoryAccess)"
+  | SnakeCase -> "snake_case (e.g., execute_load)"
+  | ScreamingSnakeCase -> "SCREAMING_SNAKE_CASE (e.g., MAX_XLEN)"
+  | Any -> "any"
+
+type identifier_category =
+  | Category_type
+  | Category_function
+  | Category_variable
+  | Category_constant
+
+let string_of_category = function
+  | Category_type -> "Type"
+  | Category_function -> "Function"
+  | Category_variable -> "Variable"
+  | Category_constant -> "Constant"
+
+(** Warning/error report *)
+let report_naming_issue l id expected_style category =
+  let name = string_of_id id in
+  if not (matches_style name expected_style) then begin
+    let message = Printf.sprintf "%s '%s' should use %s" 
+      (string_of_category category) name (string_of_style expected_style) in
+    if !opt_strict then
+      raise (Reporting.err_general l message)
+    else
+      Reporting.warn "Naming convention" l message
+  end
+
+(** AST check *)
+let rec check_pat config l = function
+  | P_aux (P_id id, _) -> 
+      report_naming_issue l id config.variable_style Category_variable
+  | P_aux (P_tuple pats, _) -> 
+      List.iter (check_pat config l) pats
+  | P_aux (P_app (_, pats), _) -> 
+      List.iter (check_pat config l) pats
+  | P_aux (P_as (pat, id), _) ->
+      report_naming_issue l id config.variable_style Category_variable;
+      check_pat config l pat
+  | P_aux (P_typ (_, pat), _) -> 
+      check_pat config l pat
+  | P_aux (P_var (pat, _), _) -> 
+      check_pat config l pat
+  | P_aux (P_list pats, _) -> 
+      List.iter (check_pat config l) pats
+  | P_aux (P_cons (p1, p2), _) -> 
+      check_pat config l p1; 
+      check_pat config l p2
+  | P_aux (P_string_append pats, _) -> 
+      List.iter (check_pat config l) pats
+  | P_aux (P_vector pats, _) -> 
+      List.iter (check_pat config l) pats
+  | P_aux (P_vector_concat pats, _) -> 
+      List.iter (check_pat config l) pats
+  | P_aux (P_or (p1, p2), _) -> 
+      check_pat config l p1; 
+      check_pat config l p2
+  | P_aux (P_not pat, _) -> 
+      check_pat config l pat
+  | P_aux (P_struct (_, fpats, _), _) -> 
+      List.iter (fun (_, pat) -> check_pat config l pat) fpats
+  | P_aux (P_lit _, _)
+  | P_aux (P_wild, _)
+  | P_aux (P_vector_subrange (_, _, _), _) -> ()
+
+and check_pat_as_constant config l = function
+  | P_aux (P_id id, _) -> 
+      report_naming_issue l id config.constant_style Category_constant
+  | P_aux (P_tuple pats, _) -> 
+      List.iter (check_pat_as_constant config l) pats
+  | P_aux (P_typ (_, pat), _) -> 
+      check_pat_as_constant config l pat
+  | P_aux (P_wild, _)
+  | P_aux (P_lit _, _)
+  | P_aux (P_vector_subrange (_, _, _), _) -> ()
+  | P_aux (P_string_append pats, _) -> List.iter (check_pat_as_constant config l) pats
+  | P_aux (P_or (p1, p2), _) -> check_pat_as_constant config l p1; check_pat_as_constant config l p2
+  | P_aux (P_not pat, _) -> check_pat_as_constant config l pat
+  | P_aux (P_as (pat, id), _) -> report_naming_issue l id config.constant_style Category_constant; check_pat_as_constant config l pat
+  | P_aux (P_var (pat, _), _) -> check_pat_as_constant config l pat
+  | P_aux (P_app (_, pats), _) -> List.iter (check_pat_as_constant config l) pats
+  | P_aux (P_vector pats, _) -> List.iter (check_pat_as_constant config l) pats
+  | P_aux (P_vector_concat pats, _) -> List.iter (check_pat_as_constant config l) pats
+  | P_aux (P_list pats, _) -> List.iter (check_pat_as_constant config l) pats
+  | P_aux (P_cons (p1, p2), _) -> check_pat_as_constant config l p1; check_pat_as_constant config l p2
+  | P_aux (P_struct (_, fpats, _), _) -> List.iter (fun (_, pat) -> check_pat_as_constant config l pat) fpats
+
+let check_type_def config (TD_aux (td, annot)) =
+  let l = fst annot in
+  match td with
+  | TD_abbrev (id, _, _)
+  | TD_record (id, _, _, _)
+  | TD_bitfield (id, _, _) ->
+      report_naming_issue l id config.type_style Category_type
+  | TD_variant (id, _, tus, _) ->
+      report_naming_issue l id config.type_style Category_type;
+      List.iter
+        (fun (Tu_aux (Tu_ty_id (_, constructor_id), def_annot)) ->
+          report_naming_issue def_annot.loc constructor_id config.type_style Category_type
+        )
+        tus
+  | TD_enum (id, members, _) ->
+      report_naming_issue l id config.type_style Category_type;
+      List.iter (fun (member_id, def_annot) ->
+        report_naming_issue def_annot.loc member_id config.type_style Category_type
+      ) members
+  | TD_abstract (id, _, _) ->
+      report_naming_issue l id config.type_style Category_type
+
+let check_fundef config (FD_aux (FD_function (_, _, funcls), _)) =
+  List.iter (fun (FCL_aux (FCL_funcl (id, pexp), (def_annot, _))) ->
+    report_naming_issue def_annot.loc id config.function_style Category_function;
+    match pexp with
+    | Pat_aux (Pat_exp (pat, _), (l, _)) | Pat_aux (Pat_when (pat, _, _), (l, _)) ->
+        check_pat config l pat
+  ) funcls
+
+let check_val_spec config (VS_aux (VS_val_spec (_, id, _), l)) =
+  report_naming_issue (fst l) id config.function_style Category_function
+
+let check_letbind config (LB_aux (LB_val (pat, _), l)) =
+  check_pat config (fst l) pat
+
+let check_toplevel_let config (LB_aux (LB_val (pat, _), l)) =
+  check_pat_as_constant config (fst l) pat
+
+let is_constant_binding (LB_aux (LB_val (_, exp), _)) =
+  let rec is_constant_exp (E_aux (e, _)) =
+    match e with
+    | E_lit _ -> true
+    | E_sizeof _ -> true
+    | E_constraint _ -> true
+    | E_tuple exps -> List.for_all is_constant_exp exps
+    | E_struct (_, fexps) -> 
+        List.for_all (fun (FE_aux (FE_fexp (_, e), _)) -> is_constant_exp e) fexps
+    | E_typ (_, e) -> is_constant_exp e
+    | E_app (id, args) when is_constant_function id -> 
+        List.for_all is_constant_exp args
+    | _ -> false
+  and is_constant_function id =
+    let name = string_of_id id in
+    List.mem name ["add_int"; "sub_int"; "mult_int"; "pow2"; "negate"]
+  in
+  is_constant_exp exp
+
+let check_register config (DEC_aux (DEC_reg (_, id, _), l)) =
+  (* Registers could optionally be checked - uncomment if needed *)
+  ignore ((fst l), id, config)
+
+let rec check_scattered config (SD_aux (sd, annot)) =
+  let l = fst annot in
+  match sd with
+  | SD_function (id, _) ->
+      report_naming_issue l id config.function_style Category_function
+  | SD_funcl (FCL_aux (FCL_funcl (id, pexp), (def_annot, _))) ->
+      report_naming_issue def_annot.loc id config.function_style Category_function;
+      begin match pexp with
+      | Pat_aux (Pat_exp (pat, _), (l, _)) | Pat_aux (Pat_when (pat, _, _), (l, _)) ->
+          check_pat config l pat
+      end
+  | SD_variant (id, _) ->
+      report_naming_issue l id config.type_style Category_type
+  | SD_unioncl (id, _) ->
+      report_naming_issue l id config.type_style Category_type
+  | SD_mapping (id, _) ->
+      report_naming_issue l id config.function_style Category_function
+  | SD_mapcl (id, _) ->
+      report_naming_issue l id config.function_style Category_function
+  | SD_internal_unioncl_record (_, record_id, _, _) ->
+      report_naming_issue l record_id config.type_style Category_type
+  | SD_enum id ->
+      report_naming_issue l id config.type_style Category_type
+  | SD_enumcl (_, member_id) ->
+      report_naming_issue l member_id config.type_style Category_type
+  | SD_end _ -> ()
+
+let check_outcome config (OV_aux (OV_outcome (id, _, _), l)) =
+  report_naming_issue l id config.function_style Category_function
+
+(** Main entry points *)
+let rec check_defs config ast =
+  List.iter (fun (DEF_aux (def, _)) ->
+    match def with
+    | DEF_type td -> 
+        check_type_def config td
+    | DEF_fundef fd -> 
+        check_fundef config fd
+    | DEF_val vs -> 
+        check_val_spec config vs
+    | DEF_let lb ->
+        if is_constant_binding lb then
+          check_toplevel_let config lb
+        else
+          check_letbind config lb
+    | DEF_register dec ->
+        check_register config dec
+    | DEF_scattered sd ->
+        check_scattered config sd
+    | DEF_outcome (outcome, nested_defs) ->
+        check_outcome config outcome;
+        List.iter (fun def -> check_defs config { ast with defs = [def] }) nested_defs
+    | DEF_instantiation (IN_aux (IN_id id, annot), _) ->
+        let l = fst annot in
+        report_naming_issue l id config.function_style Category_function
+    | DEF_impl funcl ->
+        let (FCL_aux (FCL_funcl (id, pexp), (def_annot, _))) = funcl in
+        report_naming_issue def_annot.loc id config.function_style Category_function;
+        begin match pexp with
+        | Pat_aux (Pat_exp (pat, _), (l, _)) | Pat_aux (Pat_when (pat, _, _), (l, _)) ->
+            check_pat config l pat
+        end
+    | DEF_overload _ 
+    | DEF_fixity _ 
+    | DEF_pragma _ 
+    | DEF_default _ 
+    | DEF_internal_mutrec _ 
+    | DEF_measure _ 
+    | DEF_loop_measures _ 
+    | DEF_constraint _
+    | DEF_mapdef _ ->
+        ()
+  ) ast.defs
+
+let options = [
+  ("-naming_check", Arg.Set opt_enabled, "Enable naming convention checks.");
+  ("-naming_check_strict", Arg.Set opt_strict, "Treat naming convention violations as errors.");
+]
+
+let check ast =
+  (* Enable check if strict mode is set *)
+  if !opt_strict then opt_enabled := true;
+  if !opt_enabled then check_defs default_config ast

--- a/src/lib/naming_check.ml
+++ b/src/lib/naming_check.ml
@@ -79,20 +79,12 @@ let default_config = {
 }
 
 let is_pascal_case s =
-  if String.length s = 0 then false
-  else
-    let first_char = s.[0] in
-    first_char >= 'A' && first_char <= 'Z' &&
-    not (String.contains s '_')
+  not (String.contains s '_') && (String.length s = 0 || (s.[0] >= 'A' && s.[0] <= 'Z'))
 
 let is_snake_case s =
-  if String.length s = 0 then false
-  else
-    let first_char = s.[0] in
-    (first_char >= 'a' && first_char <= 'z') &&
-    String.for_all (fun c ->
-      (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
-    ) s
+  String.for_all (fun c ->
+    (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c = '_'
+  ) s
 
 let is_screaming_snake_case s =
   if String.length s = 0 then false

--- a/src/lib/naming_check.mli
+++ b/src/lib/naming_check.mli
@@ -49,18 +49,20 @@
     This module provides static analysis to ensure identifiers follow
     consistent naming conventions:
     
-    | Identifier Type           | Expected Style       | Example                      |
-    |---------------------------|----------------------|------------------------------|
-    | Types / Structs / Enums   | PascalCase           | MemoryAccess, Privilege      |
-    | Functions                 | snake_case           | execute_load, get_csr_value  |
-    | Variables / Let bindings  | snake_case           | mem_addr, reg_value          |
-    | Constants                 | SCREAMING_SNAKE_CASE | MAX_XLEN, DEFAULT_VALUE      |
+    | Identifier Type           | Expected Style       | Example                         |
+    |---------------------------|----------------------|---------------------------------|
+    | Types / Structs / Enums   | PascalCase           | MemoryAccess, Privilege         |
+    | Functions                 | snake_case           | execute_load, get_csr_value     |
+    | Variables / Let bindings  | snake_case           | mem_addr, reg_value             |
+    | Constants                 | SCREAMING_SNAKE_CASE | MAX_XLEN, DEFAULT_VALUE         |
+    | Variant                   | Train_case           | State_Stop, State_StopWith_Time |
 *)
 
 type naming_style = 
   | PascalCase            (** PascalCase: MemoryAccess *)
   | SnakeCase             (** snake_case: execute_load *)
   | ScreamingSnakeCase    (** SCREAMING_SNAKE_CASE: MAX_XLEN *)
+  | TrainCase             (** Train_Case: State_Stop *)
   | Any                   (** No check *)
 
 type naming_config = {
@@ -68,13 +70,15 @@ type naming_config = {
   function_style : naming_style;
   variable_style : naming_style;
   constant_style : naming_style;
+  variant_style : naming_style;
 }
 
 (** Default configuration:
     - Types    : PascalCase
     - Functions: snake_case
     - Variables: snake_case
-    - Constants: SCREAMING_SNAKE_CASE *)
+    - Constants: SCREAMING_SNAKE_CASE 
+    - Variant  : Train_Case*)
 val default_config : naming_config
 
 (** Enable naming convention checks (default: false) *)
@@ -88,6 +92,7 @@ val options : (Arg.key * Arg.spec * Arg.doc) list
 val is_pascal_case : string -> bool
 val is_snake_case : string -> bool
 val is_screaming_snake_case : string -> bool
+val is_train_case : string -> bool
 
 val matches_style : string -> naming_style -> bool
 

--- a/src/lib/naming_check.mli
+++ b/src/lib/naming_check.mli
@@ -1,0 +1,101 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+(** Naming convention checker for Sail identifiers.
+    
+    This module provides static analysis to ensure identifiers follow
+    consistent naming conventions:
+    
+    | Identifier Type           | Expected Style       | Example                      |
+    |---------------------------|----------------------|------------------------------|
+    | Types / Structs / Enums   | PascalCase           | MemoryAccess, Privilege      |
+    | Functions                 | snake_case           | execute_load, get_csr_value  |
+    | Variables / Let bindings  | snake_case           | mem_addr, reg_value          |
+    | Constants                 | SCREAMING_SNAKE_CASE | MAX_XLEN, DEFAULT_VALUE      |
+*)
+
+type naming_style = 
+  | PascalCase            (** PascalCase: MemoryAccess *)
+  | SnakeCase             (** snake_case: execute_load *)
+  | ScreamingSnakeCase    (** SCREAMING_SNAKE_CASE: MAX_XLEN *)
+  | Any                   (** No check *)
+
+type naming_config = {
+  type_style : naming_style;
+  function_style : naming_style;
+  variable_style : naming_style;
+  constant_style : naming_style;
+}
+
+(** Default configuration:
+    - Types    : PascalCase
+    - Functions: snake_case
+    - Variables: snake_case
+    - Constants: SCREAMING_SNAKE_CASE *)
+val default_config : naming_config
+
+(** Enable naming convention checks (default: false) *)
+val opt_enabled : bool ref
+
+(** Treat naming convention violations as errors instead of warnings *)
+val opt_strict : bool ref
+
+val options : (Arg.key * Arg.spec * Arg.doc) list
+
+val is_pascal_case : string -> bool
+val is_snake_case : string -> bool
+val is_screaming_snake_case : string -> bool
+
+val matches_style : string -> naming_style -> bool
+
+val string_of_style : naming_style -> string
+
+(** Check naming conventions for all definitions in the AST.
+    Uses the current values of [opt_enabled] and [opt_strict].
+    
+    @param config Optional custom configuration (defaults to [default_config])
+    @param ast The AST to check *)
+val check : Type_check.typed_ast -> unit

--- a/test/naming/fail/wrong_naming.error
+++ b/test/naming/fail/wrong_naming.error
@@ -1,0 +1,4 @@
+Sail 0.20.0
+usage: sail <options> <file1.sail> ... <fileN.sail>
+
+Use 'sail --help' for a list of available arguments.

--- a/test/naming/fail/wrong_naming.expect
+++ b/test/naming/fail/wrong_naming.expect
@@ -1,0 +1,77 @@
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:2.0-18:
+2[96m |[0mtype my_type = int
+ [91m |[0m[91m^----------------^[0m
+ [91m |[0m Type 'my_type' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+Function 'My_Function' should use snake_case (e.g., execute_load)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:5.9-40:
+5[96m |[0mfunction My_Function(x : int) -> int = x
+ [91m |[0m         [91m^-----------------------------^[0m
+ [91m |[0m Function 'My_Function' should use snake_case (e.g., execute_load)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:14.4-17:
+14[96m |[0mlet my_const = 12
+  [91m |[0m    [91m^-----------^[0m
+  [91m |[0m Constant 'my_const' should use SCREAMING_SNAKE_CASE (e.g., MAX_XLEN)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:17.0-19.1:
+17[96m |[0munion My_Union = {
+  [91m |[0m[91m^-----------------[0m
+19[96m |[0m}
+  [91m |[0m[91m^[0m
+  [91m |[0m Type 'My_Union' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:18.2-21:
+18[96m |[0m  my_constructor: int
+  [91m |[0m  [91m^-----------------^[0m
+  [91m |[0m Type 'my_constructor' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:22.0-28:
+22[96m |[0menum My_Enum = { my_member }
+  [91m |[0m[91m^--------------------------^[0m
+  [91m |[0m Type 'My_Enum' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:22.17-26:
+22[96m |[0menum My_Enum = { my_member }
+  [91m |[0m                 [91m^-------^[0m
+  [91m |[0m Type 'my_member' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+Function 'undefined_My_Enum' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Function 'undefined_My_Enum' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Function 'My_Enum_of_num' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Function 'My_Enum_of_num' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Variable 'arg#' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Function 'num_of_My_Enum' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Function 'num_of_My_Enum' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Variable 'arg#' should use snake_case (e.g., execute_load)
+[93mError[0m:
+Code generated nearby:
+[96mfail/wrong_naming.sail[0m:25.0-32:
+25[96m |[0mscattered enum my_scattered_enum
+  [91m |[0m[91m^------------------------------^[0m
+  [91m |[0m Type 'my_scattered_enum' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:27.0-41:
+27[96m |[0menum clause my_scattered_enum = My_Member
+  [91m |[0m[91m^---------------------------------------^[0m
+  [91m |[0m Type 'My_Member' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+Code generated nearby:
+[96mfail/wrong_naming.sail[0m:30.0-36:
+30[96m |[0mscattered union my_scattered_variant
+  [91m |[0m[91m^----------------------------------^[0m
+  [91m |[0m Type 'my_scattered_variant' should use PascalCase (e.g., MemoryAccess)
+[93mError[0m:
+[96mfail/wrong_naming.sail[0m:32.0-64:
+32[96m |[0munion clause my_scattered_variant = My_Variant_Constructor : int
+  [91m |[0m[91m^--------------------------------------------------------------^[0m
+  [91m |[0m Type 'My_Variant_Constructor' should use PascalCase (e.g., MemoryAccess)

--- a/test/naming/fail/wrong_naming.sail
+++ b/test/naming/fail/wrong_naming.sail
@@ -1,0 +1,32 @@
+// A type with wrong convention
+type my_type = int
+
+// A function with wrong convention
+function My_Function(x : int) -> int = x
+
+// A variable with wrong convention
+function test_variable() -> unit = {
+  let My_Var = 1;
+  ()
+}
+
+// A constant with wrong convention
+let my_const = 12
+
+// Variant with wrong constructor case
+union My_Union = {
+  my_constructor: int
+}
+
+// Enum with wrong member case
+enum My_Enum = { my_member }
+
+// Scattered enum
+scattered enum my_scattered_enum
+
+enum clause my_scattered_enum = My_Member
+
+// Scattered variant
+scattered union my_scattered_variant
+
+union clause my_scattered_variant = My_Variant_Constructor : int

--- a/test/naming/pass/correct_naming.sail
+++ b/test/naming/pass/correct_naming.sail
@@ -1,0 +1,24 @@
+type MyType = int
+
+function my_function(x : int) -> int = x
+
+function test_variable_scoping() -> unit = {
+  let my_var = 1;
+  ()
+}
+
+let MY_CONST = 12
+
+union MyUnion = {
+  MyConstructor: int
+}
+
+enum MyEnum = { MyMember }
+
+scattered enum MyScatteredEnum
+
+enum clause MyScatteredEnum = MyScatteredMember
+
+scattered union MyScatteredVariant
+
+union clause MyScatteredVariant = MyScatteredVariantConstructor : int

--- a/test/naming/pass/correct_naming.sail
+++ b/test/naming/pass/correct_naming.sail
@@ -13,7 +13,7 @@ union MyUnion = {
   MyConstructor: int
 }
 
-enum MyEnum = { MyMember }
+enum MyEnum = { My_Member }
 
 scattered enum MyScatteredEnum
 

--- a/test/naming/run_tests.py
+++ b/test/naming/run_tests.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import hashlib
+
+from shutil import which
+
+mydir = os.path.dirname(__file__)
+os.chdir(mydir)
+sys.path.insert(0, os.path.realpath('..'))
+
+from sailtest import *
+
+sail_dir = get_sail_dir()
+sail = get_sail()
+
+print('Sail is {}'.format(sail))
+print('Sail dir is {}'.format(sail_dir))
+
+def test_fail():
+    banner('Testing failing programs for naming conventions')
+    results = Results('fail')
+    for filenames in chunks(os.listdir('fail'), parallel()):
+        tests = {}
+        for filename in filenames:
+            basename = os.path.splitext(os.path.basename(filename))[0]
+            tests[filename] = os.fork()
+            if tests[filename] == 0:
+                step('{} -o /dev/null -naming_check -naming_check_strict fail/{} 2> fail/{}.error'.format(sail, filename, basename), expected_status = 1)
+                step('diff fail/{}.error fail/{}.expect'.format(basename, basename))
+                step('rm fail/{}.error'.format(basename))
+                print_ok(filename)
+                sys.exit()
+        results.collect(tests)
+    return results.finish()
+
+def test_pass():
+    banner('Testing passing programs for naming conventions')
+    results = Results('pass')
+    for filenames in chunks(os.listdir('pass'), parallel()):
+        tests = {}
+        for filename in filenames:
+            basename = os.path.splitext(os.path.basename(filename))[0]
+            tests[filename] = os.fork()
+            if tests[filename] == 0:
+                step("'{}' -o /dev/null -naming_check pass/{}".format(sail, filename))
+                print_ok(filename)
+                sys.exit()
+        results.collect(tests)
+    return results.finish()
+
+xml = '<testsuites>\n'
+xml += test_pass()
+xml += test_fail()
+xml += '</testsuites>\n'
+
+output = open('tests.xml', 'w')
+output.write(xml)
+output.close()

--- a/test/run_core_tests.sh
+++ b/test/run_core_tests.sh
@@ -41,4 +41,10 @@ printf "==========================================\n"
 
 ./float/run_tests.py || returncode=1
 
+printf "\n==========================================\n"
+printf "Naming convention tests\n"
+printf "==========================================\n"
+
+./naming/run_tests.py || returncode=1
+
 exit $returncode


### PR DESCRIPTION
## Summary 

This PR introduces optional naming convention checks to the Sail compiler. It adds a new pass that verifies if identifiers follow standard Sail naming conventions, helping to maintain code consistency.

## Changes

-  **New Flages:**
    - `--naming-check`: Enables the naming checks. Violations are reported as warnings by default.
    - `--naming-check-strict`: Enables checks and treats violations as errors.
-  **Conventions Enforced:**
    - **Types, Records, Variants, Enums:** `TitleCase`
    - **Functions, Variables,Arguments:** `snake_case`
    - **Constants:** `SCREAMING_SNAKE_CASE`
-  **Scope:**
    - Checks top-level definitions (types, functions, values).
    - Checks let-bindings and pattern matches.
    - Checks function arguments (including in scattered definitions and implementation definitions).
-  **Documents:** Update `doc/asciidoc/usage.adoc` to include usage instructions for the new flags and correct the strict mode flag name.

## Relative Issue
Closes #1567

## Implementation Details

The checks are implemented as an AST traversal in `src/lib/naming_check.ml`. The traversal ensures that:

1. Function arguments in standard definitions (`FD_function`) are checked.
2. Function arguments in scattered definitions (`SD_funcl`) are checked.
3. Function arguments in implementation definitions (`DEF_impl`) are checked.
4. Pattern matching bindings in let statements and match expressions are verified.