### PR TITLE
Expose in-place loop termination measures in Sail syntax

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -2141,7 +2141,7 @@ let rec locate : 'a. (l -> l) -> 'a exp -> 'a exp =
   in
   E_aux (e_aux, (f l, annot))
 
-and locate_measure : 'a. (l -> l) -> 'a internal_loop_measure -> 'a internal_loop_measure =
+and locate_measure : 'a. (l -> l) -> 'a in_place_loop_measure -> 'a in_place_loop_measure =
  fun f (Measure_aux (m, l)) ->
   let m = match m with Measure_none -> Measure_none | Measure_some exp -> Measure_some (locate f exp) in
   Measure_aux (m, f l)

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -218,11 +218,11 @@ type 'a mpat_aux =
 and 'a mpat =
 | MP_aux of 'a mpat_aux * 'a annot
 
-type 'a internal_loop_measure_aux =
+type 'a in_place_loop_measure_aux =
 | Measure_none
 | Measure_some of 'a exp
-and 'a internal_loop_measure =
-| Measure_aux of 'a internal_loop_measure_aux * Parse_ast.l
+and 'a in_place_loop_measure =
+| Measure_aux of 'a in_place_loop_measure_aux * Parse_ast.l
 and 'a exp_aux =
 | E_block of 'a exp list
 | E_id of id
@@ -231,7 +231,7 @@ and 'a exp_aux =
 | E_app of id * 'a exp list
 | E_tuple of 'a exp list
 | E_if of 'a exp * 'a exp * 'a exp
-| E_loop of loop * 'a internal_loop_measure * 'a exp * 'a exp
+| E_loop of loop * 'a in_place_loop_measure * 'a exp * 'a exp
 | E_for of id * 'a exp * 'a exp * 'a exp * order * 'a exp
 | E_vector of 'a exp list
 | E_vector_append of 'a exp * 'a exp

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -218,11 +218,11 @@ type 'a mpat_aux =
 and 'a mpat =
 | MP_aux of 'a mpat_aux * 'a annot
 
-type 'a internal_loop_measure_aux =
+type 'a in_place_loop_measure_aux =
 | Measure_none
 | Measure_some of 'a exp
-and 'a internal_loop_measure =
-| Measure_aux of 'a internal_loop_measure_aux * Parse_ast.l
+and 'a in_place_loop_measure =
+| Measure_aux of 'a in_place_loop_measure_aux * Parse_ast.l
 and 'a exp_aux =
 | E_block of 'a exp list
 | E_id of id
@@ -231,7 +231,7 @@ and 'a exp_aux =
 | E_app of id * 'a exp list
 | E_tuple of 'a exp list
 | E_if of 'a exp * 'a exp * 'a exp
-| E_loop of loop * 'a internal_loop_measure * 'a exp * 'a exp
+| E_loop of loop * 'a in_place_loop_measure * 'a exp * 'a exp
 | E_for of id * 'a exp * 'a exp * 'a exp * order * 'a exp
 | E_vector of 'a exp list
 | E_vector_append of 'a exp * 'a exp

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -831,8 +831,8 @@ module Make (Config : CONFIG) = struct
         let measure =
           match loop.termination_measure with
           | Some chunks ->
-              string "termination_measure" ^^ space
-              ^^ group (surround indent 1 (char '{') (doc_chunks opts chunks) (char '}'))
+              string "termination_measure"
+              ^^ group (surround indent 0 (char '(') (doc_chunks opts chunks) (char ')'))
               ^^ space
           | None -> empty
         in
@@ -840,7 +840,7 @@ module Make (Config : CONFIG) = struct
         let body = doc_chunks (opts |> nonatomic |> statement_like) loop.body in
         if loop.repeat_until then
           string "repeat" ^^ space ^^ measure ^^ body ^^ space ^^ string "until" ^^ space ^^ cond
-        else string "while" ^^ space ^^ measure ^^ cond ^^ space ^^ string "do" ^^ space ^^ body
+        else string "while" ^^ space ^^ cond ^^ space ^^ measure ^^ string "do" ^^ space ^^ body
     | Field (exp, id) -> doc_chunks (subatomic opts) exp ^^ char '.' ^^ doc_id id
     | Raw str -> separate hardline (lines str)
 

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1516,14 +1516,8 @@ and to_ast_exp ctx exp =
       else raise (Reporting.err_general l "Internal assume construct found (internal only construct)")
   | P.E_deref exp -> wrap (E_app (Id_aux (Id "__deref", l), [to_ast_exp ctx exp]))
 
