### PR TITLE
fix(lean): Lean backend codegen and rewriting fixes

### DIFF
--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -2976,7 +2976,7 @@ let rec rewrite_var_updates (E_aux (expaux, ((l, _) as annot)) as exp) =
         )
     | E_typ (typ, exp) -> begin
         match rewrite used_vars exp pat with
-        | Added_vars (exp', pat') -> Added_vars (E_aux (E_typ (typ, exp'), annot), pat')
+        | Added_vars (exp', pat') -> Added_vars (add_e_typ (env_of exp') (typ_of exp') exp', pat')
         | Same_vars exp' -> Same_vars (E_aux (E_typ (typ, exp'), annot))
       end
     | _ ->

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -2947,7 +2947,7 @@ let rec rewrite_var_updates (E_aux (expaux, ((l, _) as annot)) as exp) =
             | Pat_aux ((Pat_exp (_, first) | Pat_when (_, _, first)), _) :: _ -> typ_of first
             | _ -> unit_typ
           in
-          let v = annot_exp expaux pl env typ in
+          let v = annot_exp (E_typ (typ, annot_exp expaux pl env typ)) pl env typ in
           Added_vars (v, tuple_pat (if overwrite then varpats else pat :: varpats))
         )
     | E_assign (lexp, vexp) ->
@@ -2976,7 +2976,7 @@ let rec rewrite_var_updates (E_aux (expaux, ((l, _) as annot)) as exp) =
         )
     | E_typ (typ, exp) -> begin
         match rewrite used_vars exp pat with
-        | Added_vars (exp', pat') -> Added_vars (add_e_typ (env_of exp') (typ_of exp') exp', pat')
+        | Added_vars (exp', pat') -> Added_vars (E_aux (E_typ (typ, exp'), annot), pat')
         | Same_vars exp' -> Same_vars (E_aux (E_typ (typ, exp'), annot))
       end
     | _ ->

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -2947,7 +2947,7 @@ let rec rewrite_var_updates (E_aux (expaux, ((l, _) as annot)) as exp) =
             | Pat_aux ((Pat_exp (_, first) | Pat_when (_, _, first)), _) :: _ -> typ_of first
             | _ -> unit_typ
           in
-          let v = annot_exp (E_typ (typ, annot_exp expaux pl env typ)) pl env typ in
+          let v = add_e_typ env typ (annot_exp expaux pl env typ) in
           Added_vars (v, tuple_pat (if overwrite then varpats else pat :: varpats))
         )
     | E_assign (lexp, vexp) ->

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -2704,6 +2704,51 @@ and check_block' f_p env exps ret_typ =
           (s_p, texp :: exps)
     )
 
+and infer_case env pat_typ pexp =
+  let pat, guard, case, (l, uannot) = destruct_pexp pexp in
+  ignore (check_pattern_duplicates env pat);
+  let env = bind_pattern_vector_subranges pat env in
+  match bind_pat env pat pat_typ with
+  | tpat, env, guards ->
+      if prove __POS__ env nc_false then None
+      else (
+        let hint_loc l =
+          match guard with
+          | None -> Parse_ast.Hint ("guard created for this pattern", pat_loc pat, l)
+          | Some exp -> Parse_ast.Hint ("combining pattern with guard", exp_loc exp, l)
+        in
+        let guard =
+          match (guard, guards) with None, h :: t -> Some (h, t) | Some x, l -> Some (x, l) | None, [] -> None
+        in
+        let guard =
+          match guard with
+          | Some (h, t) ->
+              Some
+                (List.fold_left
+                   (fun acc guard -> mk_infix_exp ~loc:(hint_loc (exp_loc guard)) acc (mk_operator "&") guard)
+                   h t
+                )
+          | None -> None
+        in
+        let checked_guard, env' =
+          match guard with
+          | None -> (None, env)
+          | Some guard ->
+              let checked_guard = check_exp env guard bool_typ in
+              (Some checked_guard, add_opt_constraint l "guard pattern" (assert_constraint env true checked_guard) env)
+        in
+        let inferred_case = irule infer_exp env' case in
+        Some (construct_pexp (tpat, checked_guard, inferred_case, (l, (None, uannot))))
+      )
+  | exception (Type_error _ as typ_exn) -> (
+      match pat with
+      | P_aux (P_lit lit, (l, _)) ->
+          let guard' = mk_infix_exp (mk_exp (E_id (mk_id "p#"))) (mk_operator "==") (mk_exp (E_lit lit)) in
+          let guard = match guard with None -> guard' | Some guard -> mk_infix_exp guard (mk_operator "&") guard' in
+          infer_case env pat_typ (Pat_aux (Pat_when (mk_pat ~loc:l (P_id (mk_id "p#")), guard, case), (l, uannot)))
+      | _ -> raise typ_exn
+    )
+
 and check_case env pat_typ pexp typ =
   let pat, guard, case, (l, uannot) = destruct_pexp pexp in
   ignore (check_pattern_duplicates env pat);
@@ -3926,6 +3971,36 @@ and infer_exp env (E_aux (exp_aux, (l, uannot)) as exp) =
                )
             )
     end
+  | E_match (exp, cases) ->
+      let inferred_exp = irule infer_exp env exp in
+      let inferred_typ = typ_of inferred_exp in
+      begin
+        match cases with
+        | first_pexp :: rest ->
+            begin
+              match infer_case env inferred_typ first_pexp with
+              | Some inferred_first ->
+                  let _, _, first_body, _ = destruct_pexp inferred_first in
+                  let result_typ = typ_of first_body in
+                  let checked_rest = List.filter_map (fun case -> check_case env inferred_typ case result_typ) rest in
+                  let all_cases = inferred_first :: checked_rest in
+                  let all_cases, attr_update =
+                    if Option.is_some (get_attribute "complete" uannot) || Option.is_some (get_attribute "incomplete" uannot)
+                    then (all_cases, fun attrs -> attrs)
+                    else (
+                      let completeness_typ, env = bind_existential (exp_loc exp) None inferred_typ env in
+                      let ctx = pattern_completeness_ctx env in
+                      match PC.is_complete_wildcarded l ctx all_cases completeness_typ with
+                      | Some wildcarded -> (wildcarded, add_attribute (gen_loc l) "complete" None)
+                      | None -> (all_cases, add_attribute (gen_loc l) "incomplete" None)
+                    )
+                  in
+                  let update_uannot f (E_aux (aux, (l, (tannot, uannot)))) = E_aux (aux, (l, (tannot, f uannot))) in
+                  annot_exp (E_match (inferred_exp, all_cases)) result_typ |> update_uannot attr_update
+              | None -> typ_error l "Cannot infer type of match expression: first case is unreachable"
+            end
+        | [] -> typ_error l "Cannot infer type of empty match expression"
+      end
   | E_vector_append (v1, E_aux (E_vector [], _)) -> infer_exp env v1
   | E_vector_append (v1, v2) -> infer_exp env (E_aux (E_app (mk_id "append", [v1; v2]), (l, uannot)))
   | E_vector [] -> typ_error l "Cannot infer type of empty vector"

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -950,7 +950,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
         string "#v"
         ^^ wrap_with_pure as_monadic (brackets (nest 2 (separate_map comma_sp (d_of_arg ctx) (List.rev vals))))
   | E_typ (typ, e) ->
-      if has_effect e || has_generated_typ_kids typ then doc_exp as_monadic ctx e
+      if has_effect e then doc_exp as_monadic ctx e
       else wrap_with_pure as_monadic (parens (separate space [doc_exp false ctx e; colon; doc_typ ctx typ]))
   | E_tuple es -> wrap_with_pure as_monadic (parens (separate_map (comma ^^ space) (d_of_arg ctx) es))
   | E_let (lpat, lexp, e') | E_internal_plet (lpat, lexp, e') ->

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -36,6 +36,8 @@ let non_beq_types : IdSet.t ref = ref IdSet.empty
 
 let remove_empties (docs : document list) = List.filter (fun d -> d != empty) docs
 
