### PR TITLE
[Lean] Bump Lean toolchain version

### DIFF
--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -94,10 +94,10 @@ let opt_lean_lib_rev : string option ref = ref None
 let opt_enable_matchbv : bool ref = ref false
 let opt_disable_matchbv : bool ref = ref true
 
-let lean_version : string = "lean4:nightly-2026-01-22"
-let mathlib_version : string = "nightly-testing-2026-01-22"
+let lean_version : string = "lean4:nightly-2026-03-05"
+let mathlib_version : string = "nightly-testing-2026-03-05"
 let lib_default_git : string = "https://github.com/rems-project/lean-sail"
-let lib_default_rev : string = "v2"
+let lib_default_rev : string = "v3"
 
 let lean_options =
   [


### PR DESCRIPTION
The main reason for the bump is that the new Lean version has `popcount` bitblastable.