### PR TITLE
Generalise Rocq pattern semantics

### DIFF
--- a/src/lib/constant_fold.ml
+++ b/src/lib/constant_fold.ml
@@ -82,7 +82,7 @@ and exp_of_value = function
    that we avoid traversing through every element of vectors and
    lists, so a list of large lists could still sneak through *)
 let rec is_too_large = function
-  | V_int _ | V_bool _ | V_bitvector _ | V_string _ | V_unit | V_real _ | V_ref _ | V_member _ -> false
+  | V_int _ | V_bool _ | V_bitvector _ | V_string _ | V_unit | V_real _ | V_ref _ | V_member _ | V_unknown -> false
   | V_vector vs | V_tuple vs | V_list vs -> List.compare_length_with vs 256 > 0
   | V_record fields -> List.exists (fun (_, v) -> is_too_large v) fields
   | V_ctor (_, vs) -> List.exists is_too_large vs

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -103,6 +103,7 @@ type value =
 | V_member of id
 | V_ctor of id * value list
 | V_record of (id * value) list
+| V_unknown
 
 type lit_aux =
 | L_unit

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -103,6 +103,7 @@ type value =
 | V_member of id
 | V_ctor of id * value list
 | V_record of (id * value) list
+| V_unknown
 
 type lit_aux =
 | L_unit

--- a/src/lib/extraction/Datatypes.ml
+++ b/src/lib/extraction/Datatypes.ml
@@ -1,10 +1,4 @@
 
-(** val negb : bool -> bool **)
-
-let negb = function
-| true -> false
-| false -> true
-
 (** val fst : ('a1 * 'a2) -> 'a1 **)
 
 let fst = function

--- a/src/lib/extraction/Datatypes.mli
+++ b/src/lib/extraction/Datatypes.mli
@@ -1,6 +1,4 @@
 
-val negb : bool -> bool
-
 val fst : ('a1 * 'a2) -> 'a1
 
 val snd : ('a1 * 'a2) -> 'a2

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -652,39 +652,134 @@ module Make =
                           | B1 -> (true, vs0))))
         else (false, [])) bs (true, vs))
 
