### PR TITLE
[Lean] Fix miscompilation of append

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -637,7 +637,7 @@ let op_of_id id =
   | Some "_lean_mul" -> `Binop "*"
   | Some "_lean_muli" -> `Binop "*i"
   | Some "_lean_div" -> `Binop "/"
-  | Some "_lean_app" -> `Binop "++"
+  | Some "_lean_app" -> `Binop "+++" (* see issue sail#1630 *)
   | Some "_lean_bvand" -> `Binop "&&&"
   | Some "_lean_bvor" -> `Binop "|||"
   | Some "_lean_bvxor" -> `Binop "^^^"

--- a/test/c/mini_builtins.sail
+++ b/test/c/mini_builtins.sail
@@ -169,7 +169,7 @@ function test_vector_update_subrange() -> unit = {
 function main() -> unit = {
   test_add_bits();
 // Currently a problem with Lean
-//  test_append();
+  test_append();
   test_clz();
   test_ctz();
   test_divmod();

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -1895,7 +1895,7 @@ def decodeDataMemoryBarrier (CRm : (BitVec 4)) : (Option ast) :=
 
 def decodeCompareAndBranch (imm19 : (BitVec 19)) (Rt : (BitVec 5)) : (Option ast) :=
   let t : reg_index := (BitVec.toNatInt Rt)
-  let offset : (BitVec 64) := (Sail.BitVec.signExtend (imm19 ++ 0b00#2) 64)
+  let offset : (BitVec 64) := (Sail.BitVec.signExtend (imm19 +++ 0b00#2) 64)
   (some (CompareAndBranch (t, offset)))
 
 /-- Type quantifiers: k_n : Nat, k_n ≥ 0 -/

--- a/test/lean/SailTinyArmV2.expected.lean
+++ b/test/lean/SailTinyArmV2.expected.lean
@@ -1558,7 +1558,7 @@ def decodeDataMemoryBarrier (merge_var : (BitVec 4)) : (Option ast) :=
 
 def decodeCompareAndBranch (imm19 : (BitVec 19)) (Rt : (BitVec 5)) : (Option ast) :=
   let t : reg_index := (BitVec.toNatInt Rt)
-  let offset : (BitVec 64) := (Sail.BitVec.signExtend (imm19 ++ 0b00#2) 64)
+  let offset : (BitVec 64) := (Sail.BitVec.signExtend (imm19 +++ 0b00#2) 64)
   (some (CompareAndBranch (t, offset)))
 
 /-- Type quantifiers: m : Nat, n : Nat, t : Nat, 0 ≤ t ∧ t ≤ 31, 0 ≤ n ∧ n ≤ 31, 0 ≤ m

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -142,7 +142,7 @@ def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
 def unif_bitvec_append (x : (BitVec 13)) (y : (BitVec 3)) : (BitVec (4 * 4)) :=
-  (x ++ y)
+  (x +++ y)
 
 def unif_bitvec_replicate (x : (BitVec 4)) : (BitVec (2 * 8)) :=
   (BitVec.replicateBits x 4)

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -163,7 +163,7 @@ def bitvector_truncateLSB (x : (BitVec 32)) : (BitVec 16) :=
   (Sail.BitVec.truncateLsb x 16)
 
 def bitvector_append (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 32) :=
-  (x ++ y)
+  (x +++ y)
 
 def bitvector_add (x : (BitVec 16)) (y : (BitVec 16)) : (BitVec 16) :=
   (x + y)

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -343,7 +343,7 @@ def vtype_assembly_backwards (arg_ : ((BitVec 1) × (BitVec 1))) : SailM String 
     (do
       if (((BitVec.access sew 0) == 1#1) : Bool)
       then (pure (String.append (ta_flag_backwards sew) (String.append (ta_flag_backwards ta) "")))
-      else (hex_bits_2_forwards ((ta : (BitVec 1)) ++ (sew : (BitVec 1)))))
+      else (hex_bits_2_forwards ((ta : (BitVec 1)) +++ (sew : (BitVec 1)))))
 
 def vtype_assembly_forwards_matches (arg_ : String) : SailM Bool := do
   throw Error.Exit
@@ -372,7 +372,7 @@ def vtype_assembly2_forwards (arg_ : String) : SailM ((BitVec 1) × (BitVec 1)) 
 
 def vtype_assembly2_backwards (arg_ : ((BitVec 1) × (BitVec 1))) : SailM String := do
   match arg_ with
-  | (ta, sew) => (hex_bits_2_forwards ((ta : (BitVec 1)) ++ (sew : (BitVec 1))))
+  | (ta, sew) => (hex_bits_2_forwards ((ta : (BitVec 1)) +++ (sew : (BitVec 1))))
 
 def vtype_assembly2_forwards_matches (arg_ : String) : SailM Bool := do
   let head_exp_ := arg_

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -220,7 +220,7 @@ def match_width (x : (BitVec k_n)) : (BitVec (2 * k_n)) :=
     | 16 => (const16 ())
     | 32 => (const32 ())
     | n => ((BitVec.zero n), false)
-  (foo ++ foo)
+  (foo +++ foo)
 
 def match_option_bitvec (x : (Option (BitVec 16))) : Int :=
   match x with

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -14,6 +14,7 @@ from sailtest import *
 
 update_expected = args.update_expected
 run_skips = args.run_skips
+local_support_lib = args.lean_local_support_library
 
 sail_dir = get_sail_dir()
 sail = get_sail()
@@ -54,14 +55,17 @@ skip_selftests = {
 print("Sail is {}".format(sail))
 print("Sail dir is {}".format(sail_dir))
 
-def clone_support_lib(subdir) -> str:
-    lean_path = f"../{subdir}"
-    lib_path = f"../{subdir}/support-lib"
-    step(f"rm -rf {lib_path} || true")
-    step(f"git clone https://github.com/rems-project/lean-sail.git {lib_path}")
-    print("Building the support library")
-    step("lake build", cwd=lib_path)
-    return f"../../support-lib"
+def get_support_lib(subdir) -> str:
+    if local_support_lib:
+        return local_support_lib
+    else:
+        lean_path = f"../{subdir}"
+        lib_path = f"../{subdir}/support-lib"
+        step(f"rm -rf {lib_path} || true")
+        step(f"git clone https://github.com/rems-project/lean-sail.git {lib_path}")
+        print("Building the support library")
+        step("lake build", cwd=lib_path)
+        return f"../../support-lib"
 
 def test_lean(subdir: str, skip_list = None, runnable: bool = False):
     """
@@ -70,7 +74,7 @@ def test_lean(subdir: str, skip_list = None, runnable: bool = False):
     instead of `lake build`.
     """
     banner("Cloning the support library")
-    support_lib = clone_support_lib(subdir)
+    support_lib = get_support_lib(subdir)
     print("...done!")
     banner(f'Testing lean target (sub-directory: {subdir})')
     results = Results(subdir)

--- a/test/sailtest.py
+++ b/test/sailtest.py
@@ -19,6 +19,7 @@ parser.add_argument("--targets", help="Targets to use (where supported).", actio
 parser.add_argument("--update-expected", help="Update the expected file (where supported)", action="store_true")
 parser.add_argument("--run-skips", help="Run tests that would otherwise be skipped", action="store_true")
 parser.add_argument("--test", help="Run only specified test.", action='append')
+parser.add_argument("--lean-local-support-library", help="Use a local Lean support library", action='store')
 args = parser.parse_args()
 
 def is_compact():


### PR DESCRIPTION
Lean was inserting spurious coercions which would break our handling of append. Instead we define our own notation for append.

Also adds an option to run the Lean tests with a local version of the Lean support library.

Fixes #1630

-----

I also checked that it works on the RISC-V model.