### PR TITLE
Fixes for termination issues affecting scattered functions

### DIFF
--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4166,13 +4166,35 @@ let move_termination_measures env ast =
   let called_output = ref IdSet.empty in
   let rec aux acc = function
     | [] -> List.rev acc
-    | (DEF_aux (DEF_fundef (FD_aux (FD_function (r, ty, fs), (l, f_ann))), def_annot) as d) :: t -> begin
+    | (DEF_aux (DEF_fundef fd, def_annot) as d) :: t -> begin
+        match aux_fd fd with
+        | None -> aux (d :: acc) t
+        | Some (new_fd, moved_val_specs) ->
+            let new_def = DEF_aux (DEF_fundef new_fd, def_annot) in
+            aux ((new_def :: moved_val_specs) @ acc) t
+      end
+    | (DEF_aux (DEF_internal_mutrec fds, def_annot) as d) :: t -> begin
+        match Util.map_changed_default (fun x -> (x, [])) aux_fd fds with
+        | None -> aux (d :: acc) t
+        | Some xs ->
+            let new_fds, moved_val_specss = List.split xs in
+            let new_def = DEF_aux (DEF_internal_mutrec new_fds, def_annot) in
+            aux ((new_def :: List.concat moved_val_specss) @ acc) t
+      end
+    | DEF_aux (DEF_val (VS_aux (VS_val_spec (_, id, _), _)), _) :: t when IdSet.mem id !called_output -> aux acc t
+    | (DEF_aux (DEF_val (VS_aux (VS_val_spec (_, id, _), _)), _) as d) :: t ->
+        called_output := IdSet.add id !called_output;
+        aux (d :: acc) t
+    | DEF_aux (DEF_measure _, _) :: t -> aux acc t
+    | h :: t -> aux (h :: acc) t
+  and aux_fd = function
+    | FD_aux (FD_function (r, ty, fs), (l, f_ann)) -> begin
         let id = match fs with [] -> assert false (* TODO *) | FCL_aux (FCL_funcl (id, _), _) :: _ -> id in
         match Bindings.find_opt id measures with
-        | None -> aux (d :: acc) t
+        | None -> None
         | Some (pat, exp, called_fns) ->
             let r = Rec_aux (Rec_measure (pat, exp), Generated l) in
-            let new_def = DEF_aux (DEF_fundef (FD_aux (FD_function (r, ty, fs), (l, f_ann))), def_annot) in
+            let new_fd = FD_aux (FD_function (r, ty, fs), (l, f_ann)) in
             let moved_val_specs =
               List.fold_left
                 (fun moved id ->
@@ -4184,14 +4206,8 @@ let move_termination_measures env ast =
                 )
                 [] called_fns
             in
-            aux ((new_def :: moved_val_specs) @ acc) t
+            Some (new_fd, moved_val_specs)
       end
-    | DEF_aux (DEF_val (VS_aux (VS_val_spec (_, id, _), _)), _) :: t when IdSet.mem id !called_output -> aux acc t
-    | (DEF_aux (DEF_val (VS_aux (VS_val_spec (_, id, _), _)), _) as d) :: t ->
-        called_output := IdSet.add id !called_output;
-        aux (d :: acc) t
-    | DEF_aux (DEF_measure _, _) :: t -> aux acc t
-    | h :: t -> aux (h :: acc) t
   in
   let ast = { ast with defs = aux [] ast.defs } in
   move_loop_measures ast

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -4262,8 +4262,24 @@ let rewrite_explicit_measure effect_info env ast =
     let loc = Parse_ast.Generated (fst fcl_ann).loc in
     let P_aux (pat, pann), guard, body, ann = destruct_pexp pexp in
     let extra_pat = P_aux (P_id limit, (loc, empty_tannot)) in
-    let pat =
-      match pat with P_tuple pats -> P_tuple (pats @ [extra_pat]) | p -> P_tuple [P_aux (p, pann); extra_pat]
+    let _, fn_typ = Env.get_val_spec id (env_of_tannot (snd fcl_ann)) in
+    let pat, rebind =
+      match pat with
+      | P_tuple pats -> (P_tuple (pats @ [extra_pat]), fun e -> e)
+      | p -> (
+          (* If the arguments are matched by a single pattern, break it up to add the new one then rebind it later *)
+          match fn_typ with
+          | Typ_aux (Typ_fn ((_ :: _ :: _ as args), _), _) ->
+              let mk_arg_pat i _typ = P_aux (P_id (mk_id ("arg#" ^ string_of_int i)), (loc, empty_tannot)) in
+              let mk_arg_exp i _typ = E_aux (E_id (mk_id ("arg#" ^ string_of_int i)), (loc, empty_tannot)) in
+              let pats = List.mapi mk_arg_pat args in
+              let exps = List.mapi mk_arg_exp args in
+              let rebind body =
+                E_aux (E_let (P_aux (p, pann), E_aux (E_tuple exps, (loc, empty_tannot)), body), (loc, empty_tannot))
+              in
+              (P_tuple (pats @ [extra_pat]), rebind)
+          | _ -> (P_tuple [P_aux (p, pann); extra_pat], fun e -> e)
+        )
     in
     let assert_exp =
       E_aux
@@ -4304,7 +4320,7 @@ let rewrite_explicit_measure effect_info env ast =
         }
         body
     in
