### PR TITLE
Lean: use dot notation for constructors in match

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -510,7 +510,9 @@ let rec doc_pat ?(need_parens = false) ?(in_vector = false) ctx in_match_bv (P_a
       | Typ_aux (Typ_app (Id_aux (Id id', _), [A_aux (A_nexp (Nexp_aux (Nexp_constant i, _)), _)]), _)
         when in_vector && (id' = "bits" || id' = "bitvector") ->
           (fixup_match_id id |> doc_id_ctor) ^^ string ":" ^^ doc_big_int i
-      | _ -> fixup_match_id id |> doc_id_ctor
+      | _ ->
+          let prefix = if Type_check.is_enum_member id ctx.env then string "." else empty in
+          prefix ^^ (fixup_match_id id |> doc_id_ctor)
     )
   | P_tuple pats -> separate (string ", ") (List.map (doc_pat ctx in_match_bv) pats) |> parens
   | P_list pats -> separate (string ", ") (List.map (doc_pat ctx in_match_bv) pats) |> brackets

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -1095,10 +1095,10 @@ def SecurityState_of_num (arg_ : Nat) : SecurityState :=
 
 def num_of_SecurityState (arg_ : SecurityState) : Int :=
   match arg_ with
-  | SS_NonSecure => 0
-  | SS_Root => 1
-  | SS_Realm => 2
-  | SS_Secure => 3
+  | .SS_NonSecure => 0
+  | .SS_Root => 1
+  | .SS_Realm => 2
+  | .SS_Secure => 3
 
 def undefined_PARTIDspaceType (_ : Unit) : SailM PARTIDspaceType := do
   (internal_pick [PIdSpace_Secure, PIdSpace_Root, PIdSpace_Realm, PIdSpace_NonSecure])
@@ -1113,10 +1113,10 @@ def PARTIDspaceType_of_num (arg_ : Nat) : PARTIDspaceType :=
 
 def num_of_PARTIDspaceType (arg_ : PARTIDspaceType) : Int :=
   match arg_ with
-  | PIdSpace_Secure => 0
-  | PIdSpace_Root => 1
-  | PIdSpace_Realm => 2
-  | PIdSpace_NonSecure => 3
+  | .PIdSpace_Secure => 0
+  | .PIdSpace_Root => 1
+  | .PIdSpace_Realm => 2
+  | .PIdSpace_NonSecure => 3
 
 def undefined_MPAMinfo (_ : Unit) : SailM MPAMinfo := do
   (pure { mpam_sp := ← (undefined_PARTIDspaceType ())
@@ -1147,20 +1147,20 @@ def AccessType_of_num (arg_ : Nat) : AccessType :=
 
 def num_of_AccessType (arg_ : AccessType) : Int :=
   match arg_ with
-  | AccessType_IFETCH => 0
-  | AccessType_GPR => 1
-  | AccessType_ASIMD => 2
-  | AccessType_SVE => 3
-  | AccessType_SME => 4
-  | AccessType_IC => 5
-  | AccessType_DC => 6
-  | AccessType_DCZero => 7
-  | AccessType_AT => 8
-  | AccessType_NV2 => 9
-  | AccessType_SPE => 10
-  | AccessType_GCS => 11
-  | AccessType_GPTW => 12
-  | AccessType_TTW => 13
+  | .AccessType_IFETCH => 0
+  | .AccessType_GPR => 1
+  | .AccessType_ASIMD => 2
+  | .AccessType_SVE => 3
+  | .AccessType_SME => 4
+  | .AccessType_IC => 5
+  | .AccessType_DC => 6
+  | .AccessType_DCZero => 7
+  | .AccessType_AT => 8
+  | .AccessType_NV2 => 9
+  | .AccessType_SPE => 10
+  | .AccessType_GCS => 11
+  | .AccessType_GPTW => 12
+  | .AccessType_TTW => 13
 
 def undefined_VARange (_ : Unit) : SailM VARange := do
   (internal_pick [VARange_LOWER, VARange_UPPER])
@@ -1173,8 +1173,8 @@ def VARange_of_num (arg_ : Nat) : VARange :=
 
 def num_of_VARange (arg_ : VARange) : Int :=
   match arg_ with
-  | VARange_LOWER => 0
-  | VARange_UPPER => 1
+  | .VARange_LOWER => 0
+  | .VARange_UPPER => 1
 
 def undefined_MemAtomicOp (_ : Unit) : SailM MemAtomicOp := do
   (internal_pick
@@ -1197,17 +1197,17 @@ def MemAtomicOp_of_num (arg_ : Nat) : MemAtomicOp :=
 
 def num_of_MemAtomicOp (arg_ : MemAtomicOp) : Int :=
   match arg_ with
-  | MemAtomicOp_GCSSS1 => 0
-  | MemAtomicOp_ADD => 1
-  | MemAtomicOp_BIC => 2
-  | MemAtomicOp_EOR => 3
-  | MemAtomicOp_ORR => 4
-  | MemAtomicOp_SMAX => 5
-  | MemAtomicOp_SMIN => 6
-  | MemAtomicOp_UMAX => 7
-  | MemAtomicOp_UMIN => 8
-  | MemAtomicOp_SWP => 9
-  | MemAtomicOp_CAS => 10
+  | .MemAtomicOp_GCSSS1 => 0
+  | .MemAtomicOp_ADD => 1
+  | .MemAtomicOp_BIC => 2
+  | .MemAtomicOp_EOR => 3
+  | .MemAtomicOp_ORR => 4
+  | .MemAtomicOp_SMAX => 5
+  | .MemAtomicOp_SMIN => 6
+  | .MemAtomicOp_UMAX => 7
+  | .MemAtomicOp_UMIN => 8
+  | .MemAtomicOp_SWP => 9
+  | .MemAtomicOp_CAS => 10
 
 def undefined_CacheOp (_ : Unit) : SailM CacheOp := do
   (internal_pick [CacheOp_Clean, CacheOp_Invalidate, CacheOp_CleanInvalidate])
@@ -1221,9 +1221,9 @@ def CacheOp_of_num (arg_ : Nat) : CacheOp :=
 
 def num_of_CacheOp (arg_ : CacheOp) : Int :=
   match arg_ with
-  | CacheOp_Clean => 0
-  | CacheOp_Invalidate => 1
-  | CacheOp_CleanInvalidate => 2
+  | .CacheOp_Clean => 0
+  | .CacheOp_Invalidate => 1
+  | .CacheOp_CleanInvalidate => 2
 
 def undefined_CacheOpScope (_ : Unit) : SailM CacheOpScope := do
   (internal_pick
@@ -1244,15 +1244,15 @@ def CacheOpScope_of_num (arg_ : Nat) : CacheOpScope :=
 
 def num_of_CacheOpScope (arg_ : CacheOpScope) : Int :=
   match arg_ with
-  | CacheOpScope_SetWay => 0
-  | CacheOpScope_PoU => 1
-  | CacheOpScope_PoC => 2
-  | CacheOpScope_PoE => 3
-  | CacheOpScope_PoP => 4
-  | CacheOpScope_PoDP => 5
-  | CacheOpScope_PoPA => 6
-  | CacheOpScope_ALLU => 7
-  | CacheOpScope_ALLUIS => 8
+  | .CacheOpScope_SetWay => 0
+  | .CacheOpScope_PoU => 1
+  | .CacheOpScope_PoC => 2
+  | .CacheOpScope_PoE => 3
+  | .CacheOpScope_PoP => 4
+  | .CacheOpScope_PoDP => 5
+  | .CacheOpScope_PoPA => 6
+  | .CacheOpScope_ALLU => 7
+  | .CacheOpScope_ALLUIS => 8
 
 def undefined_CacheType (_ : Unit) : SailM CacheType := do
   (internal_pick [CacheType_Data, CacheType_Tag, CacheType_Data_Tag, CacheType_Instruction])
@@ -1267,10 +1267,10 @@ def CacheType_of_num (arg_ : Nat) : CacheType :=
 
 def num_of_CacheType (arg_ : CacheType) : Int :=
   match arg_ with
-  | CacheType_Data => 0
-  | CacheType_Tag => 1
-  | CacheType_Data_Tag => 2
-  | CacheType_Instruction => 3
+  | .CacheType_Data => 0
+  | .CacheType_Tag => 1
+  | .CacheType_Data_Tag => 2
+  | .CacheType_Instruction => 3
 
 def undefined_CachePASpace (_ : Unit) : SailM CachePASpace := do
   (internal_pick
@@ -1289,13 +1289,13 @@ def CachePASpace_of_num (arg_ : Nat) : CachePASpace :=
 
 def num_of_CachePASpace (arg_ : CachePASpace) : Int :=
   match arg_ with
-  | CPAS_NonSecure => 0
-  | CPAS_Any => 1
-  | CPAS_RealmNonSecure => 2
-  | CPAS_Realm => 3
-  | CPAS_Root => 4
-  | CPAS_SecureNonSecure => 5
-  | CPAS_Secure => 6
+  | .CPAS_NonSecure => 0
+  | .CPAS_Any => 1
+  | .CPAS_RealmNonSecure => 2
+  | .CPAS_Realm => 3
+  | .CPAS_Root => 4
+  | .CPAS_SecureNonSecure => 5
+  | .CPAS_Secure => 6
 
 def undefined_AccessDescriptor (_ : Unit) : SailM AccessDescriptor := do
   (pure { acctype := ← (undefined_AccessType ())
@@ -1343,8 +1343,8 @@ def MemType_of_num (arg_ : Nat) : MemType :=
 
 def num_of_MemType (arg_ : MemType) : Int :=
   match arg_ with
-  | MemType_Normal => 0
-  | MemType_Device => 1
+  | .MemType_Normal => 0
+  | .MemType_Device => 1
 
 def undefined_DeviceType (_ : Unit) : SailM DeviceType := do
   (internal_pick [DeviceType_GRE, DeviceType_nGRE, DeviceType_nGnRE, DeviceType_nGnRnE])
@@ -1359,10 +1359,10 @@ def DeviceType_of_num (arg_ : Nat) : DeviceType :=
 
 def num_of_DeviceType (arg_ : DeviceType) : Int :=
   match arg_ with
-  | DeviceType_GRE => 0
-  | DeviceType_nGRE => 1
-  | DeviceType_nGnRE => 2
-  | DeviceType_nGnRnE => 3
+  | .DeviceType_GRE => 0
+  | .DeviceType_nGRE => 1
+  | .DeviceType_nGnRE => 2
+  | .DeviceType_nGnRnE => 3
 
 def undefined_MemAttrHints (_ : Unit) : SailM MemAttrHints := do
   (pure { attrs := ← (undefined_bitvector 2)
@@ -1381,9 +1381,9 @@ def Shareability_of_num (arg_ : Nat) : Shareability :=
 
 def num_of_Shareability (arg_ : Shareability) : Int :=
   match arg_ with
-  | Shareability_NSH => 0
-  | Shareability_ISH => 1
-  | Shareability_OSH => 2
+  | .Shareability_NSH => 0
+  | .Shareability_ISH => 1
+  | .Shareability_OSH => 2
 
 def undefined_MemTagType (_ : Unit) : SailM MemTagType := do
   (internal_pick [MemTag_Untagged, MemTag_AllocationTagged, MemTag_CanonicallyTagged])
@@ -1397,9 +1397,9 @@ def MemTagType_of_num (arg_ : Nat) : MemTagType :=
 
 def num_of_MemTagType (arg_ : MemTagType) : Int :=
   match arg_ with
-  | MemTag_Untagged => 0
-  | MemTag_AllocationTagged => 1
-  | MemTag_CanonicallyTagged => 2
+  | .MemTag_Untagged => 0
+  | .MemTag_AllocationTagged => 1
+  | .MemTag_CanonicallyTagged => 2
 
 def undefined_MemoryAttributes (_ : Unit) : SailM MemoryAttributes := do
   (pure { memtype := ← (undefined_MemType ())
@@ -1424,10 +1424,10 @@ def PASpace_of_num (arg_ : Nat) : PASpace :=
 
 def num_of_PASpace (arg_ : PASpace) : Int :=
   match arg_ with
-  | PAS_NonSecure => 0
-  | PAS_Secure => 1
-  | PAS_Root => 2
-  | PAS_Realm => 3
+  | .PAS_NonSecure => 0
+  | .PAS_Secure => 1
+  | .PAS_Root => 2
+  | .PAS_Realm => 3
 
 def undefined_FullAddress (_ : Unit) : SailM FullAddress := do
   (pure { paspace := ← (undefined_PASpace ())
@@ -1447,11 +1447,11 @@ def GPCF_of_num (arg_ : Nat) : GPCF :=
 
 def num_of_GPCF (arg_ : GPCF) : Int :=
   match arg_ with
-  | GPCF_None => 0
-  | GPCF_AddressSize => 1
-  | GPCF_Walk => 2
-  | GPCF_EABT => 3
-  | GPCF_Fail => 4
+  | .GPCF_None => 0
+  | .GPCF_AddressSize => 1
+  | .GPCF_Walk => 2
+  | .GPCF_EABT => 3
+  | .GPCF_Fail => 4
 
 def undefined_GPCFRecord (_ : Unit) : SailM GPCFRecord := do
   (pure { gpf := ← (undefined_GPCF ())
@@ -1491,30 +1491,30 @@ def Fault_of_num (arg_ : Nat) : Fault :=
 
 def num_of_Fault (arg_ : Fault) : Int :=
   match arg_ with
-  | Fault_None => 0
-  | Fault_AccessFlag => 1
-  | Fault_Alignment => 2
-  | Fault_Background => 3
-  | Fault_Domain => 4
-  | Fault_Permission => 5
-  | Fault_Translation => 6
-  | Fault_AddressSize => 7
-  | Fault_SyncExternal => 8
-  | Fault_SyncExternalOnWalk => 9
-  | Fault_SyncParity => 10
-  | Fault_SyncParityOnWalk => 11
-  | Fault_GPCFOnWalk => 12
-  | Fault_GPCFOnOutput => 13
-  | Fault_AsyncParity => 14
-  | Fault_AsyncExternal => 15
-  | Fault_TagCheck => 16
-  | Fault_Debug => 17
-  | Fault_TLBConflict => 18
-  | Fault_BranchTarget => 19
-  | Fault_HWUpdateAccessFlag => 20
-  | Fault_Lockdown => 21
-  | Fault_Exclusive => 22
-  | Fault_ICacheMaint => 23
+  | .Fault_None => 0
+  | .Fault_AccessFlag => 1
+  | .Fault_Alignment => 2
+  | .Fault_Background => 3
+  | .Fault_Domain => 4
+  | .Fault_Permission => 5
+  | .Fault_Translation => 6
+  | .Fault_AddressSize => 7
+  | .Fault_SyncExternal => 8
+  | .Fault_SyncExternalOnWalk => 9
+  | .Fault_SyncParity => 10
+  | .Fault_SyncParityOnWalk => 11
+  | .Fault_GPCFOnWalk => 12
+  | .Fault_GPCFOnOutput => 13
+  | .Fault_AsyncParity => 14
+  | .Fault_AsyncExternal => 15
+  | .Fault_TagCheck => 16
+  | .Fault_Debug => 17
+  | .Fault_TLBConflict => 18
+  | .Fault_BranchTarget => 19
+  | .Fault_HWUpdateAccessFlag => 20
+  | .Fault_Lockdown => 21
+  | .Fault_Exclusive => 22
+  | .Fault_ICacheMaint => 23
 
 def undefined_ErrorState (_ : Unit) : SailM ErrorState := do
   (internal_pick
@@ -1533,13 +1533,13 @@ def ErrorState_of_num (arg_ : Nat) : ErrorState :=
 
 def num_of_ErrorState (arg_ : ErrorState) : Int :=
   match arg_ with
-  | ErrorState_UC => 0
-  | ErrorState_UEU => 1
-  | ErrorState_UEO => 2
-  | ErrorState_UER => 3
-  | ErrorState_CE => 4
-  | ErrorState_Uncategorized => 5
-  | ErrorState_IMPDEF => 6
+  | .ErrorState_UC => 0
+  | .ErrorState_UEU => 1
+  | .ErrorState_UEO => 2
+  | .ErrorState_UER => 3
+  | .ErrorState_CE => 4
+  | .ErrorState_Uncategorized => 5
+  | .ErrorState_IMPDEF => 6
 
 def undefined_FaultRecord (_ : Unit) : SailM FaultRecord := do
   (pure { statuscode := ← (undefined_Fault ())
@@ -1577,10 +1577,10 @@ def MBReqDomain_of_num (arg_ : Nat) : MBReqDomain :=
 
 def num_of_MBReqDomain (arg_ : MBReqDomain) : Int :=
   match arg_ with
-  | MBReqDomain_Nonshareable => 0
-  | MBReqDomain_InnerShareable => 1
-  | MBReqDomain_OuterShareable => 2
-  | MBReqDomain_FullSystem => 3
+  | .MBReqDomain_Nonshareable => 0
+  | .MBReqDomain_InnerShareable => 1
+  | .MBReqDomain_OuterShareable => 2
+  | .MBReqDomain_FullSystem => 3
 
 def undefined_MBReqTypes (_ : Unit) : SailM MBReqTypes := do
   (internal_pick [MBReqTypes_Reads, MBReqTypes_Writes, MBReqTypes_All])
@@ -1594,9 +1594,9 @@ def MBReqTypes_of_num (arg_ : Nat) : MBReqTypes :=
 
 def num_of_MBReqTypes (arg_ : MBReqTypes) : Int :=
   match arg_ with
-  | MBReqTypes_Reads => 0
-  | MBReqTypes_Writes => 1
-  | MBReqTypes_All => 2
+  | .MBReqTypes_Reads => 0
+  | .MBReqTypes_Writes => 1
+  | .MBReqTypes_All => 2
 
 def undefined_CacheRecord (_ : Unit) : SailM CacheRecord := do
   (pure { acctype := ← (undefined_AccessType ())
@@ -1632,11 +1632,11 @@ def Regime_of_num (arg_ : Nat) : Regime :=
 
 def num_of_Regime (arg_ : Regime) : Int :=
   match arg_ with
-  | Regime_EL3 => 0
-  | Regime_EL30 => 1
-  | Regime_EL2 => 2
-  | Regime_EL20 => 3
-  | Regime_EL10 => 4
+  | .Regime_EL3 => 0
+  | .Regime_EL30 => 1
+  | .Regime_EL2 => 2
+  | .Regime_EL20 => 3
+  | .Regime_EL10 => 4
 
 def undefined_TGx (_ : Unit) : SailM TGx := do
   (internal_pick [TGx_4KB, TGx_16KB, TGx_64KB])
@@ -1650,9 +1650,9 @@ def TGx_of_num (arg_ : Nat) : TGx :=
 
 def num_of_TGx (arg_ : TGx) : Int :=
   match arg_ with
-  | TGx_4KB => 0
-  | TGx_16KB => 1
-  | TGx_64KB => 2
+  | .TGx_4KB => 0
+  | .TGx_16KB => 1
+  | .TGx_64KB => 2
 
 def undefined_S1TTWParams (_ : Unit) : SailM S1TTWParams := do
   (pure { ha := ← (undefined_bitvector 1)
@@ -1740,8 +1740,8 @@ def TLBILevel_of_num (arg_ : Nat) : TLBILevel :=
 
 def num_of_TLBILevel (arg_ : TLBILevel) : Int :=
   match arg_ with
-  | TLBILevel_Any => 0
-  | TLBILevel_Last => 1
+  | .TLBILevel_Any => 0
+  | .TLBILevel_Last => 1
 
 def undefined_TLBIOp (_ : Unit) : SailM TLBIOp := do
   (internal_pick
@@ -1777,30 +1777,30 @@ def TLBIOp_of_num (arg_ : Nat) : TLBIOp :=
 
 def num_of_TLBIOp (arg_ : TLBIOp) : Int :=
   match arg_ with
-  | TLBIOp_DALL => 0
-  | TLBIOp_DASID => 1
-  | TLBIOp_DVA => 2
-  | TLBIOp_IALL => 3
-  | TLBIOp_IASID => 4
-  | TLBIOp_IVA => 5
-  | TLBIOp_ALL => 6
-  | TLBIOp_ASID => 7
-  | TLBIOp_IPAS2 => 8
-  | TLBIPOp_IPAS2 => 9
-  | TLBIOp_VAA => 10
-  | TLBIOp_VA => 11
-  | TLBIPOp_VAA => 12
-  | TLBIPOp_VA => 13
-  | TLBIOp_VMALL => 14
-  | TLBIOp_VMALLS12 => 15
-  | TLBIOp_RIPAS2 => 16
-  | TLBIPOp_RIPAS2 => 17
-  | TLBIOp_RVAA => 18
-  | TLBIOp_RVA => 19
-  | TLBIPOp_RVAA => 20
-  | TLBIPOp_RVA => 21
-  | TLBIOp_RPA => 22
-  | TLBIOp_PAALL => 23
+  | .TLBIOp_DALL => 0
+  | .TLBIOp_DASID => 1
+  | .TLBIOp_DVA => 2
+  | .TLBIOp_IALL => 3
+  | .TLBIOp_IASID => 4
+  | .TLBIOp_IVA => 5
+  | .TLBIOp_ALL => 6
+  | .TLBIOp_ASID => 7
+  | .TLBIOp_IPAS2 => 8
+  | .TLBIPOp_IPAS2 => 9
+  | .TLBIOp_VAA => 10
+  | .TLBIOp_VA => 11
+  | .TLBIPOp_VAA => 12
+  | .TLBIPOp_VA => 13
+  | .TLBIOp_VMALL => 14
+  | .TLBIOp_VMALLS12 => 15
+  | .TLBIOp_RIPAS2 => 16
+  | .TLBIPOp_RIPAS2 => 17
+  | .TLBIOp_RVAA => 18
+  | .TLBIOp_RVA => 19
+  | .TLBIPOp_RVAA => 20
+  | .TLBIPOp_RVA => 21
+  | .TLBIOp_RPA => 22
+  | .TLBIOp_PAALL => 23
 
 def undefined_TLBIMemAttr (_ : Unit) : SailM TLBIMemAttr := do
   (internal_pick [TLBI_AllAttr, TLBI_ExcludeXS])
@@ -1813,8 +1813,8 @@ def TLBIMemAttr_of_num (arg_ : Nat) : TLBIMemAttr :=
 
 def num_of_TLBIMemAttr (arg_ : TLBIMemAttr) : Int :=
   match arg_ with
-  | TLBI_AllAttr => 0
-  | TLBI_ExcludeXS => 1
+  | .TLBI_AllAttr => 0
+  | .TLBI_ExcludeXS => 1
 
 def undefined_TLBIRecord (_ : Unit) : SailM TLBIRecord := do
   (pure { op := ← (undefined_TLBIOp ())
@@ -1908,7 +1908,7 @@ def mem_write_request_is_exclusive (request : (Mem_write_request k_n k_vasize k_
   match request.access_kind with
   | .AK_explicit eak =>
     (match eak.variety with
-    | AV_exclusive => true
+    | .AV_exclusive => true
     | _ => false)
   | _ => false
 
@@ -1953,7 +1953,7 @@ def mem_read_request_is_exclusive (request : (Mem_read_request k_n k_vasize k_pa
   match request.access_kind with
   | .AK_explicit eak =>
     (match eak.variety with
-    | AV_exclusive => true
+    | .AV_exclusive => true
     | _ => false)
   | _ => false
 
@@ -2135,9 +2135,9 @@ def Access_variety_of_num (arg_ : Nat) : Access_variety :=
 
 def num_of_Access_variety (arg_ : Access_variety) : Int :=
   match arg_ with
-  | AV_plain => 0
-  | AV_exclusive => 1
-  | AV_atomic_rmw => 2
+  | .AV_plain => 0
+  | .AV_exclusive => 1
+  | .AV_atomic_rmw => 2
 
 def undefined_Access_strength (_ : Unit) : SailM Access_strength := do
   (internal_pick [AS_normal, AS_rel_or_acq, AS_acq_rcpc])
@@ -2151,9 +2151,9 @@ def Access_strength_of_num (arg_ : Nat) : Access_strength :=
 
 def num_of_Access_strength (arg_ : Access_strength) : Int :=
   match arg_ with
-  | AS_normal => 0
-  | AS_rel_or_acq => 1
-  | AS_acq_rcpc => 2
+  | .AS_normal => 0
+  | .AS_rel_or_acq => 1
+  | .AS_acq_rcpc => 2
 
 def undefined_Explicit_access_kind (_ : Unit) : SailM Explicit_access_kind := do
   (pure { variety := ← (undefined_Access_variety ())

--- a/test/lean/SailTinyArmV2.expected.lean
+++ b/test/lean/SailTinyArmV2.expected.lean
@@ -613,10 +613,10 @@ def SecurityState_of_num (arg_ : Nat) : SecurityState :=
 
 def num_of_SecurityState (arg_ : SecurityState) : Int :=
   match arg_ with
-  | SS_NonSecure => 0
-  | SS_Root => 1
-  | SS_Realm => 2
-  | SS_Secure => 3
+  | .SS_NonSecure => 0
+  | .SS_Root => 1
+  | .SS_Realm => 2
+  | .SS_Secure => 3
 
 def undefined_PARTIDspaceType (_ : Unit) : SailM PARTIDspaceType := do
   (internal_pick [PIdSpace_Secure, PIdSpace_Root, PIdSpace_Realm, PIdSpace_NonSecure])
@@ -631,10 +631,10 @@ def PARTIDspaceType_of_num (arg_ : Nat) : PARTIDspaceType :=
 
 def num_of_PARTIDspaceType (arg_ : PARTIDspaceType) : Int :=
   match arg_ with
-  | PIdSpace_Secure => 0
-  | PIdSpace_Root => 1
-  | PIdSpace_Realm => 2
-  | PIdSpace_NonSecure => 3
+  | .PIdSpace_Secure => 0
+  | .PIdSpace_Root => 1
+  | .PIdSpace_Realm => 2
+  | .PIdSpace_NonSecure => 3
 
 def undefined_MPAMinfo (_ : Unit) : SailM MPAMinfo := do
   (pure { mpam_sp := ← (undefined_PARTIDspaceType ())
@@ -665,20 +665,20 @@ def AccessType_of_num (arg_ : Nat) : AccessType :=
 
 def num_of_AccessType (arg_ : AccessType) : Int :=
   match arg_ with
-  | AccessType_IFETCH => 0
-  | AccessType_GPR => 1
-  | AccessType_ASIMD => 2
-  | AccessType_SVE => 3
-  | AccessType_SME => 4
-  | AccessType_IC => 5
-  | AccessType_DC => 6
-  | AccessType_DCZero => 7
-  | AccessType_AT => 8
-  | AccessType_NV2 => 9
-  | AccessType_SPE => 10
-  | AccessType_GCS => 11
-  | AccessType_GPTW => 12
-  | AccessType_TTW => 13
+  | .AccessType_IFETCH => 0
+  | .AccessType_GPR => 1
+  | .AccessType_ASIMD => 2
+  | .AccessType_SVE => 3
+  | .AccessType_SME => 4
+  | .AccessType_IC => 5
+  | .AccessType_DC => 6
+  | .AccessType_DCZero => 7
+  | .AccessType_AT => 8
+  | .AccessType_NV2 => 9
+  | .AccessType_SPE => 10
+  | .AccessType_GCS => 11
+  | .AccessType_GPTW => 12
+  | .AccessType_TTW => 13
 
 def undefined_VARange (_ : Unit) : SailM VARange := do
   (internal_pick [VARange_LOWER, VARange_UPPER])
@@ -691,8 +691,8 @@ def VARange_of_num (arg_ : Nat) : VARange :=
 
 def num_of_VARange (arg_ : VARange) : Int :=
   match arg_ with
-  | VARange_LOWER => 0
-  | VARange_UPPER => 1
+  | .VARange_LOWER => 0
+  | .VARange_UPPER => 1
 
 def undefined_MemAtomicOp (_ : Unit) : SailM MemAtomicOp := do
   (internal_pick
@@ -715,17 +715,17 @@ def MemAtomicOp_of_num (arg_ : Nat) : MemAtomicOp :=
 
 def num_of_MemAtomicOp (arg_ : MemAtomicOp) : Int :=
   match arg_ with
-  | MemAtomicOp_GCSSS1 => 0
-  | MemAtomicOp_ADD => 1
-  | MemAtomicOp_BIC => 2
-  | MemAtomicOp_EOR => 3
-  | MemAtomicOp_ORR => 4
-  | MemAtomicOp_SMAX => 5
-  | MemAtomicOp_SMIN => 6
-  | MemAtomicOp_UMAX => 7
-  | MemAtomicOp_UMIN => 8
-  | MemAtomicOp_SWP => 9
-  | MemAtomicOp_CAS => 10
+  | .MemAtomicOp_GCSSS1 => 0
+  | .MemAtomicOp_ADD => 1
+  | .MemAtomicOp_BIC => 2
+  | .MemAtomicOp_EOR => 3
+  | .MemAtomicOp_ORR => 4
+  | .MemAtomicOp_SMAX => 5
+  | .MemAtomicOp_SMIN => 6
+  | .MemAtomicOp_UMAX => 7
+  | .MemAtomicOp_UMIN => 8
+  | .MemAtomicOp_SWP => 9
+  | .MemAtomicOp_CAS => 10
 
 def undefined_CacheOp (_ : Unit) : SailM CacheOp := do
   (internal_pick [CacheOp_Clean, CacheOp_Invalidate, CacheOp_CleanInvalidate])
@@ -739,9 +739,9 @@ def CacheOp_of_num (arg_ : Nat) : CacheOp :=
 
 def num_of_CacheOp (arg_ : CacheOp) : Int :=
   match arg_ with
-  | CacheOp_Clean => 0
-  | CacheOp_Invalidate => 1
-  | CacheOp_CleanInvalidate => 2
+  | .CacheOp_Clean => 0
+  | .CacheOp_Invalidate => 1
+  | .CacheOp_CleanInvalidate => 2
 
 def undefined_CacheOpScope (_ : Unit) : SailM CacheOpScope := do
   (internal_pick
@@ -762,15 +762,15 @@ def CacheOpScope_of_num (arg_ : Nat) : CacheOpScope :=
 
 def num_of_CacheOpScope (arg_ : CacheOpScope) : Int :=
   match arg_ with
-  | CacheOpScope_SetWay => 0
-  | CacheOpScope_PoU => 1
-  | CacheOpScope_PoC => 2
-  | CacheOpScope_PoE => 3
-  | CacheOpScope_PoP => 4
-  | CacheOpScope_PoDP => 5
-  | CacheOpScope_PoPA => 6
-  | CacheOpScope_ALLU => 7
-  | CacheOpScope_ALLUIS => 8
+  | .CacheOpScope_SetWay => 0
+  | .CacheOpScope_PoU => 1
+  | .CacheOpScope_PoC => 2
+  | .CacheOpScope_PoE => 3
+  | .CacheOpScope_PoP => 4
+  | .CacheOpScope_PoDP => 5
+  | .CacheOpScope_PoPA => 6
+  | .CacheOpScope_ALLU => 7
+  | .CacheOpScope_ALLUIS => 8
 
 def undefined_CacheType (_ : Unit) : SailM CacheType := do
   (internal_pick [CacheType_Data, CacheType_Tag, CacheType_Data_Tag, CacheType_Instruction])
@@ -785,10 +785,10 @@ def CacheType_of_num (arg_ : Nat) : CacheType :=
 
 def num_of_CacheType (arg_ : CacheType) : Int :=
   match arg_ with
-  | CacheType_Data => 0
-  | CacheType_Tag => 1
-  | CacheType_Data_Tag => 2
-  | CacheType_Instruction => 3
+  | .CacheType_Data => 0
+  | .CacheType_Tag => 1
+  | .CacheType_Data_Tag => 2
+  | .CacheType_Instruction => 3
 
 def undefined_CachePASpace (_ : Unit) : SailM CachePASpace := do
   (internal_pick
@@ -807,13 +807,13 @@ def CachePASpace_of_num (arg_ : Nat) : CachePASpace :=
 
 def num_of_CachePASpace (arg_ : CachePASpace) : Int :=
   match arg_ with
-  | CPAS_NonSecure => 0
-  | CPAS_Any => 1
-  | CPAS_RealmNonSecure => 2
-  | CPAS_Realm => 3
-  | CPAS_Root => 4
-  | CPAS_SecureNonSecure => 5
-  | CPAS_Secure => 6
+  | .CPAS_NonSecure => 0
+  | .CPAS_Any => 1
+  | .CPAS_RealmNonSecure => 2
+  | .CPAS_Realm => 3
+  | .CPAS_Root => 4
+  | .CPAS_SecureNonSecure => 5
+  | .CPAS_Secure => 6
 
 def undefined_AccessDescriptor (_ : Unit) : SailM AccessDescriptor := do
   (pure { acctype := ← (undefined_AccessType ())
@@ -861,8 +861,8 @@ def MemType_of_num (arg_ : Nat) : MemType :=
 
 def num_of_MemType (arg_ : MemType) : Int :=
   match arg_ with
-  | MemType_Normal => 0
-  | MemType_Device => 1
+  | .MemType_Normal => 0
+  | .MemType_Device => 1
 
 def undefined_DeviceType (_ : Unit) : SailM DeviceType := do
   (internal_pick [DeviceType_GRE, DeviceType_nGRE, DeviceType_nGnRE, DeviceType_nGnRnE])
@@ -877,10 +877,10 @@ def DeviceType_of_num (arg_ : Nat) : DeviceType :=
 
 def num_of_DeviceType (arg_ : DeviceType) : Int :=
   match arg_ with
-  | DeviceType_GRE => 0
-  | DeviceType_nGRE => 1
-  | DeviceType_nGnRE => 2
-  | DeviceType_nGnRnE => 3
+  | .DeviceType_GRE => 0
+  | .DeviceType_nGRE => 1
+  | .DeviceType_nGnRE => 2
+  | .DeviceType_nGnRnE => 3
 
 def undefined_MemAttrHints (_ : Unit) : SailM MemAttrHints := do
   (pure { attrs := ← (undefined_bitvector 2)
@@ -899,9 +899,9 @@ def Shareability_of_num (arg_ : Nat) : Shareability :=
 
 def num_of_Shareability (arg_ : Shareability) : Int :=
   match arg_ with
-  | Shareability_NSH => 0
-  | Shareability_ISH => 1
-  | Shareability_OSH => 2
+  | .Shareability_NSH => 0
+  | .Shareability_ISH => 1
+  | .Shareability_OSH => 2
 
 def undefined_MemTagType (_ : Unit) : SailM MemTagType := do
   (internal_pick [MemTag_Untagged, MemTag_AllocationTagged, MemTag_CanonicallyTagged])
@@ -915,9 +915,9 @@ def MemTagType_of_num (arg_ : Nat) : MemTagType :=
 
 def num_of_MemTagType (arg_ : MemTagType) : Int :=
   match arg_ with
-  | MemTag_Untagged => 0
-  | MemTag_AllocationTagged => 1
-  | MemTag_CanonicallyTagged => 2
+  | .MemTag_Untagged => 0
+  | .MemTag_AllocationTagged => 1
+  | .MemTag_CanonicallyTagged => 2
 
 def undefined_MemoryAttributes (_ : Unit) : SailM MemoryAttributes := do
   (pure { memtype := ← (undefined_MemType ())
@@ -942,10 +942,10 @@ def PASpace_of_num (arg_ : Nat) : PASpace :=
 
 def num_of_PASpace (arg_ : PASpace) : Int :=
   match arg_ with
-  | PAS_NonSecure => 0
-  | PAS_Secure => 1
-  | PAS_Root => 2
-  | PAS_Realm => 3
+  | .PAS_NonSecure => 0
+  | .PAS_Secure => 1
+  | .PAS_Root => 2
+  | .PAS_Realm => 3
 
 def undefined_FullAddress (_ : Unit) : SailM FullAddress := do
   (pure { paspace := ← (undefined_PASpace ())
@@ -965,11 +965,11 @@ def GPCF_of_num (arg_ : Nat) : GPCF :=
 
 def num_of_GPCF (arg_ : GPCF) : Int :=
   match arg_ with
-  | GPCF_None => 0
-  | GPCF_AddressSize => 1
-  | GPCF_Walk => 2
-  | GPCF_EABT => 3
-  | GPCF_Fail => 4
+  | .GPCF_None => 0
+  | .GPCF_AddressSize => 1
+  | .GPCF_Walk => 2
+  | .GPCF_EABT => 3
+  | .GPCF_Fail => 4
 
 def undefined_GPCFRecord (_ : Unit) : SailM GPCFRecord := do
   (pure { gpf := ← (undefined_GPCF ())
@@ -1009,30 +1009,30 @@ def Fault_of_num (arg_ : Nat) : Fault :=
 
 def num_of_Fault (arg_ : Fault) : Int :=
   match arg_ with
-  | Fault_None => 0
-  | Fault_AccessFlag => 1
-  | Fault_Alignment => 2
-  | Fault_Background => 3
-  | Fault_Domain => 4
-  | Fault_Permission => 5
-  | Fault_Translation => 6
-  | Fault_AddressSize => 7
-  | Fault_SyncExternal => 8
-  | Fault_SyncExternalOnWalk => 9
-  | Fault_SyncParity => 10
-  | Fault_SyncParityOnWalk => 11
-  | Fault_GPCFOnWalk => 12
-  | Fault_GPCFOnOutput => 13
-  | Fault_AsyncParity => 14
-  | Fault_AsyncExternal => 15
-  | Fault_TagCheck => 16
-  | Fault_Debug => 17
-  | Fault_TLBConflict => 18
-  | Fault_BranchTarget => 19
-  | Fault_HWUpdateAccessFlag => 20
-  | Fault_Lockdown => 21
-  | Fault_Exclusive => 22
-  | Fault_ICacheMaint => 23
+  | .Fault_None => 0
+  | .Fault_AccessFlag => 1
+  | .Fault_Alignment => 2
+  | .Fault_Background => 3
+  | .Fault_Domain => 4
+  | .Fault_Permission => 5
+  | .Fault_Translation => 6
+  | .Fault_AddressSize => 7
+  | .Fault_SyncExternal => 8
+  | .Fault_SyncExternalOnWalk => 9
+  | .Fault_SyncParity => 10
+  | .Fault_SyncParityOnWalk => 11
+  | .Fault_GPCFOnWalk => 12
+  | .Fault_GPCFOnOutput => 13
+  | .Fault_AsyncParity => 14
+  | .Fault_AsyncExternal => 15
+  | .Fault_TagCheck => 16
+  | .Fault_Debug => 17
+  | .Fault_TLBConflict => 18
+  | .Fault_BranchTarget => 19
+  | .Fault_HWUpdateAccessFlag => 20
+  | .Fault_Lockdown => 21
+  | .Fault_Exclusive => 22
+  | .Fault_ICacheMaint => 23
 
 def undefined_ErrorState (_ : Unit) : SailM ErrorState := do
   (internal_pick
@@ -1051,13 +1051,13 @@ def ErrorState_of_num (arg_ : Nat) : ErrorState :=
 
 def num_of_ErrorState (arg_ : ErrorState) : Int :=
   match arg_ with
-  | ErrorState_UC => 0
-  | ErrorState_UEU => 1
-  | ErrorState_UEO => 2
-  | ErrorState_UER => 3
-  | ErrorState_CE => 4
-  | ErrorState_Uncategorized => 5
-  | ErrorState_IMPDEF => 6
+  | .ErrorState_UC => 0
+  | .ErrorState_UEU => 1
+  | .ErrorState_UEO => 2
+  | .ErrorState_UER => 3
+  | .ErrorState_CE => 4
+  | .ErrorState_Uncategorized => 5
+  | .ErrorState_IMPDEF => 6
 
 def undefined_FaultRecord (_ : Unit) : SailM FaultRecord := do
   (pure { statuscode := ← (undefined_Fault ())
@@ -1095,10 +1095,10 @@ def MBReqDomain_of_num (arg_ : Nat) : MBReqDomain :=
 
 def num_of_MBReqDomain (arg_ : MBReqDomain) : Int :=
   match arg_ with
-  | MBReqDomain_Nonshareable => 0
-  | MBReqDomain_InnerShareable => 1
-  | MBReqDomain_OuterShareable => 2
-  | MBReqDomain_FullSystem => 3
+  | .MBReqDomain_Nonshareable => 0
+  | .MBReqDomain_InnerShareable => 1
+  | .MBReqDomain_OuterShareable => 2
+  | .MBReqDomain_FullSystem => 3
 
 def undefined_MBReqTypes (_ : Unit) : SailM MBReqTypes := do
   (internal_pick [MBReqTypes_Reads, MBReqTypes_Writes, MBReqTypes_All])
@@ -1112,9 +1112,9 @@ def MBReqTypes_of_num (arg_ : Nat) : MBReqTypes :=
 
 def num_of_MBReqTypes (arg_ : MBReqTypes) : Int :=
   match arg_ with
-  | MBReqTypes_Reads => 0
-  | MBReqTypes_Writes => 1
-  | MBReqTypes_All => 2
+  | .MBReqTypes_Reads => 0
+  | .MBReqTypes_Writes => 1
+  | .MBReqTypes_All => 2
 
 def undefined_CacheRecord (_ : Unit) : SailM CacheRecord := do
   (pure { acctype := ← (undefined_AccessType ())
@@ -1150,11 +1150,11 @@ def Regime_of_num (arg_ : Nat) : Regime :=
 
 def num_of_Regime (arg_ : Regime) : Int :=
   match arg_ with
-  | Regime_EL3 => 0
-  | Regime_EL30 => 1
-  | Regime_EL2 => 2
-  | Regime_EL20 => 3
-  | Regime_EL10 => 4
+  | .Regime_EL3 => 0
+  | .Regime_EL30 => 1
+  | .Regime_EL2 => 2
+  | .Regime_EL20 => 3
+  | .Regime_EL10 => 4
 
 def undefined_TGx (_ : Unit) : SailM TGx := do
   (internal_pick [TGx_4KB, TGx_16KB, TGx_64KB])
@@ -1168,9 +1168,9 @@ def TGx_of_num (arg_ : Nat) : TGx :=
 
 def num_of_TGx (arg_ : TGx) : Int :=
   match arg_ with
-  | TGx_4KB => 0
-  | TGx_16KB => 1
-  | TGx_64KB => 2
+  | .TGx_4KB => 0
+  | .TGx_16KB => 1
+  | .TGx_64KB => 2
 
 def undefined_TLBContext (_ : Unit) : SailM TLBContext := do
   (pure { ss := ← (undefined_SecurityState ())
@@ -1220,8 +1220,8 @@ def TLBILevel_of_num (arg_ : Nat) : TLBILevel :=
 
 def num_of_TLBILevel (arg_ : TLBILevel) : Int :=
   match arg_ with
-  | TLBILevel_Any => 0
-  | TLBILevel_Last => 1
+  | .TLBILevel_Any => 0
+  | .TLBILevel_Last => 1
 
 def undefined_TLBIOp (_ : Unit) : SailM TLBIOp := do
   (internal_pick
@@ -1257,30 +1257,30 @@ def TLBIOp_of_num (arg_ : Nat) : TLBIOp :=
 
 def num_of_TLBIOp (arg_ : TLBIOp) : Int :=
   match arg_ with
-  | TLBIOp_DALL => 0
-  | TLBIOp_DASID => 1
-  | TLBIOp_DVA => 2
-  | TLBIOp_IALL => 3
-  | TLBIOp_IASID => 4
-  | TLBIOp_IVA => 5
-  | TLBIOp_ALL => 6
-  | TLBIOp_ASID => 7
-  | TLBIOp_IPAS2 => 8
-  | TLBIPOp_IPAS2 => 9
-  | TLBIOp_VAA => 10
-  | TLBIOp_VA => 11
-  | TLBIPOp_VAA => 12
-  | TLBIPOp_VA => 13
-  | TLBIOp_VMALL => 14
-  | TLBIOp_VMALLS12 => 15
-  | TLBIOp_RIPAS2 => 16
-  | TLBIPOp_RIPAS2 => 17
-  | TLBIOp_RVAA => 18
-  | TLBIOp_RVA => 19
-  | TLBIPOp_RVAA => 20
-  | TLBIPOp_RVA => 21
-  | TLBIOp_RPA => 22
-  | TLBIOp_PAALL => 23
+  | .TLBIOp_DALL => 0
+  | .TLBIOp_DASID => 1
+  | .TLBIOp_DVA => 2
+  | .TLBIOp_IALL => 3
+  | .TLBIOp_IASID => 4
+  | .TLBIOp_IVA => 5
+  | .TLBIOp_ALL => 6
+  | .TLBIOp_ASID => 7
+  | .TLBIOp_IPAS2 => 8
+  | .TLBIPOp_IPAS2 => 9
+  | .TLBIOp_VAA => 10
+  | .TLBIOp_VA => 11
+  | .TLBIPOp_VAA => 12
+  | .TLBIPOp_VA => 13
+  | .TLBIOp_VMALL => 14
+  | .TLBIOp_VMALLS12 => 15
+  | .TLBIOp_RIPAS2 => 16
+  | .TLBIPOp_RIPAS2 => 17
+  | .TLBIOp_RVAA => 18
+  | .TLBIOp_RVA => 19
+  | .TLBIPOp_RVAA => 20
+  | .TLBIPOp_RVA => 21
+  | .TLBIOp_RPA => 22
+  | .TLBIOp_PAALL => 23
 
 def undefined_TLBIMemAttr (_ : Unit) : SailM TLBIMemAttr := do
   (internal_pick [TLBI_AllAttr, TLBI_ExcludeXS])
@@ -1293,8 +1293,8 @@ def TLBIMemAttr_of_num (arg_ : Nat) : TLBIMemAttr :=
 
 def num_of_TLBIMemAttr (arg_ : TLBIMemAttr) : Int :=
   match arg_ with
-  | TLBI_AllAttr => 0
-  | TLBI_ExcludeXS => 1
+  | .TLBI_AllAttr => 0
+  | .TLBI_ExcludeXS => 1
 
 def undefined_TLBIRecord (_ : Unit) : SailM TLBIRecord := do
   (pure { op := ← (undefined_TLBIOp ())

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -389,11 +389,11 @@ def while_inner_earlyreturnpure_catch (n : Nat) : Bool := ExceptM.run do
 
 def match_early_return (x : E) : SailM E := SailME.run do
   match x with
-  | A =>
+  | .A =>
     SailME.throw (← do
         readReg r_A)
-  | B => writeReg r_B A
-  | C => writeReg r_C A
+  | .B => writeReg r_B A
+  | .C => writeReg r_C A
   readReg r_B
 
 def match_early_return_inloop (x : E) : SailM E := SailME.run do
@@ -404,11 +404,11 @@ def match_early_return_inloop (x : E) : SailM E := SailME.run do
     let () := loop_vars
     loop_vars ← do
       match x with
-      | A =>
+      | .A =>
         SailME.throw (← do
             readReg r_A)
-      | B => writeReg r_B A
-      | C => writeReg r_C A
+      | .B => writeReg r_B A
+      | .C => writeReg r_C A
   (pure loop_vars)
   readReg r_B
 
@@ -421,18 +421,18 @@ def match_early_return_inloop_2 (x : E) : SailM E := SailME.run do
     loop_vars ← do
       let y ← (( do
         match x with
-        | A =>
+        | .A =>
           SailME.throw (← do
               readReg r_A)
-        | B => readReg r_B
-        | C => readReg r_C ) : SailME E E )
+        | .B => readReg r_B
+        | .C => readReg r_C ) : SailME E E )
       (pure ())
   (pure loop_vars)
   readReg r_B
 
 def match_early_return_loop (x : E) : SailM E := SailME.run do
   match x with
-  | A =>
+  | .A =>
     (do
       let loop_i_lower := 0
       let loop_i_upper := 10
@@ -443,8 +443,8 @@ def match_early_return_loop (x : E) : SailM E := SailME.run do
           SailME.throw (← do
               readReg r_A)
       (pure loop_vars))
-  | B => writeReg r_B A
-  | C => writeReg r_C A
+  | .B => writeReg r_B A
+  | .C => writeReg r_C A
   readReg r_B
 
 /-- Type quantifiers: k_ex3009_ : Bool -/

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -158,9 +158,9 @@ def E_of_num (arg_ : Nat) : E :=
 
 def num_of_E (arg_ : E) : Int :=
   match arg_ with
-  | A => 0
-  | B => 1
-  | C => 2
+  | .A => 0
+  | .B => 1
+  | .C => 2
 
 def initialize_registers (_ : Unit) : Unit :=
   ()

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -159,17 +159,17 @@ def word_width_of_num (arg_ : Nat) : word_width :=
 
 def num_of_word_width (arg_ : word_width) : Int :=
   match arg_ with
-  | BYTE => 0
-  | HALF => 1
-  | WORD => 2
-  | DOUBLE => 3
+  | .BYTE => 0
+  | .HALF => 1
+  | .WORD => 2
+  | .DOUBLE => 3
 
 def size_bits_forwards (arg_ : word_width) : (BitVec 2) :=
   match arg_ with
-  | BYTE => 0b00#2
-  | HALF => 0b01#2
-  | WORD => 0b10#2
-  | DOUBLE => 0b11#2
+  | .BYTE => 0b00#2
+  | .HALF => 0b01#2
+  | .WORD => 0b10#2
+  | .DOUBLE => 0b11#2
 
 def size_bits_backwards (arg_ : (BitVec 2)) : word_width :=
   match arg_ with
@@ -180,10 +180,10 @@ def size_bits_backwards (arg_ : (BitVec 2)) : word_width :=
 
 def size_bits_forwards_matches (arg_ : word_width) : Bool :=
   match arg_ with
-  | BYTE => true
-  | HALF => true
-  | WORD => true
-  | DOUBLE => true
+  | .BYTE => true
+  | .HALF => true
+  | .WORD => true
+  | .DOUBLE => true
   | _ => false
 
 def size_bits_backwards_matches (arg_ : (BitVec 2)) : Bool :=
@@ -196,10 +196,10 @@ def size_bits_backwards_matches (arg_ : (BitVec 2)) : Bool :=
 
 def size_bits2_forwards (arg_ : word_width) : (BitVec 2) :=
   match arg_ with
-  | BYTE => 0b00#2
-  | HALF => 0b01#2
-  | WORD => 0b10#2
-  | DOUBLE => 0b11#2
+  | .BYTE => 0b00#2
+  | .HALF => 0b01#2
+  | .WORD => 0b10#2
+  | .DOUBLE => 0b11#2
 
 def size_bits2_backwards (arg_ : (BitVec 2)) : word_width :=
   match arg_ with
@@ -210,10 +210,10 @@ def size_bits2_backwards (arg_ : (BitVec 2)) : word_width :=
 
 def size_bits2_forwards_matches (arg_ : word_width) : Bool :=
   match arg_ with
-  | BYTE => true
-  | HALF => true
-  | WORD => true
-  | DOUBLE => true
+  | .BYTE => true
+  | .HALF => true
+  | .WORD => true
+  | .DOUBLE => true
   | _ => false
 
 def size_bits2_backwards_matches (arg_ : (BitVec 2)) : Bool :=
@@ -226,10 +226,10 @@ def size_bits2_backwards_matches (arg_ : (BitVec 2)) : Bool :=
 
 def size_bits3_forwards (arg_ : word_width) : (BitVec 2) :=
   match arg_ with
-  | BYTE => 0b00#2
-  | HALF => 0b01#2
-  | WORD => 0b10#2
-  | DOUBLE => 0b11#2
+  | .BYTE => 0b00#2
+  | .HALF => 0b01#2
+  | .WORD => 0b10#2
+  | .DOUBLE => 0b11#2
 
 def size_bits3_backwards (arg_ : (BitVec 2)) : word_width :=
   match arg_ with
@@ -240,10 +240,10 @@ def size_bits3_backwards (arg_ : (BitVec 2)) : word_width :=
 
 def size_bits3_forwards_matches (arg_ : word_width) : Bool :=
   match arg_ with
-  | BYTE => true
-  | HALF => true
-  | WORD => true
-  | DOUBLE => true
+  | .BYTE => true
+  | .HALF => true
+  | .WORD => true
+  | .DOUBLE => true
   | _ => false
 
 def size_bits3_backwards_matches (arg_ : (BitVec 2)) : Bool :=

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -65,7 +65,7 @@ open option
 open Register
 open E
 
-/-- Type quantifiers: k_ex942_ : Bool, k_ex941_ : Bool -/
+/-- Type quantifiers: k_ex808_ : Bool, k_ex807_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=
   (! (x == y))
 
@@ -163,69 +163,13 @@ def undefined_E (_ : Unit) : SailM E := do
 
 def match_enum (x : E) : (BitVec 1) :=
   match x with
-  | A => 1#1
-  | B => 1#1
-  | C => 0#1
+  | .A => 1#1
+  | .B => 1#1
+  | .C => 0#1
 
-def match_option (x : (Option (BitVec 1))) : (BitVec 1) :=
-  match x with
-  | .some x => x
-  | none => 0#1
-
-/-- Type quantifiers: y : Int, x : Int -/
-def match_pair_pat (x : Int) (y : Int) : Int :=
-  match (x, y) with
-  | (a, b) => (a +i b)
-
-/-- Type quantifiers: arg1 : Int, arg0 : Int -/
-def match_pair (arg0 : Int) (arg1 : Int) : Int :=
-  let x := (arg0, arg1)
-  match x with
-  | (a, b) => (a +i b)
-
-def match_reg (x : E) : SailM E := do
-  match x with
-  | A => readReg r_A
-  | B => readReg r_B
-  | C => readReg r_C
-
-/-- Type quantifiers: y : Int -/
-def match_let (x : E) (y : Int) : SailM Int := do
-  match x with
-  | A =>
-    (do
-      let x := (y +i y)
-      let z ← do (pure ((y +i y) +i (← (undefined_int ()))))
-      (pure (z +i x)))
-  | B => (pure 42)
-  | C => (pure 23)
-
-def match_read (x : E) : SailM Unit := do
-  writeReg r_A (← do
-    match x with
-    | A => readReg r_A
-    | B => readReg r_B
-    | C => readReg r_C)
-
-def const16 (_ : Unit) : ((BitVec 16) × Bool) :=
-  (0xFFFF#16, true)
-
-def const32 (_ : Unit) : ((BitVec 32) × Bool) :=
-  (0xEEEEEEEE#32, false)
-
-/-- Type quantifiers: k_n : Nat, k_n ≥ 0 -/
-def match_width (x : (BitVec k_n)) : (BitVec (2 * k_n)) :=
-  let (foo, _) : ((BitVec k_n) × Bool) :=
-    match (Sail.BitVec.length x) with
-    | 16 => (const16 ())
-    | 32 => (const32 ())
-    | n => ((BitVec.zero n), false)
-  (foo +++ foo)
-
-def match_option_bitvec (x : (Option (BitVec 16))) : Int :=
-  match x with
-  | .some 0xFFFF => 1
-  | _ => 0
+def match_enum2 (x : E) : (BitVec 1) :=
+  let y := x
+  0#1
 
 def initialize_registers (_ : Unit) : SailM Unit := do
   writeReg r_A (← (undefined_E ()))

--- a/test/lean/match.sail
+++ b/test/lean/match.sail
@@ -17,76 +17,9 @@ function match_enum(x : E) -> bit = {
   }
 }
 
-function match_option(x : option(bit)) -> bit = {
-  match x {
-    Some(x) => x,
-    None() => bitzero,
-  }
-}
 
-function match_pair_pat((x, y) : (int, int)) -> int = {
-  match (x, y) {
-    (a, b) => a + b,
-  }
-}
-
-function match_pair(x : (int, int)) -> int = {
-  match x {
-    (a, b) => a + b,
-  }
-}
-
-function match_reg(x : E) -> E = {
-  match x {
-    A => r_A,
-    B => r_B,
-    C => r_C,
-  }
-}
-
-function match_let (x : E, y : int) -> int = {
-  match x {
-    A => 
-    let x = y + y in
-    let z = y + y + undefined_int() in
-    z + x,
-    B => 42,
-    C => 23
-  }
-}
-
-function match_read(x : E) -> unit = {
-  r_A = match x {
-    A => r_A,
-    B => r_B,
-    C => r_C,
-  }
-}
-
-function const16() -> (bitvector(16), bool) = {
-  (0xFFFF, true)
-}
-
-function const32() -> (bitvector(32), bool) = {
-  (0xEEEE_EEEE, false)
-}
-
-val match_width : forall 'n, 'n >= 0. bitvector('n) -> bitvector(2 * 'n)
-function match_width x = {
-  let (foo, _) : (bitvector('n), bool) = match 'n {
-    16 => const16(),
-    32 => const32(),
-    n => (sail_zeros(n), false)
-  } in
-  bitvector_concat(foo, foo)
-}
-
-val match_option_bitvec : (option(bitvector(16))) -> int
-
-function match_option_bitvec (x : option(bitvector(16))) = {
-  match x {
-    Some(0xFFFF) => 1,
-    _ => 0
-  }
+function match_enum2(x : E) -> bit = {
+  let y = x;
+  bitzero
 }
 

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -216,12 +216,12 @@ def iop_of_num (arg_ : Nat) : iop :=
 
 def num_of_iop (arg_ : iop) : Int :=
   match arg_ with
-  | RISCV_ADDI => 0
-  | RISCV_SLTI => 1
-  | RISCV_SLTIU => 2
-  | RISCV_XORI => 3
-  | RISCV_ORI => 4
-  | RISCV_ANDI => 5
+  | .RISCV_ADDI => 0
+  | .RISCV_SLTI => 1
+  | .RISCV_SLTIU => 2
+  | .RISCV_XORI => 3
+  | .RISCV_ORI => 4
+  | .RISCV_ANDI => 5
 
 def execute_LOAD (imm : (BitVec 12)) (rs1 : (BitVec 5)) (rd : (BitVec 5)) : SailM Unit := do
   let addr ← (( do (pure ((← (rX rs1)) + (EXTS (m := 64) imm))) ) : SailM xlenbits )

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -182,8 +182,8 @@ def My_enum_of_num (arg_ : Nat) : My_enum :=
 
 def num_of_My_enum (arg_ : My_enum) : Int :=
   match arg_ with
-  | E1 => 0
-  | E2 => 1
+  | .E1 => 0
+  | .E2 => 1
 
 def undefined_My_struct (_ : Unit) : SailM My_struct := do
   (pure { field1 := ← (undefined_int ())
@@ -206,8 +206,8 @@ def mk_struct (i : Int) (b : (BitVec 1)) : My_struct :=
 
 def mk_struct_effectful (e : My_enum) (b : (BitVec 1)) : SailM My_struct := do
   (pure { field1 := ← match e with
-            | E1 => readReg r
-            | E2 => (pure 2)
+            | .E1 => readReg r
+            | .E2 => (pure 2)
           field2 := b })
 
 def undef_struct (x : (BitVec 1)) : SailM My_struct := do

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -160,7 +160,7 @@ def e_test_of_num (arg_ : Nat) : e_test :=
 
 def num_of_e_test (arg_ : e_test) : Int :=
   match arg_ with
-  | VAL => 0
+  | .VAL => 0
 
 def undefined_s_test (_ : Unit) : SailM s_test := do
   (pure { f := ← (undefined_e_test ()) })

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -158,36 +158,36 @@ def E_of_num (arg_ : Nat) : E :=
 
 def num_of_E (arg_ : E) : Int :=
   match arg_ with
-  | A => 0
-  | B => 1
-  | C => 2
+  | .A => 0
+  | .B => 1
+  | .C => 2
 
 def measure (x : E) : Int :=
   match x with
-  | A => 10
-  | B => 5
-  | C => 1
+  | .A => 10
+  | .B => 5
+  | .C => 1
 
 def enabled (e : E) : Bool :=
   match e with
-  | A => (enabled B)
-  | B => (enabled C)
-  | C => true
+  | .A => (enabled B)
+  | .B => (enabled C)
+  | .C => true
 termination_by (let e := e
 (measure e)).toNat
 
 def measure2 (x : E) : Int :=
   match x with
-  | A => 10
-  | B => 5
-  | C => 1
+  | .A => 10
+  | .B => 5
+  | .C => 1
 
 /-- Type quantifiers: k_ex1014_ : Bool -/
 def enabled2 (b : Bool) (e : E) : Bool :=
   match e with
-  | A => (enabled2 b B)
-  | B => (enabled2 b C)
-  | C => b
+  | .A => (enabled2 b B)
+  | .B => (enabled2 b C)
+  | .C => b
 termination_by (let (_, x) := (b, e)
 (measure2 x)).toNat
 


### PR DESCRIPTION
This fixes ambiguous situations that arised recently in the RISC-V model.

Fixes #1654.