### PR TITLE
C++: a couple of fixes to switch block generation

### DIFF
--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1749,9 +1749,10 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         (* Create a switch that does something for each constructor *)
         let each_ctor v f ctors =
           c_switch (ksprintf string "(%skind)" v)
-            (List.filter_map
+            (List.map
                (fun (ctor_id, ctyp) ->
-                 Option.map (fun op -> (ksprintf string "Kind_%s" (sgen_id ctor_id), [op])) (f ctor_id ctyp)
+                 let enum_label = ksprintf string "Kind_%s" (sgen_id ctor_id) in
+                 (enum_label, match f ctor_id ctyp with Some op -> [op] | None -> [])
                )
                ctors
             )

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -207,11 +207,16 @@ let c_case_block b = nest 2 (separate hardline ([lbrace] @ b @ [c_stmt "break"])
 
 (* Generate a C switch statement. There's no default case. *)
 let c_switch cond cases =
-  string "switch" ^^ space ^^ cond ^^ space ^^ lbrace ^^ hardline
-  ^^ separate_map hardline
-       (fun (case_exp, case_block) -> string "case" ^^ space ^^ case_exp ^^ colon ^^ space ^^ c_case_block case_block)
-       cases
-  ^^ hardline ^^ rbrace
+  match cases with
+  | [] -> string "{}"
+  | _ ->
+      string "switch" ^^ space ^^ cond ^^ space ^^ lbrace ^^ hardline
+      ^^ separate_map hardline
+           (fun (case_exp, case_block) ->
+             string "case" ^^ space ^^ case_exp ^^ colon ^^ space ^^ c_case_block case_block
+           )
+           cases
+      ^^ hardline ^^ rbrace
 
 module C_config (Opts : sig
   val branch_coverage : out_channel option


### PR DESCRIPTION
This fixes -Wswitch warnings when compiling the RISC-V model.

- Avoid generating empty switches.
- Generate empty case blocks for labels that have no code instead of filtering them.
