### PR TITLE
Allow multiple attributes on the same AST node to be comma separated

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -82,7 +82,7 @@ and chunk =
   | Comment of comment_type * int * int * string * bool
   | Doc_comment of doc_comment
   | Spacer of bool * int
-  | Attribute of string * chunks
+  | Attributes of (string * chunks option) list
   | Function of {
       id : id;
       clause : bool;
@@ -146,9 +146,14 @@ let rec prerr_chunk indent = function
       Printf.eprintf "%sComment: blank=%d col=%d trailing=%b %s%s%s\n" indent n col trailing s contents e
   | Doc_comment { contents; _ } -> Printf.eprintf "%sDoc_comment: /*!%s*/\n" indent contents
   | Spacer (line, w) -> Printf.eprintf "%sSpacer:%b %d\n" indent line w
-  | Attribute (attr, chunks) ->
-      Printf.eprintf "%sAttribute:%s\n" indent attr;
-      Queue.iter (prerr_chunk (indent ^ "    ")) chunks
+  | Attributes attrs ->
+      Printf.eprintf "%sAttributes:\n" indent;
+      List.iter
+        (fun (attr, chunks_opt) ->
+          Printf.eprintf "%s  %s:" indent attr;
+          match chunks_opt with Some chunks -> Queue.iter (prerr_chunk (indent ^ "    ")) chunks | None -> ()
+        )
+        attrs
   | Atom str -> Printf.eprintf "%sAtom:%s\n" indent str
   | String_literal str -> Printf.eprintf "%sString_literal:%s\n" indent str
   | Multiline_string_literal lines ->
@@ -663,13 +668,20 @@ let rec chunk_attribute_data comments chunks (AD_aux (aux, l)) =
       else if bare_attribute_string s then Queue.add (Atom s) chunks
       else Queue.add (String_literal s) chunks
 
-let chunk_attribute comments chunks attr arg =
-  match arg with
-  | None -> Queue.add (Atom (Printf.sprintf "$[%s]" attr)) chunks
-  | Some adata ->
-      let inner_chunks = Queue.create () in
-      chunk_attribute_data comments inner_chunks adata;
-      Queue.add (Attribute (attr, inner_chunks)) chunks
+let chunk_attributes comments chunks attrs =
+  let attrs =
+    List.map
+      (fun (_, attr, arg) ->
+        match arg with
+        | None -> (attr, None)
+        | Some adata ->
+            let inner_chunks = Queue.create () in
+            chunk_attribute_data comments inner_chunks adata;
+            (attr, Some inner_chunks)
+      )
+      attrs
+  in
+  Queue.add (Attributes attrs) chunks
 
 let rec chunk_atyp comments chunks (ATyp_aux (aux, l)) =
   pop_comments comments chunks l;
@@ -840,8 +852,8 @@ let rec chunk_pat comments chunks (P_aux (aux, l)) =
         chunk_delimit ~within:l ~delim:"," ~get_loc:(fun (FP_aux (_, l)) -> l) ~chunk:chunk_fpat comments fpats
       in
       Queue.add (Tuple ("struct {", "}", 1, fpats)) chunks
-  | P_attribute (attr, arg, pat) ->
-      chunk_attribute comments chunks attr arg;
+  | P_attribute (attrs, pat) ->
+      chunk_attributes comments chunks attrs;
       Queue.add (Spacer (false, 1)) chunks;
       chunk_pat comments chunks pat
 
@@ -876,7 +888,7 @@ let flatten_block exps =
 (* Check if a sequence of cases in a match or try statement is aligned *)
 let is_aligned pexps =
   let rec pexp_exp_column = function
-    | Pat_aux (Pat_attribute (_, _, pexp), _) -> pexp_exp_column pexp
+    | Pat_aux (Pat_attribute (_, pexp), _) -> pexp_exp_column pexp
     | Pat_aux (Pat_exp (_, E_aux (_, l)), _) -> starting_column_num l
     | Pat_aux (Pat_when (_, _, E_aux (_, l)), _) -> starting_column_num l
   in
@@ -910,8 +922,8 @@ let rec chunk_exp comments chunks (E_aux (aux, l)) =
   | E_config s -> Queue.add (Atom ("config " ^ s)) chunks
   | E_undef -> Queue.add (Atom "undefined") chunks
   | E_lit lit -> Queue.add (chunk_of_lit lit) chunks
-  | E_attribute (attr, arg, exp) ->
-      chunk_attribute comments chunks attr arg;
+  | E_attribute (attrs, exp) ->
+      chunk_attributes comments chunks attrs;
       Queue.add (Spacer (false, 1)) chunks;
       chunk_exp comments chunks exp
   | E_app (id, [E_aux (E_lit (L_aux (L_unit, _)), _)]) -> Queue.add (App (id, [])) chunks
@@ -1204,9 +1216,9 @@ and chunk_vector_update comments (E_aux (aux, l) as exp) =
 
 and chunk_pexp ?attr_chunks ?delim comments chunks (Pat_aux (aux, l)) =
   match aux with
-  | Pat_attribute (attr, arg, pexp) ->
+  | Pat_attribute (attrs, pexp) ->
       let chunks = match attr_chunks with Some chunks -> chunks | None -> Queue.create () in
-      chunk_attribute comments chunks attr arg;
+      chunk_attributes comments chunks attrs;
       Queue.add (Spacer (false, 1)) chunks;
       chunk_pexp ~attr_chunks:chunks ?delim comments chunks pexp
   | Pat_exp (pat, exp) ->
@@ -1239,8 +1251,8 @@ let chunk_funcl comments funcl =
         Queue.add (Atom "private") chunks;
         Queue.add (Spacer (false, 1)) chunks;
         chunk_funcl' comments funcl
-    | FCL_attribute (attr, arg, funcl) ->
-        chunk_attribute comments chunks attr arg;
+    | FCL_attribute (attrs, funcl) ->
+        chunk_attributes comments chunks attrs;
         Queue.add (Spacer (false, 1)) chunks;
         chunk_funcl' comments funcl
     | FCL_doc (_, funcl) -> chunk_funcl' comments funcl
@@ -1298,7 +1310,7 @@ let rec is_hanging_fundef l = function
   | Pat_aux (Pat_exp (_, E_aux (_, exp_l)), _) | Pat_aux (Pat_when (_, _, E_aux (_, exp_l)), _) ->
       let line = starting_line_num l in
       Option.is_some line && line = starting_line_num exp_l
-  | Pat_aux (Pat_attribute (_, _, pexp), _) -> is_hanging_fundef l pexp
+  | Pat_aux (Pat_attribute (_, pexp), _) -> is_hanging_fundef l pexp
 
 let chunk_fundef comments chunks (FD_aux (FD_function (rec_opt, tannot_opt, funcls), l)) =
   pop_comments comments chunks l;
@@ -1405,9 +1417,9 @@ let build_def chunks fs =
   finish_def def_chunks chunks
 
 let rec chunk_annotations f comments chunks = function
-  | Ann_attribute (attr, arg, anns, l) ->
+  | Ann_attribute (attrs, anns, l) ->
       pop_comments comments chunks l;
-      chunk_attribute comments chunks attr arg;
+      chunk_attributes comments chunks attrs;
       Queue.add (Spacer (true, 1)) chunks;
       chunk_annotations f comments chunks anns
   | Ann_doc (doc, anns, l) ->
@@ -1416,7 +1428,7 @@ let rec chunk_annotations f comments chunks = function
       chunk_annotations f comments chunks anns
   | Ann_item x -> f comments chunks x
 
-let rec ann_item = function Ann_attribute (_, _, anns, _) | Ann_doc (_, anns, _) -> ann_item anns | Ann_item x -> x
+let rec ann_item = function Ann_attribute (_, anns, _) | Ann_doc (_, anns, _) -> ann_item anns | Ann_item x -> x
 
 let chunk_type_def comments chunks (TD_aux (aux, l)) =
   pop_comments comments chunks l;
@@ -1499,6 +1511,11 @@ let can_handle_td (TD_aux (aux, _)) = match aux with TD_enum _ -> true | _ -> fa
 let can_handle_sd (SD_aux (aux, _)) =
   match aux with SD_funcl _ | SD_end _ | SD_function _ | SD_enum _ | SD_enumcl _ -> true | _ -> false
 
+let rec has_skip_attr skip = function
+  | [] -> skip
+  | (_, "fmt", Some (AD_aux (AD_string "skip", _))) :: _ -> true
+  | _ :: attrs -> has_skip_attr skip attrs
+
 let rec chunk_def skip source last_line_span comments chunks (DEF_aux (def, l)) =
   let line_span = (starting_line_num l, ending_line_num l) in
   let spacing = def_spacer last_line_span line_span in
@@ -1524,11 +1541,11 @@ let rec chunk_def skip source last_line_span comments chunks (DEF_aux (def, l)) 
       pop_comments comments chunks l;
       Queue.add (Doc_comment doc) chunks;
       chunk_def skip source last_line_span comments chunks def
-  | DEF_attribute (attr, arg, def) ->
+  | DEF_attribute (attrs, def) ->
       pop_comments comments chunks l;
-      chunk_attribute comments chunks attr arg;
+      chunk_attributes comments chunks attrs;
       Queue.add (Spacer (false, 1)) chunks;
-      let skip = match (attr, arg) with "fmt", Some (AD_aux (AD_string "skip", _)) -> true | _ -> skip in
+      let skip = has_skip_attr skip attrs in
       chunk_def skip source last_line_span comments chunks def
   | def ->
       if skip then raw_source ()

--- a/src/lib/chunk_ast.mli
+++ b/src/lib/chunk_ast.mli
@@ -68,7 +68,7 @@ and chunk =
   | Comment of Parse_ast.comment_type * int * int * string * bool
   | Doc_comment of Parse_ast.doc_comment
   | Spacer of bool * int
-  | Attribute of string * chunks
+  | Attributes of (string * chunks option) list
   | Function of {
       id : Parse_ast.id;
       clause : bool;

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -524,10 +524,18 @@ module Make (Config : CONFIG) = struct
     | String_literal s -> utf8string ("\"" ^ String.escaped s ^ "\"")
     | Multiline_string_literal lines ->
         string "\"\"\"" ^^ hardline ^^ separate_map hardline string lines ^^ hardline ^^ string "\"\"\""
-    | Attribute (attr, arg) ->
+    | Attributes attrs ->
         (* Reset opts to defaults, so attributes are always formatted
           the same no matter where they appear. *)
-        string "$[" ^^ string attr ^^ space ^^ doc_chunks default_opts arg ^^ char ']'
+        let body =
+          separate_map
+            (char ',' ^^ space)
+            (fun (attr, arg_opt) ->
+              match arg_opt with None -> string attr | Some arg -> string attr ^^ space ^^ doc_chunks default_opts arg
+            )
+            attrs
+        in
+        string "$[" ^^ body ^^ char ']'
     | App (id, args) -> (
         match args with
         | [] -> doc_id id ^^ string "()"

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -376,9 +376,9 @@ module KindInference = struct
     | P.Ann_doc (doc, x, l) ->
         let* y = mapM_field_item f x in
         return (P.Ann_doc (doc, y, l))
-    | P.Ann_attribute (attr, arg, x, l) ->
+    | P.Ann_attribute (attrs, x, l) ->
         let* y = mapM_field_item f x in
-        return (P.Ann_attribute (attr, arg, y, l))
+        return (P.Ann_attribute (attrs, y, l))
     | P.Ann_item x ->
         let* y = f x in
         return (P.Ann_item y)
@@ -730,16 +730,16 @@ module KindInference = struct
             fpats
         in
         wrap (P.P_struct (struct_name, fpats))
-    | P.P_attribute (attr, arg, pat) ->
+    | P.P_attribute (attrs, pat) ->
         let* pat = infer_pat ctx pat in
-        wrap (P.P_attribute (attr, arg, pat))
+        wrap (P.P_attribute (attrs, pat))
 
   let rec infer_case ctx (P.Pat_aux (pexp, l)) =
     let wrap aux = return (P.Pat_aux (aux, l)) in
     match pexp with
-    | P.Pat_attribute (attr, arg, pexp) ->
+    | P.Pat_attribute (attrs, pexp) ->
         let* pexp = infer_case ctx pexp in
-        wrap (P.Pat_attribute (attr, arg, pexp))
+        wrap (P.Pat_attribute (attrs, pexp))
     | P.Pat_exp (pat, exp) ->
         let* pat = infer_pat ctx pat in
         wrap (P.Pat_exp (pat, exp))
@@ -753,9 +753,9 @@ module KindInference = struct
     | P.FCL_private fcl ->
         let* fcl = infer_funcl ctx fcl in
         wrap (P.FCL_private fcl)
-    | P.FCL_attribute (attr, arg, fcl) ->
+    | P.FCL_attribute (attrs, fcl) ->
         let* fcl = infer_funcl ctx fcl in
-        wrap (P.FCL_attribute (attr, arg, fcl))
+        wrap (P.FCL_attribute (attrs, fcl))
     | P.FCL_doc (doc_comment, fcl) ->
         let* fcl = infer_funcl ctx fcl in
         wrap (P.FCL_doc (doc_comment, fcl))
@@ -774,9 +774,9 @@ module KindInference = struct
     | P.Tu_private tu ->
         let* tu = infer_constructor ctx tu in
         wrap (P.Tu_private tu)
-    | P.Tu_attribute (attr, arg, tu) ->
+    | P.Tu_attribute (attrs, tu) ->
         let* tu = infer_constructor ctx tu in
-        wrap (P.Tu_attribute (attr, arg, tu))
+        wrap (P.Tu_attribute (attrs, tu))
     | P.Tu_doc (doc_comment, tu) ->
         let* tu = infer_constructor ctx tu in
         wrap (P.Tu_doc (doc_comment, tu))
@@ -1110,7 +1110,7 @@ module ConvertType = struct
         | Some _ -> raise (Reporting.err_general l "Union constructor has multiple documentation comments")
         | None -> to_ast_type_union kenv (Some doc_comment) attrs vis ctx tu
       end
-    | P.Tu_aux (P.Tu_attribute (attr, arg, tu), l) -> to_ast_type_union kenv doc (attrs @ [(l, attr, arg)]) vis ctx tu
+    | P.Tu_aux (P.Tu_attribute (attrs', tu), _) -> to_ast_type_union kenv doc (attrs @ attrs') vis ctx tu
     | P.Tu_aux (P.Tu_ty_id (atyp, id), l) ->
         let typ = to_ast_typ kenv ctx atyp in
         Tu_aux (Tu_ty_id (typ, to_ast_id ctx id), mk_def_annot ?doc ~attrs ?visibility:vis l ())
@@ -1312,12 +1312,13 @@ let check_duplicate_fields ~error ~field_id fields =
     IdSet.empty fields
   |> ignore
 
+let add_attributes attrs annot = List.fold_left (fun annot (l, attr, arg) -> add_attribute l attr arg annot) annot attrs
+
 let rec to_ast_pat ctx (P.P_aux (aux, l)) =
   match aux with
-  | P.P_attribute (attr, arg, pat) ->
+  | P.P_attribute (attrs, pat) ->
       let (P_aux (aux, (pat_l, annot))) = to_ast_pat ctx pat in
-      (* The location of an E_attribute node is just the attribute by itself *)
-      let annot = add_attribute l attr arg annot in
+      let annot = add_attributes attrs annot in
       P_aux (aux, (pat_l, annot))
   | _ ->
       let aux =
@@ -1402,10 +1403,10 @@ let rec to_ast_exp ctx exp =
   match exp with
   (* Will have just been removed by parse_infix_exp *)
   | P.E_infix _ -> assert false
-  | P.E_attribute (attr, arg, exp) ->
+  | P.E_attribute (attrs, exp) ->
       let (E_aux (exp, (exp_l, annot))) = to_ast_exp ctx exp in
       (* The location of an E_attribute node is just the attribute itself *)
-      let annot = add_attribute l attr arg annot in
+      let annot = add_attributes attrs annot in
       E_aux (exp, (exp_l, annot))
   | P.E_block exps -> (
       match to_ast_fexps false ctx exps with
@@ -1566,9 +1567,9 @@ and to_ast_lexp_vector_concat ctx (P.E_aux (exp_aux, l) as exp) =
 
 and to_ast_case ctx (P.Pat_aux (pexp_aux, l) : P.pexp) : uannot pexp =
   match pexp_aux with
-  | P.Pat_attribute (attr, arg, pexp) ->
+  | P.Pat_attribute (attrs, pexp) ->
       let (Pat_aux (pexp, (pexp_l, annot))) = to_ast_case ctx pexp in
-      let annot = add_attribute l attr arg annot in
+      let annot = add_attributes attrs annot in
       Pat_aux (pexp, (pexp_l, annot))
   | P.Pat_exp (pat, exp) -> Pat_aux (Pat_exp (to_ast_pat ctx pat, to_ast_exp ctx exp), (l, empty_uannot))
   | P.Pat_when (pat, guard, exp) ->
@@ -1696,9 +1697,9 @@ let rec type_union_strip = function
   | P.Tu_aux (P.Tu_private tu, l) ->
       let unstrip, tu = type_union_strip tu in
       ((fun tu -> P.Tu_aux (P.Tu_private (unstrip tu), l)), tu)
-  | P.Tu_aux (P.Tu_attribute (attr, arg, tu), l) ->
+  | P.Tu_aux (P.Tu_attribute (attrs, tu), l) ->
       let unstrip, tu = type_union_strip tu in
-      ((fun tu -> P.Tu_aux (P.Tu_attribute (attr, arg, unstrip tu), l)), tu)
+      ((fun tu -> P.Tu_aux (P.Tu_attribute (attrs, unstrip tu), l)), tu)
   | P.Tu_aux (P.Tu_doc (doc, tu), l) ->
       let unstrip, tu = type_union_strip tu in
       ((fun tu -> P.Tu_aux (P.Tu_doc (doc, unstrip tu), l)), tu)
@@ -1802,7 +1803,7 @@ let to_ast_reserved_type_id ctx id =
   else id
 
 let rec to_ast_field f doc attrs = function
-  | P.Ann_attribute (attr, arg, x, l) -> to_ast_field f doc (attrs @ [(l, attr, arg)]) x
+  | P.Ann_attribute (attrs', x, l) -> to_ast_field f doc (attrs @ attrs') x
   | P.Ann_doc (doc_comment, x, l) -> (
       match doc with
       | Some _ -> raise (Reporting.err_general l "Field has multiple documentation comments")
@@ -2008,7 +2009,7 @@ let use_function_type_variables id ctx =
 let rec to_ast_funcl doc attrs ctx (P.FCL_aux (fcl, l) : P.funcl) : uannot funcl =
   match fcl with
   | P.FCL_private fcl -> raise (Reporting.err_general l "private visibility modifier on function clause")
-  | P.FCL_attribute (attr, arg, fcl) -> to_ast_funcl doc (attrs @ [(l, attr, arg)]) ctx fcl
+  | P.FCL_attribute (attrs', fcl) -> to_ast_funcl doc (attrs @ attrs') ctx fcl
   | P.FCL_doc (doc_comment, fcl) -> begin
       match doc with
       | Some _ -> raise (Reporting.err_general l "Function clause has multiple documentation comments")
@@ -2100,7 +2101,7 @@ let apply_when_guard guard (MCL_aux (mcl, annot)) =
 
 let rec to_ast_mapcl doc attrs ctx (P.MCL_aux (mcl, l)) =
   match mcl with
-  | P.MCL_attribute (attr, arg, mcl) -> to_ast_mapcl doc (attrs @ [(l, attr, arg)]) ctx mcl
+  | P.MCL_attribute (attrs', mcl) -> to_ast_mapcl doc (attrs @ attrs') ctx mcl
   | P.MCL_doc (doc_comment, mcl) -> (
       match doc with
       | Some _ -> raise (Reporting.err_general l "Function clause has multiple documentation comments")
@@ -2231,7 +2232,7 @@ let rec to_ast_def doc attrs vis ctx (P.DEF_aux (def, l)) : untyped_def list ctx
       | Some _ -> raise (Reporting.err_general l "Toplevel definition has multiple visibility modifiers")
       | None -> to_ast_def doc attrs (Some (Private l)) ctx def
     end
-  | P.DEF_attribute (attr, arg, def) -> to_ast_def doc (attrs @ [(l, attr, arg)]) vis ctx def
+  | P.DEF_attribute (attrs', def) -> to_ast_def doc (attrs @ attrs') vis ctx def
   | P.DEF_doc (doc_comment, def) -> begin
       match doc with
       | Some _ -> raise (Reporting.err_general l "Toplevel definition has multiple documentation comments")

--- a/src/lib/parse_ast.ml
+++ b/src/lib/parse_ast.ml
@@ -78,7 +78,7 @@ open Attribute_data
 type 'a annot = l * 'a
 
 type 'a field_annot =
-  | Ann_attribute of string * attribute_data option * 'a field_annot * l
+  | Ann_attribute of (l * string * attribute_data option) list * 'a field_annot * l
   | Ann_doc of doc_comment * 'a field_annot * l
   | Ann_item of 'a
 
@@ -197,7 +197,7 @@ type pat_aux =
   | P_cons of pat * pat (* cons pattern *)
   | P_string_append of pat list (* string append pattern, x ^^ y *)
   | P_struct of id option * fpat list (* struct pattern *)
-  | P_attribute of string * attribute_data option * pat
+  | P_attribute of (l * string * attribute_data option) list * pat
 
 and pat = P_aux of pat_aux * l
 
@@ -258,7 +258,7 @@ and exp_aux =
   | E_assert of exp * exp
   | E_var of exp * exp * exp
   | E_undef
-  | E_attribute of string * attribute_data option * exp
+  | E_attribute of (l * string * attribute_data option) list * exp
   | E_internal_plet of pat * exp * exp
   | E_internal_return of exp
   | E_internal_assume of atyp * exp
@@ -276,7 +276,7 @@ and pexp_aux =
   (* Pattern match *)
   | Pat_exp of pat * exp
   | Pat_when of pat * exp * exp
-  | Pat_attribute of string * attribute_data option * pexp
+  | Pat_attribute of (l * string * attribute_data option) list * pexp
 
 and pexp = Pat_aux of pexp_aux * l
 
@@ -295,7 +295,7 @@ type funcl = FCL_aux of funcl_aux * l
 and funcl_aux =
   (* Function clause *)
   | FCL_private of funcl
-  | FCL_attribute of string * attribute_data option * funcl
+  | FCL_attribute of (l * string * attribute_data option) list * funcl
   | FCL_doc of doc_comment * funcl
   | FCL_funcl of id * pexp
 
@@ -304,7 +304,7 @@ type type_union = Tu_aux of type_union_aux * l
 and type_union_aux =
   (* Type union constructors *)
   | Tu_private of type_union
-  | Tu_attribute of string * attribute_data option * type_union
+  | Tu_attribute of (l * string * attribute_data option) list * type_union
   | Tu_doc of doc_comment * type_union
   | Tu_ty_id of atyp * id
   | Tu_ty_anon_rec of (id * atyp) field_annot list * id
@@ -358,7 +358,7 @@ type mapcl = MCL_aux of mapcl_aux * l
 
 and mapcl_aux =
   (* mapping clause (bidirectional pattern-match) *)
-  | MCL_attribute of string * attribute_data option * mapcl
+  | MCL_attribute of (l * string * attribute_data option) list * mapcl
   | MCL_doc of doc_comment * mapcl
   | MCL_bidir of mpexp * mpexp
   | MCL_forwards_deprecated of mpexp * exp
@@ -455,7 +455,7 @@ type def_aux =
   | DEF_register of dec_spec (* register declaration *)
   | DEF_pragma of string * pragma
   | DEF_private of def
-  | DEF_attribute of string * attribute_data option * def
+  | DEF_attribute of (l * string * attribute_data option) list * def
   | DEF_doc of doc_comment * def
   | DEF_internal_mutrec of fundef list
 

--- a/src/lib/parse_ast_diff.ml
+++ b/src/lib/parse_ast_diff.ml
@@ -220,6 +220,11 @@ let rec diff_attribute_data (AD_aux (lhs, l)) (AD_aux (rhs, _)) =
   | AD_string _ -> diff_eq ~at:l lhs rhs
   | AD_bool _ -> diff_eq ~at:l lhs rhs
 
+let diff_attribute (l, attr1, arg1) (_, attr2, arg2) =
+  diff_eq ~at:l attr1 attr2 &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
+
+let diff_attributes ~at:l attrs1 attrs2 = diff_list ~at:l diff_attribute attrs1 attrs2
+
 let rec diff_pat (P_aux (lhs, l)) (P_aux (rhs, _)) =
   match lhs with
   | P_lit lit1 -> (
@@ -267,10 +272,9 @@ let rec diff_pat (P_aux (lhs, l)) (P_aux (rhs, _)) =
           diff_option ~at:l diff_id id_opt1 id_opt2 &&& lazy (diff_list ~at:l diff_fpat fps1 fps2)
       | _ -> Some l
     )
-  | P_attribute (attr1, arg1, p1) -> (
+  | P_attribute (attrs1, p1) -> (
       match rhs with
-      | P_attribute (attr2, arg2, p2) ->
-          diff_eq ~at:l attr1 attr2 &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2) &&& lazy (diff_pat p1 p2)
+      | P_attribute (attrs2, p2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_pat p1 p2)
       | _ -> Some l
     )
 
@@ -439,12 +443,9 @@ let rec diff_exp lhs rhs =
       | E_var (lexp2, v2, body2) -> diff_exp lexp1 lexp2 &&& lazy (diff_exp v1 v2) &&& lazy (diff_exp body1 body2)
       | _ -> Some l
     )
-  | E_attribute (attr1, arg1, exp1) -> (
+  | E_attribute (attrs1, exp1) -> (
       match rhs with
-      | E_attribute (attr2, arg2, exp2) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_exp exp1 exp2)
+      | E_attribute (attrs2, exp2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_exp exp1 exp2)
       | _ -> Some l
     )
   | E_internal_plet (pat1, v1, body1) -> (
@@ -479,12 +480,9 @@ and diff_pexp (Pat_aux (lhs, l)) (Pat_aux (rhs, _)) =
           diff_pat pat1 pat2 &&& lazy (diff_exp guard1 guard2) &&& lazy (diff_exp exp1 exp2)
       | _ -> Some l
     )
-  | Pat_attribute (attr1, arg1, pexp1) -> (
+  | Pat_attribute (attrs1, pexp1) -> (
       match rhs with
-      | Pat_attribute (attr2, arg2, pexp2) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_pexp pexp1 pexp2)
+      | Pat_attribute (attrs2, pexp2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_pexp pexp1 pexp2)
       | _ -> Some l
     )
 
@@ -547,12 +545,9 @@ let diff_mpexp (MPat_aux (lhs, l)) (MPat_aux (rhs, _)) =
 
 let rec diff_mapcl (MCL_aux (lhs, l)) (MCL_aux (rhs, _)) =
   match lhs with
-  | MCL_attribute (attr1, arg1, mcl1) -> (
+  | MCL_attribute (attrs1, mcl1) -> (
       match rhs with
-      | MCL_attribute (attr2, arg2, mcl2) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_mapcl mcl1 mcl2)
+      | MCL_attribute (attrs2, mcl2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_mapcl mcl1 mcl2)
       | _ -> Some l
     )
   | MCL_doc (comment1, mcl1) -> (
@@ -598,12 +593,10 @@ let diff_val_spec (VS_aux (lhs, l)) (VS_aux (rhs, _)) =
 
 let rec diff_field_annot ~at:outer_l f lhs rhs =
   match lhs with
-  | Ann_attribute (attr1, arg1, x1, l) -> (
+  | Ann_attribute (attrs1, x1, l) -> (
       match rhs with
-      | Ann_attribute (attr2, arg2, x2, _) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_field_annot ~at:outer_l f x1 x2)
+      | Ann_attribute (attrs2, x2, _) ->
+          diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_field_annot ~at:outer_l f x1 x2)
       | _ -> Some l
     )
   | Ann_doc (comment1, x1, l) -> (
@@ -636,12 +629,9 @@ let rec diff_funcl (FCL_aux (lhs, l)) (FCL_aux (rhs, _)) =
   | FCL_private fcl1 -> (
       match rhs with FCL_private fcl2 -> diff_funcl fcl1 fcl2 | _ -> Some l
     )
-  | FCL_attribute (attr1, arg1, fcl1) -> (
+  | FCL_attribute (attrs1, fcl1) -> (
       match rhs with
-      | FCL_attribute (attr2, arg2, fcl2) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_funcl fcl1 fcl2)
+      | FCL_attribute (attrs2, fcl2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_funcl fcl1 fcl2)
       | _ -> Some l
     )
   | FCL_doc (comment1, fcl1) -> (
@@ -658,12 +648,9 @@ let rec diff_type_union (Tu_aux (lhs, l)) (Tu_aux (rhs, _)) =
   | Tu_private tu1 -> (
       match rhs with Tu_private tu2 -> diff_type_union tu1 tu2 | _ -> Some l
     )
-  | Tu_attribute (attr1, arg1, tu1) -> (
+  | Tu_attribute (attrs1, tu1) -> (
       match rhs with
-      | Tu_attribute (attr2, arg2, tu2) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_type_union tu1 tu2)
+      | Tu_attribute (attrs2, tu2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_type_union tu1 tu2)
       | _ -> Some l
     )
   | Tu_doc (comment1, tu1) -> (
@@ -922,12 +909,9 @@ let rec diff_def (DEF_aux (lhs, l)) (DEF_aux (rhs, _)) =
   | DEF_private def1 -> (
       match rhs with DEF_private def2 -> diff_def def1 def2 | _ -> Some l
     )
-  | DEF_attribute (attr1, arg1, def1) -> (
+  | DEF_attribute (attrs1, def1) -> (
       match rhs with
-      | DEF_attribute (attr2, arg2, def2) ->
-          diff_eq ~at:l attr1 attr2
-          &&& lazy (diff_option ~at:l diff_attribute_data arg1 arg2)
-          &&& lazy (diff_def def1 def2)
+      | DEF_attribute (attrs2, def2) -> diff_attributes ~at:l attrs1 attrs2 &&& lazy (diff_def def1 def2)
       | _ -> Some l
     )
   | DEF_doc (comment1, def1) -> (

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -518,8 +518,8 @@ pat1:
 pat:
   | pat1
     { $1 }
-  | attribute pat
-    { mk_pat (P_attribute (fst $1, snd $1, $2)) $startpos $endpos($1) }
+  | attributes pat
+    { mk_pat (P_attribute ($1, $2)) $startpos $endpos($1) }
   | pat1 As typ
     { mk_pat (P_var ($1, $3)) $startpos $endpos }
   | pat1 Match typ
@@ -645,8 +645,8 @@ loop_exp:
 exp:
   | exp0
     { $1 }
-  | attribute exp
-    { mk_exp (E_attribute (fst $1, snd $1, $2)) $startpos $endpos($1) }
+  | attributes exp
+    { mk_exp (E_attribute ($1, $2)) $startpos $endpos($1) }
   | exp0 Eq exp
     { mk_exp (E_assign ($1, $3)) $startpos $endpos }
   | Let_ letbind In exp
@@ -725,14 +725,14 @@ case:
     { mk_pexp (Pat_exp (p, body)) $startpos $endpos }
   | p = pat; If_; guard = exp; EqGt; body = exp
     { mk_pexp (Pat_when (p, guard, body)) $startpos $endpos }
-  | a = attribute; c = attr_case
-    { mk_pexp (Pat_attribute (fst a, snd a, c)) $startpos $endpos(a) }
+  | attrs = attributes; c = attr_case
+    { mk_pexp (Pat_attribute (attrs, c)) $startpos $endpos(attrs) }
 
 attr_case:
   | Lparen; c = case; Rparen
     { c }
-  | a = attribute; c = attr_case
-    { mk_pexp (Pat_attribute (fst a, snd a, c)) $startpos $endpos(a) }
+  | attrs = attributes; c = attr_case
+    { mk_pexp (Pat_attribute (attrs, c)) $startpos $endpos(attrs) }
 
 case_list:
   | case
@@ -888,11 +888,17 @@ attribute_data:
   | Lsquare; xs = separated_list_trailing(Comma, attribute_data) Rsquare
     { AD_aux (AD_list xs, loc $startpos $endpos) }
 
-attribute:
-  | attr = Attribute; Rsquare
-    { (attr, None) }
-  | attr = Attribute; d = attribute_data; Rsquare
-    { (attr, Some d) }
+comma_attributes:
+  | attr = Id; d = attribute_data?; Comma; attrs = comma_attributes
+    { (loc $startpos $endpos(d), attr, d) :: attrs }
+  | attr = Id; d = attribute_data?; Rsquare
+    { [(loc $startpos $endpos(d), attr, d)] }
+
+attributes:
+  | attr = Attribute; d = attribute_data?; Comma; attrs = comma_attributes
+    { (loc $startpos $endpos(d), attr, d) :: attrs }
+  | attr = Attribute; d = attribute_data?; Rsquare
+    { [(loc $startpos $endpos, attr, d)] }
 
 attribute_data_eof:
   | d = attribute_data; Eof
@@ -907,8 +913,8 @@ doc_comment:
 funcl_annotation:
   | visibility = Private
     { (fun funcl -> FCL_aux (FCL_private funcl, loc $startpos(visibility) $endpos(visibility))) }
-  | attr = attribute
-    { (fun funcl -> FCL_aux (FCL_attribute (fst attr, snd attr, funcl), loc $startpos(attr) $endpos(attr))) }
+  | attrs = attributes
+    { (fun funcl -> FCL_aux (FCL_attribute (attrs, funcl), loc $startpos(attrs) $endpos(attrs))) }
   | doc = doc_comment
     { (fun funcl -> FCL_aux (FCL_doc (doc, funcl), loc $startpos(doc) $endpos(doc))) }
 
@@ -983,8 +989,8 @@ atomic_index_range:
 r_id_def:
   | doc = doc_comment; r = r_id_def
     { Ann_doc (doc, r, loc $startpos(doc) $endpos(doc)) }
-  | attr = attribute; r = r_id_def
-    { Ann_attribute (fst attr, snd attr, r, loc $startpos(attr) $endpos(attr)) }
+  | attrs = attributes; r = r_id_def
+    { Ann_attribute (attrs, r, loc $startpos(attrs) $endpos(attrs)) }
   | n = id; Colon; r = index_range
     { Ann_item (n, r) }
 
@@ -1074,8 +1080,8 @@ enum_functions:
 enum_member:
   | doc = doc_comment; e = enum_member
     { Ann_doc (doc, e, loc $startpos(doc) $endpos(doc)) }
-  | attr = attribute; e = enum_member
-    { Ann_attribute (fst attr, snd attr, e, loc $startpos(attr) $endpos(attr)) }
+  | attrs = attributes; e = enum_member
+    { Ann_attribute (attrs, e, loc $startpos(attrs) $endpos(attrs)) }
   | e = id
     { Ann_item e }
 
@@ -1098,8 +1104,8 @@ enum:
 struct_field:
   | doc = doc_comment; f = struct_field
     { Ann_doc (doc, f, loc $startpos(doc) $endpos(doc)) }
-  | attr = attribute; f = struct_field
-    { Ann_attribute (fst attr, snd attr, f, loc $startpos(attr) $endpos(attr)) }
+  | attrs = attributes; f = struct_field
+    { Ann_attribute (attrs, f, loc $startpos(attrs) $endpos(attrs)) }
   | n = id; Colon; t = typ
     { Ann_item (n, t) }
 
@@ -1114,8 +1120,8 @@ struct_fields:
 type_union:
   | visibility = Private; tu = type_union
     { Tu_aux (Tu_private tu, loc $startpos(visibility) $endpos(visibility)) }
-  | attr = attribute; tu = type_union
-    { Tu_aux (Tu_attribute (fst attr, snd attr, tu), loc $startpos(attr) $endpos(attr)) }
+  | attrs = attributes; tu = type_union
+    { Tu_aux (Tu_attribute (attrs, tu), loc $startpos(attrs) $endpos(attrs)) }
   | doc = doc_comment; tu = type_union
     { Tu_aux (Tu_doc (doc, tu), loc $startpos(doc) $endpos(doc)) }
   | id Colon typ
@@ -1216,8 +1222,8 @@ fmpat:
     { mk_mpexp (MPat_when ($1, $3)) $startpos $endpos }
 
 mapcl:
-  | attr = attribute; mcl = mapcl
-    { MCL_aux (MCL_attribute (fst attr, snd attr, mcl), loc $startpos(attr) $endpos(attr)) }
+  | attrs = attributes; mcl = mapcl
+    { MCL_aux (MCL_attribute (attrs, mcl), loc $startpos(attrs) $endpos(attrs)) }
   | doc = doc_comment; mcl = mapcl
     { MCL_aux (MCL_doc (doc, mcl), loc $startpos(doc) $endpos(doc)) }
   | mcl = mapcl0
@@ -1430,8 +1436,8 @@ def_aux:
 def(AUX):
   | visibility = Private; def = def(AUX)
     { DEF_aux (DEF_private def, loc $startpos(visibility) $endpos(visibility)) }
-  | attr = attribute; def = def(AUX)
-    { DEF_aux (DEF_attribute (fst attr, snd attr, def), loc $startpos(attr) $endpos(attr)) }
+  | attrs = attributes; def = def(AUX)
+    { DEF_aux (DEF_attribute (attrs, def), loc $startpos(attrs) $endpos(attrs)) }
   | doc = doc_comment; def = def(AUX)
     { DEF_aux (DEF_doc (doc, def), loc $startpos(doc) $endpos(doc)) }
   | d = AUX


### PR DESCRIPTION
Previously, to have multiple attributes they needed to be entirely separate, i.e.
```
$[attribute1] $[attribute2]
<DEF>
```
Now they can be optionally comma-separated:
```
$[attribute1, attribute2]
<DEF>
```