### PR TITLE
Add stdout output to SMT error message for potentially useful information.

### DIFF
--- a/src/lib/constraint.ml
+++ b/src/lib/constraint.ml
@@ -385,11 +385,14 @@ let rec call_smt' l abstract extra constraints =
               in
               Unix.open_process_full cmd (Unix.environment ())
             in
-            let smt_output =
-              try List.combine problems (input_lines smt_out (List.length problems))
-              with End_of_file -> List.combine problems ["unknown"]
+            let smt_output, smt_raw_output =
+              try
+                let raw_output = input_lines smt_out (List.length problems) in
+                (List.combine problems raw_output, raw_output)
+              with End_of_file -> (List.combine problems ["unknown"], [])
             in
-            let smt_errors = input_all smt_err in
+            (* In case of errors, the output on stdout might be useful. *)
+            let smt_errors = List.append (input_all smt_err) smt_raw_output in
             let status = Unix.close_process_full (smt_out, smt_in, smt_err) in
             (status, smt_output, smt_errors)
           with exn -> raise (Reporting.err_general l ("Error when calling smt: " ^ Printexc.to_string exn))


### PR DESCRIPTION
This improves compilation failure messages from
```
Error:
SMT solver returned unexpected status 1
```
to something like
```
Error:
SMT solver returned unexpected status 1
(error "line 22 column 499: unknown constant znum_triggers")
```
which would help diagnosing such issues.