### PR TITLE
Fix for issue 1554

### DIFF
--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -492,12 +492,12 @@ let place_phi_functions graph df =
 
 module NameGraph = Graph.Make (Name)
 
-let phi_dependencies cfg =
+let variable_dependencies cfg =
   let deps = ref NameGraph.empty in
   let decl_nodes = ref NameMap.empty in
   for n = 0 to cfg.next - 1 do
     match cfg.nodes.(n) with
-    | Some ((ssa, _), _, _) ->
+    | Some ((ssa, cfnode), _, _) -> (
         List.iter
           (function
             | Phi (id, _, args) ->
@@ -506,7 +506,23 @@ let phi_dependencies cfg =
                 List.iter (fun arg -> deps := NameGraph.add_edge id arg !deps) args
             | _ -> ()
             )
-          ssa
+          ssa;
+        match cfnode with
+        | CF_block (instrs, _) ->
+            List.iter
+              (fun instr ->
+                let reads = instr_reads ~direct:true instr in
+                let writes = instr_writes ~direct:true instr in
+                NameSet.iter
+                  (fun write ->
+                    decl_nodes := NameMap.add write n !decl_nodes;
+                    NameSet.iter (fun read -> deps := NameGraph.add_edge write read !deps) reads
+                  )
+                  writes
+              )
+              instrs
+        | _ -> ()
+      )
     | None -> ()
   done;
   (!deps, !decl_nodes)

--- a/src/lib/jib_ssa.mli
+++ b/src/lib/jib_ssa.mli
@@ -104,7 +104,9 @@ module NameGraph : sig
   include Graph.S with type node = Jib.name and type node_set = Set.Make(Name).t and type graph = Graph.Make(Name).graph
 end
 
-val phi_dependencies : (ssa_elem list * cf_node) array_graph -> NameGraph.graph * int NameMap.t
+(** Return a graph of variable dependencies (from writes to reads). The second element of the return tuple is the node
+    containing the variable declaration. *)
+val variable_dependencies : (ssa_elem list * cf_node) array_graph -> NameGraph.graph * int NameMap.t
 
 (** Convert a list of instructions into SSA form *)
 val ssa :

--- a/src/sail_sv_backend/jib_sv.ml
+++ b/src/sail_sv_backend/jib_sv.ml
@@ -1303,92 +1303,25 @@ module Make (Config : CONFIG) = struct
         | _ -> DoChildren
     end
 
-  (* We want to be able tp find the final assigned value of any
+  (* We want to be able to find the final assigned value of any
      variable v in the SSA control flow graph, as that is the variable
      that will be passed on to output ports if needed. *)
   let get_final_names ssa_vars cfg =
     let open Jib_ssa in
-    let phi_graph, phi_nodes = phi_dependencies cfg in
-    let phi_names, final_names =
-      phi_graph |> NameGraph.topsort
+    let var_graph, _ = variable_dependencies cfg in
+    let var_names, final_names =
+      var_graph |> NameGraph.topsort
       |> List.fold_left
            (fun (seen, fins) ssa_name ->
-             let name, n = Jib_ssa.unssa_name ssa_name in
+             let name, _ = Jib_ssa.unssa_name ssa_name in
              if NameSet.mem name seen then (seen, fins) else (NameSet.add name seen, NameMap.add name ssa_name fins)
            )
            (NameSet.empty, NameMap.empty)
     in
-    (* Once we find the final assignment to a variable v by a phi function,
-       we explore all successor nodes from where that phi function is to check for cases like:
-
-       v_a = phi(v_b, v_c);
-       v_d = f(v_a);
-       v_e = g(v_d);
-
-       here v_e is the last assignment to v, not v_a
-    *)
-    let rec explore_successors node name ssa_name =
-      match get_vertex cfg node with
-      | Some ((_, cf_node), _, succs) ->
-          let num_succs = IntSet.cardinal succs in
-          let ssa_name =
-            match cf_node with
-            | CF_block (instrs, _) ->
-                let last_write =
-                  List.fold_left
-                    (fun acc instr ->
-                      match acc with
-                      | None ->
-                          let writes =
-                            instr_writes ~direct:true instr
-                            |> NameSet.filter (fun w ->
-                                   let w', _ = unssa_name w in
-                                   Name.compare name w' = 0
-                               )
-                          in
-                          let num_writes = NameSet.cardinal writes in
-                          if num_writes = 0 then None
-                          else (
-                            assert (num_writes = 1);
-                            let write = NameSet.min_elt writes in
-                            Some write
-                          )
-                      | Some v -> Some v
-                    )
-                    None (List.rev instrs)
-                in
-                Option.value last_write ~default:ssa_name
-            | _ -> ssa_name
-          in
-          if num_succs = 0 then ssa_name
-          else
-            (* Note if we have successors like
-
-                 A
-                / \
-               B   C
-                \ /
-                 D
-
-               There could be updates in D, but there cannot be any in
-               B or C because then D would have a phi function, and we
-               would then have started from there. Therefore we can
-               just choose a single successor here. *)
-            explore_successors (IntSet.min_elt succs) name ssa_name
-      | None -> assert false
-    in
-    let final_names =
-      NameMap.mapi
-        (fun name ssa_name ->
-          let node = NameMap.find ssa_name phi_nodes in
-          explore_successors node name ssa_name
-        )
-        final_names
-    in
     let final_names =
       NameMap.fold
         (fun name nums fins ->
-          if NameSet.mem name phi_names then fins
+          if NameSet.mem name var_names then fins
           else NameMap.add name (Jib_ssa.ssa_name (IntSet.max_elt nums) name) fins
         )
         ssa_vars final_names

--- a/test/c/issue1554.expect
+++ b/test/c/issue1554.expect
@@ -1,0 +1,2 @@
+mstatus = 0b000
+mstatus = 0b011

--- a/test/c/issue1554.sail
+++ b/test/c/issue1554.sail
@@ -1,0 +1,23 @@
+default Order dec
+$include <prelude.sail>
+
+register mstatus : bits(3)
+
+function exception_handler (x : bool, b : bits(2)) -> unit = {
+  match b {
+    0b00 => mstatus = 0b011,
+    0b01 => {
+      mstatus = 0b000;
+      mstatus = [ mstatus with 1 .. 0 = if x then 0b10 else 0b01 ];
+    },
+
+    _ => exit(),
+  };
+}
+
+function main() -> unit = {
+  mstatus = 0b000;
+  print_bits("mstatus = ", mstatus);
+  exception_handler(false, 0b00);
+  print_bits("mstatus = ", mstatus);
+}

--- a/test/sv/run_tests.py
+++ b/test/sv/run_tests.py
@@ -34,7 +34,8 @@ skip_tests = {
     'simple_while3', # loops
     'ref_cmp',
     'concurrency_interface_v2',
-    'concurrency_interface_v2_var'
+    'concurrency_interface_v2_var',
+    'config_abstract_bool' # bug
 }
 
 print("Sail is {}".format(sail))


### PR DESCRIPTION
When generating SystemVerilog, calculating dependencies for phi functions could sometimes fail in certain patterns where registers would be written, then read by a conditional. This fixes and simplifies the code by just computing a full variable dependency graph from the SSA graph, rather than only looking at the phi functions.