### PR TITLE
Move undefined from literal to expression

### DIFF
--- a/src/lib/anf.ml
+++ b/src/lib/anf.ml
@@ -115,6 +115,7 @@ and 'a aval =
   | AV_vector of 'a aval list * 'a
   | AV_record of 'a aval Bindings.t * 'a
   | AV_cval of cval * 'a
+  | AV_undef of 'a
 
 and 'a alexp = AL_id of name * 'a | AL_addr of name * 'a | AL_field of 'a alexp * id
 
@@ -193,6 +194,7 @@ let rec aval_typ = function
   | AV_vector (_, typ) -> typ
   | AV_record (_, typ) -> typ
   | AV_cval (_, typ) -> typ
+  | AV_undef typ -> typ
 
 let aexp_typ (AE_aux (aux, _)) =
   match aux with
@@ -226,6 +228,7 @@ let rec aval_rename from_id to_id = function
   | AV_vector (avals, typ) -> AV_vector (List.map (aval_rename from_id to_id) avals, typ)
   | AV_record (avals, typ) -> AV_record (Bindings.map (aval_rename from_id to_id) avals, typ)
   | AV_cval (cval, typ) -> AV_cval (cval_rename from_id to_id cval, typ)
+  | AV_undef typ -> AV_undef typ
 
 let rec alexp_rename from_id to_id = function
   | AL_id (id, typ) when Name.compare from_id id = 0 -> AL_id (to_id, typ)
@@ -591,6 +594,7 @@ and pp_block = function
   | aexp :: aexps -> pp_aexp aexp ^^ semi ^^ hardline ^^ pp_block aexps
 
 and pp_aval = function
+  | AV_undef typ -> pp_annot typ (string "undefined")
   | AV_lit (lit, typ) -> pp_annot typ (string (string_of_lit lit))
   | AV_id (id, lvar) -> pp_lvar lvar (pp_name id)
   | AV_abstract (id, typ) -> string "sizeof" ^^ parens (pp_annot typ (pp_id id))
@@ -735,6 +739,7 @@ let rec anf (E_aux (e_aux, (l, tannot)) as exp) =
   in
 
   match e_aux with
+  | E_undef -> mk_aexp (AE_val (AV_undef (typ_of exp)))
   | E_lit lit -> mk_aexp (ae_lit lit (typ_of exp))
   | E_block [] ->
       Reporting.warn "" l

--- a/src/lib/anf.mli
+++ b/src/lib/anf.mli
@@ -137,6 +137,7 @@ and 'a aval =
   | AV_vector of 'a aval list * 'a
   | AV_record of 'a aval Bindings.t * 'a
   | AV_cval of cval * 'a
+  | AV_undef of 'a
 
 and 'a alexp = AL_id of name * 'a | AL_addr of name * 'a | AL_field of 'a alexp * id
 

--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -756,6 +756,7 @@ and map_exp_annot_aux f = function
   | E_assert (test, msg) -> E_assert (map_exp_annot f test, map_exp_annot f msg)
   | E_internal_value v -> E_internal_value v
   | E_var (lexp, exp1, exp2) -> E_var (map_lexp_annot f lexp, map_exp_annot f exp1, map_exp_annot f exp2)
+  | E_undef -> E_undef
   | E_internal_plet (pat, exp1, exp2) ->
       E_internal_plet (map_pat_annot f pat, map_exp_annot f exp1, map_exp_annot f exp2)
   | E_internal_return exp -> E_internal_return (map_exp_annot f exp)
@@ -1158,7 +1159,6 @@ let string_of_lit (L_aux (lit, _)) =
   | L_num n -> Big_int.to_string n
   | L_hex hex -> "0x" ^ string_of_hex_lit ~case:Uppercase hex
   | L_bin bin -> "0b" ^ string_of_bin_lit bin
-  | L_undef -> "undefined"
   | L_real r -> Q.to_string (Util.Rational.from_rocq r)
   | L_string str -> "\"" ^ str ^ "\""
 
@@ -1207,6 +1207,7 @@ let rec string_of_exp (E_aux (exp, _)) =
       "struct" ^ name_string ^ " { " ^ string_of_list "; " string_of_fexp fexps ^ " }"
   | E_var (lexp, binding, exp) ->
       "var " ^ string_of_lexp lexp ^ " = " ^ string_of_exp binding ^ " in " ^ string_of_exp exp
+  | E_undef -> "undefined"
   | E_internal_return exp -> "internal_return (" ^ string_of_exp exp ^ ")"
   | E_internal_plet (pat, exp, body) ->
       "internal_plet " ^ string_of_pat pat ^ " = " ^ string_of_exp exp ^ " in " ^ string_of_exp body
@@ -1729,6 +1730,7 @@ let rec subst id value (E_aux (e_aux, annot) as exp) =
     | E_assert (exp1, exp2) -> E_assert (subst id value exp1, subst id value exp2)
     | E_internal_value v -> E_internal_value v
     | E_var (lexp, exp1, exp2) -> E_var (subst_lexp id value lexp, subst id value exp1, subst id value exp2)
+    | E_undef -> E_undef
     | E_internal_assume (nc, exp) -> E_internal_assume (nc, subst id value exp)
     | E_internal_plet _ | E_internal_return _ -> failwith ("subst " ^ string_of_exp exp)
   in
@@ -1929,6 +1931,7 @@ let rec locate : 'a. (l -> l) -> 'a exp -> 'a exp =
     | E_assert (exp, message) -> E_assert (locate f exp, locate f message)
     | E_constraint constr -> E_constraint (locate_nc f constr)
     | E_var (lexp, exp1, exp2) -> E_var (locate_lexp f lexp, locate f exp1, locate f exp2)
+    | E_undef -> E_undef
     | E_internal_plet (pat, exp1, exp2) -> E_internal_plet (locate_pat f pat, locate f exp1, locate f exp2)
     | E_internal_return exp -> E_internal_return (locate f exp)
     | E_internal_value value -> E_internal_value value

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -228,7 +228,7 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
           | Typ_aux ((Typ_id id | Typ_app (id, _)), _) -> graph := G.add_edge self (Type id) !graph
           | _ -> Reporting.unreachable (fst annot) __POS__ "Struct without struct type"
         end
-      | E_lit (L_aux (L_undef, l)) -> begin
+      | E_undef -> begin
           (* Make undefined literals depend on the undefined functions generated for the type (if any)
              to ensure that `rewrite_undefined` works *)
           try
@@ -242,7 +242,7 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
             in
             (* The `mwords` parameter of `undefined_of_type` shouldn't change the set of functions called,
                so just pass `true`. *)