-and to_ast_measure ctx (P.Measure_aux (m, l)) : uannot internal_loop_measure =
-  let m =
-    match m with
-    | P.Measure_none -> Measure_none
-    | P.Measure_some exp ->
-        if !opt_allow_internal then Measure_some (to_ast_exp ctx exp)
-        else raise (Reporting.err_general l "Internal loop termination measure found (internal only construct)")
-  in
+and to_ast_measure ctx (P.Measure_aux (m, l)) : uannot in_place_loop_measure =
+  let m = match m with P.Measure_none -> Measure_none | P.Measure_some exp -> Measure_some (to_ast_exp ctx exp) in
   Measure_aux (m, l)
 
 and to_ast_lexp ctx exp =

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -608,11 +608,10 @@ exp_eof:
   | exp Eof
     { $1 }
 
-/* Internal syntax for loop measures, rejected in normal code by initial_check */
-internal_loop_measure:
+in_place_loop_measure:
   |
     { mk_measure Measure_none $startpos $endpos }
-  | TerminationMeasure Lcurly exp Rcurly
+  | TerminationMeasure Lparen exp Rparen
     { mk_measure (Measure_some $3) $startpos $endpos }
 
 %inline to_or_downto:
@@ -687,12 +686,12 @@ exp:
   | Foreach loop_exp Do exp
     { let (v, f, t, step, order) = $2 in
       mk_exp (E_for (v, f, t, step, order, $4)) $startpos $endpos }
-  | Repeat internal_loop_measure exp Until exp
+  | Repeat in_place_loop_measure exp Until exp
     { mk_exp (E_loop (Until, $2, $5, $3)) $startpos $endpos }
-  | While internal_loop_measure exp Do exp
-    { mk_exp (E_loop (While, $2, $3, $5)) $startpos $endpos }
-  | While internal_loop_measure exp Lcurly block Rcurly
-    { mk_exp (E_loop (While, $2, $3, mk_exp (E_block $5) $startpos($4) $endpos($6))) $startpos $endpos }
+  | While exp in_place_loop_measure Do exp
+    { mk_exp (E_loop (While, $3, $2, $5)) $startpos $endpos }
+  | While exp in_place_loop_measure Lcurly block Rcurly
+    { mk_exp (E_loop (While, $3, $2, mk_exp (E_block $5) $startpos($4) $endpos($6))) $startpos $endpos }
 
   /* Debugging only, will be rejected in initial_check if debugging isn't on */
   | InternalPLet pat Eq exp In exp

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -510,7 +510,7 @@ module Printer (Config : PRINT_CONFIG) = struct
     | E_struct (struct_name, fexps) ->
         separate space [doc_struct_name struct_name; string "{"; doc_fexps fexps; string "}"]
     | E_loop (While, measure, cond, exp) ->
-        separate space ([string "while"] @ doc_measure measure @ [doc_exp cond; string "do"; doc_exp exp])
+        separate space ([string "while"; doc_exp cond] @ doc_measure measure @ [string "do"; doc_exp exp])
     | E_loop (Until, measure, cond, exp) ->
         separate space ([string "repeat"] @ doc_measure measure @ [doc_exp exp; string "until"; doc_exp cond])
     | E_struct_update (exp, fexps) ->
