### PR TITLE
Use QArith rationals

### DIFF
--- a/lib/sail.c
+++ b/lib/sail.c
@@ -1526,6 +1526,13 @@ void to_real(real *rop, const sail_int op)
   mpq_canonicalize(*rop);
 }
 
+void frac_to_real(real *rop, const sail_int num, const sail_int den)
+{
+  mpz_set(mpq_numref(*rop), num);
+  mpz_set(mpq_denref(*rop), den);
+  mpq_canonicalize(*rop);
+}
+
 bool EQUAL(real)(const real op1, const real op2)
 {
   return mpq_cmp(op1, op2) == 0;
@@ -1584,16 +1591,26 @@ void CREATE_OF(real, sail_string)(real *rop, const_sail_string op)
   int total;
 
   mpq_init(*rop);
-  gmp_sscanf(op, "%Zd.%n%Zd%n", sail_lib_tmp1, &decimal, sail_lib_tmp2, &total);
-
-  int len = total - decimal;
-  mpz_ui_pow_ui(sail_lib_tmp3, 10, len);
-  mpz_set(mpq_numref(*rop), sail_lib_tmp2);
-  mpz_set(mpq_denref(*rop), sail_lib_tmp3);
-  mpq_canonicalize(*rop);
-  mpz_set(mpq_numref(sail_lib_tmp_real), sail_lib_tmp1);
-  mpz_set_ui(mpq_denref(sail_lib_tmp_real), 1);
-  mpq_add(*rop, *rop, sail_lib_tmp_real);
+  if (gmp_sscanf(op, "%Zd.%n%Zd%n", sail_lib_tmp1, &decimal, sail_lib_tmp2, &total) == 2) {
+    int len = total - decimal;
+    mpz_ui_pow_ui(sail_lib_tmp3, 10, len);
+    mpz_set(mpq_numref(*rop), sail_lib_tmp2);
+    mpz_set(mpq_denref(*rop), sail_lib_tmp3);
+    mpq_canonicalize(*rop);
+    mpz_set(mpq_numref(sail_lib_tmp_real), sail_lib_tmp1);
+    mpz_set_ui(mpq_denref(sail_lib_tmp_real), 1);
+    mpq_add(*rop, *rop, sail_lib_tmp_real);
+  } else if (gmp_sscanf(op, "%Zd/%Zd", sail_lib_tmp1, sail_lib_tmp2, &total) == 2) {
+    mpz_set(mpq_numref(*rop), sail_lib_tmp1);
+    mpz_set(mpq_denref(*rop), sail_lib_tmp2);
+    mpq_canonicalize(*rop);
+  } else if (gmp_sscanf(op, "%Zd", sail_lib_tmp1, &total) == 1) {
+    mpz_set(mpq_numref(*rop), sail_lib_tmp1);
+    mpz_set_ui(mpq_denref(*rop), 1);
+    mpq_canonicalize(*rop);
+  } else {
+    fprintf(stderr, "Failed to parse rational number\n");
+  }
 }
 
 void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op)
@@ -1601,16 +1618,26 @@ void CONVERT_OF(real, sail_string)(real *rop, const_sail_string op)
   int decimal;
   int total;
 
-  gmp_sscanf(op, "%Zd.%n%Zd%n", sail_lib_tmp1, &decimal, sail_lib_tmp2, &total);
-
-  int len = total - decimal;
-  mpz_ui_pow_ui(sail_lib_tmp3, 10, len);
-  mpz_set(mpq_numref(*rop), sail_lib_tmp2);
-  mpz_set(mpq_denref(*rop), sail_lib_tmp3);
-  mpq_canonicalize(*rop);
-  mpz_set(mpq_numref(sail_lib_tmp_real), sail_lib_tmp1);
-  mpz_set_ui(mpq_denref(sail_lib_tmp_real), 1);
-  mpq_add(*rop, *rop, sail_lib_tmp_real);
+  if (gmp_sscanf(op, "%Zd.%n%Zd%n", sail_lib_tmp1, &decimal, sail_lib_tmp2, &total) == 2) {
+    int len = total - decimal;
+    mpz_ui_pow_ui(sail_lib_tmp3, 10, len);
+    mpz_set(mpq_numref(*rop), sail_lib_tmp2);
+    mpz_set(mpq_denref(*rop), sail_lib_tmp3);
+    mpq_canonicalize(*rop);
+    mpz_set(mpq_numref(sail_lib_tmp_real), sail_lib_tmp1);
+    mpz_set_ui(mpq_denref(sail_lib_tmp_real), 1);
+    mpq_add(*rop, *rop, sail_lib_tmp_real);
+  } else if (gmp_sscanf(op, "%Zd/%Zd", sail_lib_tmp1, sail_lib_tmp2, &total) == 2) {
+    mpz_set(mpq_numref(*rop), sail_lib_tmp1);
+    mpz_set(mpq_denref(*rop), sail_lib_tmp2);
+    mpq_canonicalize(*rop);
+  } else if (gmp_sscanf(op, "%Zd", sail_lib_tmp1, &total) == 1) {
+    mpz_set(mpq_numref(*rop), sail_lib_tmp1);
+    mpz_set_ui(mpq_denref(*rop), 1);
+    mpq_canonicalize(*rop);
+  } else {
+    fprintf(stderr, "Failed to parse rational number\n");
+  }
 }
 
 unit print_real(const_sail_string str, const real op)

