### PR TITLE
Run Z3 in parallel during typechecking

### DIFF
--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -432,6 +432,7 @@ let rec options =
       ("-dmono_continue", Arg.Set Rewrites.opt_dmono_continue, " (debug) continue despite monomorphisation errors");
       ("-dmono_limit", Arg.Set_int Monomorphise.opt_size_set_limit, " (debug) adjust maximum size of split allowed");
       ("-dpattern_warning_no_literals", Arg.Set Pattern_completeness.opt_debug_no_literals, "");
+      ("-dsequential", Arg.Set Parmap.opt_sequential, " (debug) Run without any internal parallelism");
       ( "-dbacktrace",
         Arg.Int (fun l -> Reporting.opt_backtrace_length := l),
         "<length> (debug) length of backtrace to show when reporting unreachable code"
@@ -797,7 +798,7 @@ let main () =
 
 let () =
   try
-    try main () with
+    try Parmap.toplevel_handler main with
     | Sys_error s -> raise (Reporting.err_general Parse_ast.Unknown s)
     | Failure s -> raise (Reporting.err_general Parse_ast.Unknown s)
   with Reporting.Fatal_error e ->

--- a/src/lib/constraint.ml
+++ b/src/lib/constraint.ml
@@ -50,6 +50,8 @@ open Ast_compare
 open Ast_util
 open Util
 
+module ParUnix = Parmap.ParUnix
+
 let opt_smt_verbose = ref false
 
 type solver = {
@@ -157,7 +159,7 @@ let smt_type l = function
   | K_bool -> Atom "Bool"
   | K_type -> raise (Reporting.err_unreachable l __POS__ "Tried to pass Type kinded variable to SMT solver")
 
-let to_smt l abstract vars constr =
+let to_smt solver l abstract vars constr =
   (* Numbering all SMT variables v0, ... vn, rather than generating
      names based on their Sail names (e.g. using zencode) ensures that
      alpha-equivalent constraints generate the same SMT problem, which
@@ -195,7 +197,7 @@ let to_smt l abstract vars constr =
     match aux with
     | Nexp_id id -> Atom (Util.zencode_string (string_of_id id))
     | Nexp_var v -> fst (smt_var v)
-    | Nexp_constant c when Big_int.less_equal c (Big_int.of_int (-1)) && not !opt_solver.negative_literals ->
+    | Nexp_constant c when Big_int.less_equal c (Big_int.of_int (-1)) && not solver.negative_literals ->
         sfun "-" [Atom "0"; Atom (Big_int.to_string (Big_int.abs c))]
     | Nexp_constant c -> Atom (Big_int.to_string c)
     | Nexp_app (id, nexps) -> sfun (string_of_id id) (List.map smt_nexp nexps)
@@ -206,7 +208,7 @@ let to_smt l abstract vars constr =
         match nexp_simp nexp with
         | Nexp_aux (Nexp_constant c, _) when Big_int.greater_equal c Big_int.zero ->
             Atom (Big_int.to_string (Big_int.pow_int_positive 2 (Big_int.to_int c)))
-        | nexp when !opt_solver.uninterpret_power ->
+        | nexp when solver.uninterpret_power ->
             let exp = smt_nexp nexp in
             exponentials := exp :: !exponentials;
             sfun "sailexp" [exp]
@@ -252,22 +254,22 @@ let sailexp_concrete n =
       sfun "=" [sfun "sailexp" [Atom (string_of_int i)]; Atom (Big_int.to_string (Big_int.pow_int_positive 2 i))]
   )
 
-let smtlib_of_constraints ?(get_model = false) l abstract vars extra constr :
+let smtlib_of_constraints ?(get_model = false) solver l abstract vars extra constr :
     string * (kid -> sexpr * bool) * sexpr list =
   let open Buffer in
   let buf = create 512 in
-  add_string buf !opt_solver.header;
-  let variables, problem, var_map, exponentials = to_smt l abstract vars constr in
+  add_string buf solver.header;
+  let variables, problem, var_map, exponentials = to_smt solver l abstract vars constr in
   add_list buf '\n' add_sexpr variables;
   add_char buf '\n';
-  if !opt_solver.uninterpret_power then add_string buf "(declare-fun sailexp (Int) Int)\n";
+  if solver.uninterpret_power then add_string buf "(declare-fun sailexp (Int) Int)\n";
   add_list buf '\n' (fun buf sexpr -> add_sexpr buf (sfun "assert" [sexpr])) extra;
   add_char buf '\n';
   add_sexpr buf (sfun "assert" [problem]);
   add_string buf "\n(check-sat)";
   if get_model then add_string buf "\n(get-model)";
   add_char buf '\n';
-  add_string buf !opt_solver.footer;
+  add_string buf solver.footer;
   (Buffer.contents buf, var_map, exponentials)
 
 type smt_result = Unknown | Sat | Unsat
@@ -333,7 +335,7 @@ let constraint_to_smt l constr =
     kopts_of_constraint constr |> KOptSet.elements |> List.map kopt_pair
     |> List.fold_left (fun m (k, v) -> KBindings.add k v m) KBindings.empty
   in
-  let vars, sexpr, var_map, exponentials = to_smt l Bindings.empty vars constr in
+  let vars, sexpr, var_map, exponentials = to_smt !opt_solver l Bindings.empty vars constr in
   let vars = string_of_list "\n" pp_sexpr vars in
   ( vars ^ "\n(assert " ^ pp_sexpr sexpr ^ ")",
     (fun v ->
@@ -343,25 +345,15 @@ let constraint_to_smt l constr =
     List.map pp_sexpr exponentials
   )
 
-let rec call_smt' l abstract extra constraints =
+let rec call_smt' solver l abstract extra constraints =
   let vars =
     kopts_of_constraint constraints |> KOptSet.elements |> List.map kopt_pair
     |> List.fold_left (fun m (k, v) -> KBindings.add k v m) KBindings.empty
   in
   let problems = [constraints] in
-  let smt_file, _, exponentials = smtlib_of_constraints l abstract vars extra constraints in
+  let smt_file, _, exponentials = smtlib_of_constraints solver l abstract vars extra constraints in
 
   if !opt_smt_verbose then prerr_endline (Printf.sprintf "SMTLIB2 constraints are: \n%s%!" smt_file);
-
-  let rec input_lines chan = function
-    | 0 -> []
-    | n ->
-        let l = input_line chan in
-        let ls = input_lines chan (n - 1) in
-        l :: ls
-  in
-
-  let rec input_all chan = match input_line chan with l -> l :: input_all chan | exception End_of_file -> [] in
 
   let digest = Digest.string smt_file in
 
@@ -377,37 +369,36 @@ let rec call_smt' l abstract extra constraints =
         close_out tmp_chan;
         let status, smt_output, smt_errors =
           try
-            let smt_out, smt_in, smt_err =
-              let cmd =
-                !opt_solver.command ^ " "
-                ^ Util.string_of_list " " (fun x -> x) (Array.to_list (!opt_solver.args input_file))
-              in
-              Unix.open_process_full cmd (Unix.environment ())
+            let cmd =
+              solver.command ^ " " ^ Util.string_of_list " " (fun x -> x) (Array.to_list (solver.args input_file))
             in
-            let smt_output, smt_raw_output =
-              try
-                let raw_output = input_lines smt_out (List.length problems) in
-                (List.combine problems raw_output, raw_output)
-              with End_of_file -> (List.combine problems ["unknown"], [])
+            let status, out_str, err_str = ParUnix.open_process_full cmd (Unix.environment ()) None in
+            let rec result_lines problems lines =
+              match (problems, lines) with
+              | problem :: problems, line :: lines -> (problem, line) :: result_lines problems lines
+              | problem :: problems, [] -> (problem, "unknown") :: result_lines problems lines
+              | [], _ -> []
             in
+
+            let smt_output = result_lines problems (String.split_on_char '\n' out_str) in
             (* In case of errors, the output on stdout might be useful. *)
-            let smt_errors = List.append (input_all smt_err) smt_raw_output in
-            let status = Unix.close_process_full (smt_out, smt_in, smt_err) in
+            let smt_errors = err_str ^ "\n" ^ out_str in
             (status, smt_output, smt_errors)
           with exn -> raise (Reporting.err_general l ("Error when calling smt: " ^ Printexc.to_string exn))
         in
         let _ =
           match status with
-          | Unix.WEXITED 0 -> ()
+          | Unix.WEXITED 0 -> Sys.remove input_file
           | Unix.WEXITED n ->
               raise
                 (Reporting.err_general l
-                   ("SMT solver returned unexpected status " ^ string_of_int n ^ "\n" ^ String.concat "\n" smt_errors)
+                   ("SMT solver returned unexpected status " ^ string_of_int n ^ "\n" ^ smt_errors ^ "\nInput file: "
+                  ^ input_file
+                   )
                 )
           | Unix.WSIGNALED n | Unix.WSTOPPED n ->
               raise (Reporting.err_general l ("SMT solver killed by signal " ^ string_of_int n))
         in
-        Sys.remove input_file;
 
         (* The output should contain exactly one of 'unsat', 'sat' or 'unknown'. *)
         let result =
@@ -440,24 +431,23 @@ let rec call_smt' l abstract extra constraints =
   ( ( match result with
     | Unsat -> Unsat
     | Sat -> Sat
-    | Unknown when exponentials <> [] && not !opt_solver.uninterpret_power ->
+    | Unknown when exponentials <> [] && not solver.uninterpret_power ->
         (* If we get an unknown result for a constraint involving `2^x`,
            then try replacing `2^` with an uninterpreted function to see
            if the problem would be unsat in that case. *)
-        opt_solver := { !opt_solver with uninterpret_power = true };
-        let result = call_smt_uninterpret_power ~bound:64 l abstract constraints in
-        opt_solver := { !opt_solver with uninterpret_power = false };
-        result
+        call_smt_uninterpret_power ~bound:64 { solver with uninterpret_power = true } l abstract constraints
     | Unknown -> Unknown
     ),
     exponentials
   )
 
-and call_smt_uninterpret_power ~bound l abstract constraints =
-  match call_smt' l abstract (sailexp_concrete bound) constraints with
+and call_smt_uninterpret_power ~bound solver l abstract constraints =
+  match call_smt' solver l abstract (sailexp_concrete bound) constraints with
   | Unsat, _ -> Unsat
   | Sat, exponentials -> (
-      match call_smt' l abstract (sailexp_concrete bound @ List.map bound_exponential exponentials) constraints with
+      match
+        call_smt' solver l abstract (sailexp_concrete bound @ List.map bound_exponential exponentials) constraints
+      with
       | Sat, _ -> Sat
       | _ -> Unknown
     )
@@ -465,21 +455,22 @@ and call_smt_uninterpret_power ~bound l abstract constraints =
 
 let call_smt l abstract constraints =
   let t = Profile.start_smt () in
+  let solver = !opt_solver in
   let result =
-    if !opt_solver.uninterpret_power then call_smt_uninterpret_power ~bound:64 l abstract constraints
-    else fst (call_smt' l abstract [] constraints)
+    if solver.uninterpret_power then call_smt_uninterpret_power ~bound:64 solver l abstract constraints
+    else fst (call_smt' solver l abstract [] constraints)
   in
   Profile.finish_smt t;
   result
 
-let solve_smt_file l abstract extra constraints =
+let solve_smt_file solver l abstract extra constraints =
   let vars =
     kopts_of_constraint constraints |> KOptSet.elements |> List.map kopt_pair
     |> List.fold_left (fun m (k, v) -> KBindings.add k v m) KBindings.empty
   in
-  smtlib_of_constraints ~get_model:true l abstract vars extra constraints
+  smtlib_of_constraints ~get_model:true !opt_solver l abstract vars extra constraints
 
-let call_smt_solve l smt_file smt_vars var =
+let call_smt_solve solver l smt_file smt_vars var =
   let smt_var = pp_sexpr (fst (smt_vars var)) in
   if !opt_smt_verbose then
     prerr_endline (Printf.sprintf "SMTLIB2 constraints are (solve for %s): \n%s%!" smt_var smt_file)
@@ -567,8 +558,9 @@ let call_smt_solve_bitvector l smt_file smt_vars =
   |> Util.option_all
 
 let solve_smt l abstract constraints var =
-  let smt_file, smt_vars, _ = solve_smt_file l abstract [] constraints in
-  call_smt_solve l smt_file smt_vars var
+  let solver = !opt_solver in
+  let smt_file, smt_vars, _ = solve_smt_file solver l abstract [] constraints in
+  call_smt_solve solver l smt_file smt_vars var
 
 let solve_all_smt l abstract constraints var =
   let rec aux results =
@@ -581,19 +573,19 @@ let solve_all_smt l abstract constraints var =
   in
   aux []
 
-let solve_unique_smt' l abstract constraints exp_defn exp_bound var =
-  let smt_file, smt_vars, exponentials = solve_smt_file l abstract (exp_defn @ exp_bound) constraints in
+let solve_unique_smt' solver l abstract constraints exp_defn exp_bound var =
+  let smt_file, smt_vars, exponentials = solve_smt_file solver l abstract (exp_defn @ exp_bound) constraints in
   let digest = Digest.string (smt_file ^ pp_sexpr (fst (smt_vars var))) in
   let result =
     match DigestMap.find_opt digest !known_uniques with
     | Some (Some result) -> Some (Big_int.of_int result)
     | Some None -> None
     | None -> (
-        match call_smt_solve l smt_file smt_vars var with
+        match call_smt_solve solver l smt_file smt_vars var with
         | Some result -> (
             let t = Profile.start_smt () in
             let smt_result' =
-              fst (call_smt' l abstract exp_defn (nc_and constraints (nc_neq (nconstant result) (nvar var))))
+              fst (call_smt' solver l abstract exp_defn (nc_and constraints (nc_neq (nconstant result) (nvar var))))
             in
             Profile.finish_smt t;
             match smt_result' with
@@ -618,16 +610,17 @@ let solve_unique_smt' l abstract constraints exp_defn exp_bound var =
 
 let solve_unique_smt l abstract constraints var =
   let t = Profile.start_smt () in
+  let solver = !opt_solver in
   let result =
-    match solve_unique_smt' l abstract constraints [] [] var with
+    match solve_unique_smt' solver l abstract constraints [] [] var with
     | Some result, _ -> Some result
     | None, [] -> None
     | None, exponentials ->
-        opt_solver := { !opt_solver with uninterpret_power = true };
         let sailexp = sailexp_concrete 64 in
         let exp_bound = List.map bound_exponential exponentials in
-        let result, _ = solve_unique_smt' l abstract constraints sailexp exp_bound var in
-        opt_solver := { !opt_solver with uninterpret_power = false };
+        let result, _ =
+          solve_unique_smt' { solver with uninterpret_power = true } l abstract constraints sailexp exp_bound var
+        in
         result
   in
   Profile.finish_smt t;

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -70,6 +70,26 @@
  (module libsail_sites)
  (sites libsail))
 
+; The parallel implementation of map uses effect handlers and matching
+; syntax, which is on,y available from OCaml 5.3.0 onwards. On older
+; compilers fall back to a sequential implementation.
+
+(rule
+ (target parmap.ml)
+ (enabled_if
+  (>= %{ocaml_version} 5.3.0))
+ (deps parmap.par.ml)
+ (action
+  (copy parmap.par.ml parmap.ml)))
+
+(rule
+ (target parmap.ml)
+ (enabled_if
+  (< %{ocaml_version} 5.3.0))
+ (deps parmap.seq.ml)
+ (action
+  (copy parmap.seq.ml parmap.ml)))
+
 (library
  (name libsail)
  (public_name libsail)

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -1111,7 +1111,7 @@ module Make =
               | Monad.Continue x'' -> wrap (E_try (x'', arms))
               | Monad.Caught exn ->
                 wrap (E_match ((E_aux ((E_internal_value exn), annot0)),
-                  (app arms (Tannot.fallthrough :: []))))))
+                  (app arms ((Tannot.fallthrough ()) :: []))))))
        | E_assert (x, msg) ->
          Monad.bind (get_bool x) (fun b ->
            match b with

--- a/src/lib/extraction/TypeAnnot.ml
+++ b/src/lib/extraction/TypeAnnot.ml
@@ -24,5 +24,5 @@ module type S =
 
   val is_bitvector : t -> bool
 
-  val fallthrough : t pexp
+  val fallthrough : unit -> t pexp
  end

--- a/src/lib/extraction/TypeAnnot.mli
+++ b/src/lib/extraction/TypeAnnot.mli
@@ -24,5 +24,5 @@ module type S =
 
   val is_bitvector : t -> bool
 
-  val fallthrough : t pexp
+  val fallthrough : unit -> t pexp
  end

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -234,7 +234,7 @@ let is_value = function E_aux (E_internal_value _, _) -> true | _ -> false
 let exp_of_value v = E_aux (E_internal_value v, (Parse_ast.Unknown, Type_check.empty_tannot))
 let value_of_exp = function E_aux (E_internal_value v, _) -> v | _ -> failwith "value_of_exp coerction failed"
 
-let fallthrough =
+let fallthrough () =
   let open Type_check in
   let open Type_error in
   try
@@ -278,7 +278,7 @@ module Semantics = Extraction.Semantics.Make (struct
 
   let is_bitvector tannot = is_bitvector_typ (Type_check.typ_of_tannot tannot)
 
-  let fallthrough = fallthrough
+  let fallthrough () = fallthrough ()
 end)
 
 module Monad = Extraction.Semantics.Monad

--- a/src/lib/jib_compile.ml
+++ b/src/lib/jib_compile.ml
@@ -2166,6 +2166,8 @@ module Make (C : CONFIG) = struct
           );
       ]
 
+  type compiled_def = Compiled of cdef list | Parallel of (unit -> cdef list)
+
   let compile_funcl ctx def_annot id pat guard exp =
     let debug_attr = get_def_attribute "jib_debug" def_annot in
     let mapping_function_attr = get_def_attribute "mapping_function" def_annot in
@@ -2195,141 +2197,125 @@ module Make (C : CONFIG) = struct
     let arg_ctyps = List.map (ctyp_of_typ ctx) arg_typs in
     let ret_ctyp = ctyp_of_typ ctx ret_typ in
 
-    (* Compile the function arguments as patterns. *)
-    let arg_setup, compiled_args, arg_cleanup =
-      compile_arg_pats ctx (fun l b -> ijump l b fundef_label) pat arg_ctyps
-    in
-    let ctx =
-      (* We need the primop analyzer to be aware of the function argument types, so put them in ctx *)
-      List.fold_left2
-        (fun ctx (id, _) ctyp -> { ctx with locals = NameMap.add id (Immutable, ctyp) ctx.locals })
-        ctx compiled_args arg_ctyps
-    in
-
-    let known_ids = IdSet.fold (fun id -> NameSet.add (name id)) (pat_ids pat) (letbind_ids ctx) in
-    let guard_bindings = ref NameSet.empty in
-    let guard_instrs =
-      match guard with
-      | Some guard ->
-          let (AE_aux (_, { loc = l; _ }) as guard) = anf guard in
-          guard_bindings := aexp_bindings guard;
-          let guard_aexp = C.optimize_anf ctx (no_shadow known_ids guard) in
-          let guard_setup, guard_call, guard_cleanup = compile_aexp ctx guard_aexp in
-          let guard_label = label "guard_" in
-          let gs = ngensym () in
-          [
-            iblock
-              ([idecl l CT_bool gs]
-              @ guard_setup
-              @ [guard_call (CL_id (gs, CT_bool))]
-              @ guard_cleanup
-              @ [ijump (id_loc id) (V_id (gs, CT_bool)) guard_label; imatch_failure l; ilabel guard_label]
-              );
-          ]
-      | None -> []
-    in
-
-    (* Optimize and compile the expression to ANF. *)
-    let aexp = C.optimize_anf ctx (no_shadow (NameSet.union known_ids !guard_bindings) (anf exp)) in
-
-    if Option.is_some debug_attr then (
-      prerr_endline Util.("ANF for " ^ string_of_id id ^ ":" |> yellow |> bold |> clear);
-      prerr_endline (Document.to_string (pp_aexp aexp))
-    );
-
-    let compile_body ctx =
-      let setup, call, cleanup = compile_aexp ctx aexp in
-      let destructure, destructure_cleanup =
-        compiled_args |> List.map snd |> combine_destructure_cleanup |> fix_destructure (id_loc id) fundef_label
-      in
-
-      let instrs =
-        arg_setup @ destructure @ guard_instrs @ setup
-        @ [call (CL_id (return, ret_ctyp))]
-        @ cleanup @ destructure_cleanup @ arg_cleanup
-      in
-      let instrs = fix_early_return (exp_loc exp) (CL_id (return, ret_ctyp)) instrs in
-      let instrs = unique_names instrs in
-      let instrs = fix_exception ~return:(Some ret_ctyp) ctx instrs in
-      coverage_function_entry ctx id (exp_loc exp) @ instrs
-    in
-
-    let compiled_args = List.map fst compiled_args in
-    let instrs = compile_body ctx in
-
-    if Option.is_some debug_attr then (
-      let type_string = Util.string_of_list ", " string_of_ctyp arg_ctyps ^ " -> " ^ string_of_ctyp ret_ctyp in
-      prerr_endline Util.("IR for " ^ string_of_id id ^ ": " ^ type_string |> yellow |> bold |> clear);
-      List.iter (fun instr -> prerr_endline (string_of_instr instr)) instrs
-    );
-
-    if Option.is_some test_no_gmp then
-      List.iter
-        (fun instr ->
-          iter_instr
-            (function
-              | I_aux (I_decl (ctyp, _), (_, l)) | I_aux (I_init (ctyp, _, _), (_, l)) ->
-                  if ctyp_equal ctyp CT_lint || ctyp_equal ctyp CT_lbits then
-                    raise (Reporting.err_general l "Found GMP large integer or bitvector with test_no_gmp attribute")
-              | _ -> ()
-              )
-            instr
-        )
-        instrs;
-
-    (* If the function is a mapping, we generate an infallible version (that never causes a match_failure) *)
-    let mapping_infallible, return_ctx =
+    (* Now we have enough information to compute the return context for this compilation step. *)
+    let return_ctx =
       match mapping_function_attr with
-      | Some (attr_l, _) ->
-          let instrs =
-            compile_body
-              { ctx with def_annot = Some (add_def_attribute (gen_loc attr_l) "mapping_infallible" None def_annot) }
-          in
+      | Some _ ->
           let id = append_id id "_infallible" in
-          ( [
+          { orig_ctx with valspecs = Bindings.add id (None, arg_ctyps, ret_ctyp, empty_uannot) orig_ctx.valspecs }
+      | None -> orig_ctx
+    in
+
+    let do_funcl_compilation () =
+      (* Compile the function arguments as patterns. *)
+      let arg_setup, compiled_args, arg_cleanup =
+        compile_arg_pats ctx (fun l b -> ijump l b fundef_label) pat arg_ctyps
+      in
+      let ctx =
+        (* We need the primop analyzer to be aware of the function argument types, so put them in ctx *)
+        List.fold_left2
+          (fun ctx (id, _) ctyp -> { ctx with locals = NameMap.add id (Immutable, ctyp) ctx.locals })
+          ctx compiled_args arg_ctyps
+      in
+
+      let known_ids = IdSet.fold (fun id -> NameSet.add (name id)) (pat_ids pat) (letbind_ids ctx) in
+      let guard_bindings = ref NameSet.empty in
+      let guard_instrs =
+        match guard with
+        | Some guard ->
+            let (AE_aux (_, { loc = l; _ }) as guard) = anf guard in
+            guard_bindings := aexp_bindings guard;
+            let guard_aexp = C.optimize_anf ctx (no_shadow known_ids guard) in
+            let guard_setup, guard_call, guard_cleanup = compile_aexp ctx guard_aexp in
+            let guard_label = label "guard_" in
+            let gs = ngensym () in
+            [
+              iblock
+                ([idecl l CT_bool gs]
+                @ guard_setup
+                @ [guard_call (CL_id (gs, CT_bool))]
+                @ guard_cleanup
+                @ [ijump (id_loc id) (V_id (gs, CT_bool)) guard_label; imatch_failure l; ilabel guard_label]
+                );
+            ]
+        | None -> []
+      in
+
+      (* Optimize and compile the expression to ANF. *)
+      let aexp = C.optimize_anf ctx (no_shadow (NameSet.union known_ids !guard_bindings) (anf exp)) in
+
+      if Option.is_some debug_attr then (
+        prerr_endline Util.("ANF for " ^ string_of_id id ^ ":" |> yellow |> bold |> clear);
+        prerr_endline (Document.to_string (pp_aexp aexp))
+      );
+
+      let compile_body ctx =
+        let setup, call, cleanup = compile_aexp ctx aexp in
+        let destructure, destructure_cleanup =
+          compiled_args |> List.map snd |> combine_destructure_cleanup |> fix_destructure (id_loc id) fundef_label
+        in
+
+        let instrs =
+          arg_setup @ destructure @ guard_instrs @ setup
+          @ [call (CL_id (return, ret_ctyp))]
+          @ cleanup @ destructure_cleanup @ arg_cleanup
+        in
+        let instrs = fix_early_return (exp_loc exp) (CL_id (return, ret_ctyp)) instrs in
+        let instrs = unique_names instrs in
+        let instrs = fix_exception ~return:(Some ret_ctyp) ctx instrs in
+        coverage_function_entry ctx id (exp_loc exp) @ instrs
+      in
+
+      let compiled_args = List.map fst compiled_args in
+      let instrs = compile_body ctx in
+
+      if Option.is_some debug_attr then (
+        let type_string = Util.string_of_list ", " string_of_ctyp arg_ctyps ^ " -> " ^ string_of_ctyp ret_ctyp in
+        prerr_endline Util.("IR for " ^ string_of_id id ^ ": " ^ type_string |> yellow |> bold |> clear);
+        List.iter (fun instr -> prerr_endline (string_of_instr instr)) instrs
+      );
+
+      if Option.is_some test_no_gmp then
+        List.iter
+          (fun instr ->
+            iter_instr
+              (function
+                | I_aux (I_decl (ctyp, _), (_, l)) | I_aux (I_init (ctyp, _, _), (_, l)) ->
+                    if ctyp_equal ctyp CT_lint || ctyp_equal ctyp CT_lbits then
+                      raise (Reporting.err_general l "Found GMP large integer or bitvector with test_no_gmp attribute")
+                | _ -> ()
+                )
+              instr
+          )
+          instrs;
+
+      (* If the function is a mapping, we generate an infallible version (that never causes a match_failure) *)
+      let mapping_infallible =
+        match mapping_function_attr with
+        | Some (attr_l, _) ->
+            let instrs =
+              compile_body
+                { ctx with def_annot = Some (add_def_attribute (gen_loc attr_l) "mapping_infallible" None def_annot) }
+            in
+            let id = append_id id "_infallible" in
+            [
               CDEF_aux (CDEF_val (id, params, arg_ctyps, ret_ctyp, None), def_annot);
               CDEF_aux (CDEF_fundef (id, Return_plain, compiled_args, instrs), def_annot);
-            ],
-            { orig_ctx with valspecs = Bindings.add id (None, arg_ctyps, ret_ctyp, empty_uannot) orig_ctx.valspecs }
-          )
-      | None -> ([], orig_ctx)
+            ]
+        | None -> []
+      in
+      [CDEF_aux (CDEF_fundef (id, Return_plain, compiled_args, instrs), def_annot)] @ mapping_infallible
     in
 
-    ([CDEF_aux (CDEF_fundef (id, Return_plain, compiled_args, instrs), def_annot)] @ mapping_infallible, return_ctx)
+    (Parallel do_funcl_compilation, return_ctx)
 
   (** Compile a Sail toplevel definition into an IR definition **)
   let rec compile_def n total ctx (DEF_aux (aux, _) as def) =
-    match aux with
-    | DEF_fundef (FD_aux (FD_function (_, _, [FCL_aux (FCL_funcl (id, _), _)]), _)) when !opt_memo_cache -> (
-        let digest = strip_def def |> Pretty_print_sail.doc_def |> Document.to_string |> Digest.string in
-        let cachefile = Filename.concat "_sbuild" ("ccache" ^ Digest.to_hex digest) in
-        let cached =
-          if Sys.file_exists cachefile then (
-            let in_chan = open_in cachefile in
-            try
-              let compiled = Marshal.from_channel in_chan in
-              close_in in_chan;
-              Some (compiled, ctx)
-            with _ ->
-              close_in in_chan;
-              None
-          )
-          else None
-        in
-        match cached with
-        | Some (compiled, ctx) ->
-            Util.progress "Compiling " (string_of_id id) n total;
-            (compiled, ctx)
-        | None ->
-            let compiled, ctx = compile_def' n total ctx def in
-            let out_chan = open_out cachefile in
-            Marshal.to_channel out_chan compiled [Marshal.Closures];
-            close_out out_chan;
-            (compiled, { ctx with def_annot = None })
-      )
-    | _ ->
-        let compiled, ctx = compile_def' n total ctx def in
-        (compiled, { ctx with def_annot = None })
+    let compiled, ctx = compile_def' n total ctx def in
+    (compiled, { ctx with def_annot = None })
+
+  and compile_def_force n total ctx def =
+    match compile_def n total ctx def with Compiled cdefs, ctx -> (cdefs, ctx) | Parallel f, ctx -> (f (), ctx)
 
   and compile_def' n total ctx (DEF_aux (aux, def_annot) as def) =
     let def_env = def_annot.env in
@@ -2338,7 +2324,7 @@ module Make (C : CONFIG) = struct
     match aux with
     | DEF_register (DEC_aux (DEC_reg (typ, id, None), _)) ->
         let ctyp = ctyp_of_typ ctx typ in
-        ( [CDEF_aux (CDEF_register (name id, ctyp, []), def_annot)],
+        ( Compiled [CDEF_aux (CDEF_register (name id, ctyp, []), def_annot)],
           { ctx with registers = Bindings.add id ctyp ctx.registers }
         )
     | DEF_register (DEC_aux (DEC_reg (typ, id, Some exp), _)) ->
@@ -2347,7 +2333,7 @@ module Make (C : CONFIG) = struct
         let setup, call, cleanup = compile_aexp ctx aexp in
         let instrs = setup @ [call (CL_id (name id, ctyp))] @ cleanup in
         let instrs = unique_names instrs in
-        ( [CDEF_aux (CDEF_register (name id, ctyp, instrs), def_annot)],
+        ( Compiled [CDEF_aux (CDEF_register (name id, ctyp, instrs), def_annot)],
           { ctx with registers = Bindings.add id ctyp ctx.registers }
         )
     | DEF_val (VS_aux (VS_val_spec (_, id, ext), _)) ->
@@ -2362,7 +2348,7 @@ module Make (C : CONFIG) = struct
         in
         let ctx' = { ctx with local_env = Env.add_typquant (id_loc id) quant ctx.local_env } in
         let arg_ctyps, ret_ctyp = (List.map (ctyp_of_typ ctx') arg_typs, ctyp_of_typ ctx' ret_typ) in
-        ( [CDEF_aux (CDEF_val (id, params, arg_ctyps, ret_ctyp, extern), def_annot)],
+        ( Compiled [CDEF_aux (CDEF_val (id, params, arg_ctyps, ret_ctyp, extern), def_annot)],
           {
             ctx with
             valspecs = Bindings.add id (extern, arg_ctyps, ret_ctyp, uannot_of_def_annot def_annot) ctx.valspecs;
@@ -2371,7 +2357,7 @@ module Make (C : CONFIG) = struct
     | DEF_fundef (FD_aux (FD_function (_, _, [FCL_aux (FCL_funcl (id, pexp), _)]), _)) -> (
         Util.progress "Compiling " (string_of_id id) n total;
         match Bindings.find_opt id C.fun_to_wires with
-        | Some slots -> (compile_fun_to_wires ctx def_annot id slots, ctx)
+        | Some slots -> (Compiled (compile_fun_to_wires ctx def_annot id slots), ctx)
         | None -> (
             match pexp with
             | Pat_aux (Pat_exp (pat, exp), _) -> compile_funcl ctx def_annot id pat None exp
@@ -2384,7 +2370,7 @@ module Make (C : CONFIG) = struct
         raise (Reporting.err_general l "Encountered function with multiple clauses")
     | DEF_type type_def ->
         let tdef_opt, ctx = compile_type_def ctx type_def in
-        (List.map (fun tdef -> CDEF_aux (CDEF_type tdef, def_annot)) (Option.to_list tdef_opt), ctx)
+        (Compiled (List.map (fun tdef -> CDEF_aux (CDEF_type tdef, def_annot)) (Option.to_list tdef_opt)), ctx)
     | DEF_let (pat, exp) ->
         let debug_attr = get_def_attribute "jib_debug" def_annot in
         let ctyp = ctyp_of_typ ctx (typ_of_pat pat) in
@@ -2415,7 +2401,7 @@ module Make (C : CONFIG) = struct
             (Util.string_of_list ", " (fun (id, ctyp) -> string_of_id id ^ " : " ^ string_of_ctyp ctyp) bindings);
           List.iter (fun instr -> prerr_endline (string_of_instr instr)) instrs
         );
-        ( [CDEF_aux (CDEF_let (n, bindings, instrs), def_annot)],
+        ( Compiled [CDEF_aux (CDEF_let (n, bindings, instrs), def_annot)],
           {
             ctx with
             letbinds = n :: ctx.letbinds;
@@ -2424,30 +2410,34 @@ module Make (C : CONFIG) = struct
         )
     (* Only DEF_default that matters is default Order, but all order
        polymorphism is specialised by this point. *)
-    | DEF_default _ -> ([], ctx)
+    | DEF_default _ -> (Compiled [], ctx)
     (* Overloading resolved by type checker *)
-    | DEF_overload _ -> ([], ctx)
+    | DEF_overload _ -> (Compiled [], ctx)
     (* Only the parser and sail pretty printer care about this. *)
-    | DEF_fixity _ -> ([], ctx)
-    | DEF_pragma ("abstract", Pragma_line (id_str, _)) -> ([CDEF_aux (CDEF_pragma ("abstract", id_str), def_annot)], ctx)
+    | DEF_fixity _ -> (Compiled [], ctx)
+    | DEF_pragma ("abstract", Pragma_line (id_str, _)) ->
+        (Compiled [CDEF_aux (CDEF_pragma ("abstract", id_str), def_annot)], ctx)
     | DEF_pragma ("c_in_main", Pragma_line (source, _)) ->
-        ([CDEF_aux (CDEF_pragma ("c_in_main", source), def_annot)], ctx)
+        (Compiled [CDEF_aux (CDEF_pragma ("c_in_main", source), def_annot)], ctx)
     | DEF_pragma ("c_in_main_post", Pragma_line (source, _)) ->
-        ([CDEF_aux (CDEF_pragma ("c_in_main_post", source), def_annot)], ctx)
+        (Compiled [CDEF_aux (CDEF_pragma ("c_in_main_post", source), def_annot)], ctx)
     (* We just ignore any pragmas we don't want to deal with. *)
-    | DEF_pragma _ -> ([], ctx)
+    | DEF_pragma _ -> (Compiled [], ctx)
     (* Termination measures only needed for Coq, and other theorem prover output *)
-    | DEF_measure _ -> ([], ctx)
-    | DEF_loop_measures _ -> ([], ctx)
+    | DEF_measure _ -> (Compiled [], ctx)
+    | DEF_loop_measures _ -> (Compiled [], ctx)
     | DEF_internal_mutrec fundefs ->
         let defs = List.map (fun fdef -> mk_def (DEF_fundef fdef) def_env) fundefs in
-        List.fold_left
-          (fun (cdefs, ctx) def ->
-            let cdefs', ctx = compile_def n total ctx def in
-            (cdefs @ cdefs', ctx)
-          )
-          ([], ctx) defs
-    | DEF_constraint _ -> ([], ctx)
+        let cdefs, ctx =
+          List.fold_left
+            (fun (cdefs, ctx) def ->
+              let cdefs', ctx = compile_def_force n total ctx def in
+              (cdefs @ cdefs', ctx)
+            )
+            ([], ctx) defs
+        in
+        (Compiled cdefs, ctx)
+    | DEF_constraint _ -> (Compiled [], ctx)
     (* Scattereds, mapdefs, and event related definitions should be removed by this point *)
     | DEF_scattered _ | DEF_mapdef _ | DEF_outcome _ | DEF_impl _ | DEF_instantiation _ ->
         Reporting.unreachable (def_loc def) __POS__
@@ -3045,14 +3035,6 @@ module Make (C : CONFIG) = struct
     let g = G.prune roots NodeSet.empty g in
     let ast = Callgraph.filter_ast NodeSet.empty g ast in
 
-    if !opt_memo_cache then (
-      try
-        if Sys.is_directory "_sbuild" then ()
-        else raise (Reporting.err_general Parse_ast.Unknown "_sbuild exists, but is a file not a directory!")
-      with Sys_error _ -> Unix.mkdir "_sbuild" 0o775
-    )
-    else ();
-
     let total = List.length ast.defs in
     let _, chunks, ctx =
       List.fold_left
@@ -3062,6 +3044,11 @@ module Make (C : CONFIG) = struct
         )
         (1, [], ctx)
         (move_constraint_contexts ctx.tc_env [] ast.defs)
+    in
+    let chunks =
+      Parmap.map ~parallelism:(Parmap.recommended_parallelism ())
+        (function Compiled cdefs -> cdefs | Parallel f -> f ())
+        chunks
     in
     let cdefs = List.concat (List.rev chunks) in
 

--- a/src/lib/jib_compile.mli
+++ b/src/lib/jib_compile.mli
@@ -191,9 +191,5 @@ end
 val callgraph : cdef list -> IdGraph.graph
 
 module Make (C : CONFIG) : sig
-  (** Compile a Sail definition into a Jib definition. The first two arguments are is the current definition number and
-      the total number of definitions, and can be used to drive a progress bar (see Util.progress). *)
-  val compile_def : int -> int -> ctx -> typed_def -> cdef list * ctx
-
   val compile_ast : ctx -> typed_ast -> cdef list * ctx
 end

--- a/src/lib/parmap.mli
+++ b/src/lib/parmap.mli
@@ -1,4 +1,6 @@
-(* ************************************************************************ *)
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
 (*  Sail and the Sail architecture models here, comprising all files and    *)
 (*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
 (*  are subject to the BSD two-clause licence below.                        *)
@@ -26,12 +28,13 @@
 (*                                                                          *)
 (*  All rights reserved.                                                    *)
 (*                                                                          *)
-(*  This work was partially supported by EPSRC grant EP/K008528/1 REMS:     *)
-(*  Rigorous Engineering for Mainstream Systems, an ARM iCASE award, EPSRC  *)
-(*  IAA KTF funding, and donations from Arm. This project has received      *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
 (*  funding from the European Research Council (ERC) under the European     *)
-(*  Union's Horizon 2020 research and innovation programme (grant agreement *)
-(*  No 789108, ELVER).                                                      *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
 (*                                                                          *)
 (*  This software was developed by SRI International and the University of  *)
 (*  Cambridge Computer Laboratory (Department of Computer Science and       *)
@@ -39,70 +42,33 @@
 (*  and FA8750-10-C-0237 ("CTSRD").                                         *)
 (*                                                                          *)
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
-(* ************************************************************************ *)
+(****************************************************************************)
 
-(** * Information from type annotations
+(** This module provides a parallel map function that uses OCaml 5 Effect handlers to provide a limited form of
+    parallelism.
 
-Sail annotates terms with custom type annotation data, which we
-don't have access to here. Instead whenever we need to access
-information from these annotations, we use a functor parameterised by
-the signature [S], which provides the methods we need.
+    Functions called underneath [map] or [toplevel_handler] can use the functions in the [ParUnix] module to open
+    subprocesses which will, in the case of [map], will be ran in parallel as the [map] implementation continues to
+    apply the provided function to subsequent elements of the list (which may themselves invoke subprocesses, up to the
+    [parallism] limit, at which point the map function will wait).
 
-This file is not intended to be imported unqualified. Other modules
-can import the [Types] submodule to use those inductives unqualified
-however. *)
+    The [toplevel_handler] does not provide any parallism, but is instead wrapped around the main function as a global
+    handler to catch any uses of the [ParUnix] functions that do not occur underneath a [map].
 
-From Stdlib Require Import Unicode.Utf8.
+    This is intended for parts of Sail that make heavy use of the SMT solver, because it allows us to do things like
+    e.g. process function bodies in parallel. *)
 
-From Sail Require Import Ast.
+(** When true, makes [map] behave exactly as [List.map]. Useful for debugging and testing, as it makes the output fully
+    deterministic. Default [false]. *)
+val opt_sequential : bool ref
 
-Module Types.
-  (** Type annotations are used to disambiguate identifiers in the Sail AST. *)
-  Inductive id_type : Set :=
-  | Local_variable : id_type
-  | Global_register : id_type
-  | Enum_member : id_type.
+module ParUnix : sig
+  val open_process_full : string -> string Array.t -> string option -> Unix.process_status * string * string
+end
 
-  (** Type annotations determine how vector concatentation patterns
-  << x @ y >> in Sail are split apart. *)
-  Inductive vector_concat_split : Set :=
-  | No_split : vector_concat_split
-  | Split : nat → vector_concat_split.
-End Types.
+(** Always returns a value greater than or equal to 1. *)
+val recommended_parallelism : unit -> int
 
-(** The signature contains the following functions:
+val map : parallelism:int -> ('a -> 'b) -> 'a list -> 'b list
 
-- [get_type]. Currently only used for [E_undefined]. It would be nice
-  to remove this.
-
-- [get_id_type]. See [id_type].
-
-- [get_split]. See [vector_concat_split].
-
-- [is_bitvector]. The bitvector syntax in Sail is overloaded between
-  bitvectors and generic vectors, so we use the typing information to
-  distinguish the two.
-
-- [fallthrough]. When evaluating try expressions, we need a
-  type-annotated expression which is essentially just
-  << exn => throw exn >> but we don't have the type-system in Rocq,
-  so we get such an expression from this module. This is a little ugly,
-  so it would be good to re-define the semantics in a way that avoids
-  needing this.
-*)
-
-Module Type S.
-  Import Types.
-
-  Parameter t : Set.
-
-  Parameter get_type : t → typ.
-
-  Parameter get_id_type : t → id → id_type.
-
-  Parameter get_split : t → vector_concat_split.
-
-  Parameter is_bitvector : t → bool.
-
-  Parameter fallthrough : unit → Ast.pexp t.
-End S.
+val toplevel_handler : (unit -> unit) -> unit

--- a/src/lib/parmap.par.ml
+++ b/src/lib/parmap.par.ml
@@ -1,0 +1,155 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2026                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Effect
+open Effect.Deep
+
+let opt_sequential = ref false
+
+type channels = in_channel * out_channel * in_channel
+
+type open_result = Unix.process_status * string * string
+
+type _ Effect.t += Open_process_full : (string * string Array.t * string option) -> open_result t
+
+module ParUnix = struct
+  let open_process_full cmd env to_stdin = perform (Open_process_full (cmd, env, to_stdin))
+end
+
+let recommended_parallelism () = Domain.recommended_domain_count ()
+
+let read_all ch =
+  let buf = Buffer.create 4096 in
+  let chunk = Bytes.create 4096 in
+  ( try
+      while true do
+        let n = input ch chunk 0 4096 in
+        if n = 0 then raise End_of_file;
+        Buffer.add_subbytes buf chunk 0 n
+      done
+    with End_of_file -> ()
+  );
+  Buffer.contents buf
+
+let parmap (type a b) ~parallelism f (xs : a list) : b list =
+  let xs = Array.of_list xs in
+  let len = Array.length xs in
+  let tmp : b option Array.t = Array.make len None in
+  let waiting : (int * int * channels * (open_result, unit) continuation) Queue.t = Queue.create () in
+  let next = ref 0 in
+  let run i action =
+    match action () with
+    | effect Open_process_full (cmd, env, to_stdin), cont ->
+        let ((_, stdin, _) as channels) = Unix.open_process_full cmd env in
+        (match to_stdin with None -> () | Some str -> output_string stdin str);
+        let pid = Unix.process_full_pid channels in
+        close_out stdin;
+        Queue.add (i, pid, channels, cont) waiting
+    | y -> tmp.(i) <- Some y
+  in
+  let rec go () =
+    if not (!next = len && Queue.is_empty waiting) then (
+      (* Find any waiting task which has finished, removing it from the queue. *)
+      let ready =
+        let pending = Queue.length waiting in
+        let rec scan k =
+          if k = 0 then None
+          else (
+            let i, pid, channels, cont = Queue.pop waiting in
+            let res, status = Unix.waitpid [Unix.WNOHANG] pid in
+            if res = 0 then (
+              Queue.add (i, pid, channels, cont) waiting;
+              scan (k - 1)
+            )
+            else (
+              let out_chan, _, err_chan = channels in
+              let out_str = read_all out_chan in
+              let err_str = read_all err_chan in
+              close_in out_chan;
+              close_in err_chan;
+              Some ((status, out_str, err_str), cont)
+            )
+          )
+        in
+        scan pending
+      in
+      ( match ready with
+      | Some (result, cont) -> continue cont result
+      | None ->
+          if Queue.length waiting >= parallelism then ()
+          else (
+            let i = !next in
+            if i = len then ()
+            else (
+              incr next;
+              run i (fun () -> f xs.(i))
+            )
+          )
+      );
+      go ()
+    )
+  in
+  go ();
+  Option.get (Util.option_all (Array.to_list tmp))
+
+let map ~parallelism f xs = if !opt_sequential then List.map f xs else parmap ~parallelism f xs
+
+let run_process cmd env to_stdin =
+  let out_chan, in_chan, err_chan = Unix.open_process_full cmd env in
+  (match to_stdin with None -> () | Some str -> output_string in_chan str);
+  close_out in_chan;
+  let stdout_str = read_all out_chan in
+  let stderr_str = read_all err_chan in
+  let status = Unix.close_process_full (out_chan, in_chan, err_chan) in
+  (status, stdout_str, stderr_str)
+
+let toplevel_handler f =
+  let rec run action =
+    match action () with
+    | effect Open_process_full (cmd, env, to_stdin), cont -> run (fun () -> continue cont (run_process cmd env to_stdin))
+    | () -> ()
+  in
+  run f

--- a/src/lib/parmap.seq.ml
+++ b/src/lib/parmap.seq.ml
@@ -1,4 +1,6 @@
-(* ************************************************************************ *)
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
 (*  Sail and the Sail architecture models here, comprising all files and    *)
 (*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
 (*  are subject to the BSD two-clause licence below.                        *)
@@ -26,12 +28,13 @@
 (*                                                                          *)
 (*  All rights reserved.                                                    *)
 (*                                                                          *)
-(*  This work was partially supported by EPSRC grant EP/K008528/1 REMS:     *)
-(*  Rigorous Engineering for Mainstream Systems, an ARM iCASE award, EPSRC  *)
-(*  IAA KTF funding, and donations from Arm. This project has received      *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
 (*  funding from the European Research Council (ERC) under the European     *)
-(*  Union's Horizon 2020 research and innovation programme (grant agreement *)
-(*  No 789108, ELVER).                                                      *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
 (*                                                                          *)
 (*  This software was developed by SRI International and the University of  *)
 (*  Cambridge Computer Laboratory (Department of Computer Science and       *)
@@ -39,70 +42,38 @@
 (*  and FA8750-10-C-0237 ("CTSRD").                                         *)
 (*                                                                          *)
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
-(* ************************************************************************ *)
+(****************************************************************************)
 
-(** * Information from type annotations
+let opt_sequential = ref false
 
-Sail annotates terms with custom type annotation data, which we
-don't have access to here. Instead whenever we need to access
-information from these annotations, we use a functor parameterised by
-the signature [S], which provides the methods we need.
+let read_all ch =
+  let buf = Buffer.create 4096 in
+  let chunk = Bytes.create 4096 in
+  ( try
+      while true do
+        let n = input ch chunk 0 4096 in
+        if n = 0 then raise End_of_file;
+        Buffer.add_subbytes buf chunk 0 n
+      done
+    with End_of_file -> ()
+  );
+  Buffer.contents buf
 
-This file is not intended to be imported unqualified. Other modules
-can import the [Types] submodule to use those inductives unqualified
-however. *)
+let run_process cmd env to_stdin =
+  let out_chan, in_chan, err_chan = Unix.open_process_full cmd env in
+  (match to_stdin with None -> () | Some str -> output_string in_chan str);
+  close_out in_chan;
+  let stdout_str = read_all out_chan in
+  let stderr_str = read_all err_chan in
+  let status = Unix.close_process_full (out_chan, in_chan, err_chan) in
+  (status, stdout_str, stderr_str)
 
-From Stdlib Require Import Unicode.Utf8.
+module ParUnix = struct
+  let open_process_full cmd env to_stdin = run_process cmd env to_stdin
+end
 
-From Sail Require Import Ast.
+let recommended_parallelism () = 1
 
-Module Types.
-  (** Type annotations are used to disambiguate identifiers in the Sail AST. *)
-  Inductive id_type : Set :=
-  | Local_variable : id_type
-  | Global_register : id_type
-  | Enum_member : id_type.
+let map ~parallelism:_ f xs = List.map f xs
 
-  (** Type annotations determine how vector concatentation patterns
-  << x @ y >> in Sail are split apart. *)
-  Inductive vector_concat_split : Set :=
-  | No_split : vector_concat_split
-  | Split : nat → vector_concat_split.
-End Types.
-
-(** The signature contains the following functions:
-
-- [get_type]. Currently only used for [E_undefined]. It would be nice
-  to remove this.
-
-- [get_id_type]. See [id_type].
-
-- [get_split]. See [vector_concat_split].
-
-- [is_bitvector]. The bitvector syntax in Sail is overloaded between
-  bitvectors and generic vectors, so we use the typing information to
-  distinguish the two.
-
-- [fallthrough]. When evaluating try expressions, we need a
-  type-annotated expression which is essentially just
-  << exn => throw exn >> but we don't have the type-system in Rocq,
-  so we get such an expression from this module. This is a little ugly,
-  so it would be good to re-define the semantics in a way that avoids
-  needing this.
-*)
-
-Module Type S.
-  Import Types.
-
-  Parameter t : Set.
-
-  Parameter get_type : t → typ.
-
-  Parameter get_id_type : t → id → id_type.
-
-  Parameter get_split : t → vector_concat_split.
-
-  Parameter is_bitvector : t → bool.
-
-  Parameter fallthrough : unit → Ast.pexp t.
-End S.
+let toplevel_handler f = f ()

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -5554,17 +5554,15 @@ and check_defs : Env.t -> untyped_def list -> typed_def list * Env.t =
   let total = List.length defs in
   check_defs_progress check_def 1 total env defs
 
-let check : Env.t -> untyped_ast -> typed_ast * Env.t =
- fun env ast ->
-  let total = List.length ast.defs in
-  let defs, env = check_defs_progress check_def 1 total env ast.defs in
-  ({ ast with defs }, env)
-
-let check_lazy : Env.t -> untyped_ast -> typed_lazy_ast * Env.t =
- fun env ast ->
+let check_lazy env (ast : untyped_ast) : typed_lazy_ast * Env.t =
   let total = List.length ast.defs in
   let defs, env = check_defs_progress check_def_lazy 1 total env ast.defs in
-  ({ lazy_defs = defs; comments = ast.comments }, Env.open_all_modules env)
+  ({ lazy_defs = defs; comments = ast.comments }, env)
+
+let check env (ast : untyped_ast) : typed_ast * Env.t =
+  let lazy_ast, env = check_lazy env ast in
+  let defs = Parmap.map ~parallelism:(Parmap.recommended_parallelism ()) force_lazy_def lazy_ast.lazy_defs in
+  ({ defs; comments = lazy_ast.comments }, env)
 
 let rec check_with_envs : Env.t -> untyped_def list -> (typed_def list * Env.t) list =
  fun env defs ->

--- a/src/rocq/lib/Semantics.v
+++ b/src/rocq/lib/Semantics.v
@@ -1993,7 +1993,7 @@ Module Make (Tannot : TypeAnnot.S).
         | _ =>
             x' ← catch (step x);
             match x' with
-            | Caught exn => wrap (E_match (E_aux (E_internal_value exn) annot) (arms ++ [Tannot.fallthrough]))
+            | Caught exn => wrap (E_match (E_aux (E_internal_value exn) annot) (arms ++ [Tannot.fallthrough ()]))
             | Continue x'' => wrap (E_try x'' arms)
             end
         end

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -456,7 +456,7 @@ def match_early_return_loop (x : E) : SailM E := SailME.run do
   | .C => writeReg r_C A
   readReg r_B
 
-/-- Type quantifiers: k_ex3009_ : Bool -/
+/-- Type quantifiers: k_ex2748_ : Bool -/
 def ite_early_return (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
@@ -467,7 +467,7 @@ def ite_early_return (x : Bool) : SailM E := SailME.run do
     else readReg r_B ) : SailME E E )
   readReg r_B
 
-/-- Type quantifiers: k_ex3011_ : Bool -/
+/-- Type quantifiers: k_ex2749_ : Bool -/
 def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
   let loop_i_lower := 0
   let loop_i_upper := 10
@@ -486,7 +486,7 @@ def ite_early_return_inloop (x : Bool) : SailM E := SailME.run do
   (pure loop_vars)
   readReg r_B
 
-/-- Type quantifiers: k_ex3015_ : Bool -/
+/-- Type quantifiers: k_ex2750_ : Bool -/
 def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
   if (x : Bool)
   then
@@ -506,7 +506,7 @@ def ite_early_return_loop (x : Bool) : SailM E := SailME.run do
 def unit_type (x : E) : SailM Unit := do
   writeReg r_A x
 
-/-- Type quantifiers: k_ex3019_ : Bool -/
+/-- Type quantifiers: k_ex2751_ : Bool -/
 def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do
@@ -518,7 +518,7 @@ def ite_early_return_seq (x : Bool) : SailM E := SailME.run do
     else readReg r_B ) : SailME E E )
   readReg r_B
 
-/-- Type quantifiers: k_ex3021_ : Bool -/
+/-- Type quantifiers: k_ex2752_ : Bool -/
 def ite_early_return_exit (x : Bool) : SailM E := SailME.run do
   writeReg r_A (← readReg r_C)
   let y ← (( do

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -158,13 +158,13 @@ def concat_str_bits (str : String) (x : (BitVec k_n)) : String :=
 def concat_str_dec (str : String) (x : Int) : String :=
   (HAppend.hAppend str (Int.repr x))
 
-/-- Type quantifiers: k_ex937_ : Bool -/
+/-- Type quantifiers: k_ex883_ : Bool -/
 def test_exit (b : Bool) : SailM Unit := do
   if (b : Bool)
   then throw Error.Exit
   else (pure ())
 
-/-- Type quantifiers: k_ex939_ : Bool -/
+/-- Type quantifiers: k_ex884_ : Bool -/
 def test_assert (b : Bool) : SailM (BitVec 1) := do
   assert b "b is false"
   (pure 1#1)

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -157,7 +157,7 @@ def EXTZ {m : _} (v : (BitVec k_n)) : (BitVec m) :=
 def foo (x : (BitVec 8)) : (BitVec 16) :=
   (EXTZ (m := 16) x)
 
-/-- Type quantifiers: k_ex1005_ : Bool, n : Nat, n ≥ 0 -/
+/-- Type quantifiers: k_ex951_ : Bool, n : Nat, n ≥ 0 -/
 def slice_mask2 {n : _} (i : (BitVec n)) (l : (BitVec n)) (b : Bool) : (BitVec n) :=
   if (b : Bool)
   then i

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -189,7 +189,7 @@ def undefined_My_struct (_ : Unit) : SailM My_struct := do
   (pure { field1 := ← (undefined_int ())
           field2 := ← (undefined_bitvector 1) })
 
-/-- Type quantifiers: k_ex1200_ : Bool -/
+/-- Type quantifiers: k_ex1137_ : Bool -/
 def test_reg_if_struct (x : My_struct) (b : Bool) : SailM My_struct := do
   let y ← do
     (pure { x with field1 := ← if (b : Bool)

--- a/test/lean/run_tests.py
+++ b/test/lean/run_tests.py
@@ -102,6 +102,7 @@ def test_lean(subdir: str, skip_list = None, runnable: bool = False):
                     '--splice',
                     'rocq-print.splice',
                     '--strict-bitvector',
+                    '--dsequential', # Lean output includes type variables in comments, so we need this for consistent output
                 ] if runnable else [ ]
                 if not runnable:
                     extra_flags.append('--lean-matchbv')

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -191,7 +191,7 @@ def measure2 (x : E) : Int :=
   | .B => 5
   | .C => 1
 
-/-- Type quantifiers: k_ex1014_ : Bool -/
+/-- Type quantifiers: k_ex951_ : Bool -/
 def enabled2 (b : Bool) (e : E) : Bool :=
   match e with
   | .A => (enabled2 b B)

--- a/test/oneoff/no_z3/test.sail
+++ b/test/oneoff/no_z3/test.sail
@@ -1,0 +1,5 @@
+default Order dec
+
+val foo : forall 'n, 'n >= 16. bitvector('n) -> unit
+
+let _ = foo(0x0)

--- a/test/oneoff/no_z3/test.sh
+++ b/test/oneoff/no_z3/test.sh
@@ -6,5 +6,5 @@ rm -f no_z3.result
 SAIL="$(which sail)"
 GREP="$(which grep)"
 export PATH=""
-$SAIL --version 2> no_z3.result || true
+$SAIL test.sail 2> no_z3.result || true
 $GREP "SMT solver returned unexpected status" no_z3.result

--- a/test/typecheck/pass/bool_constraint/v1.expect
+++ b/test/typecheck/pass/bool_constraint/v1.expect
@@ -9,13 +9,13 @@ All external bindings should be marked as either pure or impure
 12[96m |[0m  if b then n else 4
   [91m |[0m                   [91m^[0m
   [91m |[0m int(4) is not a subtype of {('m : Int), (('b & 'm == 'n) | (not('b) & 'm == 3)). int('m)}
-  [91m |[0m as (('b & 'ex180 == 'n) | (not('b) & 'ex180 == 3)) could not be proven
+  [91m |[0m as (('b & 'ex198 == 'n) | (not('b) & 'ex198 == 3)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex180:
+  [91m |[0m type variable 'ex198:
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:9.25-73:
   [91m |[0m 9[96m |[0m  (bool('b), int('n)) -> {'m, 'b & 'm == 'n | not('b) & 'm == 3. int('m)}
   [91m |[0m  [92m |[0m                         [92m^----------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/bool_constraint/v1.sail[0m:12.19-20:
   [91m |[0m 12[96m |[0m  if b then n else 4
   [91m |[0m   [93m |[0m                   [93m^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 4 == 'ex180
+  [91m |[0m   [93m |[0m has constraint: 4 == 'ex198

--- a/test/typecheck/pass/existential_ast/v1.expect
+++ b/test/typecheck/pass/existential_ast/v1.expect
@@ -7,5 +7,5 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 [93mType error[0m:
 [96mpass/existential_ast/v1.sail[0m:46.7-21:
 46[96m |[0m  Some(Ctor2(y, x, c))
-  [91m |[0m       [91m^------------^[0m [91mchecking function argument has type (range(0, 31), int('ex198#), bitvector(4))[0m
+  [91m |[0m       [91m^------------^[0m [91mchecking function argument has type (range(0, 31), int('ex146#), bitvector(4))[0m
   [91m |[0m range(0, 31) is not contained within range(0, 31)

--- a/test/typecheck/pass/existential_ast/v2.expect
+++ b/test/typecheck/pass/existential_ast/v2.expect
@@ -7,5 +7,5 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 [93mType error[0m:
 [96mpass/existential_ast/v2.sail[0m:39.7-21:
 39[96m |[0m  Some(Ctor2(y, x, c))
-  [91m |[0m       [91m^------------^[0m [91mchecking function argument has type (range(0, 30), int('ex198#), bitvector(4))[0m
+  [91m |[0m       [91m^------------^[0m [91mchecking function argument has type (range(0, 30), int('ex146#), bitvector(4))[0m
   [91m |[0m range(0, 30) is not contained within range(0, 30)

--- a/test/typecheck/pass/existential_ast/v3.expect
+++ b/test/typecheck/pass/existential_ast/v3.expect
@@ -9,4 +9,4 @@ Old set syntax, {|1, 2, 3|} can now be written as {1, 2, 3}.
 26[96m |[0m  Some(Ctor1(a, x, c))
   [91m |[0m       [91m^------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor1
-  [91m |[0m [94m*[0m 'ex256# in {32, 64}
+  [91m |[0m [94m*[0m 'ex204# in {32, 64}

--- a/test/typecheck/pass/existential_ast3/v1.expect
+++ b/test/typecheck/pass/existential_ast3/v1.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v1.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(33), int('ex221)) is not a subtype of (int('ex216), int('ex217))
+  [91m |[0m (int(33), int('ex169)) is not a subtype of (int('ex164), int('ex165))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex216:
+  [91m |[0m type variable 'ex164:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex217:
+  [91m |[0m type variable 'ex165:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex221:
+  [91m |[0m type variable 'ex169:
   [91m |[0m [96mpass/existential_ast3/v1.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (33, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v2.expect
+++ b/test/typecheck/pass/existential_ast3/v2.expect
@@ -2,10 +2,10 @@
 [96mpass/existential_ast3/v2.sail[0m:17.48-65:
 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m                                                [91m^---------------^[0m
-  [91m |[0m (int(31), int('ex221)) is not a subtype of (int('ex216), int('ex217))
+  [91m |[0m (int(31), int('ex169)) is not a subtype of (int('ex164), int('ex165))
   [91m |[0m as false could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex216:
+  [91m |[0m type variable 'ex164:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.23-25:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                       [92m^^[0m [92mderived from here[0m
@@ -13,7 +13,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex217:
+  [91m |[0m type variable 'ex165:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:16.26-28:
   [91m |[0m 16[96m |[0m  let (datasize, n) : {'d 'n, datasize('d) & 0 <= 'n < 'd. (int('d), int('n))} =
   [91m |[0m   [92m |[0m                          [92m^^[0m [92mderived from here[0m
@@ -21,7 +21,7 @@
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m
   [91m |[0m 
-  [91m |[0m type variable 'ex221:
+  [91m |[0m type variable 'ex169:
   [91m |[0m [96mpass/existential_ast3/v2.sail[0m:17.48-65:
   [91m |[0m 17[96m |[0m    if b == 0b0 then (64, unsigned(b @ a)) else (31, unsigned(a));
   [91m |[0m   [93m |[0m                                                [93m^---------------^[0m [93mbound here[0m

--- a/test/typecheck/pass/existential_ast3/v3.expect
+++ b/test/typecheck/pass/existential_ast3/v3.expect
@@ -3,4 +3,4 @@
 25[96m |[0m    Some(Ctor(64, unsigned(0b0 @ b @ a)))
   [91m |[0m         [91m^-----------------------------^[0m [91mchecking function argument has type ast[0m
   [91m |[0m Could not resolve quantifiers for Ctor
-  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex253# & 'ex253# < 64))
+  [91m |[0m [94m*[0m (64 in {32, 64} & (0 <= 'ex201# & 'ex201# < 64))

--- a/test/typecheck/pass/existential_ast3/v4.expect
+++ b/test/typecheck/pass/existential_ast3/v4.expect
@@ -3,13 +3,13 @@
 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m                  [91m^^[0m
   [91m |[0m int(64) is not a subtype of {('d : Int), (('is_64 & 'd == 63) | (not('is_64) & 'd == 32)). int('d)}
-  [91m |[0m as (('is_64 & 'ex265 == 63) | (not('is_64) & 'ex265 == 32)) could not be proven
+  [91m |[0m as (('is_64 & 'ex213 == 63) | (not('is_64) & 'ex213 == 32)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex265:
+  [91m |[0m type variable 'ex213:
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:35.18-79:
   [91m |[0m 35[96m |[0m  let 'datasize : {'d, ('is_64 & 'd == 63) | (not('is_64) & 'd == 32). int('d)} =
   [91m |[0m   [92m |[0m                  [92m^-----------------------------------------------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v4.sail[0m:36.18-20:
   [91m |[0m 36[96m |[0m    if is_64 then 64 else 32;
   [91m |[0m   [93m |[0m                  [93m^^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: 64 == 'ex265
+  [91m |[0m   [93m |[0m has constraint: 64 == 'ex213

--- a/test/typecheck/pass/existential_ast3/v5.expect
+++ b/test/typecheck/pass/existential_ast3/v5.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m                                                  [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 2))
-  [91m |[0m as (0 <= 'ex273 & 'ex273 <= ('datasize - 2)) could not be proven
+  [91m |[0m as (0 <= 'ex221 & 'ex221 <= ('datasize - 2)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex273:
+  [91m |[0m type variable 'ex221:
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v5.sail[0m:37.50-65:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 2) = if is_64 then unsigned(b @ a) else unsigned(a);
   [91m |[0m   [93m |[0m                                                  [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex273 & 'ex273 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex221 & 'ex221 <= 63)

--- a/test/typecheck/pass/existential_ast3/v6.expect
+++ b/test/typecheck/pass/existential_ast3/v6.expect
@@ -3,13 +3,13 @@
 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m                                                                       [91m^-------------^[0m
   [91m |[0m range(0, 63) is not a subtype of range(0, ('datasize - 1))
-  [91m |[0m as (0 <= 'ex279 & 'ex279 <= ('datasize - 1)) could not be proven
+  [91m |[0m as (0 <= 'ex227 & 'ex227 <= ('datasize - 1)) could not be proven
   [91m |[0m 
-  [91m |[0m type variable 'ex279:
+  [91m |[0m type variable 'ex227:
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.10-33:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [92m |[0m          [92m^---------------------^[0m [92mderived from here[0m
   [91m |[0m [96mpass/existential_ast3/v6.sail[0m:37.71-86:
   [91m |[0m 37[96m |[0m  let n : range(0, 'datasize - 1) = if is_64 then unsigned(b @ a) else unsigned(b @ a);
   [91m |[0m   [93m |[0m                                                                       [93m^-------------^[0m [93mbound here[0m
-  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex279 & 'ex279 <= 63)
+  [91m |[0m   [93m |[0m has constraint: (0 <= 'ex227 & 'ex227 <= 63)

--- a/test/typecheck/pass/reg_32_64/v3.expect
+++ b/test/typecheck/pass/reg_32_64/v3.expect
@@ -17,5 +17,5 @@ Explicit effect annotations are deprecated. They are no longer used and can be r
   [91m |[0m [94m*[0m sub_int
   [91m |[0m   [96mpass/reg_32_64/v3.sail[0m:29.15-17:
   [91m |[0m   29[96m |[0m  reg_deref(R)['d - 1 .. 0]
-  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex13#)[0m
+  [91m |[0m     [91m |[0m               [91m^^[0m [91mchecking function argument has type int('ex9#)[0m
   [91m |[0m     [91m |[0m Cannot re-write sizeof('d)

--- a/test/typecheck/run_tests.py
+++ b/test/typecheck/run_tests.py
@@ -45,7 +45,7 @@ def test_pass():
                 for variantname in os.listdir(variantdir) if os.path.isdir(variantdir) else []:
                     if re.match('.+\.sail$', variantname):
                         variantbasename = os.path.splitext(os.path.basename(variantname))[0]
-                        step('\'{}\' --no-memo-z3 --strict-bitvector pass/{}/{} 2> pass/{}/{}.error'.format(sail, basename, variantname, basename, variantbasename), expected_status = 1)
+                        step('\'{}\' --no-memo-z3 --dsequential --no-memo-z3 --strict-bitvector pass/{}/{} 2> pass/{}/{}.error'.format(sail, basename, variantname, basename, variantbasename), expected_status = 1)
                         step('diff pass/{}/{}.error pass/{}/{}.expect'.format(basename, variantbasename, basename, variantbasename))
                         step('rm pass/{}/{}.error'.format(basename, variantbasename))
                         i = i + 1
@@ -64,7 +64,7 @@ def test_projects():
             tests[filename] = os.fork()
             if tests[filename] == 0:
                 if filename.startswith('fail'):
-                    step('\'{}\' --no-memo-z3 --strict-bitvector project/{} --all-modules 2> project/{}.error'.format(sail, filename, basename), expected_status = 1)
+                    step('\'{}\' --no-memo-z3 --dsequential --strict-bitvector project/{} --all-modules 2> project/{}.error'.format(sail, filename, basename), expected_status = 1)
                     step('diff project/{}.error project/{}.expect'.format(basename, basename))
                     step('rm project/{}.error'.format(basename))
                 else:
@@ -83,7 +83,7 @@ def test_fail():
             basename = os.path.splitext(os.path.basename(filename))[0]
             tests[filename] = os.fork()
             if tests[filename] == 0:
-                step('\'{}\' --no-memo-z3 --strict-bitvector fail/{} 2> fail/{}.error'.format(sail, filename, basename), expected_status = 1)
+                step('\'{}\' --no-memo-z3 --dsequential --strict-bitvector fail/{} 2> fail/{}.error'.format(sail, filename, basename), expected_status = 1)
                 step('diff fail/{}.error fail/{}.expect'.format(basename, basename))
                 step('rm fail/{}.error'.format(basename))
                 print_ok(filename)

--- a/test/typecheck/update_errors.sh
+++ b/test/typecheck/update_errors.sh
@@ -9,11 +9,11 @@ do
     shopt -s nullglob;
     for file in $DIR/pass/${i%.sail}/*.sail;
     do
-        $SAIL --no-memo-z3 --strict-bitvector pass/${i%.sail}/$(basename $file) 2> ${file%.sail}.expect || true;
+        $SAIL --dsequential --no-memo-z3 --strict-bitvector pass/${i%.sail}/$(basename $file) 2> ${file%.sail}.expect || true;
     done
 done
 
 for file in $DIR/fail/*.sail;
 do
-    $SAIL --no-memo-z3 --strict-bitvector fail/$(basename $file) 2> ${file%.sail}.expect || true;
+    $SAIL --dsequential --no-memo-z3 --strict-bitvector fail/$(basename $file) 2> ${file%.sail}.expect || true;
 done


### PR DESCRIPTION
Implement a parallel map using OCaml 5 effect handlers. There is no actually concurrency inside Sail, instead the effect handlers are used to allow the map implemention to move ahead to the next element of the list while a previous element being processed runs a subprocess like Z3.

This reduces up-front typechecking time when there is no SMT problem cache quite significantly.

Dune switches between the parallel implementation based on OCaml version, recruiting OCaml 5.3 for handlers and the `effect` keyword in match statements.