### PR TITLE
Attempt to fix SMT generation for count_trailing_zeros.

### DIFF
--- a/src/lib/smt_gen.ml
+++ b/src/lib/smt_gen.ml
@@ -1354,11 +1354,7 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
   let builtin_count_trailing_zeros v ret_ctyp =
     let rec tzcnt ret_sz sz smt =
       if sz == 1 then
-        Ite
-          ( Fn ("=", [Extract (0, 0, sz, smt); Bitvec_lit [Sail2_values.B0]]),
-            bvint ret_sz (Big_int.of_int 1),
-            bvint ret_sz Big_int.zero
-          )
+        Ite (Fn ("=", [smt; Bitvec_lit [Sail2_values.B0]]), bvint ret_sz (Big_int.of_int 1), bvint ret_sz Big_int.zero)
       else (
         assert (sz land (sz - 1) = 0);
         let hsz = sz / 2 in
@@ -1383,43 +1379,26 @@ module Make (Config : CONFIG) (Primop_gen : PRIMOP_GEN) = struct
     | CT_fbits sz when sz land (sz - 1) = 0 -> return (tzcnt ret_sz sz smt)
     | CT_fbits sz ->
         let padded_sz = smallest_greater_power_of_two sz in
-        let padding = bvzero (padded_sz - sz) in
+        let padding = bvone (padded_sz - sz) in
         assert (padded_sz > sz);
-        return
-          (Fn
-             ( "bvsub",
-               [tzcnt ret_sz padded_sz (Fn ("concat", [padding; smt])); bvint ret_sz (Big_int.of_int (padded_sz - sz))]
-             )
-          )
+        return (tzcnt ret_sz padded_sz (Fn ("concat", [padding; smt])))
     | CT_lbits ->
         if ret_sz > lbits_index then
           return
-            (Fn
-               ( "bvsub",
-                 [
-                   tzcnt ret_sz lbits_size (Fn ("contents", [smt]));
-                   Fn
-                     ( "bvsub",
-                       [
-                         bvint ret_sz (Big_int.of_int lbits_size);
-                         Fn ("concat", [bvzero (ret_sz - lbits_index); Fn ("len", [smt])]);
-                       ]
-                     );
-                 ]
+            (tzcnt ret_sz lbits_size
+               (Fn
+                  ( "bvor",
+                    [
+                      Fn
+                        ( "bvshl",
+                          [bvone lbits_size; Fn ("concat", [bvzero (lbits_size - lbits_index); Fn ("len", [smt])])]
+                        );
+                      Fn ("contents", [smt]);
+                    ]
+                  )
                )
             )
-        else (
-          let trailing_zeros =
-            Fn
-              ( "bvsub",
-                [
-                  tzcnt lbits_index lbits_size (Fn ("contents", [smt]));
-                  Fn ("bvsub", [bvint lbits_index (Big_int.of_int lbits_size); Fn ("len", [smt])]);
-                ]
-              )
-          in
-          return (Extract (ret_sz - 1, 0, lbits_index, trailing_zeros))
-        )
+        else failwith "count_trailing_zeros: unimplemented for lbits with small return size"
     | _ -> builtin_type_error "count_trailing_zeros" [v] (Some ret_ctyp)
 
   let rec builtin_eq_anything x y =

--- a/test/smt/lzcnt.unsat.sail
+++ b/test/smt/lzcnt.unsat.sail
@@ -5,12 +5,14 @@ $include <prelude.sail>
 val lzcnt = pure "count_leading_zeros" : forall 'w. bits('w) -> range(0, 'w)
 
 $property
-function prop() -> bool = {
+function prop(l : nat) -> bool = {
   let p1 = lzcnt(0x0) == 4;
   let p2 = lzcnt(0x00) == 8;
   let p3 = lzcnt(0x02) == 6;
   let p4 = lzcnt(0b01111111) == 1;
   let p5 = lzcnt(0b1) == 0;
   let p6 = lzcnt(0xF) == 0;
-  p1 & p2 & p3 & p4 & p5 & p6
+  let p7 = lzcnt(0x007aaaaaaaaaaaaaa) == 9;
+  let p8 = (l != 3) | (lzcnt(replicate_bits(0b0, l)) == l);
+  p1 & p2 & p3 & p4 & p5 & p6 & p7 & p8
 }

--- a/test/smt/tzcnt.unsat.sail
+++ b/test/smt/tzcnt.unsat.sail
@@ -2,15 +2,17 @@ default Order dec
 
 $include <prelude.sail>
 
-val lzcnt = pure "count_trailing_zeros" : forall 'w. bits('w) -> range(0, 'w)
+val tzcnt = pure "count_trailing_zeros" : forall 'w. bits('w) -> range(0, 'w)
 
 $property
-function prop() -> bool = {
-  let p1 = lzcnt(0x0) == 4;
-  let p2 = lzcnt(0x00) == 8;
-  let p3 = lzcnt(0x20) == 5;
-  let p4 = lzcnt(0b10000000) == 7;
-  let p5 = lzcnt(0b1) == 0;
-  let p6 = lzcnt(0xF) == 0;
-  p1 & p2 & p3 & p4 & p5 & p6
+function prop(l : nat) -> bool = {
+  let p1 = tzcnt(0x0) == 4;
+  let p2 = tzcnt(0x00) == 8;
+  let p3 = tzcnt(0x20) == 5;
+  let p4 = tzcnt(0b10000000) == 7;
+  let p5 = tzcnt(0b1) == 0;
+  let p6 = tzcnt(0xF) == 0;
+  let p7 = tzcnt(0b0010000) == 4;
+  let p8 = (l != 3) | (tzcnt(replicate_bits(0b0, l)) == 3);
+  p1 & p2 & p3 & p4 & p5 & p6 & p7 & p8
 }


### PR DESCRIPTION
I've used a failwith "unimplemented" on a case that I don't think is reachable.

Also add more interesting SMT tests for count_leading_zeros and count_trailing_zeros e.g. not power-of-two and non fixed width bitvector.