-  (** val pattern_match_literal : lit -> value -> bool **)
+  type match_result =
+  | Matched of binding IdMap.t
+  | MaybeMatched of binding IdMap.t
+  | Unmatched
+
+  (** val match_result_rect :
+      (binding IdMap.t -> 'a1) -> (binding IdMap.t -> 'a1) -> 'a1 ->
+      match_result -> 'a1 **)
+
+  let match_result_rect f f0 f1 = function
+  | Matched t0 -> f t0
+  | MaybeMatched t0 -> f0 t0
+  | Unmatched -> f1
+
+  (** val match_result_rec :
+      (binding IdMap.t -> 'a1) -> (binding IdMap.t -> 'a1) -> 'a1 ->
+      match_result -> 'a1 **)
+
+  let match_result_rec f f0 f1 = function
+  | Matched t0 -> f t0
+  | MaybeMatched t0 -> f0 t0
+  | Unmatched -> f1
+
+  (** val merge_match_result :
+      match_result -> match_result -> match_result **)
+
+  let merge_match_result l r =
+    match l with
+    | Matched l_b ->
+      (match r with
+       | Matched r_b -> Matched (merge_bindings l_b r_b)
+       | MaybeMatched r_b -> MaybeMatched (merge_bindings l_b r_b)
+       | Unmatched -> Unmatched)
+    | MaybeMatched l_b ->
+      (match r with
+       | Matched r_b -> MaybeMatched (merge_bindings l_b r_b)
+       | MaybeMatched r_b -> MaybeMatched (merge_bindings l_b r_b)
+       | Unmatched -> Unmatched)
+    | Unmatched -> Unmatched
+
+  (** val empty_bindings : binding IdMap.t **)
+
+  let empty_bindings =
+    IdMap.empty
+
+  (** val simple_match : match_result **)
+
+  let simple_match =
+    Matched empty_bindings
+
+  (** val simple_match_if : bool -> match_result **)
+
+  let simple_match_if = function
+  | true -> simple_match
+  | false -> Unmatched
+
+  (** val match_binds : id -> binding -> match_result -> match_result **)
+
+  let match_binds name value0 = function
+  | Matched b -> Matched (IdMap.add name value0 b)
+  | MaybeMatched b -> MaybeMatched (IdMap.add name value0 b)
+  | Unmatched -> Unmatched
+
+  (** val neg_match : match_result -> match_result **)
+
+  let neg_match = function
+  | Matched _ -> Unmatched
+  | MaybeMatched b -> MaybeMatched b
+  | Unmatched -> simple_match
+
+  (** val or_match : match_result -> match_result -> match_result **)
+
+  let or_match l r =
+    match l with
+    | Matched l_b -> Matched l_b
+    | MaybeMatched l_b ->
+      (match r with
+       | Matched r_b -> Matched r_b
+       | _ -> MaybeMatched l_b)
+    | Unmatched -> r
+
+  (** val pattern_match_literal : lit -> value -> match_result **)
 
   let pattern_match_literal l v =
     let L_aux (aux, _) = l in
     (match aux with
-     | L_unit -> (match v with
-                  | V_unit -> true
-                  | _ -> false)
-     | L_true -> (match v with
-                  | V_bool b -> b
-                  | _ -> false)
+     | L_unit ->
+       (match v with
+        | V_unit -> simple_match
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
+     | L_true ->
+       (match v with
+        | V_bool b -> if b then simple_match else Unmatched
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
      | L_false ->
        (match v with
-        | V_bool b -> if b then false else true
-        | _ -> false)
-     | L_num n -> (match v with
-                   | V_int m -> Z.eqb n m
-                   | _ -> false)
+        | V_bool b -> if b then Unmatched else simple_match
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
+     | L_num n ->
+       (match v with
+        | V_int m -> simple_match_if (Z.eqb n m)
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
      | L_hex s ->
        (match v with
-        | V_bitvector vs -> same_bits (bitlist_of_hex_lit s) vs
-        | _ -> false)
+        | V_bitvector vs ->
+          simple_match_if (same_bits (bitlist_of_hex_lit s) vs)
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
      | L_bin s ->
        (match v with
-        | V_bitvector vs -> same_bits (bitlist_of_bin_lit s) vs
-        | _ -> false)
-     | L_string s1 -> (match v with
-                       | V_string s2 -> (=) s1 s2
-                       | _ -> false)
+        | V_bitvector vs ->
+          simple_match_if (same_bits (bitlist_of_bin_lit s) vs)
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
+     | L_string s1 ->
+       (match v with
+        | V_string s2 -> simple_match_if ((=) s1 s2)
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched)
      | L_real r1 ->
        (match v with
-        | V_real r2 -> coq_Qeq_bool r1 r2
-        | _ -> false))
+        | V_real r2 -> simple_match_if (coq_Qeq_bool r1 r2)
+        | V_unknown -> MaybeMatched empty_bindings
+        | _ -> Unmatched))
 
   (** val get_struct_field : id -> (id * value) list -> value **)
 
@@ -694,16 +789,6 @@ module Make =
     let (name', v) = p in
     if id_eqb name name' then v else get_struct_field name rest_fields
 
-  (** val no_match : bool * binding IdMap.t **)
-
-  let no_match =
-    (false, IdMap.empty)
-
-  (** val empty_bindings : binding IdMap.t **)
-
-  let empty_bindings =
-    IdMap.empty
-
   (** val complete_bindings : binding IdMap.t -> value IdMap.t **)
 
   let complete_bindings m =
@@ -712,32 +797,25 @@ module Make =
       | Complete v -> v
       | Partial vs -> complete_value vs) m
 
-  (** val pattern_match : T.tannot pat -> value -> bool * binding IdMap.t **)
+  (** val pattern_match : T.tannot pat -> value -> match_result **)
 
   let rec pattern_match p v =
     let P_aux (aux, annot0) = p in
     (match aux with
-     | P_lit l -> ((pattern_match_literal l v), empty_bindings)
-     | P_wild -> (true, [])
+     | P_lit l -> pattern_match_literal l v
      | P_or (lhs_p, rhs_p) ->
-       let (lhs_matched, lhs_bound) = pattern_match lhs_p v in
-       let (rhs_matched, rhs_bound) = pattern_match rhs_p v in
-       if lhs_matched
-       then (true, lhs_bound)
-       else if rhs_matched then (true, rhs_bound) else no_match
-     | P_not p0 ->
-       let (p_matched, _) = pattern_match p0 v in ((negb p_matched), [])
-     | P_as (p0, n) ->
-       let (matched, bindings) = pattern_match p0 v in
-       (matched, (IdMap.add n (Complete v) bindings))
+       or_match (pattern_match lhs_p v) (pattern_match rhs_p v)
+     | P_not p0 -> neg_match (pattern_match p0 v)
+     | P_as (p0, n) -> match_binds n (Complete v) (pattern_match p0 v)
      | P_typ (_, p0) -> pattern_match p0 v
      | P_id n ->
        (match T.get_id_type (snd annot0) n with
         | Enum_member ->
           (match v with
-           | V_member m -> ((id_eqb n m), empty_bindings)
-           | _ -> no_match)
-        | _ -> (true, (IdMap.add n (Complete v) empty_bindings)))
+           | V_member m -> simple_match_if (id_eqb n m)
+           | V_unknown -> MaybeMatched empty_bindings
+           | _ -> Unmatched)
+        | _ -> Matched (IdMap.add n (Complete v) empty_bindings))
      | P_var (p0, _) -> pattern_match p0 v
      | P_app (ctor, ps) ->
        (match v with
@@ -745,38 +823,26 @@ module Make =
           if id_eqb ctor v_ctor
           then fst
                  (fold_left (fun match_info p0 ->
-                   let (y, y0) = match_info in
-                   let (y1, vars) = y in
-                   if y1
-                   then (match y0 with
-                         | [] -> (no_match, [])
-                         | v0 :: vs0 ->
-                           let (matched, more_vars) = pattern_match p0 v0 in
-                           ((matched, (merge_bindings vars more_vars)), vs0))
-                   else (match y0 with
-                         | [] -> (no_match, [])
-                         | _ :: vs0 -> (no_match, vs0)))
-                   ps ((true, []), vs))
-          else no_match
-        | _ -> no_match)
+                   let (prev, y) = match_info in
+                   (match y with
+                    | [] -> (Unmatched, [])
+                    | v0 :: vs0 ->
+                      ((merge_match_result prev (pattern_match p0 v0)), vs0)))
+                   ps (simple_match, vs))
+          else Unmatched
+        | _ -> Unmatched)
      | P_vector ps ->
        (match to_gvector v with
         | V_vector vs ->
           fst
             (fold_left (fun match_info p0 ->
-              let (y, y0) = match_info in
-              let (y1, vars) = y in
-              if y1
-              then (match y0 with
-                    | [] -> (no_match, [])
-                    | v0 :: vs0 ->
-                      let (matched, more_vars) = pattern_match p0 v0 in
-                      ((matched, (merge_bindings vars more_vars)), vs0))
-              else (match y0 with
-                    | [] -> (no_match, [])
-                    | _ :: vs0 -> (no_match, vs0)))
-              ps ((true, []), vs))
-        | _ -> no_match)
+              let (prev, y) = match_info in
+              (match y with
+               | [] -> (Unmatched, [])
+               | v0 :: vs0 ->
+                 ((merge_match_result prev (pattern_match p0 v0)), vs0)))
+              ps (simple_match, vs))
+        | _ -> Unmatched)
      | P_vector_concat ps ->
        (match v with
         | V_bitvector bs ->
@@ -784,118 +850,90 @@ module Make =
             (fold_left (fun match_info p0 ->
               let P_aux (_, annot1) = p0 in
               (match T.get_split (snd annot1) with
-               | No_split -> (no_match, [])
+               | No_split -> (Unmatched, [])
                | Split s ->
-                 let (p1, bs0) = match_info in
-                 let (b, bound) = p1 in
-                 if b
-                 then (match bs0 with
-                       | [] -> (no_match, [])
-                       | _ :: _ ->
-                         let (bs_take, bs_drop) = take_drop s bs0 in
-                         let (matched, more_bound) =
-                           pattern_match p0 (V_bitvector bs_take)
-                         in
-                         ((matched, (merge_bindings bound more_bound)),
-                         bs_drop))
-                 else (match bs0 with
-                       | [] -> (no_match, [])
-                       | _ :: _ -> (no_match, bs0))))
-              ps ((true, []), bs))
+                 let (prev, bs0) = match_info in
+                 (match bs0 with
+                  | [] -> (Unmatched, [])
+                  | _ :: _ ->
+                    let (bs_take, bs_drop) = take_drop s bs0 in
+                    ((merge_match_result prev
+                       (pattern_match p0 (V_bitvector bs_take))),
+                    bs_drop))))
+              ps (simple_match, bs))
         | V_vector vs ->
           fst
             (fold_left (fun match_info p0 ->
               let P_aux (_, annot1) = p0 in
               (match T.get_split (snd annot1) with
-               | No_split -> (no_match, [])
+               | No_split -> (Unmatched, [])
                | Split s ->
-                 let (p1, vs0) = match_info in
-                 let (b, bound) = p1 in
-                 if b
-                 then (match vs0 with
-                       | [] -> (no_match, [])
-                       | _ :: _ ->
-                         let (vs_take, vs_drop) = take_drop s vs0 in
-                         let (matched, more_bound) =
-                           pattern_match p0 (V_vector vs_take)
-                         in
-                         ((matched, (merge_bindings bound more_bound)),
-                         vs_drop))
-                 else (match vs0 with
-                       | [] -> (no_match, [])
-                       | _ :: _ -> (no_match, vs0))))
-              ps ((true, []), vs))
-        | _ -> no_match)
+                 let (prev, vs0) = match_info in
+                 (match vs0 with
+                  | [] -> (Unmatched, [])
+                  | _ :: _ ->
+                    let (vs_take, vs_drop) = take_drop s vs0 in
+                    ((merge_match_result prev
+                       (pattern_match p0 (V_vector vs_take))),
+                    vs_drop))))
+              ps (simple_match, vs))
+        | _ -> Unmatched)
      | P_vector_subrange (id0, n, m) ->
