### PR TITLE
Add default cases to C case statements where needed.

### DIFF
--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -206,8 +206,8 @@ let c_return exp = string "return" ^^ space ^^ exp ^^ semi
 
 let c_case_block b = nest 2 (separate hardline ([lbrace] @ b @ [c_stmt "break"])) ^^ hardline ^^ rbrace
 
-(* Generate a C switch statement. There's no default case. *)
-let c_switch cond cases =
+(* Generate a C switch statement. If default is true, then we generate a `default: break;` case at the end. *)
+let c_switch ?(default = false) cond cases =
   match cases with
   | [] -> string "{}"
   | _ ->
@@ -217,6 +217,7 @@ let c_switch cond cases =
              string "case" ^^ space ^^ case_exp ^^ colon ^^ space ^^ c_case_block case_block
            )
            cases
+      ^^ (if default then hardline ^^ string "default" ^^ colon ^^ space ^^ string "break" ^^ semi else empty)
       ^^ hardline ^^ rbrace
 
 module C_config (Opts : sig
@@ -1735,16 +1736,18 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
         in
         (* Create a switch that does something for each constructor *)
         let each_ctor v f ctors =
-          let cases =
-            List.filter_map
-              (fun (ctor_id, ctyp) ->
-                Option.map (fun op -> (ksprintf string "Kind_%s" (sgen_id ctor_id), [op])) (f ctor_id ctyp)
+          let cases, default =
+            List.fold_left
+              (fun (cases, default) (ctor_id, ctyp) ->
+                match f ctor_id ctyp with
+                | Some op -> ((ksprintf string "Kind_%s" (sgen_id ctor_id), [op]) :: cases, default)
+                | None -> (cases, true)
               )
-              ctors
+              ([], false) ctors
           in
           (* Avoid outputting empty switches. This is here instead of in `c_switch` because
             in `c_switch` we don't know that the condition expression has no side effects. *)
-          if cases = [] then empty else c_switch (ksprintf string "(%skind)" v) cases
+          if cases = [] then empty else c_switch ~default (ksprintf string "(%skind)" v) (List.rev cases)
         in
         let codegen_init =
           let n = sgen_id id in


### PR DESCRIPTION
This avoids a warning on clang.