### PR TITLE
Rocq: add a generic Countable instance when of_num/num_of functions are missing

### DIFF
--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -3107,7 +3107,30 @@ let doc_typdef global generic_eq_types countable_types enum_number_defs (TD_aux 
       let countable_pp =
         match (global.library_style, num_fns) with
         | BBV, _ -> empty
-        | Stdpp, None -> empty
+        | Stdpp, None ->
+            (* If there isn't a reasonable encode/decode pair, produce a generic one *)
+            separate hardline
+              ([
+                 string "#[export]";
+                 string "Instance Countable_" ^^ id_pp ^^ string " : Countable " ^^ id_pp ^^ string ".";
+                 string "refine {|";
+                 string "  encode x := match x with";
+               ]
+              @ List.mapi
+                  (fun i id -> string "  | " ^^ doc_id_ctor bare_ctxt id ^^ string (" => " ^ string_of_int (i + 1)))
+                  enums
+              @ [string "  end%positive;"; string "  decode x := match x with"]
+              @ List.mapi
+                  (fun i id -> string ("  | " ^ string_of_int (i + 1)) ^^ string " => Some " ^^ doc_id_ctor bare_ctxt id)
+                  enums
+              @ [
+                  string "  | _ => None";
+                  string "  end%positive;";
+                  string "|}.";
+                  string "abstract (intro x; destruct x; reflexivity).";
+                  string "Defined.";
+                ]
+              )
         | Stdpp, Some (of_num_id_pp, num_of_id_pp) ->
             separate hardline
               [

--- a/test/coq/pass/scattered-enum-struct.sail
+++ b/test/coq/pass/scattered-enum-struct.sail
@@ -1,0 +1,12 @@
+default Order dec
+$include <prelude.sail>
+
+scattered enum foo
+enum clause foo = Abc
+enum clause foo = Def
+end foo
+
+struct bar = {
+  field1: int,
+  field2: foo,
+}


### PR DESCRIPTION
In particular, the front-end doesn't currently generate these functions for scattered enums.  If the enum was then used as part of a larger type, the Countable instance construction for that type would fail.