-            funcalls_of_exp (undefined_of_typ true l (fun _ -> empty_uannot) typ)
+            funcalls_of_exp (undefined_of_typ true (fst annot) (fun _ -> empty_uannot) typ)
             |> IdSet.iter (fun f -> graph := G.add_edge self (Function f) !graph)
           with _ -> ()
         end
@@ -378,7 +378,7 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
     | DEF_register (DEC_aux (DEC_reg (typ, id, opt_exp), annot)) ->
         (* Determine dependencies of initial expressions (or `undefined` if missing, which will add
            dependencies to `undefined_*` functions) *)
-        let exp = match opt_exp with Some exp -> exp | None -> E_aux (E_lit (mk_lit L_undef), annot) in
+        let exp = match opt_exp with Some exp -> exp | None -> E_aux (E_undef, annot) in
         ignore (fold_exp (rw_exp (Register id)) exp);
         IdSet.iter (fun typ_id -> graph := G.add_edge (Register id) (Type typ_id) !graph) (typ_ids typ)
     | DEF_measure (id, pat, exp) ->

--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -528,7 +528,6 @@ let chunk_of_lit (L_aux (aux, _)) =
   | L_num n -> Atom (Big_int.to_string n)
   | L_hex b -> Atom ("0x" ^ b)
   | L_bin b -> Atom ("0b" ^ b)
-  | L_undef -> Atom "undefined"
   | L_string s -> String_literal s
   | L_multiline_string lines -> Multiline_string_literal lines
   | L_real r -> Atom r
@@ -908,6 +907,7 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
   | E_id id -> Queue.add (Atom (string_of_id id)) chunks
   | E_ref id -> Queue.add (Atom ("ref " ^ string_of_id id)) chunks
   | E_config s -> Queue.add (Atom ("config " ^ s)) chunks
+  | E_undef -> Queue.add (Atom "undefined") chunks
   | E_lit lit -> Queue.add (chunk_of_lit lit) chunks
   | E_attribute (attr, arg, exp) ->
       chunk_attribute comments chunks attr arg;

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -92,7 +92,7 @@ let rec is_value (E_aux (e, (l, annot))) =
   | E_struct (_, fes) -> List.for_all (fun (FE_aux (FE_fexp (_, e), _)) -> is_value e) fes
   | E_app (id, es) -> is_constructor id && List.for_all is_value es
   (* We add casts to undefined to keep the type information in the AST *)
-  | E_typ (typ, E_aux (E_lit (L_aux (L_undef, _)), _)) -> true
+  | E_typ (typ, E_aux (E_undef, _)) -> true
   (* Also keep casts around, as type inference fails without (e.g., for records for vectors) *)
   | E_typ (_, e') -> is_value e'
   (* TODO: more? *)
@@ -198,12 +198,12 @@ let reduce_cast typ exp l annot =
             ^ string_of_n_constraint nc
              )
           )
-  | E_aux (E_lit (L_aux (L_undef, _)), _), Some ([kopt], nc, typ'') when atom_typ_kid (kopt_kid kopt) typ'' ->
+  | E_aux (E_undef, _), Some ([kopt], nc, typ'') when atom_typ_kid (kopt_kid kopt) typ'' ->
       let nexp = fabricate_nexp_exist env Unknown typ [kopt_kid kopt] nc typ'' in
       let newtyp = subst_kids_typ (KBindings.singleton (kopt_kid kopt) nexp) typ'' in
       E_aux (E_typ (newtyp, exp), (Generated l, replace_typ newtyp annot))
-  | E_aux (E_typ (_, (E_aux (E_lit (L_aux (L_undef, _)), _) as exp)), _), Some ([kopt], nc, typ'')
-    when atom_typ_kid (kopt_kid kopt) typ'' ->
+  | E_aux (E_typ (_, (E_aux (E_undef, _) as exp)), _), Some ([kopt], nc, typ'') when atom_typ_kid (kopt_kid kopt) typ''
+    ->
       let nexp = fabricate_nexp_exist env Unknown typ [kopt_kid kopt] nc typ'' in
       let newtyp = subst_kids_typ (KBindings.singleton (kopt_kid kopt) nexp) typ'' in
       E_aux (E_typ (newtyp, exp), (Generated l, replace_typ newtyp annot))
@@ -230,7 +230,7 @@ let construct_lit_vector args =
 let keep_undef_typ value =
   let e_aux (e, ann) =
     match e with
-    | E_lit (L_aux (L_undef, _)) ->
+    | E_undef ->
         (* Add cast to undefined... *)
         E_aux (E_typ (typ_of_annot ann, E_aux (e, ann)), ann)
     | E_typ (typ, E_aux (E_typ (_, e), _)) ->
@@ -346,7 +346,7 @@ let const_props target env ast =
             ),
             assigns
           )
-      | E_lit _ | E_sizeof _ | E_constraint _ | E_config _ -> (exp, assigns)
+      | E_undef | E_lit _ | E_sizeof _ | E_constraint _ | E_config _ -> (exp, assigns)
       | E_typ (t, e') ->
           let e'', assigns = const_prop_exp substs assigns e' in
           if is_value e'' then (reduce_cast t e'' l annot, assigns) else re (E_typ (t, e'')) assigns
@@ -683,6 +683,13 @@ let const_props target env ast =
               end
             | _ -> GiveUp
           )
+        | E_undef, P_var (P_aux (P_id id, p_id_annot), TP_aux (TP_var kid, _)) ->
+            (* For undefined we fix the type-level size (because there's no good
+               way to construct an undefined size), but leave the term as undefined
+               to make the meaning clear. *)
+            let nexp = fabricate_nexp l annot in
+            let typ = subst_kids_typ (KBindings.singleton kid nexp) (typ_of_annot p_id_annot) in
+            DoesMatch ([(id, E_aux (E_typ (typ, E_aux (e, (l, empty_tannot))), (l, empty_tannot)))], [(kid, nexp)])
         | E_lit (L_aux (lit_e, lit_l)), P_lit (L_aux (lit_p, _)) ->
             if lit_match (lit_e, lit_p) then DoesMatch ([], []) else DoesNotMatch
         | E_lit (L_aux (lit_e, lit_l)), P_var (P_aux (P_id id, p_id_annot), TP_aux (TP_var kid, _)) -> begin
@@ -691,10 +698,6 @@ let const_props target env ast =
             (* For undefined we fix the type-level size (because there's no good
                way to construct an undefined size), but leave the term as undefined
                to make the meaning clear. *)
-            | L_undef ->
-                let nexp = fabricate_nexp l annot in
-                let typ = subst_kids_typ (KBindings.singleton kid nexp) (typ_of_annot p_id_annot) in
-                DoesMatch ([(id, E_aux (E_typ (typ, E_aux (e, (l, empty_tannot))), (l, empty_tannot)))], [(kid, nexp)])
             | _ ->
                 Reporting.print_err lit_l "Monomorphisation"
                   ("Unexpected kind of literal for var match: " ^ string_of_lit (L_aux (lit_e, lit_l)));
