### PR TITLE
bump bracket depth for Clang in Lean backend

### DIFF
--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -379,6 +379,7 @@ let create_lake_project (ctx : lean_context) executable =
    ^ "\"]\nmoreLeanArgs = [\"--tstack=400000\"]\n\n[[lean_lib]]\nname = \"" ^ ctx.out_name_camel ^ "\""
     );
   output_string ctx.lakefile "\nleanOptions.weak.linter.style.nameCheck = false";
+  output_string ctx.lakefile "\nmoreLeancArgs= [\"-fbracket-depth=500\"]";
   output_support_lib ctx;
   if !opt_lean_real_numbers then (
     output_string ctx.lakefile "\n\n[[require]]\n";


### PR DESCRIPTION
In the context of sail-riscv, some recent changes have made it so that clang hits the curly bracket nesting limit on the compiled Lean code extracted via Sail.

The fix requires passing some C flag to clang while it's building the extracted code, so the limit must be increased in the lakefile.toml generated by the Lean backend.

The default limit was 256, and empirically, we needed a number between 300 and 350.  Setting to 500 seems like a reasonable number for now.