-       (true,
+       Matched
          (IdMap.add id0 (Partial (Non_empty (((v, n), m), [])))
-           empty_bindings))
+           empty_bindings)
      | P_tuple ps ->
        (match ps with
-        | [] -> (match v with
-                 | V_unit -> (true, [])
-                 | _ -> no_match)
+        | [] ->
+          (match v with
+           | V_unit -> simple_match
+           | V_unknown -> simple_match
+           | _ -> Unmatched)
         | _ :: _ ->
           (match v with
            | V_tuple vs ->
              fst
                (fold_left (fun match_info p0 ->
-                 let (y, y0) = match_info in
-                 let (y1, vars) = y in
-                 if y1
-                 then (match y0 with
-                       | [] -> (no_match, [])
-                       | v0 :: vs0 ->
-                         let (matched, more_vars) = pattern_match p0 v0 in
-                         ((matched, (merge_bindings vars more_vars)), vs0))
-                 else (match y0 with
-                       | [] -> (no_match, [])
-                       | _ :: vs0 -> (no_match, vs0)))
-                 ps ((true, []), vs))
-           | _ -> no_match))
+                 let (prev, y) = match_info in
+                 (match y with
+                  | [] -> (Unmatched, [])
+                  | v0 :: vs0 ->
+                    ((merge_match_result prev (pattern_match p0 v0)), vs0)))
+                 ps (simple_match, vs))
+           | _ -> Unmatched))
      | P_list ps ->
        (match v with
         | V_list vs ->
           if Nat.eqb (length ps) (length vs)
           then fst
                  (fold_left (fun match_info p0 ->
-                   let (y, y0) = match_info in
-                   let (y1, vars) = y in
-                   if y1
-                   then (match y0 with
-                         | [] -> (no_match, [])
-                         | v0 :: vs0 ->
-                           let (matched, more_vars) = pattern_match p0 v0 in
-                           ((matched, (merge_bindings vars more_vars)), vs0))
-                   else (match y0 with
-                         | [] -> (no_match, [])
-                         | _ :: vs0 -> (no_match, vs0)))
-                   ps ((true, []), vs))
-          else no_match
-        | _ -> no_match)
+                   let (prev, y) = match_info in
+                   (match y with
+                    | [] -> (Unmatched, [])
+                    | v0 :: vs0 ->
+                      ((merge_match_result prev (pattern_match p0 v0)), vs0)))
+                   ps (simple_match, vs))
+          else Unmatched
+        | _ -> Unmatched)
      | P_cons (p0, ps) ->
        (match v with
         | V_list l ->
           (match l with
-           | [] -> no_match
+           | [] -> Unmatched
            | v0 :: vs ->
-             let (hd_matched, hd_bound) = pattern_match p0 v0 in
-             let (tl_matched, tl_bound) = pattern_match ps (V_list vs) in
-             (((&&) hd_matched tl_matched),
-             (merge_bindings hd_bound tl_bound)))
-        | _ -> no_match)
-     | P_string_append _ -> (true, empty_bindings)
+             merge_match_result (pattern_match p0 v0)
+               (pattern_match ps (V_list vs)))
+        | _ -> Unmatched)
      | P_struct (_, field_patterns, _) ->
        (match v with
         | V_record fields ->
-          fold_left (fun match_info fp ->
-            let (prev_matched, prev_bound) = match_info in
+          fold_left (fun prev fp ->
             let (name, p0) = fp in
             let v0 = get_struct_field name fields in
-            let (matched, bound) = pattern_match p0 v0 in
-            (((&&) prev_matched matched), (merge_bindings prev_bound bound)))
-            field_patterns (true, [])
-        | _ -> no_match))
+            merge_match_result prev (pattern_match p0 v0)) field_patterns
+            simple_match
+        | _ -> Unmatched)
+     | _ -> simple_match)
 
   (** val lookup_field :
       Parse_ast.l -> id -> (id * value) list -> value Monad.t **)