@@ -748,9 +751,9 @@ let const_props target env ast =
             Reporting.print_err l "Monomorphisation"
               ("Unexpected kind of pattern for vector literal: " ^ string_of_pat pat);
             GiveUp
-        | E_typ (undef_typ, E_aux (E_lit (L_aux (L_undef, lit_l)), _)), P_lit (L_aux (lit_p, _)) -> DoesNotMatch
-        | ( E_typ (undef_typ, (E_aux (E_lit (L_aux (L_undef, lit_l)), _) as e_undef)),
-            P_var (P_aux (P_id id, p_id_annot), TP_aux (TP_var kid, _)) ) ->
+        | E_typ (undef_typ, E_aux (E_undef, _)), P_lit (L_aux (lit_p, _)) -> DoesNotMatch
+        | E_typ (undef_typ, (E_aux (E_undef, _) as e_undef)), P_var (P_aux (P_id id, p_id_annot), TP_aux (TP_var kid, _))
+          ->
             (* For undefined we fix the type-level size (because there's no good
                way to construct an undefined size), but leave the term as undefined
                to make the meaning clear. *)
@@ -759,7 +762,7 @@ let const_props target env ast =
             let ksubst = KidSet.fold (fun k b -> KBindings.add k nexp b) kids KBindings.empty in
             let typ = subst_kids_typ ksubst (typ_of_annot p_id_annot) in
             DoesMatch ([(id, E_aux (E_typ (typ, e_undef), (l, empty_tannot)))], KBindings.bindings ksubst)
-        | E_typ (undef_typ, E_aux (E_lit (L_aux (L_undef, lit_l)), _)), _ ->
+        | E_typ (undef_typ, E_aux (E_undef, _)), _ ->
             Reporting.print_err l' "Monomorphisation" ("Unexpected kind of pattern for literal: " ^ string_of_pat pat);
             GiveUp
         | E_typ (_, exp'), _ -> check_exp_pat exp' pat

--- a/src/lib/effects.ml
+++ b/src/lib/effects.ml
@@ -158,7 +158,7 @@ let infer_def_direct_effects asserts_termination def =
       | E_id id -> begin
           match Env.lookup_id id env with Register _ -> effects := EffectSet.add Register !effects | _ -> ()
         end
-      | E_lit (L_aux (L_undef, _)) -> effects := EffectSet.add Undefined !effects
+      | E_undef -> effects := EffectSet.add Undefined !effects
       | E_throw _ -> effects := EffectSet.add Throw !effects
       | E_exit _ | E_assert _ -> effects := EffectSet.add Exit !effects
       | E_app (f, _) when Id.compare f (mk_id "__deref") = 0 -> effects := EffectSet.add Register !effects
@@ -479,7 +479,7 @@ let rewrite_attach_effects effect_info =
           | Some side_effects -> if pure side_effects then no_effect else monadic_effect
           | None -> no_effect
         end
-      | E_lit (L_aux (L_undef, _)) -> monadic_effect
+      | E_undef -> monadic_effect
       | E_id id -> begin match Env.lookup_id id env with Register _ -> monadic_effect | _ -> no_effect end
       | E_throw _ -> monadic_effect
       | E_exit _ | E_assert _ -> monadic_effect

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -112,7 +112,6 @@ type lit_aux =
 | L_hex of hex_digit non_empty list
 | L_bin of bin_digit non_empty list
 | L_string of string
-| L_undef
 | L_real of coq_Q
 
 type nexp_aux =
@@ -267,6 +266,7 @@ and 'a exp_aux =
 | E_try of 'a exp * 'a pexp list
 | E_assert of 'a exp * 'a exp
 | E_var of 'a lexp * 'a exp * 'a exp
+| E_undef
 | E_internal_plet of 'a pat * 'a exp * 'a exp
 | E_internal_return of 'a exp
 | E_internal_value of value

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -112,7 +112,6 @@ type lit_aux =
 | L_hex of hex_digit non_empty list
 | L_bin of bin_digit non_empty list
 | L_string of string
-| L_undef
 | L_real of coq_Q
 
 type nexp_aux =
@@ -267,6 +266,7 @@ and 'a exp_aux =
 | E_try of 'a exp * 'a pexp list
 | E_assert of 'a exp * 'a exp
 | E_var of 'a lexp * 'a exp * 'a exp
+| E_undef
 | E_internal_plet of 'a pat * 'a exp * 'a exp
 | E_internal_return of 'a exp
 | E_internal_value of value

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -619,20 +619,19 @@ module Make =
        Monad.bind (bv_concat l rest) (fun rest' -> Monad.pure (app bs rest'))
      | _ -> Monad.Runtime_type_error l)
 
-  (** val value_of_lit : lit -> typ -> value Monad.t **)
+  (** val value_of_lit : lit -> value **)
 
-  let value_of_lit lit0 typ0 =
-    let L_aux (aux, _) = lit0 in
+  let value_of_lit = function
+  | L_aux (aux, _) ->
     (match aux with
-     | L_unit -> Monad.pure V_unit
-     | L_true -> Monad.pure (V_bool true)
-     | L_false -> Monad.pure (V_bool false)
-     | L_num n -> Monad.pure (V_int n)
-     | L_hex h -> Monad.pure (V_bitvector (bitlist_of_hex_lit h))
-     | L_bin b -> Monad.pure (V_bitvector (bitlist_of_bin_lit b))
-     | L_string s -> Monad.pure (V_string s)
-     | L_undef -> Monad.get_undefined typ0
-     | L_real r -> Monad.pure (V_real r))
+     | L_unit -> V_unit
+     | L_true -> V_bool true
+     | L_false -> V_bool false
+     | L_num n -> V_int n
+     | L_hex h -> V_bitvector (bitlist_of_hex_lit h)
+     | L_bin b -> V_bitvector (bitlist_of_bin_lit b)
+     | L_string s -> V_string s
+     | L_real r -> V_real r)
 
   (** val same_bits : bit list -> bit list -> bool **)
 
@@ -682,7 +681,6 @@ module Make =
      | L_string s1 -> (match v with
                        | V_string s2 -> (=) s1 s2
                        | _ -> false)