+let has_generated_typ_kids typ = KidSet.exists is_kid_generated (tyvars_of_typ typ)
+
 let opens = ref IdSet.empty
 
 type context = {
@@ -560,7 +562,9 @@ and doc_vector_concat pats =
   brackets (separate_map comma doc_part pats)
 
 let doc_pat_typ_ascription ctx (P_aux (p, (l, annot)) as pat) =
-  match p with P_typ (ptyp, p) -> Some (doc_typ ctx ptyp) | _ -> None
+  match p with
+  | P_typ (ptyp, p) when not (has_generated_typ_kids ptyp) -> Some (doc_typ ctx ptyp)
+  | _ -> None
 
 (* Copied from the Coq PP *)
 let rebind_cast_pattern_vars pat typ exp =
@@ -946,7 +950,7 @@ and doc_exp (as_monadic : bool) ctx (E_aux (e, (l, annot)) as full_exp) =
         string "#v"
         ^^ wrap_with_pure as_monadic (brackets (nest 2 (separate_map comma_sp (d_of_arg ctx) (List.rev vals))))
   | E_typ (typ, e) ->
-      if has_effect e then doc_exp as_monadic ctx e
+      if has_effect e || has_generated_typ_kids typ then doc_exp as_monadic ctx e
       else wrap_with_pure as_monadic (parens (separate space [doc_exp false ctx e; colon; doc_typ ctx typ]))
   | E_tuple es -> wrap_with_pure as_monadic (parens (separate_map (comma ^^ space) (d_of_arg ctx) es))
   | E_let (lpat, lexp, e') | E_internal_plet (lpat, lexp, e') ->

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1252,9 +1252,9 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       let id = doc_id_ctor id in
       nest 2
         (flow (break 1) [string "inductive"; id; string "where"]
-        ^^ enums_doc ^^ hardline ^^ string "deriving" ^^ space ^^ separate comma_sp derivers ^^ hardline
-        ^^ string "open" ^^ space ^^ id
+        ^^ enums_doc ^^ hardline ^^ string "deriving" ^^ space ^^ separate comma_sp derivers
         )
+      ^^ hardline ^^ string "open" ^^ space ^^ id
   | TD_record (id, tq, fields, _) ->
       let fields = List.map (doc_typ_id ctx) fields in
       let fields_doc = separate hardline fields in
@@ -1275,13 +1275,15 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
   | TD_abbrev (id, tq, A_aux (A_typ t, _)) when string_of_id id = "fp_bits" ->
       string (Printf.sprintf "-- Abbreviation %s skipped" (string_of_id id)) (* FIXME *)
   | TD_abbrev (id, tq, A_aux (A_typ t, _)) ->
-      let vars = doc_typ_quant_only_vars ctx tq in
+      let vars = doc_typ_quant_relevant ctx tq in
+      let vars = List.map parens vars in
       let vars = separate space vars in
       nest 2 (flow (break 1) (remove_empties [string "abbrev"; doc_id_ctor id; vars; coloneq; doc_typ ctx t]))
   | TD_abbrev (id, tq, A_aux (A_nexp ne, _)) ->
-      let vars = doc_typ_quant_only_vars ctx tq in
+      let vars = doc_typ_quant_relevant ctx tq in
+      let vars = List.map parens vars in
       let vars = separate space vars in
-      nest 2 (flow (break 1) [string "abbrev"; doc_id_ctor id; colon; string "Int"; coloneq; doc_nexp ctx ne])
+      nest 2 (flow (break 1) (remove_empties [string "abbrev"; doc_id_ctor id; vars; colon; string "Int"; coloneq; doc_nexp ctx ne]))
   | TD_abbrev (id, TypQ_aux (TypQ_no_forall, _), A_aux (A_bool nc, _)) ->
       (* We currently cannot handle explicit parameters because of the Int/Nat mismatch. *)
       nest 2 (flow (break 1) [string "abbrev"; doc_id_ctor id; colon; string "Bool"; coloneq; doc_nconstraint ctx nc])
@@ -1297,9 +1299,9 @@ let doc_typdef ctx (TD_aux (td, tannot) as full_typdef) =
       doc_typ_quant_in_comment ctx tq
       ^^ nest 2
            (nest 2 (flow space (remove_empties [string "inductive"; doc_id_ctor id; rectyp; string "where"]))
-           ^^ pp_tus ^^ hardline ^^ string "deriving" ^^ space ^^ separate comma_sp derivers ^^ hardline
-           ^^ string "open" ^^ space ^^ doc_id_ctor id
+           ^^ pp_tus ^^ hardline ^^ string "deriving" ^^ space ^^ separate comma_sp derivers
            )
+      ^^ hardline ^^ string "open" ^^ space ^^ doc_id_ctor id
   | _ -> failwith ("Type definition " ^ string_of_type_def_con full_typdef ^ " not translatable yet.")
 
 (* Copied from the Coq PP *)

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -36,8 +36,6 @@ let non_beq_types : IdSet.t ref = ref IdSet.empty
 
 let remove_empties (docs : document list) = List.filter (fun d -> d != empty) docs
 
-let has_generated_typ_kids typ = KidSet.exists is_kid_generated (tyvars_of_typ typ)
-
 let opens = ref IdSet.empty
 
 type context = {
@@ -562,9 +560,7 @@ and doc_vector_concat pats =
   brackets (separate_map comma doc_part pats)
 
 let doc_pat_typ_ascription ctx (P_aux (p, (l, annot)) as pat) =
-  match p with
-  | P_typ (ptyp, p) when not (has_generated_typ_kids ptyp) -> Some (doc_typ ctx ptyp)
-  | _ -> None
+  match p with P_typ (ptyp, p) -> Some (doc_typ ctx ptyp) | _ -> None
 
 (* Copied from the Coq PP *)
 let rebind_cast_pattern_vars pat typ exp =

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -254,7 +254,8 @@ type lean_context = {
 
 let file_to_module (filename : string) =
   let base = Filename.basename filename in
-  Filename.chop_extension base
+  let name = Filename.chop_extension base in
+  Str.global_replace (Str.regexp_string ".") "" name
 
 let file_prelude version =
   let p =

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev MAIRType := (BitVec 64)
 
@@ -28,7 +28,7 @@ abbrev S2PIRType := (BitVec 64)
 
 inductive SecurityState where | SS_NonSecure | SS_Root | SS_Realm | SS_Secure
   deriving BEq, Inhabited, Repr
-  open SecurityState
+open SecurityState
 
 abbrev PARTIDtype := (BitVec 16)
 
@@ -36,7 +36,7 @@ abbrev PMGtype := (BitVec 8)
 
 inductive PARTIDspaceType where | PIdSpace_Secure | PIdSpace_Root | PIdSpace_Realm | PIdSpace_NonSecure
   deriving BEq, Inhabited, Repr
-  open PARTIDspaceType
+open PARTIDspaceType
 
 structure MPAMinfo where
   mpam_sp : PARTIDspaceType
@@ -46,31 +46,31 @@ structure MPAMinfo where
 
 inductive AccessType where | AccessType_IFETCH | AccessType_GPR | AccessType_ASIMD | AccessType_SVE | AccessType_SME | AccessType_IC | AccessType_DC | AccessType_DCZero | AccessType_AT | AccessType_NV2 | AccessType_SPE | AccessType_GCS | AccessType_GPTW | AccessType_TTW
   deriving BEq, Inhabited, Repr
-  open AccessType
+open AccessType
 
 inductive VARange where | VARange_LOWER | VARange_UPPER
   deriving BEq, Inhabited, Repr
-  open VARange
+open VARange
 
 inductive MemAtomicOp where | MemAtomicOp_GCSSS1 | MemAtomicOp_ADD | MemAtomicOp_BIC | MemAtomicOp_EOR | MemAtomicOp_ORR | MemAtomicOp_SMAX | MemAtomicOp_SMIN | MemAtomicOp_UMAX | MemAtomicOp_UMIN | MemAtomicOp_SWP | MemAtomicOp_CAS
   deriving BEq, Inhabited, Repr
-  open MemAtomicOp
+open MemAtomicOp
 
 inductive CacheOp where | CacheOp_Clean | CacheOp_Invalidate | CacheOp_CleanInvalidate
   deriving BEq, Inhabited, Repr
-  open CacheOp
+open CacheOp
 
 inductive CacheOpScope where | CacheOpScope_SetWay | CacheOpScope_PoU | CacheOpScope_PoC | CacheOpScope_PoE | CacheOpScope_PoP | CacheOpScope_PoDP | CacheOpScope_PoPA | CacheOpScope_ALLU | CacheOpScope_ALLUIS
   deriving BEq, Inhabited, Repr
-  open CacheOpScope
+open CacheOpScope
 
 inductive CacheType where | CacheType_Data | CacheType_Tag | CacheType_Data_Tag | CacheType_Instruction
   deriving BEq, Inhabited, Repr
-  open CacheType
+open CacheType
 
 inductive CachePASpace where | CPAS_NonSecure | CPAS_Any | CPAS_RealmNonSecure | CPAS_Realm | CPAS_Root | CPAS_SecureNonSecure | CPAS_Secure
   deriving BEq, Inhabited, Repr
-  open CachePASpace
+open CachePASpace
 
 structure AccessDescriptor where
   acctype : AccessType
@@ -110,11 +110,11 @@ structure AccessDescriptor where
 
 inductive MemType where | MemType_Normal | MemType_Device
   deriving BEq, Inhabited, Repr
-  open MemType
+open MemType
 
 inductive DeviceType where | DeviceType_GRE | DeviceType_nGRE | DeviceType_nGnRE | DeviceType_nGnRnE
   deriving BEq, Inhabited, Repr
-  open DeviceType
+open DeviceType
 
 structure MemAttrHints where
   attrs : (BitVec 2)
@@ -124,11 +124,11 @@ structure MemAttrHints where
 
 inductive Shareability where | Shareability_NSH | Shareability_ISH | Shareability_OSH
   deriving BEq, Inhabited, Repr
-  open Shareability
+open Shareability
 
 inductive MemTagType where | MemTag_Untagged | MemTag_AllocationTagged | MemTag_CanonicallyTagged
   deriving BEq, Inhabited, Repr
-  open MemTagType
+open MemTagType
 
 structure MemoryAttributes where
   memtype : MemType
@@ -143,7 +143,7 @@ structure MemoryAttributes where
 
 inductive PASpace where | PAS_NonSecure | PAS_Secure | PAS_Root | PAS_Realm
   deriving BEq, Inhabited, Repr
-  open PASpace
+open PASpace
 
 structure FullAddress where
   paspace : PASpace
@@ -152,7 +152,7 @@ structure FullAddress where
 
 inductive GPCF where | GPCF_None | GPCF_AddressSize | GPCF_Walk | GPCF_EABT | GPCF_Fail
   deriving BEq, Inhabited, Repr
-  open GPCF
+open GPCF
 
 structure GPCFRecord where
   gpf : GPCF
@@ -161,11 +161,11 @@ structure GPCFRecord where
 
 inductive Fault where | Fault_None | Fault_AccessFlag | Fault_Alignment | Fault_Background | Fault_Domain | Fault_Permission | Fault_Translation | Fault_AddressSize | Fault_SyncExternal | Fault_SyncExternalOnWalk | Fault_SyncParity | Fault_SyncParityOnWalk | Fault_GPCFOnWalk | Fault_GPCFOnOutput | Fault_AsyncParity | Fault_AsyncExternal | Fault_TagCheck | Fault_Debug | Fault_TLBConflict | Fault_BranchTarget | Fault_HWUpdateAccessFlag | Fault_Lockdown | Fault_Exclusive | Fault_ICacheMaint
   deriving BEq, Inhabited, Repr
-  open Fault
+open Fault
 
 inductive ErrorState where | ErrorState_UC | ErrorState_UEU | ErrorState_UEO | ErrorState_UER | ErrorState_CE | ErrorState_Uncategorized | ErrorState_IMPDEF
   deriving BEq, Inhabited, Repr
-  open ErrorState
+open ErrorState
 
 structure FaultRecord where
   statuscode : Fault
@@ -192,11 +192,11 @@ structure FaultRecord where
 
 inductive MBReqDomain where | MBReqDomain_Nonshareable | MBReqDomain_InnerShareable | MBReqDomain_OuterShareable | MBReqDomain_FullSystem
   deriving BEq, Inhabited, Repr
-  open MBReqDomain
+open MBReqDomain
 
 inductive MBReqTypes where | MBReqTypes_Reads | MBReqTypes_Writes | MBReqTypes_All
   deriving BEq, Inhabited, Repr
-  open MBReqTypes
+open MBReqTypes
 
 structure CacheRecord where
   acctype : AccessType
@@ -221,11 +221,11 @@ structure CacheRecord where
 
 inductive Regime where | Regime_EL3 | Regime_EL30 | Regime_EL2 | Regime_EL20 | Regime_EL10
   deriving BEq, Inhabited, Repr
-  open Regime
+open Regime
 
 inductive TGx where | TGx_4KB | TGx_16KB | TGx_64KB
   deriving BEq, Inhabited, Repr
-  open TGx
+open TGx
 
 structure S1TTWParams where
   ha : (BitVec 1)
@@ -318,15 +318,15 @@ structure TranslationInfo where
 
 inductive TLBILevel where | TLBILevel_Any | TLBILevel_Last
   deriving BEq, Inhabited, Repr
-  open TLBILevel
+open TLBILevel
 
 inductive TLBIOp where | TLBIOp_DALL | TLBIOp_DASID | TLBIOp_DVA | TLBIOp_IALL | TLBIOp_IASID | TLBIOp_IVA | TLBIOp_ALL | TLBIOp_ASID | TLBIOp_IPAS2 | TLBIPOp_IPAS2 | TLBIOp_VAA | TLBIOp_VA | TLBIPOp_VAA | TLBIPOp_VA | TLBIOp_VMALL | TLBIOp_VMALLS12 | TLBIOp_RIPAS2 | TLBIPOp_RIPAS2 | TLBIOp_RVAA | TLBIOp_RVA | TLBIPOp_RVAA | TLBIPOp_RVA | TLBIOp_RPA | TLBIOp_PAALL
   deriving BEq, Inhabited, Repr
-  open TLBIOp
+open TLBIOp
 
 inductive TLBIMemAttr where | TLBI_AllAttr | TLBI_ExcludeXS
   deriving BEq, Inhabited, Repr
-  open TLBIMemAttr
+open TLBIMemAttr
 
 structure TLBIRecord where
   op : TLBIOp
@@ -359,7 +359,7 @@ inductive arm_acc_type where
   | SAcc_GCS (_ : Unit)
   | SAcc_GPTW (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open arm_acc_type
+open arm_acc_type
 
 structure TLBIInfo where
   rec' : TLBIRecord
@@ -380,7 +380,7 @@ inductive Barrier where
   | Barrier_PSSBB (_ : Unit)
   | Barrier_SB (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open Barrier
+open Barrier
 
 abbrev boolean := (BitVec 1)
 
@@ -397,7 +397,7 @@ inductive ast where
   | DataMemoryBarrier (_ : Unit)
   | CompareAndBranch (_ : (reg_index × (BitVec 64)))
   deriving Inhabited, BEq, Repr
-  open ast
+open ast
 
 inductive Register : Type where
   | R0

--- a/test/lean/SailTinyArmV2.expected.lean
+++ b/test/lean/SailTinyArmV2.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV2
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive SecurityState where | SS_NonSecure | SS_Root | SS_Realm | SS_Secure
   deriving BEq, Inhabited, Repr
-  open SecurityState
+open SecurityState
 
 abbrev PARTIDtype := (BitVec 16)
 
@@ -30,7 +30,7 @@ abbrev PMGtype := (BitVec 8)
 
 inductive PARTIDspaceType where | PIdSpace_Secure | PIdSpace_Root | PIdSpace_Realm | PIdSpace_NonSecure
   deriving BEq, Inhabited, Repr
-  open PARTIDspaceType
+open PARTIDspaceType
 
 structure MPAMinfo where
   mpam_sp : PARTIDspaceType
@@ -40,31 +40,31 @@ structure MPAMinfo where
 
 inductive AccessType where | AccessType_IFETCH | AccessType_GPR | AccessType_ASIMD | AccessType_SVE | AccessType_SME | AccessType_IC | AccessType_DC | AccessType_DCZero | AccessType_AT | AccessType_NV2 | AccessType_SPE | AccessType_GCS | AccessType_GPTW | AccessType_TTW
   deriving BEq, Inhabited, Repr
-  open AccessType
+open AccessType
 
 inductive VARange where | VARange_LOWER | VARange_UPPER
   deriving BEq, Inhabited, Repr
-  open VARange
+open VARange
 
 inductive MemAtomicOp where | MemAtomicOp_GCSSS1 | MemAtomicOp_ADD | MemAtomicOp_BIC | MemAtomicOp_EOR | MemAtomicOp_ORR | MemAtomicOp_SMAX | MemAtomicOp_SMIN | MemAtomicOp_UMAX | MemAtomicOp_UMIN | MemAtomicOp_SWP | MemAtomicOp_CAS
   deriving BEq, Inhabited, Repr
-  open MemAtomicOp
+open MemAtomicOp
 
 inductive CacheOp where | CacheOp_Clean | CacheOp_Invalidate | CacheOp_CleanInvalidate
   deriving BEq, Inhabited, Repr
-  open CacheOp
+open CacheOp
 
 inductive CacheOpScope where | CacheOpScope_SetWay | CacheOpScope_PoU | CacheOpScope_PoC | CacheOpScope_PoE | CacheOpScope_PoP | CacheOpScope_PoDP | CacheOpScope_PoPA | CacheOpScope_ALLU | CacheOpScope_ALLUIS
   deriving BEq, Inhabited, Repr
-  open CacheOpScope
+open CacheOpScope
 
 inductive CacheType where | CacheType_Data | CacheType_Tag | CacheType_Data_Tag | CacheType_Instruction
   deriving BEq, Inhabited, Repr
-  open CacheType
+open CacheType
 
 inductive CachePASpace where | CPAS_NonSecure | CPAS_Any | CPAS_RealmNonSecure | CPAS_Realm | CPAS_Root | CPAS_SecureNonSecure | CPAS_Secure
   deriving BEq, Inhabited, Repr
-  open CachePASpace
+open CachePASpace
 
 structure AccessDescriptor where
   acctype : AccessType
@@ -104,11 +104,11 @@ structure AccessDescriptor where
 
 inductive MemType where | MemType_Normal | MemType_Device
   deriving BEq, Inhabited, Repr
-  open MemType
+open MemType
 
 inductive DeviceType where | DeviceType_GRE | DeviceType_nGRE | DeviceType_nGnRE | DeviceType_nGnRnE
   deriving BEq, Inhabited, Repr
-  open DeviceType
+open DeviceType
 
 structure MemAttrHints where
   attrs : (BitVec 2)
@@ -118,11 +118,11 @@ structure MemAttrHints where
 
 inductive Shareability where | Shareability_NSH | Shareability_ISH | Shareability_OSH
   deriving BEq, Inhabited, Repr
-  open Shareability
+open Shareability
 
 inductive MemTagType where | MemTag_Untagged | MemTag_AllocationTagged | MemTag_CanonicallyTagged
   deriving BEq, Inhabited, Repr
-  open MemTagType
+open MemTagType
 
 structure MemoryAttributes where
   memtype : MemType
@@ -137,7 +137,7 @@ structure MemoryAttributes where
 
 inductive PASpace where | PAS_NonSecure | PAS_Secure | PAS_Root | PAS_Realm
   deriving BEq, Inhabited, Repr
-  open PASpace
+open PASpace
 
 structure FullAddress where
   paspace : PASpace
@@ -146,7 +146,7 @@ structure FullAddress where
 
 inductive GPCF where | GPCF_None | GPCF_AddressSize | GPCF_Walk | GPCF_EABT | GPCF_Fail
   deriving BEq, Inhabited, Repr
-  open GPCF
+open GPCF
 
 structure GPCFRecord where
   gpf : GPCF
@@ -155,11 +155,11 @@ structure GPCFRecord where
 
 inductive Fault where | Fault_None | Fault_AccessFlag | Fault_Alignment | Fault_Background | Fault_Domain | Fault_Permission | Fault_Translation | Fault_AddressSize | Fault_SyncExternal | Fault_SyncExternalOnWalk | Fault_SyncParity | Fault_SyncParityOnWalk | Fault_GPCFOnWalk | Fault_GPCFOnOutput | Fault_AsyncParity | Fault_AsyncExternal | Fault_TagCheck | Fault_Debug | Fault_TLBConflict | Fault_BranchTarget | Fault_HWUpdateAccessFlag | Fault_Lockdown | Fault_Exclusive | Fault_ICacheMaint
   deriving BEq, Inhabited, Repr
-  open Fault
+open Fault
 
 inductive ErrorState where | ErrorState_UC | ErrorState_UEU | ErrorState_UEO | ErrorState_UER | ErrorState_CE | ErrorState_Uncategorized | ErrorState_IMPDEF
   deriving BEq, Inhabited, Repr
-  open ErrorState
+open ErrorState
 
 structure FaultRecord where
   statuscode : Fault
@@ -186,11 +186,11 @@ structure FaultRecord where
 
 inductive MBReqDomain where | MBReqDomain_Nonshareable | MBReqDomain_InnerShareable | MBReqDomain_OuterShareable | MBReqDomain_FullSystem
   deriving BEq, Inhabited, Repr
-  open MBReqDomain
+open MBReqDomain
 
 inductive MBReqTypes where | MBReqTypes_Reads | MBReqTypes_Writes | MBReqTypes_All
   deriving BEq, Inhabited, Repr
-  open MBReqTypes
+open MBReqTypes
 
 structure CacheRecord where
   acctype : AccessType
@@ -215,11 +215,11 @@ structure CacheRecord where
 
 inductive Regime where | Regime_EL3 | Regime_EL30 | Regime_EL2 | Regime_EL20 | Regime_EL10
   deriving BEq, Inhabited, Repr
-  open Regime
+open Regime
 
 inductive TGx where | TGx_4KB | TGx_16KB | TGx_64KB
   deriving BEq, Inhabited, Repr
-  open TGx
+open TGx
 
 structure TLBContext where
   ss : SecurityState
@@ -263,15 +263,15 @@ structure TranslationStartInfo where
 
 inductive TLBILevel where | TLBILevel_Any | TLBILevel_Last
   deriving BEq, Inhabited, Repr
-  open TLBILevel
+open TLBILevel
 
 inductive TLBIOp where | TLBIOp_DALL | TLBIOp_DASID | TLBIOp_DVA | TLBIOp_IALL | TLBIOp_IASID | TLBIOp_IVA | TLBIOp_ALL | TLBIOp_ASID | TLBIOp_IPAS2 | TLBIPOp_IPAS2 | TLBIOp_VAA | TLBIOp_VA | TLBIPOp_VAA | TLBIPOp_VA | TLBIOp_VMALL | TLBIOp_VMALLS12 | TLBIOp_RIPAS2 | TLBIPOp_RIPAS2 | TLBIOp_RVAA | TLBIOp_RVA | TLBIPOp_RVAA | TLBIPOp_RVA | TLBIOp_RPA | TLBIOp_PAALL
   deriving BEq, Inhabited, Repr
-  open TLBIOp
+open TLBIOp
 
 inductive TLBIMemAttr where | TLBI_AllAttr | TLBI_ExcludeXS
   deriving BEq, Inhabited, Repr
-  open TLBIMemAttr
+open TLBIMemAttr
 
 structure TLBIRecord where
   op : TLBIOp
@@ -310,7 +310,7 @@ inductive Barrier where
   | Barrier_PSSBB (_ : Unit)
   | Barrier_SB (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open Barrier
+open Barrier
 
 abbrev reg_index := Nat
 
@@ -327,7 +327,7 @@ inductive ast where
   | DataMemoryBarrier (_ : MBReqTypes)
   | CompareAndBranch (_ : (reg_index × (BitVec 64)))
   deriving Inhabited, BEq, Repr
-  open ast
+open ast
 
 inductive Register : Type where
   | R0

--- a/test/lean/abbrev_open.expected.lean
+++ b/test/lean/abbrev_open.expected.lean
@@ -20,37 +20,23 @@ inductive option (k_a : Type) where
   deriving Inhabited, BEq, Repr
 open option
 
-inductive My_enum where | E1 | E2
+abbrev datasize := Int
+
+abbrev xlen (k_N : Int) := Nat
+
+inductive Color where | Red | Green | Blue
   deriving BEq, Inhabited, Repr
-open My_enum
+open Color
 
-structure My_struct where
-  field1 : Int
-  field2 : (BitVec 1)
-  deriving BEq, Inhabited, Repr
+inductive Shape where
+  | Circle (_ : Int)
+  | Square (_ : Int)
+  deriving Inhabited, BEq, Repr
+open Shape
 
-/-- Type quantifiers: k_n : Int, k_vasize : Int, k_pa : Type, k_ts : Type, k_arch_ak : Type, k_n > 0
-  ∧ k_vasize ≥ 0 -/
-structure My_mem_write_request
-  (k_n : Nat) (k_vasize : Nat) (k_pa : Type) (k_ts : Type) (k_arch_ak : Type) where
-  va : (Option (BitVec k_vasize))
-  pa : k_pa
-  translation : k_ts
-  size : Int
-  value : (Option (BitVec (8 * k_n)))
-  tag : (Option Bool)
-  deriving BEq, Inhabited, Repr
+abbrev Register := PEmpty
+abbrev RegisterType : Register -> Type := PEmpty.elim
 
-inductive Register : Type where
-  | r
-  deriving DecidableEq, Hashable, Repr
-open Register
-
-abbrev RegisterType : Register → Type
-  | .r => Int
-
-instance : Inhabited (RegisterRef RegisterType Int) where
-  default := .Reg r
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
@@ -75,10 +61,10 @@ open ConcurrencyInterfaceV1
 namespace Out.Functions
 
 open option
-open Register
-open My_enum
+open Shape
+open Color
 
-/-- Type quantifiers: k_ex941_ : Bool, k_ex940_ : Bool -/
+/-- Type quantifiers: k_ex843_ : Bool, k_ex842_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -171,57 +157,26 @@ def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
 def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
-def undefined_My_enum (_ : Unit) : SailM My_enum := do
-  (internal_pick [E1, E2])
+def undefined_Color (_ : Unit) : SailM Color := do
+  (internal_pick [Red, Green, Blue])
 
-/-- Type quantifiers: arg_ : Nat, 0 ≤ arg_ ∧ arg_ ≤ 1 -/
-def My_enum_of_num (arg_ : Nat) : My_enum :=
+/-- Type quantifiers: arg_ : Nat, 0 ≤ arg_ ∧ arg_ ≤ 2 -/
+def Color_of_num (arg_ : Nat) : Color :=
   match arg_ with
-  | 0 => E1
-  | _ => E2
+  | 0 => Red
+  | 1 => Green
+  | _ => Blue
 
-def num_of_My_enum (arg_ : My_enum) : Int :=
+def num_of_Color (arg_ : Color) : Int :=
   match arg_ with
-  | E1 => 0
-  | E2 => 1
+  | Red => 0
+  | Green => 1
+  | Blue => 2
 
-def undefined_My_struct (_ : Unit) : SailM My_struct := do
-  (pure { field1 := ← (undefined_int ())
-          field2 := ← (undefined_bitvector 1) })
+def initialize_registers (_ : Unit) : Unit :=
+  ()
 
-def struct_field2 (s : My_struct) : (BitVec 1) :=
-  s.field2
-
-def struct_update_field2 (s : My_struct) (b : (BitVec 1)) : My_struct :=
-  { s with field2 := b }
-
-/-- Type quantifiers: i : Int -/
-def struct_update_both_fields (s : My_struct) (i : Int) (b : (BitVec 1)) : My_struct :=
-  { s with field1 := i, field2 := b }
-
-/-- Type quantifiers: i : Int -/
-def mk_struct (i : Int) (b : (BitVec 1)) : My_struct :=
-  { field1 := i
-    field2 := b }
-
-def mk_struct_effectful (e : My_enum) (b : (BitVec 1)) : SailM My_struct := do
-  (pure { field1 := ← match e with
-            | E1 => readReg r
-            | E2 => (pure 2)
-          field2 := b })
-
-def undef_struct (x : (BitVec 1)) : SailM My_struct := do
-  (undefined_My_struct ())
-
-def match_struct (value : My_struct) : Int :=
-  match value with
-  | { field2 := 0, field1 := g__0 } => 0
-  | { field1 := field1, field2 := _ } => field1
-
-def initialize_registers (_ : Unit) : SailM Unit := do
-  writeReg r (← (undefined_int ()))
-
-def sail_model_init (x_0 : Unit) : SailM Unit := do
+def sail_model_init (x_0 : Unit) : Unit :=
   (initialize_registers ())
 
 end Out.Functions

--- a/test/lean/abbrev_open.sail
+++ b/test/lean/abbrev_open.sail
@@ -1,0 +1,14 @@
+default Order dec
+
+$include <prelude.sail>
+
+type datasize = {32, 64}
+
+type xlen('N) = range(0, 'N)
+
+enum Color = Red | Green | Blue
+
+union Shape = {
+  Circle : int,
+  Square : int,
+}

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev cr_type := (BitVec 8)
 

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive E where | A | B | C
   deriving BEq, Inhabited, Repr
-  open E
+open E
 
 inductive Register : Type where
   | r

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive E where | A | B | C
   deriving BEq, Inhabited, Repr
-  open E
+open E
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive Register : Type where
   | dummy

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/generated_kid_ascription.expected.lean
+++ b/test/lean/generated_kid_ascription.expected.lean
@@ -1,0 +1,163 @@
+import Sail
+open PreSail
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 1_000_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+open ConcurrencyInterfaceV1
+
+abbrev bit := (BitVec 1)
+
+abbrev bits (k_n : Int) := (BitVec k_n)
+
+/-- Type quantifiers: k_a : Type -/
+inductive option (k_a : Type) where
+  | Some (_ : k_a)
+  | None (_ : Unit)
+  deriving Inhabited, BEq, Repr
+open option
+
+abbrev Register := PEmpty
+abbrev RegisterType : Register -> Type := PEmpty.elim
+
+abbrev exception := Unit
+
+abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
+
+
+XXXXXXXXX
+
+import Sail
+import Out.Defs
+import Out.Specialization
+import Out.FakeReal
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 1_000_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+open ConcurrencyInterfaceV1
+
+namespace Out.Functions
+
+open option
+
+/-- Type quantifiers: k_ex851_ : Bool, k_ex850_ : Bool -/
+def neq_bool (x : Bool) (y : Bool) : Bool :=
+  (! (x == y))
+
+/-- Type quantifiers: x : Int -/
+def __id (x : Int) : Int :=
+  x
+
+/-- Type quantifiers: n : Int, m : Int -/
+def _shl_int_general (m : Int) (n : Int) : Int :=
+  if ((n ≥b 0) : Bool)
+  then (Int.shiftl m n)
+  else (Int.shiftr m (Neg.neg n))
+
+/-- Type quantifiers: n : Int, m : Int -/
+def _shr_int_general (m : Int) (n : Int) : Int :=
+  if ((n ≥b 0) : Bool)
+  then (Int.shiftr m n)
+  else (Int.shiftl m (Neg.neg n))
+
+/-- Type quantifiers: m : Int, n : Int -/
+def fdiv_int (n : Int) (m : Int) : Int :=
+  if (((n <b 0) && (m >b 0)) : Bool)
+  then ((Int.tdiv (n +i 1) m) -i 1)
+  else
+    (if (((n >b 0) && (m <b 0)) : Bool)
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m))
+
+/-- Type quantifiers: m : Int, n : Int -/
+def fmod_int (n : Int) (m : Int) : Int :=
+  (n -i (m *i (fdiv_int n m)))
+
+/-- Type quantifiers: len : Nat, k_v : Nat, len ≥ 0 ∧ k_v ≥ 0 -/
+def sail_mask (len : Nat) (v : (BitVec k_v)) : (BitVec len) :=
+  if ((len ≤b (Sail.BitVec.length v)) : Bool)
+  then (Sail.BitVec.truncate v len)
+  else (Sail.BitVec.zeroExtend v len)
+
+/-- Type quantifiers: n : Nat, n ≥ 0 -/
+def sail_ones (n : Nat) : (BitVec n) :=
+  (Complement.complement (BitVec.zero n))
+
+/-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
+def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
+  if ((l ≥b n) : Bool)
+  then ((sail_ones n) <<< i)
+  else
+    (let one : (BitVec n) := (sail_mask n (1#1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i))
+
+/-- Type quantifiers: n : Nat, n > 0 -/
+def to_bytes_le {n : _} (b : (BitVec (8 * n))) : (Vector (BitVec 8) n) := Id.run do
+  let res := (vectorInit (BitVec.zero 8))
+  let loop_i_lower := 0
+  let loop_i_upper := (n -i 1)
+  let mut loop_vars := res
+  for i in [loop_i_lower:loop_i_upper:1]i do
+    let res := loop_vars
+    loop_vars := (vectorUpdate res i (Sail.BitVec.extractLsb b ((8 *i i) +i 7) (8 *i i)))
+  (pure loop_vars)
+
+/-- Type quantifiers: n : Nat, n > 0 -/
+def from_bytes_le {n : _} (v : (Vector (BitVec 8) n)) : (BitVec (8 * n)) := Id.run do
+  let res := (BitVec.zero (8 *i n))
+  let loop_i_lower := 0
+  let loop_i_upper := (n -i 1)
+  let mut loop_vars := res
+  for i in [loop_i_lower:loop_i_upper:1]i do
+    let res := loop_vars
+    loop_vars := (Sail.BitVec.updateSubrange res ((8 *i i) +i 7) (8 *i i) (GetElem?.getElem! v i))
+  (pure loop_vars)
+
+/-- Type quantifiers: k_a : Type -/
+def is_none (opt : (Option k_a)) : Bool :=
+  match opt with
+  | .some _ => false
+  | none => true
+
+/-- Type quantifiers: k_a : Type -/
+def is_some (opt : (Option k_a)) : Bool :=
+  match opt with
+  | .some _ => true
+  | none => false
+
+/-- Type quantifiers: k_n : Int -/
+def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
+  (HAppend.hAppend str (BitVec.toFormatted x))
+
+/-- Type quantifiers: x : Int -/
+def concat_str_dec (str : String) (x : Int) : String :=
+  (HAppend.hAppend str (Int.repr x))
+
+/-- Type quantifiers: k_ex948_ : Bool -/
+def test (x : (BitVec 1)) (wide : Bool) : Int :=
+  let n : Int :=
+    if (wide : Bool)
+    then 64
+    else 32
+  let acc := (BitVec.zero n)
+  let acc :=
+    match x with
+    | 0 => (sail_ones n)
+    | _ => acc
+  (BitVec.toNatInt acc)
+
+def initialize_registers (_ : Unit) : Unit :=
+  ()
+
+def sail_model_init (x_0 : Unit) : Unit :=
+  (initialize_registers ())
+
+end Out.Functions

--- a/test/lean/generated_kid_ascription.sail
+++ b/test/lean/generated_kid_ascription.sail
@@ -1,0 +1,19 @@
+// Regression test for generated type kid filtering.
+// After rewrite_var_updates, the match acquires an E_typ wrapper
+// whose type mentions a generated kid (k___datasize or similar).
+// The Lean printer must suppress this ascription to avoid emitting
+// invalid Lean identifiers.
+default Order dec
+
+$include <prelude.sail>
+
+val test : (bits(1), bool) -> int
+function test(x, wide) = {
+  let n : {32, 64} = if wide then 64 else 32;
+  acc = sail_zeros(n);
+  match x {
+    0b0 => acc = sail_ones(n),
+    _   => ()
+  };
+  unsigned(acc)
+}

--- a/test/lean/guardedmatch.expected.lean
+++ b/test/lean/guardedmatch.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev xlen : Int := 32
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive Register : Type where
   | B

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive Register : Type where
   | r

--- a/test/lean/map_tactics.expected.lean
+++ b/test/lean/map_tactics.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive word_width where | BYTE | HALF | WORD | DOUBLE
   deriving BEq, Inhabited, Repr
-  open word_width
+open word_width
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive E where | A | B | C
   deriving BEq, Inhabited, Repr
-  open E
+open E
 
 inductive Register : Type where
   | r_C

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
@@ -164,7 +164,7 @@ def write_CSR (merge_var : (BitVec 12)) : SailM Bool := do
     (pure true)
   | _ => do
     (do
-      assert false "Pattern match failure at match_bv.sail:36.0-38.1"
+      assert false "Pattern match failure at test/lean/match_bv.sail:36.0-38.1"
       throw Error.Exit)
 
 def write_CSR2 (merge_var : (BitVec 12)) : SailM Bool := do
@@ -173,7 +173,7 @@ def write_CSR2 (merge_var : (BitVec 12)) : SailM Bool := do
     (pure true)
   | _ => do
     (do
-      assert false "Pattern match failure at match_bv.sail:41.0-43.1"
+      assert false "Pattern match failure at test/lean/match_bv.sail:41.0-43.1"
       throw Error.Exit)
 
 def initialize_registers (_ : Unit) : Unit :=

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -164,7 +164,7 @@ def write_CSR (merge_var : (BitVec 12)) : SailM Bool := do
     (pure true)
   | _ => do
     (do
-      assert false "Pattern match failure at test/lean/match_bv.sail:36.0-38.1"
+      assert false "Pattern match failure at match_bv.sail:36.0-38.1"
       throw Error.Exit)
 
 def write_CSR2 (merge_var : (BitVec 12)) : SailM Bool := do
@@ -173,7 +173,7 @@ def write_CSR2 (merge_var : (BitVec 12)) : SailM Bool := do
     (pure true)
   | _ => do
     (do
-      assert false "Pattern match failure at test/lean/match_bv.sail:41.0-43.1"
+      assert false "Pattern match failure at match_bv.sail:41.0-43.1"
       throw Error.Exit)
 
 def initialize_registers (_ : Unit) : Unit :=

--- a/test/lean/match_partial_update_dep_bits.expected.lean
+++ b/test/lean/match_partial_update_dep_bits.expected.lean
@@ -1,0 +1,175 @@
+import Sail
+open PreSail
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 1_000_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+open ConcurrencyInterfaceV1
+
+abbrev bit := (BitVec 1)
+
+abbrev bits k_n := (BitVec k_n)
+
+/-- Type quantifiers: k_a : Type -/
+inductive option (k_a : Type) where
+  | Some (_ : k_a)
+  | None (_ : Unit)
+  deriving Inhabited, BEq, Repr
+  open option
+
+inductive boxed_imm where
+  | Boxed32 (_ : (BitVec 32))
+  | Boxed64 (_ : (BitVec 64))
+  deriving Inhabited, BEq, Repr
+  open boxed_imm
+
+abbrev Register := PEmpty
+abbrev RegisterType : Register -> Type := PEmpty.elim
+
+abbrev exception := Unit
+
+abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
+
+
+XXXXXXXXX
+
+import Sail
+import Out.Defs
+import Out.Specialization
+import Out.FakeReal
+
+set_option maxHeartbeats 1_000_000_000
+set_option maxRecDepth 1_000_000
+set_option linter.unusedVariables false
+set_option match.ignoreUnusedAlts true
+
+open Sail
+open ConcurrencyInterfaceV1
+
+namespace Out.Functions
+
+open option
+open boxed_imm
+
+/-- Type quantifiers: k_ex939_ : Bool, k_ex938_ : Bool -/
+def neq_bool (x : Bool) (y : Bool) : Bool :=
+  (! (x == y))
+
+/-- Type quantifiers: x : Int -/
+def __id (x : Int) : Int :=
+  x
+
+/-- Type quantifiers: n : Int, m : Int -/
+def _shl_int_general (m : Int) (n : Int) : Int :=
+  if ((n ≥b 0) : Bool)
+  then (Int.shiftl m n)
+  else (Int.shiftr m (Neg.neg n))
+
+/-- Type quantifiers: n : Int, m : Int -/
+def _shr_int_general (m : Int) (n : Int) : Int :=
+  if ((n ≥b 0) : Bool)
+  then (Int.shiftr m n)
+  else (Int.shiftl m (Neg.neg n))
+
+/-- Type quantifiers: m : Int, n : Int -/
+def fdiv_int (n : Int) (m : Int) : Int :=
+  if (((n <b 0) && (m >b 0)) : Bool)
+  then ((Int.tdiv (n +i 1) m) -i 1)
+  else
+    (if (((n >b 0) && (m <b 0)) : Bool)
+    then ((Int.tdiv (n -i 1) m) -i 1)
+    else (Int.tdiv n m))
+
+/-- Type quantifiers: m : Int, n : Int -/
+def fmod_int (n : Int) (m : Int) : Int :=
+  (n -i (m *i (fdiv_int n m)))
+
+/-- Type quantifiers: len : Nat, k_v : Nat, len ≥ 0 ∧ k_v ≥ 0 -/
+def sail_mask (len : Nat) (v : (BitVec k_v)) : (BitVec len) :=
+  if ((len ≤b (Sail.BitVec.length v)) : Bool)
+  then (Sail.BitVec.truncate v len)
+  else (Sail.BitVec.zeroExtend v len)
+
+/-- Type quantifiers: n : Nat, n ≥ 0 -/
+def sail_ones (n : Nat) : (BitVec n) :=
+  (Complement.complement (BitVec.zero n))
+
+/-- Type quantifiers: l : Int, i : Int, n : Nat, n ≥ 0 -/
+def slice_mask {n : _} (i : Int) (l : Int) : (BitVec n) :=
+  if ((l ≥b n) : Bool)
+  then ((sail_ones n) <<< i)
+  else
+    (let one : (BitVec n) := (sail_mask n (1#1 : (BitVec 1)))
+    (((one <<< l) - one) <<< i))
+
+/-- Type quantifiers: n : Nat, n > 0 -/
+def to_bytes_le {n : _} (b : (BitVec (8 * n))) : (Vector (BitVec 8) n) := Id.run do
+  let res := (vectorInit (BitVec.zero 8))
+  let loop_i_lower := 0
+  let loop_i_upper := (n -i 1)
+  let mut loop_vars := res
+  for i in [loop_i_lower:loop_i_upper:1]i do
+    let res := loop_vars
+    loop_vars := (vectorUpdate res i (Sail.BitVec.extractLsb b ((8 *i i) +i 7) (8 *i i)))
+  (pure loop_vars)
+
+/-- Type quantifiers: n : Nat, n > 0 -/
+def from_bytes_le {n : _} (v : (Vector (BitVec 8) n)) : (BitVec (8 * n)) := Id.run do
+  let res := (BitVec.zero (8 *i n))
+  let loop_i_lower := 0
+  let loop_i_upper := (n -i 1)
+  let mut loop_vars := res
+  for i in [loop_i_lower:loop_i_upper:1]i do
+    let res := loop_vars
+    loop_vars := (Sail.BitVec.updateSubrange res ((8 *i i) +i 7) (8 *i i) (GetElem?.getElem! v i))
+  (pure loop_vars)
+
+/-- Type quantifiers: k_a : Type -/
+def is_none (opt : (Option k_a)) : Bool :=
+  match opt with
+  | .some _ => false
+  | none => true
+
+/-- Type quantifiers: k_a : Type -/
+def is_some (opt : (Option k_a)) : Bool :=
+  match opt with
+  | .some _ => true
+  | none => false
+
+/-- Type quantifiers: k_n : Int -/
+def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
+  (HAppend.hAppend str (BitVec.toFormatted x))
+
+/-- Type quantifiers: x : Int -/
+def concat_str_dec (str : String) (x : Int) : String :=
+  (HAppend.hAppend str (Int.repr x))
+
+/-- Type quantifiers: k_ex1040_ : Bool -/
+def partial_update_match (shift : (BitVec 2)) (imm12 : (BitVec 12)) (use64 : Bool) : boxed_imm :=
+  let datasize : Int :=
+    if (use64 : Bool)
+    then 64
+    else 32
+  let imm := (BitVec.zero datasize)
+  let imm :=
+    match shift with
+    | 0b00 => (Sail.BitVec.zeroExtend imm12 datasize)
+    | 0b01 => (Sail.BitVec.zeroExtend (imm12 +++ 0x000#12) datasize)
+    | _ =>
+      (let _ : Unit := (print "reserved")
+      imm)
+  if ((datasize == 64) : Bool)
+  then (Boxed64 imm)
+  else (Boxed32 imm)
+
+def initialize_registers (_ : Unit) : Unit :=
+  ()
+
+def sail_model_init (x_0 : Unit) : Unit :=
+  (initialize_registers ())
+
+end Out.Functions

--- a/test/lean/match_partial_update_dep_bits.expected.lean
+++ b/test/lean/match_partial_update_dep_bits.expected.lean
@@ -11,20 +11,20 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive boxed_imm where
   | Boxed32 (_ : (BitVec 32))
   | Boxed64 (_ : (BitVec 64))
   deriving Inhabited, BEq, Repr
-  open boxed_imm
+open boxed_imm
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/match_partial_update_dep_bits.sail
+++ b/test/lean/match_partial_update_dep_bits.sail
@@ -1,0 +1,23 @@
+default Order dec
+
+$include <prelude.sail>
+
+union boxed_imm = {
+  Boxed32 : bits(32),
+  Boxed64 : bits(64)
+}
+
+function partial_update_match(shift : bits(2), imm12 : bits(12), use64 : bool) -> boxed_imm = {
+  let datasize : {32, 64} = if use64 then 64 else 32;
+  imm = sail_zeros(datasize);
+  match shift {
+    0b00 => imm = sail_zero_extend(imm12, datasize),
+    0b01 => imm = sail_zero_extend(imm12 @ 0x000, datasize),
+    _ => print("reserved")
+  };
+  if datasize == 64 then {
+    Boxed64(imm)
+  } else {
+    Boxed32(imm)
+  }
+}

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev reg_index := Nat
 

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 structure My_struct where
   field1 : Int

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev xlen : Int := 64
 
@@ -30,13 +30,13 @@ abbrev regbits := (BitVec 5)
 
 inductive iop where | RISCV_ADDI | RISCV_SLTI | RISCV_SLTIU | RISCV_XORI | RISCV_ORI | RISCV_ANDI
   deriving BEq, Inhabited, Repr
-  open iop
+open iop
 
 inductive ast where
   | ITYPE (_ : ((BitVec 12) × regbits × regbits × iop))
   | LOAD (_ : ((BitVec 12) × regbits × regbits))
   deriving Inhabited, BEq, Repr
-  open ast
+open ast
 
 inductive Register : Type where
   | Xs
@@ -240,7 +240,7 @@ def execute (merge_var : ast) : SailM Unit := do
   | .LOAD (imm, rs1, rd) => (execute_LOAD imm rs1 rd)
   | _ =>
     (do
-      assert false "Pattern match failure at riscv_duopod.sail:138.0-142.1"
+      assert false "Pattern match failure at test/lean/riscv_duopod.sail:138.0-142.1"
       throw Error.Exit)
 
 def decode (merge_var : (BitVec 32)) : (Option ast) :=

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -240,7 +240,7 @@ def execute (merge_var : ast) : SailM Unit := do
   | .LOAD (imm, rs1, rd) => (execute_LOAD imm rs1 rd)
   | _ =>
     (do
-      assert false "Pattern match failure at test/lean/riscv_duopod.sail:138.0-142.1"
+      assert false "Pattern match failure at riscv_duopod.sail:138.0-142.1"
       throw Error.Exit)
 
 def decode (merge_var : (BitVec 32)) : (Option ast) :=

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive e_test where | VAL
   deriving BEq, Inhabited, Repr
-  open e_test
+open e_test
 
 structure s_test where
   f : e_test

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -11,18 +11,18 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive E where | A | B | C
   deriving BEq, Inhabited, Repr
-  open E
+open E
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -11,14 +11,14 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 abbrev xlen : Int := 64
 
@@ -28,7 +28,7 @@ abbrev xlenbits := (BitVec 64)
 
 abbrev booltype : Bool := xlen = 64
 
-abbrev my_bits k_n := (BitVec k_n)
+abbrev my_bits (k_n : Int) := (BitVec k_n)
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -11,19 +11,19 @@ open ConcurrencyInterfaceV1
 
 abbrev bit := (BitVec 1)
 
-abbrev bits k_n := (BitVec k_n)
+abbrev bits (k_n : Int) := (BitVec k_n)
 
 /-- Type quantifiers: k_a : Type -/
 inductive option (k_a : Type) where
   | Some (_ : k_a)
   | None (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open option
+open option
 
 inductive virtaddr where
   | virtaddr (_ : (BitVec 32))
   deriving Inhabited, BEq, Repr
-  open virtaddr
+open virtaddr
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -22,14 +22,14 @@ inductive shape where
   | Rectangle (_ : rectangle)
   | Circle (_ : circle)
   deriving Inhabited, BEq, Repr
-  open shape
+open shape
 
 /-- Type quantifiers: k_a : Type -/
 inductive my_option (k_a : Type) where
   | MySome (_ : k_a)
   | MyNone (_ : Unit)
   deriving Inhabited, BEq, Repr
-  open my_option
+open my_option
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim


### PR DESCRIPTION
## Motivation

These fixes were discovered while extracting the [sail-small-arm](https://github.com/AdrianPR0/sail-small-arm) (ARMv8.5-A subset) model to Lean using `--lean`. Together they allow the model to pass Sail extraction and produce valid Lean code.

## Changes

### 1. Preserve typing through `rewrite_var_updates` for partial mutable match updates (`rewrites.ml`)

When `rewrite_var_updates` transforms a `match` where only some arms assign to a mutable local with a dependent bitvector width (e.g. `bits('R)` with `'R in {32, 64}`), the late `recheck_defs` pass cannot re-infer the match's result type after `strip_ast` removes annotations.

Fix: wrap the rewritten match in an explicit `E_typ` so the type survives stripping, and preserve existing `E_typ` wrappers in the `Added_vars` path instead of rebuilding them via `add_e_typ`.

### 2. Filter generated type kids from Lean type ascriptions (`pretty_print_lean.ml`)

The `E_typ` wrappers added by fix 1 can mention internal generated kids like `k___datasize`. These are not valid Lean identifiers and must not appear in emitted code.

Fix: add `has_generated_typ_kids` and skip Lean type ascriptions (both in expressions and patterns) when the type mentions generated kids.

### 3. Sanitize dotted filenames (`sail_plugin_lean.ml`)

Multi-segment Sail filenames like `armV8.h.sail` produced invalid Lean module names (`ArmV8.h`). Lean's module system does not support dots in identifiers.

Fix: strip interior dots in `file_to_module`, so `armV8.h.sail` maps to `ArmV8h`.

Note: this fix is only exercised in multi-file mode (`--lean` without `--lean-single-file`), so it cannot be covered by the existing single-file test harness.

### 4. Emit typed binders for type abbreviations (`pretty_print_lean.ml`)

`TD_abbrev` emitted bare type variable names (`abbrev bits k_n := ...`) which Lean cannot type-check because it has no way to infer the kinds.

Fix: use `doc_typ_quant_relevant` (which emits `(k_n : Int)`) instead of `doc_typ_quant_only_vars` for both `A_typ` and `A_nexp` abbreviations.

### 5. Move `open` outside `nest 2` for enums and variants (`pretty_print_lean.ml`)

The `open` statement for `TD_enum` and `TD_variant` was indented inside the type definition's `nest 2` block, causing Lean to parse it as part of the definition body rather than a top-level command.

Fix: emit `open` after the closing parenthesis of the `nest 2` block, at column 0.

## Tests

- `match_partial_update_dep_bits.sail`: exercises fix 1 (partial mutable match update with dependent width)
- `generated_kid_ascription.sail`: exercises fix 2 (generated type kid suppression in Lean ascriptions)
- `abbrev_open.sail`: exercises fixes 4 and 5 (typed abbreviation binders and `open` indentation)
- All 31 existing `test/lean/*.expected.lean` files regenerated to reflect fixes 4 and 5

## Update: revised fix for `E_match` inference (in #1657)

Following feedback on this PR about the `E_typ` annotation approach in `rewrite_var_updates` (fixes 1 and 2 above), we revised the approach in #1657 with a more principled fix that respects the bidirectionality of Sail's type system:

- **`rewrites.ml`**: Use `add_e_typ` (which guards against generated kids via `resolve_generated_kids`/`is_src_typ`) instead of unconditionally inserting `E_typ`.
- **`type_check.ml`**: Add `infer_case` and an `E_match` case to `infer_exp`, mirroring the existing `E_if` inference logic (infer the first case's body type, check remaining cases against it). This makes `E_match` inherently inferable without any annotations.
- **`pretty_print_lean.ml`**: Remove the `has_generated_typ_kids` filter from the `E_typ` case, since generated kids no longer appear in `E_typ` nodes.

Rather than adding potentially-invalid type annotations to non-inferable terms, we make the term inferable. All test suites pass (typecheck: 137/137, lean diff: 39/39, lean runnable: 232/232), and `sail-small-arm` extracts cleanly.

Posted by Cursor assistant (model: claude-4.6-opus-high-thinking) on behalf of the user (Quang Dao) with approval.