@@ -1517,45 +1555,43 @@ module Make =
                (match p0 with
                 | Pat_exp (pat0, body) ->
                   let filtered_var = pattern_match pat0 v in
-                  let (matched, arm_substs) = filtered_var in
-                  if matched
-                  then Monad.pure
-                         (fold_right (fun s body0 ->
-                           substitute (fst s) (snd s) body0) body
-                           (complete_bindings arm_substs))
-                  else wrap (E_match (head_exp, next_arms))
+                  (match filtered_var with
+                   | Matched arm_substs ->
+                     Monad.pure
+                       (fold_right (fun s body0 ->
+                         substitute (fst s) (snd s) body0) body
+                         (complete_bindings arm_substs))
+                   | _ -> wrap (E_match (head_exp, next_arms)))
                 | Pat_when (pat0, guard, body) ->
                   let filtered_var = pattern_match pat0 v in
-                  let (matched, arm_substs) = filtered_var in
-                  if matched
-                  then let guard0 =
-                         fold_right (fun s g -> substitute (fst s) (snd s) g)
-                           guard (complete_bindings arm_substs)
-                       in
-                       let E_aux (e0, _) = guard0 in
-                       (match e0 with
-                        | E_internal_value v_guard ->
-                          (match v_guard with
-                           | V_bool b ->
-                             if b
-                             then let filtered_var0 = pattern_match pat0 v in
-                                  let (matched0, arm_substs0) = filtered_var0
-                                  in
-                                  if matched0
-                                  then Monad.pure
-                                         (fold_right (fun s body0 ->
-                                           substitute (fst s) (snd s) body0)
-                                           body
-                                           (complete_bindings arm_substs0))
-                                  else wrap (E_match (head_exp, next_arms))
-                             else wrap (E_match (head_exp, next_arms))
-                           | _ -> Monad.Runtime_type_error (fst pexp_annot))
-                        | _ ->
-                          Monad.bind (step0 guard0) (fun guard' ->
-                            wrap (E_match (head_exp, ((Pat_aux ((Pat_when
-                              (pat0, guard', body)),
-                              pexp_annot)) :: next_arms)))))
-                  else wrap (E_match (head_exp, next_arms))))
+                  (match filtered_var with
+                   | Matched arm_substs ->
+                     let guard0 =
+                       fold_right (fun s g -> substitute (fst s) (snd s) g)
+                         guard (complete_bindings arm_substs)
+                     in
+                     let E_aux (e0, _) = guard0 in
+                     (match e0 with
+                      | E_internal_value v_guard ->
+                        (match v_guard with
+                         | V_bool b ->
+                           if b
+                           then let filtered_var0 = pattern_match pat0 v in
+                                (match filtered_var0 with
+                                 | Matched arm_substs0 ->
+                                   Monad.pure
+                                     (fold_right (fun s body0 ->
+                                       substitute (fst s) (snd s) body0) body
+                                       (complete_bindings arm_substs0))
+                                 | _ -> wrap (E_match (head_exp, next_arms)))
+                           else wrap (E_match (head_exp, next_arms))
+                         | _ -> Monad.Runtime_type_error (fst pexp_annot))
+                      | _ ->
+                        Monad.bind (step0 guard0) (fun guard' ->
+                          wrap (E_match (head_exp, ((Pat_aux ((Pat_when
+                            (pat0, guard', body)),
+                            pexp_annot)) :: next_arms)))))
+                   | _ -> wrap (E_match (head_exp, next_arms)))))
           | _ ->
             Monad.bind (step0 head_exp) (fun head_exp' ->
               wrap (E_match (head_exp', arms))))
@@ -1566,13 +1602,12 @@ module Make =
          (match e with
           | E_internal_value v ->
             let filtered_var = pattern_match pat0 v in
-            let (matched, body_substs) = filtered_var in
-            if matched
-            then Monad.pure
-                   (fold_left (fun body0 s ->
-                     substitute (fst s) (snd s) body0)
-                     (complete_bindings body_substs) body)
-            else Monad.Match_failure (fst annot0)
+            (match filtered_var with
+             | Matched body_substs ->
+               Monad.pure
+                 (fold_left (fun body0 s -> substitute (fst s) (snd s) body0)
+                   (complete_bindings body_substs) body)
+             | _ -> Monad.Match_failure (fst annot0))
           | _ ->
             Monad.bind (step0 x) (fun x' ->
               wrap (E_let ((LB_aux ((LB_val (pat0, x')), lb_annot)), body))))

--- a/src/lib/extraction/Semantics.mli
+++ b/src/lib/extraction/Semantics.mli
@@ -176,17 +176,40 @@ module Make :
 
   val same_bits : bit list -> bit list -> bool
 
-  val pattern_match_literal : lit -> value -> bool
+  type match_result =
+  | Matched of binding IdMap.t
+  | MaybeMatched of binding IdMap.t
+  | Unmatched
 
-  val get_struct_field : id -> (id * value) list -> value
+  val match_result_rect :
+    (binding IdMap.t -> 'a1) -> (binding IdMap.t -> 'a1) -> 'a1 ->
+    match_result -> 'a1
 
-  val no_match : bool * binding IdMap.t
+  val match_result_rec :
+    (binding IdMap.t -> 'a1) -> (binding IdMap.t -> 'a1) -> 'a1 ->
+    match_result -> 'a1
+
+  val merge_match_result : match_result -> match_result -> match_result
 
   val empty_bindings : binding IdMap.t
 
+  val simple_match : match_result
+
+  val simple_match_if : bool -> match_result
+
+  val match_binds : id -> binding -> match_result -> match_result
+
+  val neg_match : match_result -> match_result
+
+  val or_match : match_result -> match_result -> match_result
+
+  val pattern_match_literal : lit -> value -> match_result
+
+  val get_struct_field : id -> (id * value) list -> value
+
   val complete_bindings : binding IdMap.t -> value IdMap.t
 
-  val pattern_match : T.tannot pat -> value -> bool * binding IdMap.t
+  val pattern_match : T.tannot pat -> value -> match_result
 
   val lookup_field : Parse_ast.l -> id -> (id * value) list -> value Monad.t
 

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -526,12 +526,14 @@ let rec initialize_registers allow_registers undef_registers gstate =
     | DEF_aux (DEF_let (LB_aux (LB_val (pat, exp), annot)), def_annot) -> (
         try
           let evaluated = eval_exp (initial_lstate, gstate) exp in
-          let _, bindings = pattern_match pat evaluated in
-          {
-            gstate with
-            letbinds =
-              List.fold_left (fun lbs (id, v) -> Bindings.add id v lbs) gstate.letbinds (complete_bindings bindings);
-          }
+          match pattern_match pat evaluated with
+          | Matched bindings ->
+              {
+                gstate with
+                letbinds =
+                  List.fold_left (fun lbs (id, v) -> Bindings.add id v lbs) gstate.letbinds (complete_bindings bindings);
+              }
+          | _ -> gstate
         with _ -> gstate
       )
     | _ -> gstate

--- a/src/lib/rocq/theories/Ast.v
+++ b/src/lib/rocq/theories/Ast.v
@@ -141,7 +141,8 @@ Inductive value : Set :=
 | V_ref : id -> value
 | V_member : id -> value
 | V_ctor : id -> list value -> value
-| V_record : list (id * value) -> value.
+| V_record : list (id * value) -> value
+| V_unknown.
 
 Inductive lit_aux : Set :=
 | L_unit : lit_aux

--- a/src/lib/rocq/theories/SailExtraction.v
+++ b/src/lib/rocq/theories/SailExtraction.v
@@ -1,0 +1,15 @@
+Require Extraction.
+
+Set Extraction KeepSingleton.
+Set Extraction Output Directory ".".
+
+Require Import Bit.
+Require Import Ast.
+Require Import Value_type.
+Require Import AstInduction.
+Require Import IdUtil.
+Require Import Semantics.
+
+Extraction Blacklist Nat List String.
+
+Separate Extraction Primops l attribute_data hex_digits_of_bitlist def impldef opt_default Make IdMap.

--- a/src/lib/rocq/theories/Semantics.v
+++ b/src/lib/rocq/theories/Semantics.v
@@ -123,6 +123,7 @@ Module Monad.
     | Write_var r v cont => Write_var r v (fun u => bind (cont u) f)
     | Get_undefined t cont => Get_undefined t (fun v => bind (cont v) f)
     end.
+
   Notation "x ← y ; z" := (bind y (fun x : _ => z))
     (at level 20, y at level 100, z at level 200, only parsing).
 
@@ -1714,7 +1715,3 @@ Module Make (T : SemanticExt).
     lia.
   Defined.
 End Make.
-
-Extraction Blacklist Nat List String.
-
-Separate Extraction Primops l attribute_data hex_digits_of_bitlist def impldef opt_default Make IdMap.

--- a/src/lib/rocq/theories/Semantics.v
+++ b/src/lib/rocq/theories/Semantics.v
@@ -42,8 +42,6 @@ Definition combine_binding (l r : option binding) : option binding :=
 Definition merge_bindings (l r : IdMap.t binding) : IdMap.t binding :=
   IdMap.map2 combine_binding l r.
 
-Infix "⋈" := merge_bindings (right associativity, at level 60).
-
 Definition to_gvector (v : value) : value :=
   match v with
   | V_bitvector bs => V_vector (List.map (fun b => V_bitvector [b]) bs)
@@ -721,18 +719,66 @@ Module Make (T : SemanticExt).
     assumption.
   Qed.
 
-  Definition pattern_match_literal (l : Ast.lit) (v : value) : bool :=
+  Inductive match_result : Type :=
+  | Matched : IdMap.t binding -> match_result
+  | MaybeMatched : IdMap.t binding -> match_result
+  | Unmatched : match_result.
+
+  Definition merge_match_result (l r : match_result) : match_result :=
+    match (l, r) with
+    | (Unmatched, _) => Unmatched
+    | (_, Unmatched) => Unmatched
+    | (MaybeMatched l_b, MaybeMatched r_b) => MaybeMatched (merge_bindings l_b r_b)
+    | (Matched l_b,      MaybeMatched r_b) => MaybeMatched (merge_bindings l_b r_b)
+    | (MaybeMatched l_b, Matched r_b     ) => MaybeMatched (merge_bindings l_b r_b)
+    | (Matched l_b,      Matched r_b     ) => Matched (merge_bindings l_b r_b)
+    end.
+
+  Infix "⋈" := merge_match_result (right associativity, at level 60).
+
+  Definition empty_bindings : IdMap.t binding := @IdMap.empty binding.
+
+  Definition simple_match : match_result := Matched empty_bindings.
+
+  Definition simple_match_if (b : bool) : match_result :=
+    if b then simple_match else Unmatched.
+
+  Definition match_binds (name : Ast.id) (value : binding) (r : match_result) : match_result :=
+    match r with
+    | Unmatched => Unmatched
+    | MaybeMatched b => MaybeMatched (IdMap.add name value b)
+    | Matched b => Matched (IdMap.add name value b)
+    end.
+
+  Definition neg_match (r : match_result) : match_result :=
+    match r with
+    | Unmatched => simple_match
+    | MaybeMatched b => MaybeMatched b
+    | Matched _ => Unmatched
+    end.
+
+  Definition or_match (l r : match_result) : match_result :=
+    match (l, r) with
+    | (Matched l_b, _) => Matched l_b
+    | (_, Matched r_b) => Matched r_b
+    | (MaybeMatched l_b, _) => MaybeMatched l_b
+    | (_, MaybeMatched r_b) => MaybeMatched r_b
+    | _ => Unmatched
+    end.
+
+  Definition pattern_match_literal (l : Ast.lit) (v : value) : match_result :=
     let 'L_aux aux annot := l in
     match (aux, v) with
-    | (L_unit, V_unit) => true
-    | (L_true, V_bool true) => true
-    | (L_false, V_bool false) => true
-    | (L_num n, V_int m) => Z.eqb n m
-    | (L_hex s, V_bitvector vs) => same_bits (bitlist_of_hex_lit s) vs
-    | (L_bin s, V_bitvector vs) => same_bits (bitlist_of_bin_lit s) vs
-    | (L_string s1, V_string s2) => String.eqb s1 s2
-    | (L_real r1, V_real r2) => QArith_base.Qeq_bool r1 r2
-    | _ => false
+    | (L_unit,      V_unit        ) => simple_match
+    | (L_true,      V_bool true   ) => simple_match
+    | (L_false,     V_bool false  ) => simple_match
+    | (L_num n,     V_int m       ) => simple_match_if (Z.eqb n m)
+    | (L_hex s,     V_bitvector vs) => simple_match_if (same_bits (bitlist_of_hex_lit s) vs)
+    | (L_bin s,     V_bitvector vs) => simple_match_if (same_bits (bitlist_of_bin_lit s) vs)
+    | (L_string s1, V_string s2   ) => simple_match_if (String.eqb s1 s2)
+    | (L_real r1,   V_real r2     ) => simple_match_if (QArith_base.Qeq_bool r1 r2)
+    | (_,           V_unknown     ) => MaybeMatched empty_bindings
+    | _ => Unmatched
     end.
 
   Fixpoint get_struct_field (name : id) (fields : list (id * value)) {struct fields} : value :=
@@ -745,10 +791,6 @@ Module Make (T : SemanticExt).
     | [] => V_unit
     end.
 
-  Definition no_match : bool * IdMap.t binding := (false, @IdMap.empty binding).
-
-  Definition empty_bindings : IdMap.t binding := @IdMap.empty binding.
-
   Definition complete_bindings (m : IdMap.t binding) : IdMap.t value :=
     IdMap.map
       (fun b =>
@@ -759,26 +801,23 @@ Module Make (T : SemanticExt).
       )
       m.
 
-  Fixpoint pattern_match (p : Ast.pat T.tannot) (v : value) {struct p} : bool * IdMap.t binding :=
+  Fixpoint pattern_match (p : Ast.pat T.tannot) (v : value) {struct p} : match_result :=
     let 'P_aux aux annot := p in
     match aux with
-    | P_wild => (true, [])
+    | P_wild => simple_match
     | P_id n =>
         match T.get_id_type (snd annot) n with
         | Enum_member =>
             match v with
-            | V_member m =>
-                (id_eqb n m, empty_bindings)
-            | _ => no_match
+            | V_member m => simple_match_if (id_eqb n m)
+            | V_unknown  => MaybeMatched empty_bindings
+            | _          => Unmatched
             end
-        | _ =>
-            (true, IdMap.add n (Complete v) empty_bindings)
+        | _ => Matched (IdMap.add n (Complete v) empty_bindings)
         end
     | P_typ _ p => pattern_match p v
-    | P_lit l => (pattern_match_literal l v, empty_bindings)
-    | P_as p n =>
-        let '(matched, bindings) := pattern_match p v in
-        (matched, IdMap.add n (Complete v) bindings)
+    | P_lit l => pattern_match_literal l v
+    | P_as p n => match_binds n (Complete v) (pattern_match p v)
     | P_app ctor ps =>
         match v with
         | V_ctor v_ctor vs =>
@@ -787,24 +826,20 @@ Module Make (T : SemanticExt).
                      (fun match_info p =>
                         match match_info with
                         (* The arguments and pattern are different lengths, so no match *)
-                        | (_, []) => (no_match, [])
-                        (* A previous argument pattern already failed *)
-                        | ((false, _), v :: vs) => (no_match, vs)
-                        | ((true, vars), v :: vs) =>
-                            let '(matched, more_vars) := pattern_match p v in
-                            ((matched, vars ⋈ more_vars), vs)
+                        | (_, []) => (Unmatched, [])
+                        | (prev, v :: vs) => (prev ⋈ pattern_match p v, vs)
                         end
                      )
                      ps
-                     ((true, []), vs))
+                     (simple_match, vs))
             else
-              no_match
-        | _ => no_match
+              Unmatched
+        | _ => Unmatched
         end
     | P_tuple [] =>
         match v with
-        | V_unit => (true, [])
-        | _ => no_match
+        | V_unit | V_unknown => simple_match
+        | _ => Unmatched
         end
     | P_tuple ps =>
         match v with
@@ -813,17 +848,13 @@ Module Make (T : SemanticExt).
                    (fun match_info p =>
                       match match_info with
                       (* The tuple and pattern are different lengths, so no match *)
-                      | (_, []) => (no_match, [])
-                      (* A previous element pattern already failed *)
-                      | ((false, _), v :: vs) => (no_match, vs)
-                      | ((true, vars), v :: vs) =>
-                          let '(matched, more_vars) := pattern_match p v in
-                          ((matched, vars ⋈ more_vars), vs)
+                      | (_, []) => (Unmatched, [])
+                      | (prev, v :: vs) => (prev ⋈ pattern_match p v, vs)
                       end
                    )
                    ps
-                   ((true, []), vs))
-        | _ => no_match
+                   (simple_match, vs))
+        | _ => Unmatched
         end
     | P_list ps =>
         match v with
@@ -833,20 +864,16 @@ Module Make (T : SemanticExt).
                      (fun match_info p =>
                         match match_info with
                         (* The list and pattern are different lengths, so no match *)
-                        | (_, []) => (no_match, [])
-                        (* A previous element pattern already failed *)
-                        | ((false, _), v :: vs) => (no_match, vs)
-                        | ((true, vars), v :: vs) =>
-                            let '(matched, more_vars) := pattern_match p v in
-                            ((matched, vars ⋈ more_vars), vs)
+                        | (_, []) => (Unmatched, [])
+                        | (prev, v :: vs) => (prev ⋈ pattern_match p v, vs)
                         end
                      )
                      ps
-                     ((true, []), vs))
+                     (simple_match, vs))
             else
-              no_match
+              Unmatched
         (* Matching a list on a non-list *)
-        | _ => no_match
+        | _ => Unmatched
         end
     | P_vector ps =>
         match to_gvector v with
@@ -855,18 +882,14 @@ Module Make (T : SemanticExt).
                    (fun match_info p =>
                       match match_info with
                       (* The vector and pattern are different lengths, so no match *)
-                      | (_, []) => (no_match, [])
-                      (* A previous element pattern already failed *)
-                      | ((false, _), v :: vs) => (no_match, vs)
-                      | ((true, vars), v :: vs) =>
-                          let '(matched, more_vars) := pattern_match p v in
-                     ((matched, vars ⋈ more_vars), vs)
+                      | (_, []) => (Unmatched, [])
+                      | (prev, v :: vs) => (prev ⋈ pattern_match p v, vs)
                       end
                    )
                    ps
-                   ((true, []), vs))
+                   (simple_match, vs))
         (* Matching a list on a non-list *)
-        | _ => no_match
+        | _ => Unmatched
         end
     | P_vector_concat ps =>
         match v with
@@ -877,17 +900,15 @@ Module Make (T : SemanticExt).
                     match T.get_split (snd annot) with
                     | Split s =>
                         match match_info with
-                        | (_, []) => (no_match, [])
-                        | ((false, _), bs) => (no_match, bs)
-                        | ((true, bound), bs) =>
+                        | (_, []) => (Unmatched, [])
+                        | (prev, bs) =>
                             let '(bs_take, bs_drop) := take_drop s bs in
-                            let '(matched, more_bound) := pattern_match p (V_bitvector bs_take) in
-                            ((matched, bound ⋈ more_bound), bs_drop)
+                            (prev ⋈ pattern_match p (V_bitvector bs_take), bs_drop)
                         end
-                    | No_split => (no_match, [])
+                    | No_split => (Unmatched, [])
                     end)
                    ps
-                   ((true, []), bs))
+                   (simple_match, bs))
         | V_vector vs =>
             fst (fold_left
                    (fun match_info p =>
@@ -895,59 +916,41 @@ Module Make (T : SemanticExt).
                     match T.get_split (snd annot) with
                     | Split s =>
                         match match_info with
-                        | (_, []) => (no_match, [])
-                        | ((false, _), vs) => (no_match, vs)
-                        | ((true, bound), vs) =>
+                        | (_, []) => (Unmatched, [])
+                        | (prev, vs) =>
                             let '(vs_take, vs_drop) := take_drop s vs in
-                            let '(matched, more_bound) := pattern_match p (V_vector vs_take) in
-                            ((matched, bound ⋈ more_bound), vs_drop)
+                            (prev ⋈ pattern_match p (V_vector vs_take), vs_drop)
                         end
-                    | No_split => (no_match, [])
+                    | No_split => (Unmatched, [])
                     end)
                    ps
-                   ((true, []), vs))
-        | _ => no_match
+                   (simple_match, vs))
+        | _ => Unmatched
         end
     | P_cons p ps =>
         match v with