-     | L_undef -> false
      | L_real r1 ->
        (match v with
         | V_real r2 -> coq_Qeq_bool r1 r2
@@ -1243,6 +1241,12 @@ module Make =
                then wrap (E_block xs0)
                else Monad.bind (step0 x0) (fun x' ->
                       wrap (E_block (x' :: xs0)))
+             | E_undef ->
+               let x0 = E_aux (E_undef, annot1) in
+               if is_value x0
+               then wrap (E_block xs0)
+               else Monad.bind (step0 x0) (fun x' ->
+                      wrap (E_block (x' :: xs0)))
              | E_internal_plet (p, e0, e1) ->
                let x0 = E_aux ((E_internal_plet (p, e0, e1)), annot1) in
                if is_value x0
@@ -1287,9 +1291,7 @@ module Make =
             Monad.Read_var ((PL_id (id0, Var_register)), (fun v ->
               wrap (E_internal_value v)))
           | Enum_member -> wrap (E_internal_value (V_member id0)))
-       | E_lit lit0 ->
-         Monad.bind (value_of_lit lit0 (T.get_type (snd annot0))) (fun v ->
-           wrap (E_internal_value v))
+       | E_lit lit0 -> wrap (E_internal_value (value_of_lit lit0))
        | E_typ (_, x) -> step0 x
        | E_app (id0, args) ->
          let Id_aux (i, _) = id0 in
@@ -1637,6 +1639,9 @@ module Make =
              Monad.bind (step0 x) (fun x' -> wrap (E_assert (x', msg))))
        | E_var (l, x, body) ->
          wrap (E_block ((E_aux ((E_assign (l, x)), annot0)) :: (body :: [])))
+       | E_undef ->
+         Monad.bind (Monad.get_undefined (T.get_type (snd annot0))) (fun u ->
+           wrap (E_internal_value u))
        | E_internal_plet (_, _, _) -> Monad.Runtime_type_error (fst annot0)
        | E_internal_return _ -> Monad.Runtime_type_error (fst annot0)
        | E_internal_value v -> wrap (E_internal_value v)

--- a/src/lib/extraction/Semantics.mli
+++ b/src/lib/extraction/Semantics.mli
@@ -172,7 +172,7 @@ module Make :
 
   val bv_concat : Parse_ast.l -> value list -> bit list Monad.t
 
-  val value_of_lit : lit -> typ -> value Monad.t
+  val value_of_lit : lit -> value
 
   val same_bits : bit list -> bit list -> bool
 

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1267,7 +1267,6 @@ let to_ast_lit (P.L_aux (lit, l)) =
       | P.L_one -> L_bin [Non_empty (Bin_1, [])]
       | P.L_true -> L_true
       | P.L_false -> L_false
-      | P.L_undef -> L_undef
       | P.L_num i -> L_num i
       | P.L_hex h -> (
           match parse_hex_lit ~warn_inconsistent_case:l h with
@@ -1431,6 +1430,7 @@ and to_ast_exp ctx exp =
       )
       else wrap (E_id (to_ast_id ctx id))
   | P.E_ref id -> wrap (E_ref (to_ast_id ctx id))
+  | P.E_undef -> wrap E_undef
   | P.E_lit lit -> wrap (E_lit (to_ast_lit lit))
   | P.E_typ (typ, exp) -> wrap (E_typ (to_ast_typ ctx typ, to_ast_exp ctx exp))
   | P.E_app (f, args) -> (
@@ -2513,7 +2513,7 @@ let generate_undefined_record id typq fields =
     mk_fundef
       [
         mk_funcl (prepend_id "undefined_" id) pat
-          (mk_exp (E_struct (SN_anon, List.map (fun ((id, _), _) -> mk_fexp id (mk_lit_exp L_undef)) fields)));
+          (mk_exp (E_struct (SN_anon, List.map (fun ((id, _), _) -> mk_fexp id (mk_exp E_undef)) fields)));
       ];
   ]
 
@@ -2580,7 +2580,7 @@ let generate_initialize_registers vs_ids regs =
             mk_funcl (mk_id "initialize_registers")
               (mk_pat (P_lit (mk_lit L_unit)))
               (mk_exp
-                 (E_block (List.map (fun (id, typ) -> mk_exp (E_assign (mk_lexp (LE_id id), mk_lit_exp L_undef))) regs))
+                 (E_block (List.map (fun (id, typ) -> mk_exp (E_assign (mk_lexp (LE_id id), mk_exp E_undef))) regs))
               );
           ];
       ]

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -515,7 +515,7 @@ let rec initialize_registers allow_registers undef_registers gstate =
         | None when undef_registers ->
             let env = Type_check.env_of_annot annot in
             let typ = Type_check.Env.expand_synonyms env typ in
-            let exp = mk_exp (E_typ (typ, mk_exp (E_lit (mk_lit L_undef)))) in
+            let exp = mk_exp (E_typ (typ, mk_exp E_undef)) in
             let exp = Type_check.check_exp env exp typ in
             { gstate with registers = Bindings.add id (eval_exp (initial_lstate, gstate) exp) gstate.registers }
         | None -> gstate

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -477,7 +477,7 @@ module Make (C : CONFIG) = struct
           ([iinit l CT_real gs (V_lit (VL_string str, CT_string))], V_id (gs, CT_real), [iclear CT_real gs])
         )
     | AV_lit (L_aux (L_unit, _), _) -> ([], V_lit (VL_unit, CT_unit), [])
-    | AV_lit (L_aux (L_undef, _), typ) ->
+    | AV_undef typ ->
         let ctyp = ctyp_of_typ ctx typ in
         ([], V_lit (VL_undefined, ctyp), [])
     | AV_tuple avals ->

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -1053,7 +1053,7 @@ let split_defs target all_errors (splits : split_req list) env ast =
         let re e = E_aux (e, annot) in
         match e with
         | E_block es -> re (E_block (List.map map_exp es))
-        | E_id _ | E_lit _ | E_sizeof _ | E_constraint _ | E_ref _ | E_internal_value _ | E_config _ -> ea
+        | E_id _ | E_undef | E_lit _ | E_sizeof _ | E_constraint _ | E_ref _ | E_internal_value _ | E_config _ -> ea
         | E_typ (t, e') -> re (E_typ (t, map_exp e'))
         | E_app (id, es) ->
             let es' = List.map map_exp es in
@@ -2257,6 +2257,7 @@ module Analysis = struct
                 )
             )
         end
+      | E_undef -> (dempty, assigns, empty)
       | E_lit _ -> (dempty, assigns, empty)
       | E_config _ -> (dempty, assigns, empty)
       | E_typ (_, e) -> analyse_sub env assigns e

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -122,7 +122,6 @@ type lit_aux =
   | L_num of Big_int.num (* natural number constant *)
   | L_hex of string (* bit vector constant, C-style *)
   | L_bin of string (* bit vector constant, C-style *)
-  | L_undef (* undefined value *)
   | L_string of string (* string constant *)
   | L_multiline_string of string list (* multi-line string constant *)
   | L_real of string