@@ -586,7 +586,7 @@ module Printer (Config : PRINT_CONFIG) = struct
     | None -> group ((string keyword ^//^ lhs) ^/^ string "in") ^///^ doc_exp body
 
   and doc_measure (Measure_aux (m_aux, _)) =
-    match m_aux with Measure_none -> [] | Measure_some exp -> [string "termination_measure"; braces (doc_exp exp)]
+    match m_aux with Measure_none -> [] | Measure_some exp -> [string "termination_measure" ^^ parens (doc_exp exp)]
 
   and doc_infix n exp_orig =
     let (E_aux (e_aux, (l, _)) as exp), uannot_fmt = consume_exp_uannot ~atomic:false exp_orig in

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -287,12 +287,12 @@ Inductive mpat_aux (a : Set) : Set :=
 with mpat (a : Set) : Set :=
 | MP_aux : mpat_aux a -> annot a -> mpat a.
 
-Inductive internal_loop_measure_aux (a : Set) : Set :=
-| Measure_none : internal_loop_measure_aux a
-| Measure_some : exp a -> internal_loop_measure_aux a
+Inductive in_place_loop_measure_aux (a : Set) : Set :=
+| Measure_none : in_place_loop_measure_aux a
+| Measure_some : exp a -> in_place_loop_measure_aux a
 
-with internal_loop_measure (a : Set) : Set :=
-| Measure_aux : internal_loop_measure_aux a -> loc -> internal_loop_measure a
+with in_place_loop_measure (a : Set) : Set :=
+| Measure_aux : in_place_loop_measure_aux a -> loc -> in_place_loop_measure a
 
 with exp_aux (a : Set) : Set :=
 | E_block : list (exp a) -> exp_aux a
@@ -302,7 +302,7 @@ with exp_aux (a : Set) : Set :=
 | E_app : id -> list (exp a) -> exp_aux a
 | E_tuple : list (exp a) -> exp_aux a
 | E_if : exp a -> exp a -> exp a -> exp_aux a
-| E_loop : loop -> internal_loop_measure a -> exp a -> exp a -> exp_aux a
+| E_loop : loop -> in_place_loop_measure a -> exp a -> exp a -> exp_aux a
 | E_for : id -> exp a -> exp a -> exp a -> order -> exp a -> exp_aux a
 | E_vector : list (exp a) -> exp_aux a
 | E_vector_append : exp a -> exp a -> exp_aux a

--- a/test/c/loop_termination.expect
+++ b/test/c/loop_termination.expect
@@ -1,0 +1,22 @@
+i = 1
+i = 2
+i = 3
+i = 3
+i = 2
+i = 1
+j = 1
+j = 2
+j = 3
+k = 0x01
+k = 0x02
+k = 0x03
+Caught
+Looping
+Caught inner exception
+Caught outer exception
+Outer handler
+Outer handler
+Once
+Once
+ok
+ok

--- a/test/c/loop_termination.sail
+++ b/test/c/loop_termination.sail
@@ -1,0 +1,180 @@
+default Order dec
+
+// Essentially loop_exception.sail, but with termination measures and without
+// the case where the termination measure would depend on a register
+
+$include <flow.sail>
+$include <arith.sail>
+$include <vector_dec.sail>
+$include <string.sail>
+
+$include <exception_basic.sail>
+
+val highest_set_bit : forall ('n : Int), 'n >= 0. bits('n) -> int
+
+overload ~ = {not_bool}
+
+function highest_set_bit x = {
+  foreach (i from ('n - 1) to 0 by 1 in dec)
+    if x[i] == bitone then return(i) else ();
+  return -1
+}
+
+val throws : unit -> unit effect {escape}
+
+function throws() = throw Exception()
+
+val main : unit -> unit effect {escape, wreg, rreg}
+
+function main() =
+{
+  /*
+   * Expect: "i = 1", "i = 2" and "i = 3"
+   */
+  foreach (i from 1 to 3) {
+    print_int("i = ", i)
+  };
+
+  /*
+   * Expect: "i = 3", "i = 2" and "i = 1"
+   */
+  foreach (i from 3 to 1 by 1 in dec) {
+    print_int("i = ", i)
+  };
+
+  assert(highest_set_bit(0b1) == 0);
+  assert(highest_set_bit(0b0010) == 1);
+  assert(highest_set_bit(0b10000) == 4);
+  assert(highest_set_bit(0x8000_0000_0000_0000) == 63);
+  assert(highest_set_bit(0x1_0000_0000_0000_0000) == 64);
+
+  /*
+   * Expect: "j = 1", "j = 2" and "j = 3"
+   */
+  j : int = 0;
+
+  while j < 3 termination_measure(3 - j) do {
+    j = j + 1;
+    print_int("j = ", j);
+  };
+
+  /*
+   * Expect: "k = 0x01", "k = 0x02" and "k = 0x03"
+   */
+  k : bits(8) = 0x00;
+
+  while unsigned(k) < 3 termination_measure(3 - unsigned(k)) do {
+    k = k + 1;
+    print_bits("k = ", k);
+  };
+
+  /*
+   * Expect: "Caught"
+   */
+  try {
+    while true termination_measure(1) do {
+      throw Exception();
+      assert(false, "Unreachable")
+    }
+  } catch {
+    Exception() => print_endline("Caught")
+  };
+
+  /*
+   * Expect: "Looping"
+   */
+  caught : bool = false;
+
+  while ~(caught) termination_measure(1) do {
+    try {
+      print_endline("Looping");
+      throw Exception();
+      assert(false, "Unreachable")
+    } catch {
+      Exception() => caught = true
+    }
+  };
+
+  /*
+   * Expect "Caught inner exception", "Caught outer exception"
+   */
+  try {
+    try throw Exception()
+    catch {
+      Exception() => {
+        print_endline("Caught inner exception");
+	throw Exception()
+      }
+    }
+  } catch {
+    Exception() => print_endline("Caught outer exception")
+  };
+
+  /*
+   * Expect "Outer handler"
+   */
+  try {
+    try throw Exception()
+    catch {
+      /* Exception in catch guard will throw to outer handler */
+      Exception() if { throw Exception(); false } => {
+        assert(false, "Unreachable");
+	throw Exception()
+      },
+      _ => assert(false, "Unreachable")
+    }
+  } catch {
+    Exception() => print_endline("Outer handler")
+  };
+
+  /*
+   * Expect "Outer handler"
+   */
+  try {
+    try throws()
+    catch {
+      /* Exception in catch guard will throw to outer handler */
+      Exception() if { throws(); true } => {
+        assert(false, "Unreachable");
+	throws()
+      },
+      _ => assert(false, "Unreachable")
+    }
+  } catch {
+    Exception() => print_endline("Outer handler")
+  };
+
+  /*
+   * Expect "Once"
+   */
+  repeat termination_measure(1) {
+    print_endline("Once")
+  } until true;
+
+  /*
+   * Expect "Once"
+   */
+  once : bool = false;
+
+  repeat termination_measure(1) {
+    print_endline("Once");
+    try throw Exception() catch {
+      _ => once = true,
+      _ => once = false
+    }
+  } until once;
+
+  /*
+   * Expect "ok"
+   */
+  if try true catch { _ => false } then {
+    print_endline("ok")
+  };
+
+  /*
+   * Expect "ok"
+   */
+  if try throw Exception() catch { _ => true } then {
+    print_endline("ok")
+  };
+}

--- a/test/c/run_tests.py
+++ b/test/c/run_tests.py
@@ -164,7 +164,8 @@ def test_coq(name):
     results.expect_failure("inc_tests.sail", "missing built-in functions for increasing vectors in Coq library")
     results.expect_failure("read_write_ram.sail", "uses memory primitives not provided by default in Coq")
     results.expect_failure("fail_exception.sail", "test harness can't produce expected output for uncaught exception")
-    results.expect_failure("loop_exception.sail", "Loop without termination measure")
+    # Note that loop_termination.sail is essentially loop_exception.sail without the unsupported bit
+    results.expect_failure("loop_exception.sail", "Loop requiring termination measure with a register read")
     results.expect_failure("outcome_impl.sail", "test doesn't meet Coq backend's expectations for the concurrency interface")
     results.expect_failure("outcome_impl_int.sail", "test doesn't meet Coq backend's expectations for the concurrency interface")
     results.expect_failure("outcome_impl_bool.sail", "test doesn't meet Coq backend's expectations for the concurrency interface")

--- a/test/format/default/struct_update.expect
+++ b/test/format/default/struct_update.expect
@@ -52,7 +52,7 @@ function has_loops() = {
     };
     while true do ();
     while true do { () };
-    repeat termination_measure { foo } () until true
+    repeat termination_measure(foo) () until true
 }
 
 type foo = bar

--- a/test/format/lw80_preserve/struct_update.expect
+++ b/test/format/lw80_preserve/struct_update.expect
@@ -54,7 +54,7 @@ function has_loops() = {
   ) { () };
   while true do ();
   while true do { () };
-  repeat termination_measure { foo } () until true
+  repeat termination_measure(foo) () until true
 }
 
 type foo = bar

--- a/test/format/struct_update.sail
+++ b/test/format/struct_update.sail
@@ -58,7 +58,7 @@ function has_loops() = {
     while true do {
         ()
     };
-    repeat termination_measure { foo } () until true
+    repeat termination_measure(foo) () until true
 }
 
 type foo = bar

--- a/test/sv/run_tests.py
+++ b/test/sv/run_tests.py
@@ -18,6 +18,7 @@ skip_tests = {
     'all_even_vector_length', # loops
     'for_shadow', # loops
     'loop_exception', # loops
+    'loop_termination', # loops
     'read_write_ram', # memory
     'real', # reals
     'real_prop', # reals


### PR DESCRIPTION
This tweaks the syntax for termination measures given directly in repeat and while loops, and makes it available without --dallow-internal.