### PR TITLE
Lean: put definitions in a namespace

### DIFF
--- a/src/sail_lean_backend/Sail/FakeReal.lean
+++ b/src/sail_lean_backend/Sail/FakeReal.lean
@@ -1,6 +1,10 @@
 import Sail
 import THE_MODULE_NAME.Defs
 
+namespace THE_MODULE_NAME
+
+open Defs
+
 abbrev real := Float
 
 -- val "neg_real" : real -> real

--- a/src/sail_lean_backend/Sail/Real.lean
+++ b/src/sail_lean_backend/Sail/Real.lean
@@ -4,6 +4,10 @@ import Mathlib.Data.Real.Sqrt
 import Sail
 import THE_MODULE_NAME.Defs
 
+namespace THE_MODULE_NAME
+
+open Defs
+
 noncomputable section
 
 abbrev real := ℝ

--- a/src/sail_lean_backend/Sail/Specialization.lean
+++ b/src/sail_lean_backend/Sail/Specialization.lean
@@ -1,7 +1,11 @@
 import Sail
 import THE_MODULE_NAME.Defs
 
-namespace Sail
+open Sail
+
+namespace THE_MODULE_NAME
+
+open Defs
 
 @[simp_sail]
 def sailTryCatch (e : SailM α) (h : exception → SailM α) : SailM α := PreSail.sailTryCatch e h
@@ -45,7 +49,7 @@ abbrev assert (p : Bool) (s : String) : SailM Unit := PreSail.assert p s
 
 namespace ConcurrencyInterfaceV1
 
-open PreSail.ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
 
 abbrev sail_mem_write [Arch] (req : Mem_write_request n vasize (BitVec pa_size) ts arch) : SailM (Result (Option Bool) Arch.abort) :=
   PreSail.ConcurrencyInterfaceV1.sail_mem_write req
@@ -70,7 +74,7 @@ end ConcurrencyInterfaceV1
 
 namespace ConcurrencyInterfaceV2
 
-open PreSail.ConcurrencyInterfaceV2
+open Sail.ConcurrencyInterfaceV2
 
 abbrev sail_mem_read [Arch] (req : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) :
     SailM (Result ((Vector (BitVec 8) n) × (Vector Bool nt)) Arch.abort) :=
@@ -97,7 +101,6 @@ abbrev sail_translation_end [Arch] (te : Arch.trans_end) : SailM Unit := PreSail
 abbrev sail_take_exception [Arch] (f : Arch.exn) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_take_exception f
 abbrev sail_return_exception (a : Unit) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_return_exception a
 
-
 end ConcurrencyInterfaceV2
 
 abbrev cycle_count (a : Unit) : SailM Unit := PreSail.cycle_count a
@@ -123,5 +126,3 @@ def unwrapValue [Inhabited α] (x : SailM α) : α :=
   match x.run default with
   | .ok x _ => x
   | _ => default
-
-end Sail

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1619,7 +1619,7 @@ let collect_import_files defs base =
   if res = [] then [base] else res
 
 let pp_ast_lean (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail.Type_check.typed_ast) out_name_camel
-    types_file imp_funcs_files funcs_file noncomputable =
+    types_file imp_funcs_files funcs_file =
   let regs = State.find_registers defs in
   let fun_args = populate_fun_args defs in
   let global = { effect_info; fun_args; kid_id_renames = KBindings.empty; kid_id_renames_rev = Bindings.empty } in
