### PR TITLE
Lean testing: build .o support library files

### DIFF
--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -64,7 +64,7 @@ def get_support_lib(subdir) -> str:
         step(f"rm -rf {lib_path} || true")
         step(f"git clone https://github.com/rems-project/lean-sail.git {lib_path}")
         print("Building the support library")
-        step("lake build", cwd=lib_path)
+        step("lake build +Sail:c.o", cwd=lib_path)
         return f"../../support-lib"
 
 def test_lean(subdir: str, skip_list = None, runnable: bool = False):


### PR DESCRIPTION
It looks like there has been a race when running tests in the CI, where it complains early in a suite that one of the support library `.o.export` files is missing while trying to build it.  This asks lake to produce these files during the initial support library build, which I hope will fix this.