### PR TITLE
Remove --memo-z3 option

### DIFF
--- a/aarch64/Makefile
+++ b/aarch64/Makefile
@@ -5,19 +5,19 @@ SAIL_LIB_DIR:=$(SAIL_DIR)/lib
 SAIL:=$(SAIL_DIR)/sail
 
 aarch64.c: no_vector.sail
-	$(SAIL) $(SAIL_FLAGS) $^ -c -O -undefined_gen -no_lexp_bounds_check -memo_z3 1> aarch64.c
+	$(SAIL) $(SAIL_FLAGS) $^ -c -O -undefined_gen -no_lexp_bounds_check 1> aarch64.c
 
 aarch64_c: aarch64.c
 	gcc -O2 $^ -o aarch64_c -lgmp -I $(SAIL_DIR)/lib
 
 aarch64: no_vector.sail
-	$(SAIL) $(SAIL_FLAGS) $^ -o aarch64 -ocaml -undefined_gen -no_lexp_bounds_check -memo_z3
+	$(SAIL) $(SAIL_FLAGS) $^ -o aarch64 -ocaml -undefined_gen -no_lexp_bounds_check
 
 aarch64_full: full.sail
-	$(SAIL) $^ -o aarch64_full -ocaml -undefined_gen -no_lexp_bounds_check -memo_z3
+	$(SAIL) $^ -o aarch64_full -ocaml -undefined_gen -no_lexp_bounds_check
 
 aarch64.lem: no_vector.sail
-	$(SAIL) $^ -o aarch64 -lem -lem_lib Aarch64_extras -memo_z3 -undefined_gen -no_lexp_bounds_check
+	$(SAIL) $^ -o aarch64 -lem -lem_lib Aarch64_extras -undefined_gen -no_lexp_bounds_check
 aarch64_types.lem: aarch64.lem
 
 Aarch64.thy: aarch64_extras.lem aarch64_types.lem aarch64.lem

--- a/aarch64/mono/demo/mk
+++ b/aarch64/mono/demo/mk
@@ -2,7 +2,7 @@
 set -ex
 ../../../sail ../../prelude.sail ../../no_devices.sail ../mono_rewrites.sail \
      aarch64_no_vector/spec.sail aarch64_no_vector/decode_start.sail aarch64_no_vector/decode.sail aarch64_no_vector/decode_end.sail \
-     -no_lexp_bounds_check -memo_z3 -undefined_gen \
+     -no_lexp_bounds_check -undefined_gen \
      -auto_mono -mono_rewrites -dall_split_errors -dmono_continue \
      -lem -lem_mwords -lem_sequential -lem_lib Aarch64_extras -o aarch64_mono
 lem -isa -lib "Sail=../../../src/gen_lib/" -lib "Sail=../../../src/lem_interp" ../aarch64_extras.lem aarch64_mono_types.lem aarch64_mono.lem 

--- a/aarch64/mono/demo/mk.hol
+++ b/aarch64/mono/demo/mk.hol
@@ -2,7 +2,7 @@
 set -ex
 ../../../sail ../../prelude.sail ../../no_devices.sail ../mono_rewrites.sail \
      aarch64_no_vector/spec.sail aarch64_no_vector/decode_start.sail aarch64_no_vector/decode.sail aarch64_no_vector/decode_end.sail \
-     -no_lexp_bounds_check -memo_z3 -undefined_gen \
+     -no_lexp_bounds_check -undefined_gen \
      -auto_mono -mono_rewrites -dall_split_errors -dmono_continue \
      -lem -lem_mwords -lem_sequential -lem_lib Aarch64_extras -o aarch64_mono
 # Explicitly include replacement prompt files, as Lem's choice of file depends

--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -234,10 +234,6 @@ indicated by starting with the letter `d`.
 * `--enum-casts` Allow elements of enumerations to be
   automatically cast to numbers.
 
-* `--memo-z3` Memoize calls to the Z3 solver. This can greatly improve
-  typechecking times if you are repeatedly typechecking the same
-  specification while developing it.
-
 * `--no-lexp-bounds-check` Turn off bounds checking in the left hand
   side of assignments. This option only exists for some Sail translated
   from ASL (as ASL does not do compile-time bounds checking here).

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -3384,11 +3384,6 @@ indicated by starting with the letter <code>d</code>.</p>
 automatically cast to numbers.</p>
 </li>
 <li>
-<p><code>--memo-z3</code> Memoize calls to the Z3 solver. This can greatly improve
-typechecking times if you are repeatedly typechecking the same
-specification while developing it.</p>
-</li>
-<li>
 <p><code>--no-lexp-bounds-check</code> Turn off bounds checking in the left hand
 side of assignments. This option only exists for some Sail translated
 from ASL (as ASL does not do compile-time bounds checking here).</p>

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -308,10 +308,6 @@ let rec options =
       );
       ("-plugin", Arg.String (fun plugin -> load_plugin options plugin), "<file> load a Sail plugin");
       ("-just_check", Arg.Set opt_just_check, " terminate immediately after typechecking");
-      ( "-memo_z3",
-        Arg.Set opt_memo_z3,
-        " memoize calls to z3, improving performance when typechecking repeatedly (default)"
-      );
       ("-no_memo_z3", Arg.Clear opt_memo_z3, " do not memoize calls to z3");
       ( "-memo_z3_path",
         Arg.String (fun f -> opt_memo_z3_path := f),

--- a/test/oneoff/bad_cache/test.sh
+++ b/test/oneoff/bad_cache/test.sh
@@ -4,5 +4,5 @@ set -e
 
 rm -f bad_cache.result sail_smt_cache
 echo -n -e 7fcba3a13c51ab2786c5b710e80c5f88\\x05 > sail_smt_cache
-sail --memo-z3 2> bad_cache.result || true
+sail 2> bad_cache.result || true
 diff bad_cache.result bad_cache.expect


### PR DESCRIPTION
This option is the default anyway, and it causes confusing behaviour if you have `--memo-z3` *and* `--no-memo-z3`.

This is a breaking change, but should be trivial for users to fix.

Fixes #1588