-    let body = E_aux (E_block [assert_exp; body], (loc, empty_tannot)) in
+    let body = rebind (E_aux (E_block [assert_exp; body], (loc, empty_tannot))) in
     let new_id = rec_id id in
     effect_info := Effects.copy_function_effect id !effect_info new_id;
     FCL_aux (FCL_funcl (new_id, construct_pexp (P_aux (pat, pann), guard, body, ann)), fcl_ann)

--- a/src/lib/rewrites.mli
+++ b/src/lib/rewrites.mli
@@ -128,3 +128,5 @@ val rewrite :
 val rewrites_interpreter : (string * rewriter_arg list) list
 
 val simple_typ : typ -> typ
+
+val pat_to_exp : Env.t -> tannot pat -> tannot exp

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1186,16 +1186,22 @@ let doc_funcl_body fixup_binders ctx (FCL_aux (FCL_funcl (id, pexp), annot)) =
   let is_monadic = has_effect exp || not (Effects.function_is_pure id ctx.global.effect_info) in
   if untranslatable_mapping id exp then string "throw Error.Exit" else doc_exp is_monadic (context_with_env ctx env) exp
 
-let doc_termination ctx fnpat (Rec_aux (meas, _)) =
+let doc_termination fixup_binders ctx fnpat (Rec_aux (meas, _)) =
   match meas with
   | Rec_nonrec | Rec_rec -> empty
   | Rec_measure (pat, exp) ->
       (* TODO: actually use the pattern *)
-      let term = doc_exp false ctx exp in
-      let term_by =
-        string "termination_by let " ^^ doc_pat ctx false pat ^^ string " := " ^^ doc_pat ctx false fnpat ^^ string "; "
-        ^^ parens term ^^ string ".toNat"
+      let term =
+        doc_exp false ctx
+          (fixup_binders
+             (E_aux
+                ( E_let (pat, Rewrites.pat_to_exp (env_of_pat fnpat) fnpat, exp),
+                  (Unknown, mk_tannot ctx.env (typ_of exp))
+                )
+             )
+          )
       in
+      let term_by = string "termination_by " ^^ parens term ^^ string ".toNat" in
       hardline ^^ term_by
 
 let pat_of_funcl (FCL_aux (FCL_funcl (_, funcl), _)) =
@@ -1204,7 +1210,7 @@ let pat_of_funcl (FCL_aux (FCL_funcl (_, funcl), _)) =
 let doc_funcl ctx meas funcl =
   let comment, signature, ctx, fixup_binders = doc_funcl_init ctx.global funcl in
   let fnpat = pat_of_funcl funcl in
-  let termination = doc_termination ctx fnpat meas in
+  let termination = doc_termination fixup_binders ctx fnpat meas in
   comment ^^ nest 2 (signature ^^ hardline ^^ doc_funcl_body fixup_binders ctx funcl) ^^ termination
 
 let string_of_pexp p =

--- a/test/c/scattered_termination.sail
+++ b/test/c/scattered_termination.sail
@@ -1,0 +1,28 @@
+default Order dec
+$include <prelude.sail>
+
+enum t = {A, B, C}
+
+val test1 : t -> bool
+val test2 : int -> bool
+
+scattered function test1
+
+function clause test1(A) = false
+function clause test1(B) = test2(5)
+function clause test1(C) = true
+
+end test1
+
+function test2(x) = {
+  if x > 0 then true else if x == 0 then test1(A) else test1(B)
+}
+
+termination_measure test1(x) = match x { A => 0, B => 1, C => 0 }
+termination_measure test2(x) = if x <= 0 then 2 else 0
+
+function main() -> unit = {
+  assert(test2(10));
+  assert(not_bool(test2(0)));
+  assert(test2(-10));
+}

--- a/test/c/scattered_termination.sail
+++ b/test/c/scattered_termination.sail
@@ -21,8 +21,31 @@ function test2(x) = {
 termination_measure test1(x) = match x { A => 0, B => 1, C => 0 }
 termination_measure test2(x) = if x <= 0 then 2 else 0
 
+val test3 : (t, int) -> bool
+val test4 : int -> bool
+
+scattered function test3
+
+function clause test3(A,_) = false
+function clause test3(B,_) = test4(5)
+function clause test3(C,_) = true
+
+end test3
+
+function test4(x) = {
+  if x > 0 then true else if x == 0 then test3(A,x) else test3(B,x)
+}
+
+// termination_measure test3(x,_) = match x { A => 0, B => 1, C => 0 }
+termination_measure test3(_,_) = 1
+termination_measure test4(x) = if x <= 0 then 2 else 0
+
 function main() -> unit = {
   assert(test2(10));
   assert(not_bool(test2(0)));
   assert(test2(-10));
+
+  assert(test4(10));
+  assert(not_bool(test4(0)));
+  assert(test4(-10));
 }

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -173,7 +173,8 @@ def enabled (e : E) : Bool :=
   | A => (enabled B)
   | B => (enabled C)
   | C => true
-termination_by let e := e; ((measure e)).toNat
+termination_by (let e := e
+(measure e)).toNat
 
 def measure2 (x : E) : Int :=
   match x with
@@ -187,7 +188,8 @@ def enabled2 (b : Bool) (e : E) : Bool :=
   | A => (enabled2 b B)
   | B => (enabled2 b C)
   | C => b
-termination_by let (_, x) := (b, e); ((measure2 x)).toNat
+termination_by (let (_, x) := (b, e)
+(measure2 x)).toNat
 
 def initialize_registers (_ : Unit) : Unit :=
   ()


### PR DESCRIPTION
These came up from a RISC-V model pull request, although the version merged doesn't require them.