@@ -258,6 +257,7 @@ and exp_aux =
   | E_return of exp
   | E_assert of exp * exp
   | E_var of exp * exp * exp
+  | E_undef
   | E_attribute of string * attribute_data option * exp
   | E_internal_plet of pat * exp * exp
   | E_internal_return of exp

--- a/src/lib/parse_ast_diff.ml
+++ b/src/lib/parse_ast_diff.ml
@@ -301,6 +301,9 @@ let rec diff_exp lhs rhs =
   | E_deref exp1 -> (
       match rhs with E_deref exp2 -> diff_exp exp1 exp2 | _ -> Some l
     )
+  | E_undef -> (
+      match rhs with E_undef -> None | _ -> Some l
+    )
   | E_lit lit1 -> (
       match rhs with E_lit lit2 -> diff_lit lit1 lit2 | _ -> Some l
     )

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -581,8 +581,6 @@ lit:
     { mk_lit L_unit $startpos $endpos }
   | Num
     { mk_lit (L_num $1) $startpos $endpos }
-  | Undefined
-    { mk_lit L_undef $startpos $endpos }
   | Bitzero
     { mk_lit L_zero $startpos $endpos }
   | Bitone
@@ -767,6 +765,8 @@ atomic_exp:
     { mk_exp (E_typ ($3, $1)) $startpos $endpos }
   | Config Id
     { mk_exp (E_config $2) $startpos $endpos }
+  | Undefined
+    { mk_exp E_undef $startpos $endpos }
   | lit
     { mk_exp (E_lit $1) $startpos $endpos }
   | id MinusGt id Unit

--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -636,11 +636,11 @@ module Make (C : Config) = struct
             in
             match Constraint.call_smt_solve_bitvector Parse_ast.Unknown smtlib just_vars with
             | Some lits ->
-                if !opt_debug_no_literals then Incomplete (List.init (List.length vars) (fun _ -> mk_lit_exp L_undef))
+                if !opt_debug_no_literals then Incomplete (List.init (List.length vars) (fun _ -> mk_exp E_undef))
                 else
                   Incomplete
                     (List.init (List.length vars) (fun i ->
-                         match List.assoc_opt i lits with Some lit -> mk_exp (E_lit lit) | None -> mk_lit_exp L_undef
+                         match List.assoc_opt i lits with Some lit -> mk_exp (E_lit lit) | None -> mk_exp E_undef
                      )
                     )
             | None ->
@@ -849,7 +849,7 @@ module Make (C : Config) = struct
   let rec undefs_except n c v len =
     if n = len then []
     else if n = c then v :: undefs_except (n + 1) c v len
-    else mk_lit_exp L_undef :: undefs_except (n + 1) c v len
+    else mk_exp E_undef :: undefs_except (n + 1) c v len
 
   let rec matrix_is_complete l ctx matrix =
     match find_complex_column matrix with
@@ -891,7 +891,7 @@ module Make (C : Config) = struct
             let width = row_matrix_width l matrix in
             if row_matrix_empty empty_list_matrix then Incomplete (undefs_except 0 i (mk_exp (E_list [])) width)
             else if row_matrix_empty cons_matrix then
-              Incomplete (undefs_except 0 i (mk_exp (E_cons (mk_lit_exp L_undef, mk_lit_exp L_undef))) width)
+              Incomplete (undefs_except 0 i (mk_exp (E_cons (mk_exp E_undef, mk_exp E_undef))) width)
             else begin
               match matrix_is_complete l ctx cons_matrix with
               | Incomplete unmatcheds -> Incomplete (recons l i unmatcheds)
@@ -919,7 +919,7 @@ module Make (C : Config) = struct
                     let ctor_matrix = split_matrix_ctor ctx i ctor_rows matrix in
                     if row_matrix_empty ctor_matrix then (
                       let width = row_matrix_width l matrix in
-                      Incomplete (undefs_except 0 i (mk_exp (E_app (ctor, [mk_lit_exp L_undef]))) width)
+                      Incomplete (undefs_except 0 i (mk_exp (E_app (ctor, [mk_exp E_undef]))) width)
                     )
                     else matrix_is_complete l ctx ctor_matrix |> completeness_map (rector ctor i) (union_complete cinfo)
               )

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -290,7 +290,6 @@ module Printer (Config : PRINT_CONFIG) = struct
       | L_real r ->
           let r = Util.Rational.from_rocq r in
           Printf.sprintf "div_real(to_real(%s), to_real(%s))" (Big_int.to_string (Q.num r)) (Big_int.to_string (Q.den r))
-      | L_undef -> "undefined"
       | L_string s -> "\"" ^ String.escaped s ^ "\""
       )
 
@@ -651,6 +650,7 @@ module Printer (Config : PRINT_CONFIG) = struct
       | E_assert (exp1, exp2) -> string "assert" ^^ parens (doc_exp exp1 ^^ comma ^^ space ^^ doc_exp exp2)
       | E_exit exp -> string "exit" ^^ parens (doc_exp exp)
       | E_vector exps -> brackets (separate_map (comma ^^ space) doc_exp exps)
+      | E_undef -> string "undefined"
       | E_internal_value v ->
           if !Interactive.opt_interactive then string (Value.string_of_value v |> Util.green |> Util.clear)
           else string (Value.string_of_value v)

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -246,6 +246,7 @@ let rewrite_exp rewriters (E_aux (exp, (l, annot))) =
              rewriters.rewrite_exp rewriters e2
            )
         )
+  | E_undef -> rewrap E_undef
   | E_internal_assume (nc, e) -> rewrap (E_internal_assume (nc, rewrite e))
   | E_internal_return e -> rewrap (E_internal_return (rewrite e))
   | E_internal_plet (pat, e1, e2) ->
