### PR TITLE
Increase OCaml minimum version in CI to 4.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
   build:
     strategy:
       matrix:
-        ocaml_version: [4.08.1, 5.2.1]
+        ocaml_version: [4.14.3, 5.2.1]
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
         exclude:
         - os: macos-26
-          ocaml_version: 4.08.1
+          ocaml_version: 4.14.3
         # Windows is only supported by OCaml 5 or later.
         - os: windows-2025
-          ocaml_version: 4.08.1
+          ocaml_version: 4.14.3
 
     runs-on: ${{ matrix.os }}
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,9 +9,9 @@ supported. On older Ubuntu versions such as 18.04 you will not be able
 to use opam from the package manager, and will need to install it
 following the instructions on the opam website.
 
-Use `ocaml -version` to check your OCaml version. If you have OCaml 4.08.1 or newer, that's fine, otherwise you can use `opam switch` to install a newer version:
+Use `ocaml -version` to check your OCaml version. If you have OCaml 5.2 or newer, that's fine (older versions may still work), otherwise you can use `opam switch` to install a newer version:
 ```
-opam switch create 5.1.0
+opam switch create 5.4.1
 ```
 and set up the environment for that OCaml version (note that older versions of opam suggest backticks instead of `$(...)`, but it makes no difference):
 ```


### PR DESCRIPTION
This is the long term support version of OCaml 4. The opam repository seems to be dropping support for older OCaml versions, which has been causing some issues in CI.

Recommend a minimum of 5.2 in the install document anyway, because of the tail-recursion modulo cons optimisation it has avoids some potential issues with stack overflows.