--- a/lib/sail.h
+++ b/lib/sail.h
@@ -480,6 +480,7 @@ void round_up(sail_int *rop, const real op);
 void round_down(sail_int *rop, const real op);
 
 void to_real(real *rop, const sail_int op);
+void frac_to_real(real *rop, const sail_int num, const sail_int den);
 
 bool EQUAL(real)(const real op1, const real op2);
 

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -1349,7 +1349,7 @@ let string_of_lit (L_aux (lit, _)) =
   | L_hex hex -> "0x" ^ string_of_hex_lit ~case:Uppercase hex
   | L_bin bin -> "0b" ^ string_of_bin_lit bin
   | L_undef -> "undefined"
-  | L_real r -> r
+  | L_real r -> Q.to_string (Util.Rational.from_rocq r)
   | L_string str -> "\"" ^ str ^ "\""
 
 let string_of_order (Ord_aux (aux, _)) = match aux with Ord_inc -> "inc" | Ord_dec -> "dec"

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -1,3 +1,4 @@
+open QArith_base
 open Value_type
 
 type l = Parse_ast.l
@@ -97,7 +98,7 @@ type lit_aux =
 | L_bin of bin_digit non_empty list
 | L_string of string
 | L_undef
-| L_real of string
+| L_real of coq_Q
 
 type nexp_aux =
 | Nexp_id of id

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -1,3 +1,4 @@
+open QArith_base
 open Value_type
 
 type l = Parse_ast.l
@@ -97,7 +98,7 @@ type lit_aux =
 | L_bin of bin_digit non_empty list
 | L_string of string
 | L_undef
-| L_real of string
+| L_real of coq_Q
 
 type nexp_aux =
 | Nexp_id of id

--- a/src/lib/extraction/BinInt.ml
+++ b/src/lib/extraction/BinInt.ml
@@ -91,6 +91,11 @@ module Z =
 
   let sub = Big_int_Z.sub_big_int
 