@@ -538,6 +539,7 @@ type ( 'a,
   e_return : 'exp -> 'exp_aux;
   e_assert : 'exp * 'exp -> 'exp_aux;
   e_var : 'lexp * 'exp * 'exp -> 'exp_aux;
+  e_undef : 'exp_aux;
   e_internal_plet : 'pat * 'exp * 'exp -> 'exp_aux;
   e_internal_return : 'exp -> 'exp_aux;
   e_internal_value : value -> 'exp_aux;
@@ -604,6 +606,7 @@ let rec fold_exp_aux alg = function
   | E_assert (e1, e2) -> alg.e_assert (fold_exp alg e1, fold_exp alg e2)
   | E_var (lexp, e1, e2) -> alg.e_var (fold_lexp alg lexp, fold_exp alg e1, fold_exp alg e2)
   | E_internal_plet (pat, e1, e2) -> alg.e_internal_plet (fold_pat alg.pat_alg pat, fold_exp alg e1, fold_exp alg e2)
+  | E_undef -> alg.e_undef
   | E_internal_return e -> alg.e_internal_return (fold_exp alg e)
   | E_internal_value v -> alg.e_internal_value v
   | E_internal_assume (nc, e) -> alg.e_internal_assume (nc, fold_exp alg e)
@@ -677,6 +680,7 @@ let id_exp_alg =
     e_return = (fun e1 -> E_return e1);
     e_assert = (fun (e1, e2) -> E_assert (e1, e2));
     e_var = (fun (lexp, e2, e3) -> E_var (lexp, e2, e3));
+    e_undef = E_undef;
     e_internal_plet = (fun (pat, e1, e2) -> E_internal_plet (pat, e1, e2));
     e_internal_return = (fun e -> E_internal_return e);
     e_internal_value = (fun v -> E_internal_value v);
@@ -801,6 +805,7 @@ let compute_exp_alg bot join =
     e_return = (fun (v1, e1) -> (v1, E_return e1));
     e_assert = (fun ((v1, e1), (v2, e2)) -> (join v1 v2, E_assert (e1, e2)));
     e_var = (fun ((vl, lexp), (v2, e2), (v3, e3)) -> (join_list [vl; v2; v3], E_var (lexp, e2, e3)));
+    e_undef = (bot, E_undef);
     e_internal_plet = (fun ((vp, pat), (v1, e1), (v2, e2)) -> (join_list [vp; v1; v2], E_internal_plet (pat, e1, e2)));
     e_internal_return = (fun (v, e) -> (v, E_internal_return e));
     e_internal_value = (fun v -> (bot, E_internal_value v));
@@ -896,6 +901,7 @@ let pure_exp_alg bot join =
     e_return = (fun v1 -> v1);
     e_assert = (fun (v1, v2) -> join v1 v2);
     e_var = (fun (vl, v2, v3) -> join_list [vl; v2; v3]);
+    e_undef = bot;
     e_internal_plet = (fun (vp, v1, v2) -> join_list [vp; v1; v2]);
     e_internal_return = (fun v -> v);
     e_internal_value = (fun v -> bot);
@@ -1008,7 +1014,7 @@ let default_fold_exp f x (E_aux (e, ann) as exp) =
           (x, []) es
       in
       (x, re (E_block (List.rev es)))
-  | E_id _ | E_ref _ | E_lit _ | E_config _ -> (x, exp)
+  | E_id _ | E_ref _ | E_undef | E_lit _ | E_config _ -> (x, exp)
   | E_typ (typ, e) ->
       let x, e = f x e in
       (x, re (E_typ (typ, e)))

--- a/src/lib/rewriter.mli
+++ b/src/lib/rewriter.mli
@@ -161,6 +161,7 @@ type ( 'a,
   e_return : 'exp -> 'exp_aux;
   e_assert : 'exp * 'exp -> 'exp_aux;
   e_var : 'lexp * 'exp * 'exp -> 'exp_aux;
+  e_undef : 'exp_aux;
   e_internal_plet : 'pat * 'exp * 'exp -> 'exp_aux;
   e_internal_return : 'exp -> 'exp_aux;
   e_internal_value : value -> 'exp_aux;

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -2126,9 +2126,9 @@ let rewrite_dec_spec_typs rw_typ (DEC_aux (ds, annot)) =
   match ds with DEC_reg (typ, id, opt_exp) -> DEC_aux (DEC_reg (rw_typ typ, id, opt_exp), annot)
 
 let rewrite_undefined mwords env =
-  let rewrite_e_aux (E_aux (e_aux, _) as exp) =
+  let rewrite_e_aux (E_aux (e_aux, (l, _)) as exp) =
     match e_aux with
-    | E_lit (L_aux (L_undef, l)) ->
+    | E_undef ->
         check_exp (env_of exp)
           (undefined_of_typ mwords l (fun _ -> empty_uannot) (Env.expand_synonyms (env_of exp) (typ_of exp)))
           (typ_of exp)
@@ -2449,6 +2449,7 @@ let rewrite_ast_letbind_effects effect_info env =
     | E_id _ -> k exp
     | E_ref _ -> k exp
     | E_lit _ -> k exp
+    | E_undef -> k exp
     | E_config _ -> k exp
     | E_typ (typ, exp') -> n_exp_name exp' (fun exp' -> k (pure_rewrap (E_typ (typ, exp'))))
     | E_app (op_bool, [l; r]) when is_and_bool op_bool || is_or_bool op_bool ->
@@ -3662,7 +3663,6 @@ module MakeExhaustive = struct
     | L_true -> RL_true
     | L_false -> RL_false
     | L_num _ | L_hex _ | L_bin _ | L_string _ | L_real _ -> RL_inf
-    | L_undef -> assert false
 
   let inv_rlit_of_lit (L_aux (l, _)) =
     match l with
@@ -3670,7 +3670,6 @@ module MakeExhaustive = struct
     | L_true -> [RL_false]
     | L_false -> [RL_true]
     | L_num _ | L_hex _ | L_bin _ | L_string _ | L_real _ -> [RL_inf]
-    | L_undef -> assert false
 
   type residual_pattern =
     | RP_any

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -151,7 +151,6 @@ Inductive lit_aux : Set :=
 | L_hex : list (non_empty hex_digit) -> lit_aux
 | L_bin : list (non_empty bin_digit) -> lit_aux
 | L_string : string -> lit_aux
-| L_undef : lit_aux
 | L_real : Q -> lit_aux.
 
 Inductive nexp_aux : Set :=
@@ -338,6 +337,7 @@ with exp_aux (a : Set) : Set :=
 | E_try : exp a -> list (pexp a) -> exp_aux a
 | E_assert : exp a -> exp a -> exp_aux a
 | E_var : lexp a -> exp a -> exp a -> exp_aux a
+| E_undef : exp_aux a
 | E_internal_plet : pat a -> exp a -> exp a -> exp_aux a
 | E_internal_return : exp a -> exp_aux a
 | E_internal_value : value -> exp_aux a
@@ -408,6 +408,7 @@ Arguments E_throw {_}.
 Arguments E_try {_}.
 Arguments E_assert {_}.
 Arguments E_var {_}.
+Arguments E_undef {_}.
 Arguments E_internal_plet {_}.
 Arguments E_internal_return {_}.
 Arguments E_internal_value {_}.

--- a/src/lib/rocq/theories/AstInduction.v
+++ b/src/lib/rocq/theories/AstInduction.v
@@ -370,6 +370,7 @@ Section exp_ind_g.
     (H_try : forall x arms ann, P x -> Forall (MatchArm P) arms -> P (E_aux (E_try x arms) ann))
     (H_assert : forall x msg ann, P x -> P msg -> P (E_aux (E_assert x msg) ann))
     (H_var : forall lx x body ann, P x -> P body -> P (E_aux (E_var lx x body) ann))