-        | V_list nil => no_match
-        | V_list (v :: vs) =>
-            let '(hd_matched, hd_bound) := pattern_match p v in
-            let '(tl_matched, tl_bound) := pattern_match ps (V_list vs) in
-            (andb hd_matched tl_matched, hd_bound ⋈ tl_bound)
-        | _ => no_match
+        | V_list (v :: vs) => pattern_match p v ⋈ pattern_match ps (V_list vs)
+        | _ => Unmatched
         end
-    | P_or lhs_p rhs_p =>
-        let '(lhs_matched, lhs_bound) := pattern_match lhs_p v in
-        let '(rhs_matched, rhs_bound) := pattern_match rhs_p v in
-        if lhs_matched then
-          (true, lhs_bound)
-        else if rhs_matched then
-               (true, rhs_bound)
-             else
-               no_match
-    | P_not p =>
-        let '(p_matched, _) := pattern_match p v in
-        (negb p_matched, [])
+    | P_or lhs_p rhs_p => or_match (pattern_match lhs_p v) (pattern_match rhs_p v)
+    | P_not p => neg_match (pattern_match p v)
     | P_var p _ => pattern_match p v
     | P_struct _ field_patterns _ =>
         match v with
         | V_record fields =>
             fold_left
-              (fun match_info fp =>
-                 let '(prev_matched, prev_bound) := match_info in
+              (fun prev fp =>
                  let '(name, p) := fp in
                  let v := get_struct_field name fields in
-                 let '(matched, bound) := pattern_match p v in
-                 (andb prev_matched matched, prev_bound ⋈ bound)
+                 prev ⋈ pattern_match p v
               )
               field_patterns
-              (true, [])
-        | _ => no_match
+              simple_match
+        | _ => Unmatched
         end
-    | P_vector_subrange id n m => (true, IdMap.add id (Partial (Non_empty (v, n, m) [])) empty_bindings)
+    | P_vector_subrange id n m => Matched (IdMap.add id (Partial (Non_empty (v, n, m) [])) empty_bindings)
     (* TODO *)
-    | P_string_append _ => (true, empty_bindings)
+    | P_string_append _ => simple_match
     end.
 
   Fixpoint lookup_field (l : Ast.loc) (name : id) (fields : list (id * value)) {struct fields} : t value :=
@@ -1327,34 +1330,37 @@ Module Make (T : SemanticExt).
         | E_aux (E_internal_value v) _ =>
             match arms with
             | Pat_aux (Pat_exp pat body) _ :: next_arms =>
-                let '(matched, arm_substs) := pattern_match pat v in
-                if matched then
-                  pure (fold_right (fun s body => substitute (fst s) (snd s) body) body (complete_bindings arm_substs))
-                else
-                  wrap (E_match head_exp next_arms)
+                match pattern_match pat v with
+                | Matched arm_substs =>
+                    pure (fold_right (fun s body => substitute (fst s) (snd s) body) body (complete_bindings arm_substs))
+                | _ =>
+                    wrap (E_match head_exp next_arms)
+                end
             | Pat_aux (Pat_when pat guard body) pexp_annot :: next_arms =>
-                let '(matched, arm_substs) := pattern_match pat v in
-                if matched then
-                  let guard := fold_right (fun s g => substitute (fst s) (snd s) g)  guard (complete_bindings arm_substs) in
-                  match guard with
-                  | E_aux (E_internal_value v_guard) _ =>
-                      match v_guard with
-                      | V_bool true =>
-                          let '(matched, arm_substs) := pattern_match pat v in
-                          if matched then
-                            pure (fold_right (fun s body => substitute (fst s) (snd s) body) body (complete_bindings arm_substs))
-                          else
+                match pattern_match pat v with
+                | Matched arm_substs =>
+                    let guard := fold_right (fun s g => substitute (fst s) (snd s) g)  guard (complete_bindings arm_substs) in
+                    match guard with
+                    | E_aux (E_internal_value v_guard) _ =>
+                        match v_guard with
+                        | V_bool true =>
+                            match pattern_match pat v with
+                            | Matched arm_substs =>
+                                pure (fold_right (fun s body => substitute (fst s) (snd s) body) body (complete_bindings arm_substs))
+                            | _ =>
+                                wrap (E_match head_exp next_arms)
+                            end
+                        | V_bool false =>
                             wrap (E_match head_exp next_arms)
-                      | V_bool false =>
-                          wrap (E_match head_exp next_arms)
-                      | _ => Runtime_type_error (fst pexp_annot)
-                      end
-                  | _ =>
-                      guard' ← step guard;
-                      wrap (E_match head_exp (Pat_aux (Pat_when pat guard' body) pexp_annot :: next_arms))
-                  end
-                else
-                  wrap (E_match head_exp next_arms)
+                        | _ => Runtime_type_error (fst pexp_annot)
+                        end
+                    | _ =>
+                        guard' ← step guard;
+                        wrap (E_match head_exp (Pat_aux (Pat_when pat guard' body) pexp_annot :: next_arms))
+                    end
+                | _ =>
+                    wrap (E_match head_exp next_arms)
+                end
             | [] => Match_failure (fst annot)
             end
         | _ =>
@@ -1364,11 +1370,12 @@ Module Make (T : SemanticExt).
     | E_let (LB_aux (LB_val pat x) lb_annot) body =>
         match x with
         | E_aux (E_internal_value v) _ =>
-            let '(matched, body_substs) := pattern_match pat v in
-            if matched then
-              pure (fold_left (fun body s => substitute (fst s) (snd s) body) (complete_bindings body_substs) body)
-            else
-              Match_failure (fst annot)
+            match pattern_match pat v with
+            | Matched body_substs =>
+                pure (fold_left (fun body s => substitute (fst s) (snd s) body) (complete_bindings body_substs) body)
+            | _ =>
+                Match_failure (fst annot)
+            end
         | _ =>
             x' ← step x;
             wrap (E_let (LB_aux (LB_val pat x') lb_annot) body)

--- a/src/lib/value.ml
+++ b/src/lib/value.ml
@@ -93,6 +93,7 @@ let rec string_of_value = function
       "struct {"
       ^ Util.string_of_list ", " (fun (field, v) -> string_of_id field ^ " = " ^ string_of_value v) record
       ^ "}"
+  | V_unknown -> "unknown"
 
 let mk_real r = V_real (Util.Rational.to_rocq r)
 


### PR DESCRIPTION
Pattern matching in the Rocq semantics now supports a type with unknown values. The pattern matching functions return a new `match_result` type that encapsulates the possibility of a possible match based on those unknown values.

There are various theorems that need to be proved. We need to define an ordering on values based on how unknown they are, and an ordering for how definite a pattern match result is. The pattern matching function should be an order preserving mapping between these types.