+  (** val mul :
+      Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let mul = Big_int_Z.mult_big_int
+
   (** val compare : Big_int_Z.big_int -> Big_int_Z.big_int -> comparison **)
 
   let compare = (fun x y -> let s = Big_int_Z.compare_big_int x y in
@@ -102,6 +107,10 @@ module Z =
     match compare x y with
     | Lt -> true
     | _ -> false
+
+  (** val eqb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool **)
+
+  let eqb = Big_int_Z.eq_big_int
 
   (** val to_nat : Big_int_Z.big_int -> Big_int_Z.big_int **)
 

--- a/src/lib/extraction/BinInt.mli
+++ b/src/lib/extraction/BinInt.mli
@@ -17,9 +17,13 @@ module Z :
 
   val sub : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int
 
+  val mul : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int
+
   val compare : Big_int_Z.big_int -> Big_int_Z.big_int -> comparison
 
   val ltb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
+
+  val eqb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
 
   val to_nat : Big_int_Z.big_int -> Big_int_Z.big_int
 

--- a/src/lib/extraction/Nat0.ml
+++ b/src/lib/extraction/Nat0.ml
@@ -2,8 +2,3 @@
 (** val add : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
 
 let rec add = Big_int_Z.add_big_int
-
-(** val sub : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
-
-let rec sub = (fun n m -> Big_int_Z.max_big_int Big_int_Z.zero_big_int
-  (Big_int_Z.sub_big_int n m))

--- a/src/lib/extraction/Nat0.mli
+++ b/src/lib/extraction/Nat0.mli
@@ -1,4 +1,2 @@
 
 val add : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int
-
-val sub : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int

--- a/src/lib/extraction/PeanoNat.ml
+++ b/src/lib/extraction/PeanoNat.ml
@@ -1,6 +1,21 @@
 
 module Nat =
  struct
+  (** val sub :
+      Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let rec sub n m =
+    (fun fO fS n -> if Big_int_Z.sign_big_int n <= 0 then fO ()
+  else fS (Big_int_Z.pred_big_int n))
+      (fun _ -> n)
+      (fun k ->
+      (fun fO fS n -> if Big_int_Z.sign_big_int n <= 0 then fO ()
+  else fS (Big_int_Z.pred_big_int n))
+        (fun _ -> n)
+        (fun l -> sub k l)
+        m)
+      n
+
   (** val eqb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool **)
 
   let rec eqb = Big_int_Z.eq_big_int

--- a/src/lib/extraction/PeanoNat.mli
+++ b/src/lib/extraction/PeanoNat.mli
@@ -1,5 +1,7 @@
 
 module Nat :
  sig
+  val sub : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int
+
   val eqb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
  end

--- a/src/lib/extraction/PosDef.ml
+++ b/src/lib/extraction/PosDef.ml
@@ -124,6 +124,19 @@ module Pos =
       (fun _ -> Big_int_Z.unit_big_int)
       x
 
+  (** val mul :
+      Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int **)
+
+  let rec mul x y =
+    (fun f2p1 f2p f1 p ->
+  if Big_int_Z.le_big_int p Big_int_Z.unit_big_int then f1 () else
+  let (q,r) = Big_int_Z.quomod_big_int p (Big_int_Z.big_int_of_int 2) in
+  if Big_int_Z.eq_big_int r Big_int_Z.zero_big_int then f2p q else f2p1 q)
+      (fun p -> add y (Big_int_Z.mult_int_big_int 2 (mul p y)))
+      (fun p -> Big_int_Z.mult_int_big_int 2 (mul p y))
+      (fun _ -> y)
+      x
+
   (** val compare_cont :
       comparison -> Big_int_Z.big_int -> Big_int_Z.big_int -> comparison **)
 
@@ -165,6 +178,42 @@ module Pos =
 
   let compare =
     compare_cont Eq
+
+  (** val eqb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool **)
+
+  let rec eqb p q =
+    (fun f2p1 f2p f1 p ->
+  if Big_int_Z.le_big_int p Big_int_Z.unit_big_int then f1 () else
+  let (q,r) = Big_int_Z.quomod_big_int p (Big_int_Z.big_int_of_int 2) in
+  if Big_int_Z.eq_big_int r Big_int_Z.zero_big_int then f2p q else f2p1 q)
+      (fun p0 ->
+      (fun f2p1 f2p f1 p ->
+  if Big_int_Z.le_big_int p Big_int_Z.unit_big_int then f1 () else
+  let (q,r) = Big_int_Z.quomod_big_int p (Big_int_Z.big_int_of_int 2) in
+  if Big_int_Z.eq_big_int r Big_int_Z.zero_big_int then f2p q else f2p1 q)
+        (fun q0 -> eqb p0 q0)
+        (fun _ -> false)
+        (fun _ -> false)
+        q)
+      (fun p0 ->
+      (fun f2p1 f2p f1 p ->
+  if Big_int_Z.le_big_int p Big_int_Z.unit_big_int then f1 () else
+  let (q,r) = Big_int_Z.quomod_big_int p (Big_int_Z.big_int_of_int 2) in
+  if Big_int_Z.eq_big_int r Big_int_Z.zero_big_int then f2p q else f2p1 q)
+        (fun _ -> false)
+        (fun q0 -> eqb p0 q0)
+        (fun _ -> false)
+        q)
+      (fun _ ->
+      (fun f2p1 f2p f1 p ->
+  if Big_int_Z.le_big_int p Big_int_Z.unit_big_int then f1 () else
+  let (q,r) = Big_int_Z.quomod_big_int p (Big_int_Z.big_int_of_int 2) in
+  if Big_int_Z.eq_big_int r Big_int_Z.zero_big_int then f2p q else f2p1 q)
+        (fun _ -> false)
+        (fun _ -> false)
+        (fun _ -> true)
+        q)
+      p
 
   (** val iter_op : ('a1 -> 'a1 -> 'a1) -> Big_int_Z.big_int -> 'a1 -> 'a1 **)
 

--- a/src/lib/extraction/PosDef.mli
+++ b/src/lib/extraction/PosDef.mli
@@ -11,10 +11,14 @@ module Pos :
 
   val pred_double : Big_int_Z.big_int -> Big_int_Z.big_int
 
+  val mul : Big_int_Z.big_int -> Big_int_Z.big_int -> Big_int_Z.big_int
+
   val compare_cont :
     comparison -> Big_int_Z.big_int -> Big_int_Z.big_int -> comparison
 
   val compare : Big_int_Z.big_int -> Big_int_Z.big_int -> comparison
+
+  val eqb : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
 
   val iter_op : ('a1 -> 'a1 -> 'a1) -> Big_int_Z.big_int -> 'a1 -> 'a1
 

--- a/src/lib/extraction/QArith_base.ml
+++ b/src/lib/extraction/QArith_base.ml
@@ -1,0 +1,8 @@
+open BinInt
+
+type coq_Q = { coq_Qnum : Big_int_Z.big_int; coq_Qden : Big_int_Z.big_int }
+
+(** val coq_Qeq_bool : coq_Q -> coq_Q -> bool **)
+
+let coq_Qeq_bool x y =
+  Z.eqb (Z.mul x.coq_Qnum y.coq_Qden) (Z.mul y.coq_Qnum x.coq_Qden)

--- a/src/lib/extraction/QArith_base.mli
+++ b/src/lib/extraction/QArith_base.mli
@@ -1,0 +1,5 @@
+open BinInt
+
+type coq_Q = { coq_Qnum : Big_int_Z.big_int; coq_Qden : Big_int_Z.big_int }
+
+val coq_Qeq_bool : coq_Q -> coq_Q -> bool

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -1,10 +1,12 @@
 open Ast
 open AstInduction
+open BinInt
 open Datatypes
 open IdUtil
 open List0
 open ListDef
 open PeanoNat
+open QArith_base
 open Specif
 open Value_type
 open Wf
@@ -419,15 +421,9 @@ module type SemanticExt =
 
   val is_bitvector : tannot -> bool
 
-  val num_equal : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
-
-  val rational_equal : Rational.t -> Rational.t -> bool
-
   val id_equal_string : id -> string -> bool
 
   val string_of_id : id -> string
-
-  val rational_of_string : string -> Rational.t
 
   val fallthrough : tannot pexp
 
@@ -595,7 +591,7 @@ module Make =
      | L_bin b -> Monad.pure (V_bitvector (bitlist_of_bin_lit b))
      | L_string s -> Monad.pure (V_string s)
      | L_undef -> Monad.get_undefined typ0
-     | L_real r -> Monad.pure (V_real (T.rational_of_string r)))
+     | L_real r -> Monad.pure (V_real r))
 
   (** val same_bits : bit list -> bit list -> bool **)
 
@@ -632,7 +628,7 @@ module Make =
         | V_bool b -> if b then false else true
         | _ -> false)
      | L_num n -> (match v with
-                   | V_int m -> T.num_equal n m
+                   | V_int m -> Z.eqb n m
                    | _ -> false)
      | L_hex s ->
        (match v with
@@ -648,7 +644,7 @@ module Make =
      | L_undef -> false
      | L_real r1 ->
        (match v with
-        | V_real r2 -> T.rational_equal (T.rational_of_string r1) r2
+        | V_real r2 -> coq_Qeq_bool r1 r2
         | _ -> false))
 
   (** val get_struct_field : string -> (string * value) list -> value **)

--- a/src/lib/extraction/Semantics.mli
+++ b/src/lib/extraction/Semantics.mli
@@ -1,10 +1,12 @@
 open Ast
 open AstInduction
+open BinInt
 open Datatypes
 open IdUtil
 open List0
 open ListDef
 open PeanoNat
+open QArith_base
 open Specif
 open Value_type
 open Wf
@@ -146,15 +148,9 @@ module type SemanticExt =
 
   val is_bitvector : tannot -> bool
 
-  val num_equal : Big_int_Z.big_int -> Big_int_Z.big_int -> bool
-
-  val rational_equal : Rational.t -> Rational.t -> bool
-
   val id_equal_string : id -> string -> bool
 
   val string_of_id : id -> string
-
-  val rational_of_string : string -> Rational.t
 
   val fallthrough : tannot pexp
 

--- a/src/lib/extraction/Value_type.ml
+++ b/src/lib/extraction/Value_type.ml
@@ -1,7 +1,8 @@
 open BinInt
 open Datatypes
 open ListDef
-open Nat0
+open PeanoNat
+open QArith_base
 
 type bit =
 | B0
@@ -12,7 +13,7 @@ type value =
 | V_vector of value list
 | V_list of value list
 | V_int of Big_int_Z.big_int
-| V_real of Rational.t
+| V_real of coq_Q
 | V_bool of bool
 | V_tuple of value list
 | V_unit
@@ -75,7 +76,7 @@ module Primops =
          let len = length bitlist in
          if Z.ltb n0 (Z.of_nat len)
          then None
-         else let extend = sub (Z.to_nat n0) len in
+         else let extend = Nat.sub (Z.to_nat n0) len in
               Some (V_bitvector (app (repeat B0 extend) bitlist))
        | _ -> None)
     | _ -> None

--- a/src/lib/extraction/Value_type.mli
+++ b/src/lib/extraction/Value_type.mli
@@ -1,7 +1,8 @@
 open BinInt
 open Datatypes
 open ListDef
-open Nat0
+open PeanoNat
+open QArith_base
 
 type bit =
 | B0
@@ -12,7 +13,7 @@ type value =
 | V_vector of value list
 | V_list of value list
 | V_int of Big_int_Z.big_int
-| V_real of Rational.t
+| V_real of coq_Q
 | V_bool of bool
 | V_tuple of value list
 | V_unit

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1278,7 +1278,7 @@ let to_ast_lit (P.L_aux (lit, l)) =
           | Some b -> L_bin b
           | None -> raise (Reporting.err_syntax_loc l "Failed to parse binary bitvector literal")
         )
-      | P.L_real r -> L_real r
+      | P.L_real r -> L_real (Util.Rational.to_rocq (Sail_lib.real_of_string r))
       | P.L_string s -> L_string s
       | P.L_multiline_string lines -> L_string (String.concat "\n" (List.map Scanf.unescaped lines))
       ),

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -289,19 +289,9 @@ module RocqSemantics = Semantics.Make (struct
 
   let is_bitvector tannot = is_bitvector_typ (Type_check.typ_of_tannot tannot)
 
-  let num_equal x y = Big_int.compare x y = 0
-
-  let rational_equal x y = Rational.equal x y
-
   let id_equal_string x s = string_of_id x = s
 
   let string_of_id = string_of_id
-
-  let bits_of_hex_string = Sail_lib.bits_of_string
-
-  let bits_of_bin_string s = List.map Sail_lib.bin_char (Sail_lib.list_of_string s)
-
-  let rational_of_string = Sail_lib.real_of_string
 
   let fallthrough = fallthrough
 

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -467,7 +467,8 @@ module Make (C : CONFIG) = struct
         )
     | AV_lit (L_aux (L_true, _), _) -> ([], V_lit (VL_bool true, CT_bool), [])
     | AV_lit (L_aux (L_false, _), _) -> ([], V_lit (VL_bool false, CT_bool), [])
-    | AV_lit (L_aux (L_real str, _), _) ->
+    | AV_lit (L_aux (L_real r, _), _) ->
+        let str = Q.to_string (Util.Rational.from_rocq r) in
         if C.use_real then ([], V_lit (VL_real str, CT_real), [])
         else (
           let gs = ngensym () in

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -284,7 +284,9 @@ module Printer (Config : PRINT_CONFIG) = struct
       | L_num i -> Big_int.to_string i
       | L_hex hex -> "0x" ^ string_of_hex_lit ~case:Uppercase hex
       | L_bin bin -> "0b" ^ string_of_bin_lit bin
-      | L_real r -> r
+      | L_real r ->
+          let r = Util.Rational.from_rocq r in
+          Printf.sprintf "div_real(to_real(%s), to_real(%s))" (Big_int.to_string (Q.num r)) (Big_int.to_string (Q.den r))
       | L_undef -> "undefined"
       | L_string s -> "\"" ^ String.escaped s ^ "\""
       )

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -5,6 +5,7 @@ Set Extraction Output Directory ".".
 
 From Stdlib Require Import String.
 From Stdlib Require Import ZArith.
+From Stdlib Require Import QArith.
 
 Require Import Value_type.
 
@@ -136,7 +137,7 @@ Inductive lit_aux : Set :=
 | L_bin : list (non_empty bin_digit) -> lit_aux
 | L_string : string -> lit_aux
 | L_undef : lit_aux
-| L_real : string -> lit_aux.
+| L_real : Q -> lit_aux.
 
 Inductive nexp_aux : Set :=
 | Nexp_id : id -> nexp_aux

--- a/src/lib/rocq/theories/Semantics.v
+++ b/src/lib/rocq/theories/Semantics.v
@@ -11,6 +11,7 @@ From Stdlib Require Import Lists.List.
 From Stdlib Require Import Program.
 From Stdlib Require Import String.
 From Stdlib Require Import ZArith.
+From Stdlib Require QArith.
 
 Require Import Value_type.
 Require Import Ast.
@@ -506,15 +507,9 @@ Module Type SemanticExt.
 
   Parameter is_bitvector : tannot -> bool.
 
-  Parameter num_equal : Z -> Z -> bool.
-
-  Parameter rational_equal : rational -> rational -> bool.
-
   Parameter id_equal_string : id -> string -> bool.
 
   Parameter string_of_id : id -> string.
-
-  Parameter rational_of_string : string -> rational.
 
   Parameter fallthrough : Ast.pexp tannot.
 
@@ -648,7 +643,7 @@ Module Make (T : SemanticExt).
     | L_num n => pure (V_int n)
     | L_hex h => pure (V_bitvector (bitlist_of_hex_lit h))
     | L_bin b => pure (V_bitvector (bitlist_of_bin_lit b))
-    | L_real r => pure (V_real (T.rational_of_string r))
+    | L_real r => pure (V_real r)
     | L_string s => pure (V_string s)
     | L_undef => get_undefined typ
     end.
@@ -699,11 +694,11 @@ Module Make (T : SemanticExt).
     | (L_unit, V_unit) => true
     | (L_true, V_bool true) => true
     | (L_false, V_bool false) => true
-    | (L_num n, V_int m) => T.num_equal n m
+    | (L_num n, V_int m) => Z.eqb n m
     | (L_hex s, V_bitvector vs) => same_bits (bitlist_of_hex_lit s) vs
     | (L_bin s, V_bitvector vs) => same_bits (bitlist_of_bin_lit s) vs
     | (L_string s1, V_string s2) => String.eqb s1 s2
-    | (L_real r1, V_real r2) => T.rational_equal (T.rational_of_string r1) r2
+    | (L_real r1, V_real r2) => QArith_base.Qeq_bool r1 r2
     | _ => false
     end.
 

--- a/src/lib/rocq/theories/Value_type.v
+++ b/src/lib/rocq/theories/Value_type.v
@@ -2,6 +2,7 @@ Require Extraction.
 
 From Stdlib Require Import String.
 From Stdlib Require Import ZArith.
+From Stdlib Require Import QArith.
 
 From Stdlib Require ExtrOcamlBasic.
 From Stdlib Require ExtrOcamlNatBigInt.
@@ -13,10 +14,6 @@ Set Extraction Output Directory ".".
 
 From Stdlib Require Import Bool.
 
-Parameter rational : Set.
-
-Extract Inlined Constant rational => "Rational.t".
-
 Inductive bit : Set :=
 | B0 : bit
 | B1 : bit.
@@ -26,7 +23,7 @@ Inductive value : Set :=
 | V_vector : list value -> value
 | V_list : list value -> value
 | V_int : Z -> value
-| V_real : rational -> value
+| V_real : Q -> value
 | V_bool : bool -> value
 | V_tuple : list value -> value
 | V_unit : value
@@ -69,7 +66,7 @@ Module Primops.
       if Z.ltb n (Z.of_nat len) then
         None
       else
-        let extend := (Z.to_nat n) - len in
+        let extend := Nat.sub (Z.to_nat n) len in
         Some (V_bitvector (List.repeat B0 extend ++ bitlist))
     | _ => None
     end.

--- a/src/lib/sail_lib.ml
+++ b/src/lib/sail_lib.ml
@@ -625,59 +625,51 @@ let set_slice_int (slice_len, m, n, slice) =
   let mask = uint (replicate_bits ([B1], slice_len) @ replicate_bits ([B0], n)) in
   Big_int.bitwise_or (Big_int.bitwise_xor (Big_int.bitwise_or mask m) mask) shifted_slice
 
-let eq_real (x, y) = Rational.equal x y
-let lt_real (x, y) = Rational.lt x y
-let gt_real (x, y) = Rational.gt x y
-let lteq_real (x, y) = Rational.leq x y
-let gteq_real (x, y) = Rational.geq x y
-let to_real x = Rational.of_big_int x
-let negate_real x = Rational.neg x
-let neg_real x = Rational.neg x
+let eq_real (x, y) = Q.equal x y
+let lt_real (x, y) = Q.lt x y
+let gt_real (x, y) = Q.gt x y
+let lteq_real (x, y) = Q.leq x y
+let gteq_real (x, y) = Q.geq x y
+let to_real x = Q.of_bigint x
+let negate_real x = Q.neg x
+let neg_real x = Q.neg x
 
-let string_of_real x =
-  if Big_int.equal (Rational.den x) (Big_int.of_int 1) then Big_int.to_string (Rational.num x)
-  else Big_int.to_string (Rational.num x) ^ "/" ^ Big_int.to_string (Rational.den x)
+let string_of_real x = Q.to_string x
 
 let print_real (str, r) = print_endline (str ^ string_of_real r)
 let prerr_real (str, r) = prerr_endline (str ^ string_of_real r)
 
-let round_down x = Rational.floor x
-let round_up x = Rational.ceiling x
-let quotient_real (x, y) = Rational.div x y
-let div_real (x, y) = Rational.div x y
-let mult_real (x, y) = Rational.mul x y
+let round_down x = Z.fdiv (Q.num x) (Q.den x)
+let round_up x = Z.cdiv (Q.num x) (Q.den x)
+let quotient_real (x, y) = Q.div x y
+let div_real (x, y) = Q.div x y
+let mult_real (x, y) = Q.mul x y
 let real_power (_, _) = failwith "real_power"
 let int_power (x, y) = Big_int.pow_int x (Big_int.to_int y)
-let add_real (x, y) = Rational.add x y
-let sub_real (x, y) = Rational.sub x y
+let add_real (x, y) = Q.add x y
+let sub_real (x, y) = Q.sub x y
 
-let abs_real x = Rational.abs x
+let abs_real x = Q.abs x
 
 let sqrt_real x =
   let precision = 30 in
-  let s =
-    Rational.div
-      (Rational.of_big_int (Big_int.sqrt (Rational.num x)))
-      (Rational.of_big_int (Big_int.sqrt (Rational.den x)))
-  in
-  if Rational.equal (Rational.mul s s) x then s
+  let s = Q.div (Q.of_bigint (Big_int.sqrt (Q.num x))) (Q.of_bigint (Big_int.sqrt (Q.den x))) in
+  if Q.equal (Q.mul s s) x then s
   else (
     let p = ref s in
-    let n = ref (Rational.of_int 0) in
-    let num_convergence = if Rational.gt x (Rational.of_int 1) then Rational.of_int 1 else x in
-    let convergence =
-      ref (Rational.div num_convergence (Rational.of_big_int (Big_int.pow_int_positive 10 precision)))
-    in
+    let n = ref (Q.of_int 0) in
+    let num_convergence = if Q.gt x (Q.of_int 1) then Q.of_int 1 else x in
+    let convergence = ref (Q.div num_convergence (Q.of_bigint (Big_int.pow_int_positive 10 precision))) in
     let quit_loop = ref false in
     while not !quit_loop do
-      n := Rational.div (Rational.add !p (Rational.div x !p)) (Rational.of_int 2);
+      n := Q.div (Q.add !p (Q.div x !p)) (Q.of_int 2);
 
-      if Rational.lt (Rational.abs (Rational.sub !p !n)) !convergence then quit_loop := true else p := !n
+      if Q.lt (Q.abs (Q.sub !p !n)) !convergence then quit_loop := true else p := !n
     done;
     !n
   )
 
-let random_real () = Rational.div (Rational.of_int (Random.bits ())) (Rational.of_int (Random.bits ()))
+let random_real () = Q.div (Q.of_int (Random.bits ())) (Q.of_int (Random.bits ()))
 
 let lt (x, y) = Big_int.less x y
 let gt (x, y) = Big_int.greater x y
@@ -692,20 +684,11 @@ let abs_int x = Big_int.abs x
 
 let string_of_int x = Big_int.to_string x
 
-let undefined_real () = Rational.of_int 0
+let undefined_real () = Q.of_int 0
 
 let rec pow x = function 0 -> 1 | n -> x * pow x (n - 1)
 
-let real_of_string str =
-  match Util.split_on_char '.' str with
-  | [whole; frac] ->
-      let whole = Rational.of_big_int (Big_int.of_string whole) in
-      let frac =
-        Rational.div (Rational.of_big_int (Big_int.of_string frac)) (Rational.of_int (pow 10 (String.length frac)))
-      in
-      Rational.add whole frac
-  | [_] -> Rational.of_big_int (Big_int.of_string str)
-  | _ -> failwith "invalid real literal"
+let real_of_string str = Q.of_string str
 
 let print str = Stdlib.print_string str
 
@@ -795,7 +778,7 @@ let get_time_ns () = Big_int.of_int (int_of_float (1e9 *. Unix.gettimeofday ()))
      | ZSome (n, len) ->
         if Big_int.less_equal Big_int.zero n
            && Big_int.less n (Big_int.pow_int_positive 2 {0}) then
-          ZSome ((bits_of_big_int {0} n, len))
+          ZSome ((bits_of_bigint {0} n, len))
         else
           ZNone ()
    """

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -99,6 +99,12 @@ let rec last_opt = function [x] -> Some x | _ :: xs -> last_opt xs | [] -> None
 
 let rec butlast = function [_] -> [] | x :: xs -> x :: butlast xs | [] -> []
 
+module Rational = struct
+  let from_rocq r = { Q.num = r.QArith_base.coq_Qnum; Q.den = r.QArith_base.coq_Qden }
+
+  let to_rocq r = { QArith_base.coq_Qnum = r.Q.num; QArith_base.coq_Qden = r.Q.den }
+end
+
 module Option_monad = struct
   let ( let* ) = Option.bind
   let ( let+ ) = Option.map

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -56,6 +56,11 @@ val last_opt : 'a list -> 'a option
 
 val butlast : 'a list -> 'a list
 
+module Rational : sig
+  val from_rocq : QArith_base.coq_Q -> Q.t
+  val to_rocq : Q.t -> QArith_base.coq_Q
+end
+
 module Option_monad : sig
   val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option
   val ( let+ ) : ('a -> 'b) -> 'a option -> 'b option

--- a/src/lib/value.ml
+++ b/src/lib/value.ml
@@ -78,12 +78,14 @@ let rec string_of_value = function
   | V_unit -> "()"
   | V_string str -> "\"" ^ str ^ "\""
   | V_ref str -> "ref " ^ str
-  | V_real r -> Sail_lib.string_of_real r
+  | V_real r -> Sail_lib.string_of_real (Util.Rational.from_rocq r)
   | V_member str -> str
   | V_ctor (str, vals) -> str ^ "(" ^ Util.string_of_list ", " string_of_value vals ^ ")"
   | V_record record ->
       "struct {" ^ Util.string_of_list ", " (fun (field, v) -> field ^ " = " ^ string_of_value v) record ^ "}"
   | V_attempted_read _ -> assert false
+
+let mk_real r = V_real (Util.Rational.to_rocq r)
 
 let rec eq_value v1 v2 =
   match (v1, v2) with
@@ -91,7 +93,7 @@ let rec eq_value v1 v2 =
   | V_vector v1s, V_vector v2s when List.length v1s = List.length v2s -> List.for_all2 eq_value v1s v2s
   | V_list v1s, V_list v2s when List.length v1s = List.length v2s -> List.for_all2 eq_value v1s v2s
   | V_int n, V_int m -> Big_int.equal n m
-  | V_real n, V_real m -> Rational.equal n m
+  | V_real n, V_real m -> Q.equal (Util.Rational.from_rocq n) (Util.Rational.from_rocq m)
   | V_bool b1, V_bool b2 -> b1 = b2
   | V_tuple v1s, V_tuple v2s when List.length v1s = List.length v2s -> List.for_all2 eq_value v1s v2s
   | V_unit, V_unit -> true
@@ -126,7 +128,7 @@ let coerce_listlike = function V_tuple vs -> vs | V_list vs -> vs | V_unit -> []
 
 let coerce_int = function V_int i -> i | _ -> assert false
 
-let coerce_real = function V_real r -> r | _ -> assert false
+let coerce_real = function V_real r -> Util.Rational.from_rocq r | _ -> assert false
 
 let coerce_cons = function V_list (v :: vs) -> Some (v, vs) | V_list [] -> None | _ -> assert false
 
@@ -515,7 +517,7 @@ let value_concat_str = function
   | [v1; v2] -> V_string (Sail_lib.concat_str (coerce_string v1, coerce_string v2))
   | _ -> failwith "value concat_str"
 
-let value_to_real = function [v] -> V_real (Sail_lib.to_real (coerce_int v)) | _ -> failwith "value to_real"
+let value_to_real = function [v] -> mk_real (Sail_lib.to_real (coerce_int v)) | _ -> failwith "value to_real"
 
 let value_print_real = function
   | [v1; v2] ->
@@ -523,12 +525,12 @@ let value_print_real = function
       V_unit
   | _ -> failwith "value print_real"
 
-let value_random_real = function [_] -> V_real (Sail_lib.random_real ()) | _ -> failwith "value random_real"
+let value_random_real = function [_] -> mk_real (Sail_lib.random_real ()) | _ -> failwith "value random_real"
 
-let value_sqrt_real = function [v] -> V_real (Sail_lib.sqrt_real (coerce_real v)) | _ -> failwith "value sqrt_real"
+let value_sqrt_real = function [v] -> mk_real (Sail_lib.sqrt_real (coerce_real v)) | _ -> failwith "value sqrt_real"
 
 let value_quotient_real = function
-  | [v1; v2] -> V_real (Sail_lib.quotient_real (coerce_real v1, coerce_real v2))
+  | [v1; v2] -> mk_real (Sail_lib.quotient_real (coerce_real v1, coerce_real v2))
   | _ -> failwith "value quotient_real"
 
 let value_round_up = function [v] -> V_int (Sail_lib.round_up (coerce_real v)) | _ -> failwith "value round_up"
@@ -544,22 +546,22 @@ let value_rem_round_zero = function
   | _ -> failwith "value rem_round_zero"
 
 let value_add_real = function
-  | [v1; v2] -> V_real (Sail_lib.add_real (coerce_real v1, coerce_real v2))
+  | [v1; v2] -> mk_real (Sail_lib.add_real (coerce_real v1, coerce_real v2))
   | _ -> failwith "value add_real"
 
 let value_sub_real = function
-  | [v1; v2] -> V_real (Sail_lib.sub_real (coerce_real v1, coerce_real v2))
+  | [v1; v2] -> mk_real (Sail_lib.sub_real (coerce_real v1, coerce_real v2))
   | _ -> failwith "value sub_real"
 
 let value_mult_real = function
-  | [v1; v2] -> V_real (Sail_lib.mult_real (coerce_real v1, coerce_real v2))
+  | [v1; v2] -> mk_real (Sail_lib.mult_real (coerce_real v1, coerce_real v2))
   | _ -> failwith "value mult_real"
 
 let value_div_real = function
-  | [v1; v2] -> V_real (Sail_lib.div_real (coerce_real v1, coerce_real v2))
+  | [v1; v2] -> mk_real (Sail_lib.div_real (coerce_real v1, coerce_real v2))
   | _ -> failwith "value div_real"
 
-let value_abs_real = function [v] -> V_real (Sail_lib.abs_real (coerce_real v)) | _ -> failwith "value abs_real"
+let value_abs_real = function [v] -> mk_real (Sail_lib.abs_real (coerce_real v)) | _ -> failwith "value abs_real"
 
 let value_eq_real = function
   | [v1; v2] -> V_bool (Sail_lib.eq_real (coerce_real v1, coerce_real v2))

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -848,22 +848,10 @@ let doc_lit (L_aux (lit, l)) =
   | L_bin bin -> utf8string ("('b\"" ^ string_of_bin_lit ~group_separator:"" bin ^ "\")")
   | L_undef -> utf8string "(Fail \"undefined value of unsupported type\")"
   | L_string s -> utf8string ("\"" ^ coq_escape_string s ^ "\"")
-  | L_real s ->
-      (* Lem does not support decimal syntax, so we translate a string
-         of the form "x.y" into the ratio (x * 10^len(y) + y) / 10^len(y).
-         The OCaml library has a conversion function from strings to floats, but
-         not from floats to ratios. ZArith's Q library does have the latter, but
-         using this would require adding a dependency on ZArith to Sail. *)
-      let parts = Util.split_on_char '.' s in
-      let num, denom =
-        match parts with
-        | [i] -> (Big_int.of_string i, Big_int.of_int 1)
-        | [i; f] ->
-            let denom = Big_int.pow_int_positive 10 (String.length f) in
-            (Big_int.add (Big_int.mul (Big_int.of_string i) denom) (Big_int.of_string f), denom)
-        | _ -> raise (Reporting.err_syntax_loc l "could not parse real literal")
-      in
-      parens (separate space (List.map string ["realFromFrac"; Big_int.to_string num; Big_int.to_string denom]))
+  | L_real r ->
+      let r = Util.Rational.from_rocq r in
+      parens
+        (separate space (List.map string ["realFromFrac"; Big_int.to_string (Q.num r); Big_int.to_string (Q.den r)]))
 
 let doc_quant_item_id ?(prop_vars = false) ctx delimit (QI_aux (qi, _)) =
   match qi with

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -388,7 +388,8 @@ let doc_lit ~width (L_aux (lit, l)) =
     )
   | L_undef -> utf8string "(Fail \"undefined value of unsupported type\")"
   | L_string s -> utf8string ("\"" ^ lean_escape_string s ^ "\"")
-  | L_real s -> utf8string s (* TODO test if this is really working *)
+  | L_real r -> utf8string (Q.to_string (Util.Rational.from_rocq r))
+(* TODO test if this is really working *)
 
 let string_of_exp_con (E_aux (e, _)) =
   match e with

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -516,22 +516,10 @@ let rec doc_lit_lem (L_aux (lit, l)) =
   | L_bin bin -> Semantics.bitlist_of_bin_lit bin |> flow_map (semi ^^ break 0) doc_bit |> group |> align |> brackets
   | L_undef -> utf8string "(return (failwith \"undefined value of unsupported type\"))"
   | L_string s -> utf8string ("\"" ^ String.escaped s ^ "\"")
-  | L_real s ->
-      (* Lem does not support decimal syntax, so we translate a string
-         of the form "x.y" into the ratio (x * 10^len(y) + y) / 10^len(y).
-         The OCaml library has a conversion function from strings to floats, but
-         not from floats to ratios. ZArith's Q library does have the latter, but
-         using this would require adding a dependency on ZArith to Sail. *)
-      let parts = Util.split_on_char '.' s in
-      let num, denom =
-        match parts with
-        | [i] -> (Big_int.of_string i, Big_int.of_int 1)
-        | [i; f] ->
-            let denom = Big_int.pow_int_positive 10 (String.length f) in
-            (Big_int.add (Big_int.mul (Big_int.of_string i) denom) (Big_int.of_string f), denom)
-        | _ -> raise (Reporting.err_syntax_loc l "could not parse real literal")
-      in
-      parens (separate space (List.map string ["realFromFrac"; Big_int.to_string num; Big_int.to_string denom]))
+  | L_real r ->
+      let r = Util.Rational.from_rocq r in
+      parens
+        (separate space (List.map string ["realFromFrac"; Big_int.to_string (Q.num r); Big_int.to_string (Q.den r)]))
 
 let kid_nexps_of_typquant tq =
   quant_kopts tq |> List.filter (fun k -> is_int_kopt k || is_typ_kopt k) |> List.map kopt_kid |> List.map nvar

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -182,7 +182,9 @@ let ocaml_lit (L_aux (lit_aux, _)) =
       else parens (string "Big_int.of_string" ^^ space ^^ dquotes (string (Big_int.to_string n)))
   | L_undef -> failwith "undefined should have been re-written prior to ocaml backend"
   | L_string str -> string_lit str
-  | L_real str -> parens (string "real_of_string" ^^ space ^^ dquotes (string (String.escaped str)))
+  | L_real r ->
+      let str = Q.to_string (Util.Rational.from_rocq r) in
+      parens (string "real_of_string" ^^ space ^^ dquotes (string (String.escaped str)))
   | L_bin bin -> brackets (separate_map (semi ^^ space) ocaml_bit (Semantics.bitlist_of_bin_lit bin))
   | L_hex hex -> brackets (separate_map (semi ^^ space) ocaml_bit (Semantics.bitlist_of_hex_lit hex))
 

--- a/test/typecheck/pass/add_real.sail
+++ b/test/typecheck/pass/add_real.sail
@@ -1,5 +1,3 @@
-val add_real : (real, real) -> real
-
-overload operator + = {add_real}
+$include <real.sail>
 
 let r : real = 2.2 + 0.2

--- a/test/typecheck/pass/real.sail
+++ b/test/typecheck/pass/real.sail
@@ -1,1 +1,3 @@
+$include <real.sail>
+
 let r : real = 2.2


### PR DESCRIPTION
Avoid use of string literals to represent rational values in the AST