+    (H_undef : forall ann, P (E_aux E_undef ann))
     (H_internal_plet : forall p x y ann, P x -> P y -> P (E_aux (E_internal_plet p x y) ann))
     (H_internal_return : forall x ann, P x -> P (E_aux (E_internal_return x) ann))
     (H_internal_value : forall v ann, P (E_aux (E_internal_value v) ann))
@@ -452,6 +453,7 @@ Section exp_ind_g.
           assumption.
     - apply H_assert; trivial.
     - apply H_var; trivial.
+    - apply H_undef; trivial.
     - apply H_internal_plet; trivial.
     - apply H_internal_return; trivial.
     - apply H_internal_value.
@@ -493,6 +495,7 @@ Section exp_and_lexp_ind_g.
     (H_try : forall x arms ann, P x -> Forall (MatchArm P) arms -> P (E_aux (E_try x arms) ann))
     (H_assert : forall x msg ann, P x -> P msg -> P (E_aux (E_assert x msg) ann))
     (H_var : forall lx x body ann, Q lx -> P x -> P body -> P (E_aux (E_var lx x body) ann))
+    (H_undef : forall ann, P (E_aux E_undef ann))
     (H_internal_plet : forall p x y ann, P x -> P y -> P (E_aux (E_internal_plet p x y) ann))
     (H_internal_return : forall x ann, P x -> P (E_aux (E_internal_return x) ann))
     (H_internal_value : forall v ann, P (E_aux (E_internal_value v) ann))
@@ -586,6 +589,7 @@ Section exp_and_lexp_ind_g.
             assumption.
       - apply H_assert; trivial.
       - apply H_var; trivial.
+      - apply H_undef; trivial.
       - apply H_internal_plet; trivial.
       - apply H_internal_return; trivial.
       - apply H_internal_value.
@@ -672,7 +676,7 @@ Fixpoint depth {A : Set} (x : exp A) {struct x} : nat :=
   | E_vector_append x y => max (depth x) (depth y) + 1
   | E_exit x => depth x + 1
   | E_var l x y => max (lexp_depth l) (max (depth x) (depth y)) + 1
-  | E_id _ | E_lit _ | E_sizeof _ | E_constraint _ | E_config _ | E_ref _ | E_internal_value _ => 0
+  | E_id _ | E_lit _ | E_sizeof _ | E_constraint _ | E_config _ | E_ref _ | E_undef | E_internal_value _ => 0
   (* Internal constructors we can ignore for now *)
   | E_internal_plet _ _ _ => 0
   | E_internal_return _ => 0

--- a/src/lib/rocq/theories/Semantics.v
+++ b/src/lib/rocq/theories/Semantics.v
@@ -667,18 +667,17 @@ Module Make (T : SemanticExt).
     | _ :: _ => Runtime_type_error l
     end.
 
-  Definition value_of_lit (lit : Ast.lit) (typ : Ast.typ) : t value :=
+  Definition value_of_lit (lit : Ast.lit) : value :=
     let 'L_aux aux _ := lit in
     match aux with
-    | L_unit => pure V_unit
-    | L_true => pure (V_bool true)
-    | L_false => pure (V_bool false)
-    | L_num n => pure (V_int n)
-    | L_hex h => pure (V_bitvector (bitlist_of_hex_lit h))
-    | L_bin b => pure (V_bitvector (bitlist_of_bin_lit b))
-    | L_real r => pure (V_real r)
-    | L_string s => pure (V_string s)
-    | L_undef => get_undefined typ
+    | L_unit => V_unit
+    | L_true => V_bool true
+    | L_false => V_bool false
+    | L_num n => V_int n
+    | L_hex h => V_bitvector (bitlist_of_hex_lit h)
+    | L_bin b => V_bitvector (bitlist_of_bin_lit b)
+    | L_real r => V_real r
+    | L_string s => V_string s
     end.
 
   Definition same_bits (bs : list bit) (vs : list bit) : bool :=