@@ -1645,7 +1645,7 @@ let pp_ast_lean (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail
   let main_function =
     if !the_main_function_has_been_seen then (
       let stub = main_function_stub effect_info has_registers in
-      [string ("open " ^ out_name_camel ^ ".Functions\n\n") ^^ stub]
+      [string ("open " ^ out_name_camel); string ("open " ^ out_name_camel ^ ".Functions\nopen Defs\n\n") ^^ stub]
     )
     else []
   in

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -256,17 +256,21 @@ let file_to_module (filename : string) =
   let base = Filename.basename filename in
   Filename.chop_extension base
 
-let file_prelude version =
-  let p =
+let file_prelude version namespace =
+  let non_computable = if !opt_lean_noncomputable then "noncomputable section\n" else "" in
+  Printf.sprintf
     {|set_option maxHeartbeats 1_000_000_000
 set_option maxRecDepth 1_000_000
 set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV%d
+
+%snamespace %s
+
 |}
-  in
-  Printf.sprintf "%sopen ConcurrencyInterfaceV%d\n\n" p version
+    version non_computable namespace
 
 let path_to_static_library sail_dir str = Filename.quote (sail_dir ^ "/src/sail_lean_backend/Sail/" ^ str ^ ".lean")
 
@@ -288,9 +292,10 @@ let print_function_file_prelude interface_v file out_name_camel (imp_refs : stri
           !opt_lean_import_files
     | ns -> List.iter (fun n -> output_string file ("import " ^ out_name_camel ^ "." ^ n ^ "\n")) ns
   in
-  output_string file ("\n" ^ file_prelude interface_v);
-  if !opt_lean_noncomputable then output_string file "noncomputable section\n\n";
-  output_string file ("namespace " ^ out_name_camel ^ ".Functions\n\n")
+  output_string file ("\n" ^ file_prelude interface_v out_name_camel);
+  Printf.fprintf file "open ConcurrencyInterfaceV%d\n\n" interface_v;
+  output_string file "open Defs\n";
+  output_string file "namespace Functions\n\n"
 
 let start_lean_output interface_v (out_name : string) (import_names : string list) (import_refs : string list list)
     (main_import_refs : string list) default_sail_dir =
@@ -332,7 +337,8 @@ let start_lean_output interface_v (out_name : string) (import_names : string lis
   let types_file = open_out (Filename.concat lean_src_dir "Defs.lean") in
   output_string types_file "import Sail\n";
   output_string types_file "open PreSail\n\n";
-  output_string types_file (file_prelude interface_v);
+  output_string types_file (file_prelude interface_v out_name_camel);
+  output_string types_file "namespace Defs\n\n";
   let funcs_file = open_out (Filename.concat project_dir (out_name_camel ^ ".lean")) in
   let lakefile = open_out (Filename.concat project_dir "lakefile.toml") in
   let lakemanifest = open_out (Filename.concat project_dir "lake-manifest.json") in
@@ -438,7 +444,6 @@ let output (out_name : string) env effect_info ({ defs; _ } as ast : Libsail.Typ
   let out_name_camel = Libsail.Util.to_upper_camel_case out_name in
   let executable =
     Pretty_print_lean.pp_ast_lean env effect_info ast out_name_camel ctx.types_file ctx.import_files ctx.funcs_file
-      noncomputable
   in
   create_lake_project ctx (executable && !opt_lean_executable)
 (* Uncomment for debug output of the Sail code after the rewrite passes *)

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -507,9 +511,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open ast

--- a/test/lean/SailTinyArmV2.expected.lean
+++ b/test/lean/SailTinyArmV2.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV2
+open Sail.ConcurrencyInterfaceV2
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -470,9 +474,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV2
+
+namespace Out
+
 open ConcurrencyInterfaceV2
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open ast

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
@@ -31,9 +35,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 def foo (_ : Unit) : Bool :=
   true

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -51,9 +55,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -61,9 +65,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -46,9 +50,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open E

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -49,9 +53,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/guardedmatch.expected.lean
+++ b/test/lean/guardedmatch.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -44,9 +48,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -53,9 +57,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -49,9 +53,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/map_tactics.expected.lean
+++ b/test/lean/map_tactics.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -46,9 +50,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open word_width
 open option

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -57,9 +61,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -42,9 +46,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -113,9 +117,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -72,9 +76,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -73,9 +77,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open iop

--- a/test/lean/string.expected.lean
+++ b/test/lean/string.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -33,9 +37,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 /-- Type quantifiers: k_ex517_ : Bool, k_ex516_ : Bool -/
 def neq_bool (x : Bool) (y : Bool) : Bool :=

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -70,9 +74,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open Register

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -50,9 +54,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open e_test

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -46,9 +50,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 open E

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
@@ -31,9 +35,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 def foo (y : Unit) : Unit :=
   y

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
@@ -31,9 +35,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 def let0 := (20, 300000000000000000000000)
 

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
@@ -31,9 +35,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 /-- Type quantifiers: k_a : Type -/
 def foo (x : k_a) : (k_a × k_a) :=

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -52,9 +56,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open option
 

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -47,9 +51,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open virtaddr
 open option

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 abbrev bit := (BitVec 1)
 
@@ -33,9 +37,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 /-- Type quantifiers: n : Int -/
 def foo (n : Int) : SailM (Bool × (BitVec 1) × Int × Nat × (BitVec 3)) := do

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -7,7 +7,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open ConcurrencyInterfaceV1
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
+namespace Defs
 
 structure rectangle where
   width : Int
@@ -53,9 +57,14 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
+open Sail.ConcurrencyInterfaceV1
+
+namespace Out
+
 open ConcurrencyInterfaceV1
 
-namespace Out.Functions
+open Defs
+namespace Functions
 
 open shape
 open my_option


### PR DESCRIPTION
This allows for defining types whose names conflict with the standard library. This should also help loading two different models in the same Lean package.