@@ -1374,8 +1373,7 @@ Module Make (T : SemanticExt).
             wrap (E_let (LB_aux (LB_val pat x') lb_annot) body)
         end
     | E_lit lit =>
-        v ← value_of_lit lit (T.get_type (snd annot));
-        wrap (E_internal_value v)
+        wrap (E_internal_value (value_of_lit lit))
     | E_tuple xs =>
         let '(evaluated, unevaluated) := left_to_right xs in
         match unevaluated with
@@ -1603,6 +1601,9 @@ Module Make (T : SemanticExt).
                 end
             end
         end
+    | E_undef =>
+        u ← get_undefined (T.get_type (snd annot));
+        wrap (E_internal_value u)
     | E_vector_append _ _ => Runtime_type_error (fst annot)
     | E_sizeof _ => Runtime_type_error (fst annot)
     | E_constraint _ => Runtime_type_error (fst annot)

--- a/src/lib/spec_analysis.ml
+++ b/src/lib/spec_analysis.ml
@@ -184,7 +184,7 @@ let nexp_subst_fns substs =
     let re e = E_aux (e, (l, s_tannot annot)) in
     match e with
     | E_block es -> re (E_block (List.map s_exp es))
-    | E_id _ | E_ref _ | E_lit _ | E_internal_value _ | E_config _ -> re e
+    | E_id _ | E_ref _ | E_undef | E_lit _ | E_internal_value _ | E_config _ -> re e
     | E_sizeof ne -> begin
         let ne' = subst_kids_nexp substs ne in
         match ne' with Nexp_aux (Nexp_constant i, l) -> re (E_lit (L_aux (L_num i, l))) | _ -> re (E_sizeof ne')

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -1393,7 +1393,6 @@ let infer_lit (L_aux (lit_aux, l)) =
   | L_real _ -> real_typ
   | L_bin bin -> bitvector_typ (nint (bin_lit_length bin))
   | L_hex hex -> bitvector_typ (nint (hex_lit_length hex))
-  | L_undef -> typ_error l "Cannot infer the type of undefined"
 
 let instantiate_simple_equations =
   let rec find_eqs kid (NC_aux (nc, _)) =
@@ -1839,11 +1838,8 @@ and build_overload_tree_arg env (E_aux (aux, annot) as exp) =
       | Local (_, typ) | Enum typ | Register typ -> OT_leaf (exp, overload_leaf_type (Env.expand_synonyms env typ))
       | Unbound _ -> unbound_id_error ~at:(fst annot) env v
     end
-  | E_lit lit -> begin
-      match lit with
-      | L_aux (L_undef, _) -> OT_leaf (exp, OL_unknown)
-      | _ -> OT_leaf (exp, overload_leaf_type (infer_lit lit))
-    end
+  | E_undef -> OT_leaf (exp, OL_unknown)
+  | E_lit lit -> OT_leaf (exp, overload_leaf_type (infer_lit lit))
   | E_if (_, then_branch, else_branch) ->
       let then_tree = build_overload_tree_arg env then_branch in
       let else_tree = build_overload_tree_arg env else_branch in
@@ -2540,9 +2536,9 @@ let rec check_exp env (E_aux (exp_aux, (l, uannot)) as exp : uannot exp) (Typ_au
         end
       | None -> typ_error l ("List " ^ string_of_exp exp ^ " must have list type, got " ^ string_of_typ typ)
     end
-  | E_lit (L_aux (L_undef, _) as lit), _ ->
+  | E_undef, _ ->
       if can_be_undefined ~at:l env typ then
-        if is_typ_inhabited env (Env.expand_synonyms env typ) then annot_exp (E_lit lit) typ
+        if is_typ_inhabited env (Env.expand_synonyms env typ) then annot_exp E_undef typ
         else typ_error l ("Type " ^ string_of_typ typ ^ " could be empty")
       else typ_error l ("Type " ^ string_of_typ typ ^ " cannot be undefined")
   | E_internal_assume (nc, exp), _ ->

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -847,7 +847,6 @@ let doc_lit (L_aux (lit, l)) =
   (* These need parens because of the 'sz 'b "..."' variants :( *)
   | L_hex hex -> utf8string ("(Ox\"" ^ string_of_hex_lit ~group_separator:"" ~case:Uppercase hex ^ "\")")
   | L_bin bin -> utf8string ("('b\"" ^ string_of_bin_lit ~group_separator:"" bin ^ "\")")
-  | L_undef -> utf8string "(Fail \"undefined value of unsupported type\")"
   | L_string s -> utf8string ("\"" ^ coq_escape_string s ^ "\"")
   | L_real r ->
       let r = Util.Rational.from_rocq r in
@@ -2279,6 +2278,8 @@ let doc_exp, doc_let =
     | E_config _ ->
         raise
           (Reporting.err_unreachable l __POS__ "Configuration expression should have been removed before Coq generation")
+    | E_undef ->
+        raise (Reporting.err_unreachable l __POS__ "undefined value should have been rewritten before pretty-printing")
     | E_internal_value _ ->
         raise (Reporting.err_unreachable l __POS__ "unsupported internal expression encountered while pretty-printing")
   (* In suitable places we translate terms with existential types into dependent pairs *)

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -388,7 +388,6 @@ let doc_lit ~width (L_aux (lit, l)) =
       | [Non_empty (Bin_1, [])] -> string ("1" ^ width_specifier)
       | _ -> utf8string ("0b" ^ string_of_bin_lit ~group_separator:"" bin ^ width_specifier)
     )
-  | L_undef -> utf8string "(Fail \"undefined value of unsupported type\")"
   | L_string s -> utf8string ("\"" ^ lean_escape_string s ^ "\"")
   | L_real r -> utf8string (Q.to_string (Util.Rational.from_rocq r))
 (* TODO test if this is really working *)
@@ -416,6 +415,7 @@ let string_of_exp_con (E_aux (e, _)) =
   | E_return _ -> "E_return"
   | E_assert _ -> "E_assert"
   | E_var _ -> "E_var"
+  | E_undef -> "E_undef"
   | E_internal_plet _ -> "E_internal_plet"
   | E_internal_return _ -> "E_internal_return"
   | E_internal_assume _ -> "E_internal_assume"

--- a/src/sail_lem_backend/pretty_print_lem.ml
+++ b/src/sail_lem_backend/pretty_print_lem.ml
@@ -516,7 +516,6 @@ let rec doc_lit_lem (L_aux (lit, l)) =
   | L_bin bin when !Monomorphise.opt_mwords -> utf8string ("0b" ^ string_of_bin_lit ~group_separator:"" bin)
   | L_hex hex -> Semantics.bitlist_of_hex_lit hex |> flow_map (semi ^^ break 0) doc_bit |> group |> align |> brackets
   | L_bin bin -> Semantics.bitlist_of_bin_lit bin |> flow_map (semi ^^ break 0) doc_bit |> group |> align |> brackets
-  | L_undef -> utf8string "(return (failwith \"undefined value of unsupported type\"))"
   | L_string s -> utf8string ("\"" ^ String.escaped s ^ "\"")
   | L_real r ->
       let r = Util.Rational.from_rocq r in
@@ -1013,6 +1012,7 @@ let doc_exp_lem, doc_let_lem =
         else if Env.is_register id env && match e with E_ref _ -> true | _ -> false then doc_id_lem (append_id id "_ref")
         else if is_ctor env id then doc_id_lem_ctor id
         else doc_id_lem id
+    | E_undef -> utf8string "(return (failwith \"undefined value of unsupported type\"))"
     | E_lit lit ->
         let env = env_of full_exp in
         let typ = Env.expand_synonyms env (typ_of full_exp) in

--- a/src/sail_ocaml_backend/ocaml_backend.ml
+++ b/src/sail_ocaml_backend/ocaml_backend.ml
@@ -182,7 +182,6 @@ let ocaml_lit (L_aux (lit_aux, _)) =
       else if Big_int.less_equal (Big_int.of_int min_int) n && Big_int.less_equal n (Big_int.of_int max_int) then
         parens (string "Big_int.of_int" ^^ space ^^ parens (string (Big_int.to_string n)))
       else parens (string "Big_int.of_string" ^^ space ^^ dquotes (string (Big_int.to_string n)))
-  | L_undef -> failwith "undefined should have been re-written prior to ocaml backend"
   | L_string str -> string_lit str
   | L_real r ->
       let str = Q.to_string (Util.Rational.from_rocq r) in

--- a/test/typecheck/fail/undefined_infer.expect
+++ b/test/typecheck/fail/undefined_infer.expect
@@ -2,4 +2,4 @@
 [96mfail/undefined_infer.sail[0m:1.8-17:
 1[96m |[0mlet _ = undefined
  [91m |[0m        [91m^-------^[0m
- [91m |[0m Cannot infer the type of undefined
+ [91m |[0m Cannot infer type of: undefined


### PR DESCRIPTION
The Sail undefined construct was encoded as a literal L_undefined. This didn't really fit, as in the monadic semantics it had the side effect of requesting a non-deterministic value from the environment.

It also meant that the literal type wasn't a strict subset of the value type, which complicated the definition of the semantics slightly.

This refactors the code to move L_undef to the expression type constructor E_undef.

Technically literals are allowed in more places by the grammar than expressions, but usage of undefined in those places would be nonsensical and resulted in a type error.