### PR TITLE
Remove LE_app constructor from L-expressions

### DIFF
--- a/src/lib/ast_util.ml
+++ b/src/lib/ast_util.ml
@@ -803,7 +803,6 @@ and map_lexp_annot f (LE_aux (lexp, annot)) = LE_aux (map_lexp_annot_aux f lexp,
 and map_lexp_annot_aux f = function
   | LE_id id -> LE_id id
   | LE_deref exp -> LE_deref (map_exp_annot f exp)
-  | LE_app (id, exps) -> LE_app (id, List.map (map_exp_annot f) exps)
   | LE_typ (typ, id) -> LE_typ (typ, id)
   | LE_tuple lexps -> LE_tuple (List.map (map_lexp_annot f) lexps)
   | LE_vector_concat lexps -> LE_vector_concat (List.map (map_lexp_annot f) lexps)
@@ -1251,7 +1250,6 @@ and string_of_lexp (LE_aux (lexp, _)) =
       string_of_lexp lexp ^ "[" ^ string_of_exp exp1 ^ " .. " ^ string_of_exp exp2 ^ "]"
   | LE_vector_concat lexps -> string_of_list " @ " string_of_lexp lexps
   | LE_field (lexp, id) -> string_of_lexp lexp ^ "." ^ string_of_id id
-  | LE_app (f, xs) -> string_of_id f ^ "(" ^ string_of_list ", " string_of_exp xs ^ ")"
 
 let rec string_of_index_range (BF_aux (ir, _)) =
   match ir with
@@ -1392,7 +1390,6 @@ let rec lexp_to_exp (LE_aux (lexp_aux, annot)) =
   | LE_vector (lexp, e) -> rewrap (vector_access ~loc:(fst annot) (lexp_to_exp lexp) e)
   | LE_vector_range (lexp, e1, e2) -> rewrap (vector_subrange ~loc:(fst annot) (lexp_to_exp lexp) e1 e2)
   | LE_field (lexp, id) -> rewrap (E_field (lexp_to_exp lexp, id))
-  | LE_app (id, exps) -> rewrap (E_app (id, exps))
   | LE_vector_concat [] -> rewrap (E_vector [])
   | LE_vector_concat (lexp :: lexps) ->
       List.fold_left (fun exp lexp -> rewrap (E_vector_append (exp, lexp_to_exp lexp))) (lexp_to_exp lexp) lexps
@@ -1715,7 +1712,6 @@ and subst_lexp id value (LE_aux (lexp_aux, annot)) =
     match lexp_aux with
     | LE_deref exp -> LE_deref (subst id value exp)
     | LE_id id' -> LE_id id'
-    | LE_app (f, exps) -> LE_app (f, List.map (subst id value) exps)
     | LE_typ (typ, id') -> LE_typ (typ, id')
     | LE_tuple lexps -> LE_tuple (List.map (subst_lexp id value) lexps)
     | LE_vector (lexp, exp) -> LE_vector (subst_lexp id value lexp, subst id value exp)
@@ -1915,7 +1911,6 @@ and locate_lexp : 'a. (l -> l) -> 'a lexp -> 'a lexp =
     match lexp_aux with
     | LE_id id -> LE_id (locate_id f id)
     | LE_deref exp -> LE_deref (locate f exp)
-    | LE_app (id, exps) -> LE_app (locate_id f id, List.map (locate f) exps)
     | LE_typ (typ, id) -> LE_typ (locate_typ f typ, locate_id f id)
     | LE_tuple lexps -> LE_tuple (List.map (locate_lexp f) lexps)
     | LE_vector_concat lexps -> LE_vector_concat (List.map (locate_lexp f) lexps)
@@ -2146,7 +2141,6 @@ struct
             option_chain (find_annot_lexp sl lexp) (option_mapm (find_annot_exp sl) [exp1; exp2])
         | LE_deref exp -> find_annot_exp sl exp
         | LE_tuple lexps -> option_mapm (find_annot_lexp sl) lexps
-        | LE_app (_, exps) -> option_mapm (find_annot_exp sl) exps
         | _ -> None
       in
       match result with None -> Some (l, annot) | _ -> result

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -192,7 +192,6 @@ let add_def_to_graph graph (DEF_aux (def, def_annot)) =
         | Enum _ -> graph := G.add_edge self (Constructor id) !graph
         | _ -> if IdSet.mem id (Env.get_toplevel_lets env) then graph := G.add_edge self (Letbind id) !graph else ()
       )
-    | LE_app (id, _) -> graph := G.add_edge self (Function id) !graph
     | LE_id id -> (
         match Env.lookup_id id env with
         | Register _ -> graph := G.add_edge self (Register id) !graph

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -578,7 +578,6 @@ let const_props target env ast =
       let re e = (LE_aux (e, annot), None) in
       match e with
       | LE_id id (* shouldn't end up substituting here *) | LE_typ (_, id) -> (le, Some id)
-      | LE_app (id, es) -> re (LE_app (id, List.map (fun e -> fst (const_prop_exp substs assigns e)) es)) (* or here *)
       | LE_tuple les -> re (LE_tuple (List.map (fun le -> fst (const_prop_lexp substs assigns le)) les))
       | LE_vector (le, e) ->
           re (LE_vector (fst (const_prop_lexp substs assigns le), fst (const_prop_exp substs assigns e)))

--- a/src/lib/extraction/AbsBitvector.ml
+++ b/src/lib/extraction/AbsBitvector.ml
@@ -145,9 +145,9 @@ module Dom =
           (gmap_empty Nat.eq_dec nat_countable))
         Big_int_Z.zero_big_int []))
 
-  (** val _UU03b1_ : bvn -> bvset **)
+  (** val abst : bvn -> bvset **)
 
-  let _UU03b1_ x =
+  let abst x =
     let len = x.bvn_n in
     (match bvn_to_bv len x with
      | Some x' ->
@@ -157,11 +157,6 @@ module Dom =
              (gmap_empty Nat.eq_dec nat_countable))
            (BinNat.N.to_nat len) (map Three.from_bool (bv_to_bits len x'))))
      | None -> bot)
-
-  (** val alpha : bvn -> bvset **)
-
-  let alpha =
-    _UU03b1_
 
   (** val lift_bitwise_gmap :
       (Three.ubit -> Three.ubit -> Three.ubit) -> (Big_int_Z.big_int,

--- a/src/lib/extraction/AbsBitvector.mli
+++ b/src/lib/extraction/AbsBitvector.mli
@@ -59,9 +59,7 @@ module Dom :
 
   val zwbv : bvset
 
-  val _UU03b1_ : bvn -> bvset
-
-  val alpha : bvn -> bvset
+  val abst : bvn -> bvset
 
   val lift_bitwise_gmap :
     (Three.ubit -> Three.ubit -> Three.ubit) -> (Big_int_Z.big_int,

--- a/src/lib/extraction/AbsValue.ml
+++ b/src/lib/extraction/AbsValue.ml
@@ -166,8 +166,8 @@ module Dom =
 
   let value_length = function
   | V_bitvector bv -> V_int (T.bits_length bv)
-  | V_vector vs -> V_int (DZ._UU03b1_ (Z.of_nat (length vs)))
-  | V_list vs -> V_int (DZ._UU03b1_ (Z.of_nat (length vs)))
+  | V_vector vs -> V_int (DZ.abst (Z.of_nat (length vs)))
+  | V_list vs -> V_int (DZ.abst (Z.of_nat (length vs)))
   | _ -> V_bot
 
   (** val mk_bitvector' : value list -> Dbv.t option **)
@@ -556,16 +556,16 @@ module Dom =
                 | _ -> false)
     | V_bot -> true
 
-  (** val _UU03b1_ : Ast.value -> value **)
+  (** val abst : Ast.value -> value **)
 
-  let rec _UU03b1_ = function
-  | Ast.V_bitvector bv -> V_bitvector (Dbv._UU03b1_ (Bit.Bits.to_bvn bv))
-  | Ast.V_vector xs -> V_vector (map _UU03b1_ xs)
-  | Ast.V_list xs -> V_list (map _UU03b1_ xs)
-  | Ast.V_int i -> V_int (DZ._UU03b1_ i)
+  let rec abst = function
+  | Ast.V_bitvector bv -> V_bitvector (Dbv.abst (Bit.Bits.to_bvn bv))
+  | Ast.V_vector xs -> V_vector (map abst xs)
+  | Ast.V_list xs -> V_list (map abst xs)
+  | Ast.V_int i -> V_int (DZ.abst i)
   | Ast.V_real q -> V_real (coq_Q2Qc q)
   | Ast.V_bool b -> V_bool b
-  | Ast.V_tuple xs -> V_tuple (map _UU03b1_ xs)
+  | Ast.V_tuple xs -> V_tuple (map abst xs)
   | Ast.V_unit -> V_unit
   | Ast.V_string str -> V_string str
   | Ast.V_ref id -> V_ref (Aux.unwrap id)
@@ -578,25 +578,20 @@ module Dom =
       (singletonM
         (map_singleton (gmap_partial_alter Aux.eq_eqdec Aux.id_aux_countable)
           (gmap_empty Aux.eq_eqdec Aux.id_aux_countable))
-        (Aux.unwrap id) (map _UU03b1_ xs))
+        (Aux.unwrap id) (map abst xs))
   | Ast.V_record fields ->
     V_record
       (Coq_list.foldl (fun m pat0 ->
         let (k, v) = pat0 in
         insert
           (map_insert (gmap_partial_alter Aux.eq_eqdec Aux.id_aux_countable))
-          (Aux.unwrap k) (_UU03b1_ v) m)
+          (Aux.unwrap k) (abst v) m)
         (empty (gmap_empty Aux.eq_eqdec Aux.id_aux_countable)) fields)
-
-  (** val alpha : Ast.value -> value **)
-
-  let alpha =
-    _UU03b1_
 
   (** val of_lit : lit -> value **)
 
   let of_lit l =
-    _UU03b1_ (value_of_lit l)
+    abst (value_of_lit l)
 
   (** val lookup_field : value -> id_aux -> value **)
 
@@ -710,7 +705,7 @@ module Dom =
     (** val match_bitvector_lit : bit list -> Dbv.t -> value match_result **)
 
     let match_bitvector_lit lit_bs bv =
-      let lit_bv = Dbv._UU03b1_ (Bit.Bits.to_bvn lit_bs) in
+      let lit_bv = Dbv.abst (Bit.Bits.to_bvn lit_bs) in
       if Dbv.leb lit_bv bv
       then if Dbv.leb bv lit_bv
            then simple_match
@@ -736,8 +731,8 @@ module Dom =
        | L_num n ->
          (match v with
           | V_int m ->
-            if DZ.leb (DZ._UU03b1_ n) m
-            then if DZ.leb m (DZ._UU03b1_ n)
+            if DZ.leb (DZ.abst n) m
+            then if DZ.leb m (DZ.abst n)
                  then simple_match
                  else MaybeMatched empty_bindings
             else Unmatched
@@ -954,7 +949,7 @@ module Dom =
     in
     let len = Z.succ max0 in
     let zeros0 = V_bitvector
-      (Dbv._UU03b1_ (Bit.Bits.to_bvn (repeat B0 (Z.to_nat len))))
+      (Dbv.abst (Bit.Bits.to_bvn (repeat B0 (Z.to_nat len))))
     in
     fold_left (fun bv pvalue ->
       let (y, m) = pvalue in

--- a/src/lib/extraction/AbsValue.mli
+++ b/src/lib/extraction/AbsValue.mli
@@ -125,9 +125,7 @@ module Dom :
 
   val leb : value -> value -> bool
 
-  val _UU03b1_ : Ast.value -> value
-
-  val alpha : Ast.value -> value
+  val abst : Ast.value -> value
 
   val of_lit : lit -> value
 

--- a/src/lib/extraction/Ast.ml
+++ b/src/lib/extraction/Ast.ml
@@ -277,7 +277,6 @@ and 'a exp =
 and 'a lexp_aux =
 | LE_id of id
 | LE_deref of 'a exp
-| LE_app of id * 'a exp list
 | LE_typ of typ * id
 | LE_tuple of 'a lexp list
 | LE_vector_concat of 'a lexp list

--- a/src/lib/extraction/Ast.mli
+++ b/src/lib/extraction/Ast.mli
@@ -277,7 +277,6 @@ and 'a exp =
 and 'a lexp_aux =
 | LE_id of id
 | LE_deref of 'a exp
-| LE_app of id * 'a exp list
 | LE_typ of typ * id
 | LE_tuple of 'a lexp list
 | LE_vector_concat of 'a lexp list

--- a/src/lib/extraction/AstInduction.ml
+++ b/src/lib/extraction/AstInduction.ml
@@ -2,7 +2,6 @@ open Ast
 open Datatypes
 open List0
 open ListDef
-open ListUtil
 
 (** val lexp_subexps : 'a1 lexp -> 'a1 exp list **)
 
@@ -10,7 +9,6 @@ let rec lexp_subexps = function
 | LE_aux (aux, _) ->
   (match aux with
    | LE_deref x -> x :: []
-   | LE_app (_, xs) -> xs
    | LE_tuple ls -> concat (map lexp_subexps ls)
    | LE_vector_concat ls -> concat (map lexp_subexps ls)
    | LE_vector (l0, x) -> app (lexp_subexps l0) (x :: [])
@@ -28,9 +26,6 @@ let rec update_lexp_subexps xs l = match l with
      (match xs with
       | [] -> (l, xs)
       | y :: ys -> ((LE_aux ((LE_deref y), annot)), ys))
-   | LE_app (id, args) ->
-     let (ys, zs) = take_drop (length args) xs in
-     ((LE_aux ((LE_app (id, ys)), annot)), zs)
    | LE_tuple ls ->
      let (ls0, xs0) =
        fold_left (fun acc l0 ->

--- a/src/lib/extraction/AstInduction.mli
+++ b/src/lib/extraction/AstInduction.mli
@@ -2,7 +2,6 @@ open Ast
 open Datatypes
 open List0
 open ListDef
-open ListUtil
 
 val lexp_subexps : 'a1 lexp -> 'a1 exp list
 

--- a/src/lib/extraction/Interval.ml
+++ b/src/lib/extraction/Interval.ml
@@ -132,15 +132,10 @@ module Dom =
          (&&) (low_leb (low e_UU2081_) (low e_UU2080_))
            (high_leb (high e_UU2080_) (high e_UU2081_)))
 
-  (** val _UU03b1_ : Big_int_Z.big_int -> interval **)
+  (** val abst : Big_int_Z.big_int -> interval **)
 
-  let _UU03b1_ n =
+  let abst n =
     Ends (Coq_exist ((Some n), (Some n)))
-
-  (** val alpha : Big_int_Z.big_int -> interval **)
-
-  let alpha =
-    _UU03b1_
 
   (** val concrete : interval -> Big_int_Z.big_int option **)
 

--- a/src/lib/extraction/Interval.mli
+++ b/src/lib/extraction/Interval.mli
@@ -43,9 +43,7 @@ module Dom :
 
   val leb : interval -> interval -> bool
 
-  val _UU03b1_ : Big_int_Z.big_int -> interval
-
-  val alpha : Big_int_Z.big_int -> interval
+  val abst : Big_int_Z.big_int -> interval
 
   val concrete : interval -> Big_int_Z.big_int option
 

--- a/src/lib/extraction/Lattice.ml
+++ b/src/lib/extraction/Lattice.ml
@@ -21,7 +21,7 @@ module DomainProperties =
 
   val leb : t -> t -> bool
 
-  val _UU03b1_ : C.t -> t
+  val abst : C.t -> t
  end) ->
  struct
  end
@@ -40,7 +40,7 @@ module type SAIL_INT =
 
   val leb : t -> t -> bool
 
-  val _UU03b1_ : Z.t -> t
+  val abst : Z.t -> t
 
   val lt : t -> t -> bool option
 
@@ -98,7 +98,7 @@ module type SAIL_BITS =
 
   val leb : t -> t -> bool
 
-  val _UU03b1_ : Bits.t -> t
+  val abst : Bits.t -> t
 
   val unknown_bit : t
 

--- a/src/lib/extraction/Lattice.mli
+++ b/src/lib/extraction/Lattice.mli
@@ -21,7 +21,7 @@ module DomainProperties :
 
   val leb : t -> t -> bool
 
-  val _UU03b1_ : C.t -> t
+  val abst : C.t -> t
  end) ->
  sig
  end
@@ -40,7 +40,7 @@ module type SAIL_INT =
 
   val leb : t -> t -> bool
 
-  val _UU03b1_ : Z.t -> t
+  val abst : Z.t -> t
 
   val lt : t -> t -> bool option
 
@@ -98,7 +98,7 @@ module type SAIL_BITS =
 
   val leb : t -> t -> bool
 
-  val _UU03b1_ : Bits.t -> t
+  val abst : Bits.t -> t
 
   val unknown_bit : t
 

--- a/src/lib/extraction/Semantics.ml
+++ b/src/lib/extraction/Semantics.ml
@@ -36,7 +36,6 @@ type place =
 | PL_field of place * id
 
 type destructure =
-| DL_app of id * value list
 | DL_tuple of destructure list
 | DL_vector_concat of (Types.vector_concat_split * destructure) list
 | DL_place of place
@@ -404,7 +403,6 @@ module Make =
 
   let rec destructuring_assignment annot0 d v =
     match d with
-    | DL_app (_, _) -> Monad.Runtime_type_error (fst annot0)
     | DL_tuple ds ->
       (match v with
        | V_tuple vs ->
@@ -486,9 +484,6 @@ module Make =
            | V_ref r -> Monad.pure (DL_place (PL_register r))
            | _ -> Monad.Runtime_type_error (fst annot0))
         | _ -> Monad.Runtime_type_error (fst annot0))
-     | LE_app (name, args) ->
-       let evaluated0 = all_evaluated args in
-       Monad.pure (DL_app (name, evaluated0))
      | LE_typ (_, var) ->
        (match Tannot.get_id_type (snd annot0) var with
         | Types.Local_variable ->

--- a/src/lib/extraction/Semantics.mli
+++ b/src/lib/extraction/Semantics.mli
@@ -31,7 +31,6 @@ type place =
 | PL_field of place * id
 
 type destructure =
-| DL_app of id * value list
 | DL_tuple of destructure list
 | DL_vector_concat of (Types.vector_concat_split * destructure) list
 | DL_place of place

--- a/src/lib/extraction/TransferBitvectorInterval.ml
+++ b/src/lib/extraction/TransferBitvectorInterval.ml
@@ -65,8 +65,8 @@ module Ops =
   (** val bits_unsigned_interval : Three.ubit list -> I.t **)
 
   let bits_unsigned_interval bits =
-    I.join (I._UU03b1_ (unsigned_lo bits Big_int_Z.unit_big_int))
-      (I._UU03b1_ (unsigned_hi bits Big_int_Z.unit_big_int))
+    I.join (I.abst (unsigned_lo bits Big_int_Z.unit_big_int))
+      (I.abst (unsigned_hi bits Big_int_Z.unit_big_int))
 
   (** val unsigned : B.t -> I.t **)
 
@@ -81,7 +81,7 @@ module Ops =
 
   let bits_signed_interval bits =
     match rev bits with
-    | [] -> I._UU03b1_ Big_int_Z.zero_big_int
+    | [] -> I.abst Big_int_Z.zero_big_int
     | sign :: lower_rev ->
       let lower = rev lower_rev in
       let lo = unsigned_lo lower Big_int_Z.unit_big_int in
@@ -91,10 +91,9 @@ module Ops =
           (Z.of_nat (length lower))
       in
       (match sign with
-       | Three.B0 -> I.join (I._UU03b1_ lo) (I._UU03b1_ hi)
-       | Three.B1 ->
-         I.join (I._UU03b1_ (Z.sub lo half)) (I._UU03b1_ (Z.sub hi half))
-       | Three.BU -> I.join (I._UU03b1_ (Z.sub lo half)) (I._UU03b1_ hi))
+       | Three.B0 -> I.join (I.abst lo) (I.abst hi)
+       | Three.B1 -> I.join (I.abst (Z.sub lo half)) (I.abst (Z.sub hi half))
+       | Three.BU -> I.join (I.abst (Z.sub lo half)) (I.abst hi))
 
   (** val signed : B.t -> I.t **)
 
@@ -107,13 +106,13 @@ module Ops =
   (** val zeros_nat : Big_int_Z.big_int -> B.t **)
 
   let zeros_nat n =
-    B._UU03b1_ { bvn_n = (BinNat.N.of_nat n); bvn_val =
+    B.abst { bvn_n = (BinNat.N.of_nat n); bvn_val =
       (bv_0 (BinNat.N.of_nat n)) }
 
   (** val ones_nat : Big_int_Z.big_int -> B.t **)
 
   let ones_nat n =
-    B._UU03b1_ { bvn_n = (BinNat.N.of_nat n); bvn_val =
+    B.abst { bvn_n = (BinNat.N.of_nat n); bvn_val =
       (bv_not (BinNat.N.of_nat n) (bv_0 (BinNat.N.of_nat n))) }
 
   (** val nonneg_range :
@@ -199,7 +198,7 @@ module Ops =
     let rev_bits = rev bits in
     let lo = Z.of_nat (count_leading_B0 rev_bits) in
     let hi = Z.of_nat (count_until_B1 rev_bits) in
-    I.join (I._UU03b1_ lo) (I._UU03b1_ hi)
+    I.join (I.abst lo) (I.abst hi)
 
   (** val count_leading_zeros : B.t -> I.t **)
 
@@ -213,8 +212,7 @@ module Ops =
 
   let bits_ctz_interval bits =
     let lo = Z.of_nat (count_leading_B0 bits) in
-    let hi = Z.of_nat (count_until_B1 bits) in
-    I.join (I._UU03b1_ lo) (I._UU03b1_ hi)
+    let hi = Z.of_nat (count_until_B1 bits) in I.join (I.abst lo) (I.abst hi)
 
   (** val count_trailing_zeros : B.t -> I.t **)
 
@@ -312,5 +310,5 @@ module Ops =
   | B.Top -> nonneg_top
   | B.Bvs m ->
     map_fold (fun _ -> gmap_fold Nat.eq_dec nat_countable) (fun w _ acc ->
-      I.join (I._UU03b1_ (Z.of_nat w)) acc) I.bot (let Coq_exist a = m in a)
+      I.join (I.abst (Z.of_nat w)) acc) I.bot (let Coq_exist a = m in a)
  end

--- a/src/lib/extraction/TransferBitvectorInterval.mli
+++ b/src/lib/extraction/TransferBitvectorInterval.mli
@@ -61,9 +61,7 @@ module B :
 
   val zwbv : bvset
 
-  val _UU03b1_ : bvn -> bvset
-
-  val alpha : bvn -> bvset
+  val abst : bvn -> bvset
 
   val lift_bitwise_gmap :
     (Three.ubit -> Three.ubit -> Three.ubit) -> (Big_int_Z.big_int,
@@ -158,9 +156,7 @@ module I :
 
   val leb : interval -> interval -> bool
 
-  val _UU03b1_ : Big_int_Z.big_int -> interval
-
-  val alpha : Big_int_Z.big_int -> interval
+  val abst : Big_int_Z.big_int -> interval
 
   val concrete : interval -> Big_int_Z.big_int option
 

--- a/src/lib/extraction/ZAst.ml
+++ b/src/lib/extraction/ZAst.ml
@@ -23,7 +23,6 @@ open Gmap
 type 'a zlexp_aux =
 | LZ_id of id
 | LZ_deref
-| LZ_app of id * Big_int_Z.big_int
 | LZ_typ of typ * id
 | LZ_tuple of 'a zlexp list
 | LZ_vector_concat of 'a zlexp list
@@ -40,7 +39,6 @@ let rec lexp_to_z = function
   (match aux with
    | LE_id id0 -> LZ_aux ((LZ_id id0), ann)
    | LE_deref _ -> LZ_aux (LZ_deref, ann)
-   | LE_app (id0, args) -> LZ_aux ((LZ_app (id0, (length args))), ann)
    | LE_typ (typ0, id0) -> LZ_aux ((LZ_typ (typ0, id0)), ann)
    | LE_tuple ls -> LZ_aux ((LZ_tuple (map lexp_to_z ls)), ann)
    | LE_vector_concat ls ->
@@ -61,9 +59,6 @@ let rec update_zlexp_subexps xs = function
      (match xs with
       | [] -> (None, xs)
       | y :: ys -> ((Some (LE_aux ((LE_deref y), annot0))), ys))
-   | LZ_app (id0, n) ->
-     let (ys, zs) = take_drop n xs in
-     ((Some (LE_aux ((LE_app (id0, ys)), annot0))), zs)
    | LZ_typ (typ0, id0) ->
      ((Some (LE_aux ((LE_typ (typ0, id0)), annot0))), xs)
    | LZ_tuple ls ->

--- a/src/lib/extraction/ZAst.mli
+++ b/src/lib/extraction/ZAst.mli
@@ -23,7 +23,6 @@ open Gmap
 type 'a zlexp_aux =
 | LZ_id of id
 | LZ_deref
-| LZ_app of id * Big_int_Z.big_int
 | LZ_typ of typ * id
 | LZ_tuple of 'a zlexp list
 | LZ_vector_concat of 'a zlexp list

--- a/src/lib/extraction/ZAst.mli
+++ b/src/lib/extraction/ZAst.mli
@@ -281,9 +281,7 @@ module Residual :
 
     val leb : value -> value -> bool
 
-    val _UU03b1_ : Ast.value -> value
-
-    val alpha : Ast.value -> value
+    val abst : Ast.value -> value
 
     val of_lit : lit -> value
 
@@ -585,9 +583,7 @@ module Make :
 
       val leb : value -> value -> bool
 
-      val _UU03b1_ : Ast.value -> value
-
-      val alpha : Ast.value -> value
+      val abst : Ast.value -> value
 
       val of_lit : lit -> value
 
@@ -843,9 +839,7 @@ module Make :
 
     val leb : value -> value -> bool
 
-    val _UU03b1_ : Ast.value -> value
-
-    val alpha : Ast.value -> value
+    val abst : Ast.value -> value
 
     val of_lit : lit -> value
 

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -1485,8 +1485,19 @@ let rec to_ast_exp ctx exp =
   | P.E_match (exp, pexps) -> wrap (E_match (to_ast_exp ctx exp, List.map (to_ast_case ctx) pexps))
   | P.E_try (exp, pexps) -> wrap (E_try (to_ast_exp ctx exp, List.map (to_ast_case ctx) pexps))
   | P.E_let (pat, bind, exp) -> wrap (E_let (to_ast_pat ctx pat, to_ast_exp ctx bind, to_ast_exp ctx exp))
-  | P.E_assign (lexp, exp) -> wrap (E_assign (to_ast_lexp ctx lexp, to_ast_exp ctx exp))
-  | P.E_var (lexp, exp1, exp2) -> wrap (E_var (to_ast_lexp ctx lexp, to_ast_exp ctx exp1, to_ast_exp ctx exp2))
+  | P.E_assign (lexp, exp) -> (
+      match to_ast_assign ctx lexp with
+      | Error (f, xs, lexp_l) ->
+          let exp = to_ast_exp ctx exp in
+          E_aux (E_app (f, xs @ [exp]), (l, add_attribute (gen_loc lexp_l) "setter" None empty_uannot))
+      | Ok lexp -> wrap (E_assign (lexp, to_ast_exp ctx exp))
+    )
+  | P.E_var (lexp, exp1, exp2) -> (
+      match to_ast_assign ctx lexp with
+      | Error (_, _, lexp_l) ->
+          raise (Reporting.err_general lexp_l "Setter function not allowed in 'var' variable declaration")
+      | Ok lexp -> wrap (E_var (lexp, to_ast_exp ctx exp1, to_ast_exp ctx exp2))
+    )
   | P.E_sizeof nexp -> wrap (E_sizeof (to_ast_nexp ctx nexp))
   | P.E_constraint nc -> wrap (E_constraint (to_ast_constraint ctx nc))
   | P.E_exit exp -> wrap (E_exit (to_ast_exp ctx exp))
@@ -1509,45 +1520,46 @@ and to_ast_measure ctx (P.Measure_aux (m, l)) : uannot in_place_loop_measure =
   let m = match m with P.Measure_none -> Measure_none | P.Measure_some exp -> Measure_some (to_ast_exp ctx exp) in
   Measure_aux (m, l)
 
+and to_ast_assign ctx exp =
+  let (P.E_aux (exp, l)) = parse_infix_exp ctx exp in
+  match exp with
+  | P.E_app (f, args) -> (
+      match List.map (to_ast_exp ctx) args with
+      | [E_aux (E_lit (L_aux (L_unit, _)), _)] -> Error (to_ast_id ctx f, [], l)
+      | [E_aux (E_tuple exps, _)] -> Error (to_ast_id ctx f, exps, l)
+      | args -> Error (to_ast_id ctx f, args, l)
+    )
+  | _ -> Ok (LE_aux (to_ast_lexp_aux ctx exp l, (l, empty_uannot)))
+
+and to_ast_lexp_aux ctx exp l =
+  match exp with
+  | P.E_id id -> LE_id (to_ast_id ctx id)
+  | P.E_deref exp -> LE_deref (to_ast_exp ctx exp)
+  | P.E_typ (typ, P.E_aux (P.E_id id, l')) -> LE_typ (to_ast_typ ctx typ, to_ast_id ctx id)
+  | P.E_tuple tups ->
+      let ltups = List.map (to_ast_lexp ctx) tups in
+      let is_ok_in_tup (LE_aux (le, (l, _))) =
+        match le with
+        | LE_id _ | LE_typ _ | LE_vector _ | LE_vector_concat _ | LE_field _ | LE_vector_range _ | LE_tuple _ -> ()
+        | LE_deref _ -> raise (Reporting.err_typ l "only identifiers, fields, and vectors may be set in a tuple")
+      in
+      List.iter is_ok_in_tup ltups;
+      LE_tuple ltups
+  | P.E_vector_append (exp1, exp2) -> LE_vector_concat (to_ast_lexp ctx exp1 :: to_ast_lexp_vector_concat ctx exp2)
+  | P.E_vector_access (vexp, exp) -> LE_vector (to_ast_lexp ctx vexp, to_ast_exp ctx exp)
+  | P.E_vector_subrange (vexp, exp1, exp2) ->
+      LE_vector_range (to_ast_lexp ctx vexp, to_ast_exp ctx exp1, to_ast_exp ctx exp2)
+  | P.E_field (fexp, id) -> LE_field (to_ast_lexp ctx fexp, to_ast_id ctx id)
+  | _ ->
+      raise
+        (Reporting.err_typ l
+           "Only identifiers, cast identifiers, vector accesses, vector slices, and fields can be on the lefthand side \
+            of an assignment"
+        )
+
 and to_ast_lexp ctx exp =
   let (P.E_aux (exp, l)) = parse_infix_exp ctx exp in
-  let lexp =
-    match exp with
-    | P.E_id id -> LE_id (to_ast_id ctx id)
-    | P.E_deref exp -> LE_deref (to_ast_exp ctx exp)
-    | P.E_typ (typ, P.E_aux (P.E_id id, l')) -> LE_typ (to_ast_typ ctx typ, to_ast_id ctx id)
-    | P.E_tuple tups ->
-        let ltups = List.map (to_ast_lexp ctx) tups in
-        let is_ok_in_tup (LE_aux (le, (l, _))) =
-          match le with
-          | LE_id _ | LE_typ _ | LE_vector _ | LE_vector_concat _ | LE_field _ | LE_vector_range _ | LE_tuple _ -> ()
-          | LE_app _ | LE_deref _ ->
-              raise (Reporting.err_typ l "only identifiers, fields, and vectors may be set in a tuple")
-        in
-        List.iter is_ok_in_tup ltups;
-        LE_tuple ltups
-    | P.E_app ((P.Id_aux (f, l') as f'), args) -> (
-        match f with
-        | P.Id id -> (
-            match List.map (to_ast_exp ctx) args with
-            | [E_aux (E_lit (L_aux (L_unit, _)), _)] -> LE_app (to_ast_id ctx f', [])
-            | [E_aux (E_tuple exps, _)] -> LE_app (to_ast_id ctx f', exps)
-            | args -> LE_app (to_ast_id ctx f', args)
-          )
-        | _ -> raise (Reporting.err_typ l' "memory call on lefthand side of assignment must begin with an id")
-      )
-    | P.E_vector_append (exp1, exp2) -> LE_vector_concat (to_ast_lexp ctx exp1 :: to_ast_lexp_vector_concat ctx exp2)
-    | P.E_vector_access (vexp, exp) -> LE_vector (to_ast_lexp ctx vexp, to_ast_exp ctx exp)
-    | P.E_vector_subrange (vexp, exp1, exp2) ->
-        LE_vector_range (to_ast_lexp ctx vexp, to_ast_exp ctx exp1, to_ast_exp ctx exp2)
-    | P.E_field (fexp, id) -> LE_field (to_ast_lexp ctx fexp, to_ast_id ctx id)
-    | _ ->
-        raise
-          (Reporting.err_typ l
-             "Only identifiers, cast identifiers, vector accesses, vector slices, and fields can be on the lefthand \
-              side of an assignment"
-          )
-  in
+  let lexp = to_ast_lexp_aux ctx exp l in
   LE_aux (lexp, (l, empty_uannot))
 
 and to_ast_lexp_vector_concat ctx (P.E_aux (exp_aux, l) as exp) =

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -131,7 +131,6 @@ let ids_in_exp exp =
       (pure_exp_alg IdSet.empty IdSet.union) with
       e_id = IdSet.singleton;
       le_id = IdSet.singleton;
-      le_app = (fun (id, s) -> List.fold_left IdSet.union (IdSet.singleton id) s);
       le_typ = (fun (_, id) -> IdSet.singleton id);
     }
     exp
@@ -1181,7 +1180,6 @@ let split_defs target all_errors (splits : split_req list) env ast =
         let re e = LE_aux (e, annot) in
         match e with
         | LE_id _ | LE_typ _ -> le
-        | LE_app (id, es) -> re (LE_app (id, List.map map_exp es))
         | LE_tuple les -> re (LE_tuple (List.map map_lexp les))
         | LE_vector (le, e) -> re (LE_vector (map_lexp le, map_exp e))
         | LE_vector_range (le, e1, e2) -> re (LE_vector_range (map_lexp le, map_exp e1, map_exp e2))
@@ -2528,9 +2526,6 @@ module Analysis = struct
     match lexp with
     | LE_id id | LE_typ (_, id) ->
         if IdSet.mem id env.referenced_vars then (assigns, empty) else (Bindings.add id deps assigns, empty)
-    | LE_app (id, es) ->
-        let _, assigns, r = analyse_sub env assigns (E_aux (E_tuple es, (Unknown, empty_tannot))) in
-        (assigns, r)
     | LE_tuple lexps | LE_vector_concat lexps ->
         List.fold_left
           (fun (assigns, r) lexp ->

--- a/src/lib/partial_eval.ml
+++ b/src/lib/partial_eval.ml
@@ -345,7 +345,7 @@ let v_real (q : Q.t) = Lattice.V_real { Extraction.Qcanon.this = Util.Rational.t
    value. [Bit.Bits.to_bvn] expects MSB-first input (its [bits_to_N] threads
    each bit through [acc := 2*acc + b], so the first element is most-significant)
    so we pass [bits] through unchanged. *)
-let v_bitvector_of_bits bits = Lattice.V_bitvector (Extraction.AbsBitvector.Dom.alpha (Extraction.Bit.Bits.to_bvn bits))
+let v_bitvector_of_bits bits = Lattice.V_bitvector (Extraction.AbsBitvector.Dom.abst (Extraction.Bit.Bits.to_bvn bits))
 
 (** Define a module for lifting primitives.
 
@@ -374,7 +374,7 @@ module Lifting = struct
    fun ty x ->
     match ty with
     | Unit -> V_unit
-    | Int -> V_int (Extraction.Interval.Dom.alpha x)
+    | Int -> V_int (Extraction.Interval.Dom.abst x)
     | AbsInt -> V_int x
     | BV -> v_bitvector_of_bits x
     | AbsBV -> V_bitvector x
@@ -448,7 +448,7 @@ let primop_print_string args =
   (match args with [Lattice.V_string a; Lattice.V_string b] -> Value.output_endline (a ^ b) | _ -> ());
   Lattice.V_unit
 
-let v_int_concrete n = Lattice.V_int (Extraction.Interval.Dom.alpha n)
+let v_int_concrete n = Lattice.V_int (Extraction.Interval.Dom.abst n)
 
 (* Lift a Rocq-verified interval comparison ([interval -> interval -> bool option])
    to the lattice. [None] means the relation cannot be decided from the intervals
@@ -484,7 +484,7 @@ let as_abs_bv = function
   | Lattice.V_bitvector dbv -> Some dbv
   | Lattice.V_vector _ as v -> (
       match concrete_bits v with
-      | Some bs -> Some (Extraction.AbsBitvector.Dom.alpha (Extraction.Bit.Bits.to_bvn bs))
+      | Some bs -> Some (Extraction.AbsBitvector.Dom.abst (Extraction.Bit.Bits.to_bvn bs))
       | None -> None
     )
   | _ -> None

--- a/src/lib/pretty_print_sail.ml
+++ b/src/lib/pretty_print_sail.ml
@@ -682,7 +682,6 @@ module Printer (Config : PRINT_CONFIG) = struct
     | LE_vector_range (lexp, exp1, exp2) ->
         doc_atomic_lexp lexp ^^ brackets (separate space [doc_exp exp1; string ".."; doc_exp exp2])
     | LE_vector_concat lexps -> parens (separate_map (string " @ ") doc_lexp lexps)
-    | LE_app (id, exps) -> doc_id id ^^ parens (separate_map (comma ^^ space) doc_exp exps)
     | _ -> parens (doc_lexp lexp)
 
   and doc_pexps pexps = surround 2 0 lbrace (separate_map (comma ^^ hardline) doc_pexp pexps) rbrace

--- a/src/lib/rewriter.ml
+++ b/src/lib/rewriter.ml
@@ -258,7 +258,6 @@ let rewrite_lexp rewriters (LE_aux (lexp, (l, annot))) =
   | LE_id _ | LE_typ _ -> rewrap lexp
   | LE_deref exp -> rewrap (LE_deref (rewriters.rewrite_exp rewriters exp))
   | LE_tuple tupls -> rewrap (LE_tuple (List.map (rewriters.rewrite_lexp rewriters) tupls))
-  | LE_app (id, exps) -> rewrap (LE_app (id, List.map (rewriters.rewrite_exp rewriters) exps))
   | LE_vector (lexp, exp) ->
       rewrap (LE_vector (rewriters.rewrite_lexp rewriters lexp, rewriters.rewrite_exp rewriters exp))
   | LE_vector_range (lexp, exp1, exp2) ->
@@ -516,7 +515,6 @@ type ('a, 'exp, 'exp_aux, 'lexp, 'lexp_aux, 'fexp, 'fexp_aux, 'pexp, 'pexp_aux, 
   e_aux : 'exp_aux * 'a annot -> 'exp;
   le_id : id -> 'lexp_aux;
   le_deref : 'exp -> 'lexp_aux;
-  le_app : id * 'exp list -> 'lexp_aux;
   le_typ : Ast.typ * id -> 'lexp_aux;
   le_tuple : 'lexp list -> 'lexp_aux;
   le_vector : 'lexp * 'exp -> 'lexp_aux;
@@ -580,7 +578,6 @@ and fold_exp alg (E_aux (exp_aux, annot)) = alg.e_aux (fold_exp_aux alg exp_aux,
 and fold_lexp_aux alg = function
   | LE_id id -> alg.le_id id
   | LE_deref exp -> alg.le_deref (fold_exp alg exp)
-  | LE_app (id, es) -> alg.le_app (id, List.map (fold_exp alg) es)
   | LE_tuple les -> alg.le_tuple (List.map (fold_lexp alg) les)
   | LE_typ (typ, id) -> alg.le_typ (typ, id)
   | LE_vector (lexp, e) -> alg.le_vector (fold_lexp alg lexp, fold_exp alg e)
@@ -648,7 +645,6 @@ let id_exp_alg =
     e_aux = (fun (e, annot) -> E_aux (e, annot));
     le_id = (fun id -> LE_id id);
     le_deref = (fun e -> LE_deref e);
-    le_app = (fun (id, es) -> LE_app (id, es));
     le_typ = (fun (typ, id) -> LE_typ (typ, id));
     le_tuple = (fun tups -> LE_tuple tups);
     le_vector = (fun (lexp, e2) -> LE_vector (lexp, e2));
@@ -768,7 +764,6 @@ let compute_exp_alg bot join =
     e_aux = (fun ((v, e), annot) -> (v, E_aux (e, annot)));
     le_id = (fun id -> (bot, LE_id id));
     le_deref = (fun (v, e) -> (v, LE_deref e));
-    le_app = (fun (id, es) -> split_join (fun es -> LE_app (id, es)) es);
     le_typ = (fun (typ, id) -> (bot, LE_typ (typ, id)));
     le_tuple =
       (fun ls ->
@@ -859,7 +854,6 @@ let pure_exp_alg bot join =
     e_aux = (fun (v, annot) -> v);
     le_id = (fun id -> bot);
     le_deref = (fun v -> v);
-    le_app = (fun (id, es) -> join_list es);
     le_typ = (fun (typ, id) -> bot);
     le_tuple = join_list;
     le_vector = (fun (vl, v2) -> join vl v2);
@@ -899,16 +893,6 @@ let rec default_fold_lexp f x (LE_aux (le, ann) as lexp) =
   | LE_deref e ->
       let x, e = f x e in
       (x, re (LE_deref e))
-  | LE_app (id, es) ->
-      let x, es =
-        List.fold_left
-          (fun (x, es) e ->
-            let x, e' = f x e in
-            (x, e' :: es)
-          )
-          (x, []) es
-      in
-      (x, re (LE_app (id, List.rev es)))
   | LE_tuple les ->
       let x, les =
         List.fold_left

--- a/src/lib/rewriter.mli
+++ b/src/lib/rewriter.mli
@@ -150,7 +150,6 @@ type ('a, 'exp, 'exp_aux, 'lexp, 'lexp_aux, 'fexp, 'fexp_aux, 'pexp, 'pexp_aux, 
   e_aux : 'exp_aux * 'a annot -> 'exp;
   le_id : id -> 'lexp_aux;
   le_deref : 'exp -> 'lexp_aux;
-  le_app : id * 'exp list -> 'lexp_aux;
   le_typ : Ast.typ * id -> 'lexp_aux;
   le_tuple : 'lexp list -> 'lexp_aux;
   le_vector : 'lexp * 'exp -> 'lexp_aux;

--- a/src/lib/rewrites.ml
+++ b/src/lib/rewrites.ml
@@ -102,14 +102,14 @@ let id_is_unbound id env = match Env.lookup_id id env with Unbound _ -> true | _
 
 let rec lexp_is_local (LE_aux (lexp, _)) env =
   match lexp with
-  | LE_app _ | LE_deref _ -> false
+  | LE_deref _ -> false
   | LE_id id | LE_typ (_, id) -> id_is_local_var id env
   | LE_tuple lexps | LE_vector_concat lexps -> List.for_all (fun lexp -> lexp_is_local lexp env) lexps
   | LE_vector (lexp, _) | LE_vector_range (lexp, _, _) | LE_field (lexp, _) -> lexp_is_local lexp env
 
 let rec lexp_is_local_intro (LE_aux (lexp, _)) env =
   match lexp with
-  | LE_app _ | LE_deref _ -> false
+  | LE_deref _ -> false
   | LE_id id | LE_typ (_, id) -> id_is_unbound id env
   | LE_tuple lexps | LE_vector_concat lexps -> List.for_all (fun lexp -> lexp_is_local_intro lexp env) lexps
   | LE_vector (lexp, _) | LE_vector_range (lexp, _, _) | LE_field (lexp, _) -> lexp_is_local_intro lexp env
@@ -2392,7 +2392,6 @@ let rewrite_ast_letbind_effects effect_info env =
     match lexp_aux with
     | LE_id _ -> k lexp
     | LE_deref exp -> n_exp_name exp (fun exp -> k (LE_aux (LE_deref exp, annot)))
-    | LE_app (id, es) -> n_exp_nameL es (fun es -> k (LE_aux (LE_app (id, es), annot)))
     | LE_tuple es -> n_lexpL es (fun es -> k (LE_aux (LE_tuple es, annot)))
     | LE_typ (typ, id) -> k (LE_aux (LE_typ (typ, id), annot))
     | LE_vector (lexp, e) -> n_lexp lexp (fun lexp -> n_exp_name e (fun e -> k (LE_aux (LE_vector (lexp, e), annot))))
@@ -3106,14 +3105,6 @@ let rec rewrite_var_updates (E_aux (expaux, ((l, _) as annot)) as exp) =
        "tail-position": check the definition n_exp_term and where it is used. *)
       exp
 
-let replace_memwrite_e_assign exp =
-  let e_aux (expaux, annot) =
-    match expaux with
-    | E_assign (LE_aux (LE_app (id, args), _), v) -> E_aux (E_app (id, args @ [v]), annot)
-    | _ -> E_aux (expaux, annot)
-  in
-  fold_exp { id_exp_alg with e_aux } exp
-
 let remove_reference_types exp =
   let rec rewrite_t (Typ_aux (t_aux, a)) = Typ_aux (rewrite_t_aux t_aux, a)
   and rewrite_t_aux t_aux =
@@ -3290,7 +3281,7 @@ let rewrite_ast_remove_e_assign env ast =
          )
       )
   in
-  let rewrite_exp _ e = replace_memwrite_e_assign (remove_reference_types (rewrite_var_updates e)) in
+  let rewrite_exp _ e = remove_reference_types (rewrite_var_updates e) in
   rewrite_ast_base
     { rewrite_exp; rewrite_pat; rewrite_mpat; rewrite_lexp; rewrite_fun; rewrite_def; rewrite_ast = rewrite_ast_base }
     { ast with defs = loop_specs @ ast.defs }

--- a/src/lib/spec_analysis.ml
+++ b/src/lib/spec_analysis.ml
@@ -75,7 +75,6 @@ let rec assigned_vars_in_lexp (LE_aux (le, _)) =
   | LE_id id | LE_typ (_, id) -> IdSet.singleton id
   | LE_tuple lexps | LE_vector_concat lexps ->
       List.fold_left (fun vs le -> IdSet.union vs (assigned_vars_in_lexp le)) IdSet.empty lexps
-  | LE_app (_, es) -> List.fold_left (fun vs e -> IdSet.union vs (assigned_vars e)) IdSet.empty es
   | LE_vector (le, e) -> IdSet.union (assigned_vars_in_lexp le) (assigned_vars e)
   | LE_vector_range (le, e1, e2) ->
       IdSet.union (assigned_vars_in_lexp le) (IdSet.union (assigned_vars e1) (assigned_vars e2))
@@ -227,7 +226,6 @@ let nexp_subst_fns substs =
     match e with
     | LE_id _ -> re e
     | LE_typ (typ, id) -> re (LE_typ (s_t typ, id))
-    | LE_app (id, es) -> re (LE_app (id, List.map s_exp es))
     | LE_tuple les -> re (LE_tuple (List.map s_lexp les))
     | LE_vector (le, e) -> re (LE_vector (s_lexp le, s_exp e))
     | LE_vector_range (le, e1, e2) -> re (LE_vector_range (s_lexp le, s_exp e1, s_exp e2))

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -2036,7 +2036,7 @@ let rec lexp_assignment_type env (LE_aux (aux, (l, _))) =
       | Local (Immutable, _) | Enum _ ->
           typ_error l ("Cannot modify immutable let-bound constant or enumeration constructor " ^ string_of_id v)
     )
-  | LE_deref _ | LE_app _ -> Update
+  | LE_deref _ -> Update
   | LE_field (lexp, _) -> (
       match lexp_assignment_type env lexp with
       | Update -> Update
@@ -3376,12 +3376,6 @@ and bind_assignment assign_l env (LE_aux (lexp_aux, (lexp_l, uannot)) as lexp) e
   in
   let has_typ v env = match Env.lookup_id v env with Local (Mutable, _) | Register _ -> true | _ -> false in
   match lexp_aux with
-  | LE_app (f, xs) ->
-      ( check_exp env
-          (E_aux (E_app (f, xs @ [exp]), (assign_l, add_attribute (gen_loc lexp_l) "setter" None uannot)))
-          unit_typ,
-        env
-      )
   | LE_typ (typ_annot, _) ->
       Env.wf_typ ~at:lexp_l env typ_annot;
       let checked_exp = crule check_exp env exp typ_annot in

--- a/src/rocq/lib/Ast.v
+++ b/src/rocq/lib/Ast.v
@@ -468,7 +468,6 @@ with exp {A : Set} : Set :=
 with lexp_aux {A : Set} : Set :=
 | LE_id : id → lexp_aux
 | LE_deref : exp → lexp_aux
-| LE_app : id → list exp → lexp_aux
 | LE_typ : typ → id → lexp_aux
 | LE_tuple : list lexp → lexp_aux
 | LE_vector_concat : list lexp → lexp_aux

--- a/src/rocq/lib/AstInduction.v
+++ b/src/rocq/lib/AstInduction.v
@@ -132,7 +132,6 @@ Section lexp_ind_g.
             (P : lexp A → Prop)
             (H_id : ∀ id ann, P (LE_aux (LE_id id) ann))
             (H_deref : ∀ x ann, P (LE_aux (LE_deref x) ann))
-            (H_app : ∀ f xs ann, P (LE_aux (LE_app f xs) ann))
             (H_typ : ∀ id typ ann, P (LE_aux (LE_typ typ id) ann))
             (H_tuple : ∀ ls ann, Forall P ls → P (LE_aux (LE_tuple ls) ann))
             (H_vector_concat : ∀ ls ann, Forall P ls → P (LE_aux (LE_vector_concat ls) ann))
@@ -146,7 +145,6 @@ Section lexp_ind_g.
     destruct aux.
     - apply H_id.
     - apply H_deref.
-    - apply H_app.
     - apply H_typ.
     - apply H_tuple.
       induction l.
@@ -187,7 +185,6 @@ Fixpoint lexp_subexps {A : Set} (l : lexp A) : list (exp A) :=
   match aux with
   | LE_id _ | LE_typ _ _ => []
   | LE_deref x => [x]
-  | LE_app _ xs => xs
   | LE_tuple ls
   | LE_vector_concat ls =>
       concat (map lexp_subexps ls)
@@ -213,9 +210,6 @@ Fixpoint update_lexp_subexps {A : Set} (xs : list (exp A)) (l : lexp A) : lexp A
   | LE_field l f =>
       let '(l', ys) := update_lexp_subexps xs l in
       (LE_aux (LE_field l' f) annot, ys)
-  | LE_app id args =>
-      let '(ys, zs) := take_drop (length args) xs in
-      (LE_aux (LE_app id ys) annot, zs)
   | LE_tuple ls =>
       let '(ls, xs) :=
         fold_left
@@ -388,7 +382,6 @@ Lemma lexp_subexps_identity_g : ∀ (A : Set) (l : lexp A) (es : list (exp A)),
 Proof.
   induction l using lexp_ind_g.
   all: try reflexivity.
-  - cbn. intros. rewrite take_drop_app. reflexivity.
   - induction ls.
     + reflexivity.
     + rewrite Forall_cons_iff in H.
@@ -607,7 +600,6 @@ Section exp_and_lexp_ind_g.
     (H_constraint : ∀ c ann, P (E_aux (E_constraint c) ann))
     (HL_id : ∀ id ann, Q (LE_aux (LE_id id) ann))
     (HL_deref : ∀ x ann, P x → Q (LE_aux (LE_deref x) ann))
-    (HL_app : ∀ f xs ann, Forall P xs → Q (LE_aux (LE_app f xs) ann))
     (HL_typ : ∀ typ id ann, Q (LE_aux (LE_typ typ id) ann))
     (HL_tuple : ∀ lxs ann, Forall Q lxs → Q (LE_aux (LE_tuple lxs) ann))
     (HL_vector_concat : ∀ lxs ann, Forall Q lxs → Q (LE_aux (LE_vector_concat lxs) ann))
@@ -703,11 +695,6 @@ Section exp_and_lexp_ind_g.
       destruct aux.
       - apply HL_id.
       - apply HL_deref. trivial.
-      - apply HL_app.
-        induction l.
-        + trivial.
-        + rewrite Forall_cons_iff.
-          easy.
       - apply HL_typ.
       - apply HL_tuple.
         induction l.
@@ -787,7 +774,6 @@ with lexp_depth {A : Set} (l : lexp A) {struct l} : nat :=
   let 'LE_aux aux _ := l in
   match aux with
   | LE_deref x => depth x + 1
-  | LE_app _ xs => fold_right max 0 (map depth xs) + 1
   | LE_tuple ls
   | LE_vector_concat ls => fold_right max 0 (map lexp_depth ls) + 1
   | LE_vector l n => lexp_depth l + depth n + 1
@@ -814,7 +800,6 @@ Proof.
    - reflexivity.
    - cbn. lia.
    - cbn. lia.
-   - reflexivity.
    - induction ls.
      + cbn. lia.
      + cbn.

--- a/src/rocq/lib/Domain/AbsBitvector.v
+++ b/src/rocq/lib/Domain/AbsBitvector.v
@@ -634,7 +634,7 @@ Module Dom <: SAIL_BITS.
     apply length_bv_to_bits.
   Qed.
 
-  Definition α (x : bvn) : bvset :=
+  Definition abst (x : bvn) : bvset :=
     let len := bvn_n x in
     match bvn_to_bv len x with
     | Some x' =>
@@ -642,9 +642,7 @@ Module Dom <: SAIL_BITS.
     | None => ⊥
     end.
 
-  (** ASCII alias for [α], so OCaml code consuming the extracted module can
-      use the readable name [alpha] instead of the mangled [_UU03b1_]. *)
-  Definition alpha := α.
+  Notation α := abst.
 
   Lemma abstract_bvs : ∀ {n} (x : bv n),
      α x = Bvs ({[N.to_nat n := List.map from_bool (bv_to_bits x)]} ↾ abs_valid x).

--- a/src/rocq/lib/Domain/AbsValue.v
+++ b/src/rocq/lib/Domain/AbsValue.v
@@ -1703,26 +1703,24 @@ Module Dom (DZ : SAIL_INT) (Dbv : SAIL_BITS) (T : SAIL_BITS_INT Dbv DZ) <: DOMAI
   Lemma le_join_def : ∀ x y, le x y ↔ y = join x y.
   Proof. intros. split; [ apply le_join_def_1 | apply le_join_def_2 ]. Qed.
 
-  Fixpoint α (x : Ast.value) : value :=
+  Fixpoint abst (x : Ast.value) : value :=
     match x with
     | Ast.V_bitvector bv => V_bitvector (Dbv.α (Bit.Bits.to_bvn bv))
-    | Ast.V_vector xs => V_vector (List.map α xs)
-    | Ast.V_list xs => V_list (List.map α xs)
+    | Ast.V_vector xs => V_vector (List.map abst xs)
+    | Ast.V_list xs => V_list (List.map abst xs)
     | Ast.V_int i => V_int (DZ.α i)
     | Ast.V_real q => V_real (Q2Qc q)
     | Ast.V_bool b => V_bool b
-    | Ast.V_tuple xs => V_tuple (List.map α xs)
+    | Ast.V_tuple xs => V_tuple (List.map abst xs)
     | Ast.V_unit => V_unit
     | Ast.V_string str => V_string str
     | Ast.V_ref id => V_ref (Aux.unwrap id)
     | Ast.V_member id => V_member {[ Aux.unwrap id ]}
-    | Ast.V_ctor id xs => V_ctor {[ Aux.unwrap id := List.map α xs ]}
-    | Ast.V_record fields => V_record (foldl (λ m '(k, v), <[Aux.unwrap k := α v]> m) ∅ fields)
+    | Ast.V_ctor id xs => V_ctor {[ Aux.unwrap id := List.map abst xs ]}
+    | Ast.V_record fields => V_record (foldl (λ m '(k, v), <[Aux.unwrap k := abst v]> m) ∅ fields)
     end.
 
-  (** ASCII alias for [α], so OCaml code consuming the extracted module can
-      use the readable name [alpha] instead of the mangled [_UU03b1_]. *)
-  Definition alpha := α.
+  Notation α := abst.
 
   Definition of_lit (l : Ast.lit) : value := α (ValueType.value_of_lit l).
 

--- a/src/rocq/lib/Domain/Interval.v
+++ b/src/rocq/lib/Domain/Interval.v
@@ -386,11 +386,9 @@ Module Dom <: SAIL_INT.
     | Some m => (n <= m)%Z
     end.
 
-  Definition α (n : Z) : interval := Ends (exist _ (Some n, Some n) (low_high_refl n)).
+  Definition abst (n : Z) : interval := Ends (exist _ (Some n, Some n) (low_high_refl n)).
 
-  (** ASCII alias for [α], so OCaml code consuming the extracted module can
-      use the readable name [alpha] instead of the mangled [_UU03b1_]. *)
-  Definition alpha := α.
+  Notation α := abst.
 
   (** Recover a concrete integer from an interval whose endpoints coincide.
       Anything else (open ends, [Empty], or [lo < hi]) returns [None]. *)

--- a/src/rocq/lib/Domain/Lattice.v
+++ b/src/rocq/lib/Domain/Lattice.v
@@ -84,7 +84,8 @@ Module Type DOMAIN (C : CONCRETE).
   Parameter leb_le : ∀ x y, leb x y = true ↔ x ⊑ y.
   Parameter le_join_def : ∀ x y, x ⊑ y ↔ y = x ⊔ y.
 
-  Parameter α : C.t → t.
+  Parameter abst : C.t → t.
+  Notation α := abst.
 End DOMAIN.
 
 Module DomainProperties (C : CONCRETE) (D : DOMAIN C).

--- a/src/rocq/lib/Semantics.v
+++ b/src/rocq/lib/Semantics.v
@@ -87,7 +87,6 @@ Inductive place : Set :=
 | PL_field : place → id → place.
 
 Inductive destructure : Set :=
-| DL_app : id → list value → destructure
 | DL_tuple : list destructure → destructure
 | DL_vector_concat : list (vector_concat_split * destructure) → destructure
 | DL_place : place → destructure.
@@ -677,7 +676,6 @@ Module Make (Tannot : TypeAnnot.S).
     - cbn; reflexivity.
     - cbn; try assumption...
     - cbn; reflexivity.
-    - cbn; reflexivity.
     - cbn.
       induction lxs.
       + reflexivity.
@@ -772,8 +770,6 @@ Module Make (Tannot : TypeAnnot.S).
             assignment
         | _ => Runtime_type_error (fst annot)
         end
-    | _ =>
-        Runtime_type_error (fst annot)
     end.
 
   Fixpoint lexp_to_destructure (l : lexp Tannot.t) {struct l} : t destructure :=
@@ -796,9 +792,6 @@ Module Make (Tannot : TypeAnnot.S).
         | _ =>
             Runtime_type_error (fst annot)
         end
-    | LE_app name args =>
-        let evaluated := all_evaluated args in
-        pure (DL_app name evaluated)
     | LE_tuple ls =>
         ds ← sequence (map lexp_to_destructure ls);
         pure (DL_tuple ds)

--- a/src/rocq/lib/ZAst.v
+++ b/src/rocq/lib/ZAst.v
@@ -658,8 +658,7 @@ Module Residual (Tannot : TypeAnnot.S) (B : Builder Tannot).
     ({| this := ⊥; exn := exn (fst r); eff := true |}, B.mk_return ann (snd r)).
 
   (* Join a value returned early from an inlined body into the accumulator
-     carried on the enclosing [Z_inline] node. Only [this]/[exn]/[eff] matter;
-     the residual is provided by the fall-through value, so we keep [snd ret]. *)
+     carried on the enclosing [Z_inline] node. *)
   Definition join_returns (acc : option t) (ret : t) : t :=
     match acc with
     | None => ret

--- a/src/rocq/lib/ZAst.v
+++ b/src/rocq/lib/ZAst.v
@@ -66,8 +66,7 @@ From Sail Require TypeAnnot.
 We start by re-defining l-expressions such that they contain no
 embedded expressions. The type [zlexp A] is like [lexp A] but
 essentially contains an implicit 'hole' wherever an expression would
-have gone. See the [nat] argument for the [LZ_app] constructor, which
-is the number of holes for an illustrative example of this in action.
+have gone.
 
 The end goal is to be able to losslessly transform [lexp A] into
 [zlexp A * list (exp A)] and back again.
@@ -76,7 +75,6 @@ The end goal is to be able to losslessly transform [lexp A] into
 Inductive zlexp_aux {A : Set} : Set :=
 | LZ_id : id → zlexp_aux
 | LZ_deref : zlexp_aux
-| LZ_app : id → nat → zlexp_aux
 | LZ_typ : typ → id → zlexp_aux
 | LZ_tuple : list zlexp → zlexp_aux
 | LZ_vector_concat : list zlexp → zlexp_aux
@@ -96,7 +94,6 @@ Fixpoint lexp_to_z {A : Set} (l : lexp A) : zlexp A :=
   | LE_id id => LZ_aux (LZ_id id) ann
   | LE_typ typ id => LZ_aux (LZ_typ typ id) ann
   | LE_deref _ => LZ_aux LZ_deref ann
-  | LE_app id args => LZ_aux (LZ_app id (List.length args)) ann
   | LE_tuple ls => LZ_aux (LZ_tuple (map lexp_to_z ls)) ann
   | LE_vector_concat ls =>
       LZ_aux (LZ_vector_concat (map lexp_to_z ls)) ann
@@ -131,9 +128,6 @@ Fixpoint update_zlexp_subexps {A : Set} (xs : list (exp A)) (l : zlexp A) : opti
       | (Some ls, xs) => (Some (LE_aux (LE_vector_concat (List.rev ls)) annot), xs)
       | (None, xs) => (None, xs)
       end
-  | LZ_app id n =>
-      let '(ys, zs) := take_drop n xs in
-      (Some (LE_aux (LE_app id ys) annot), zs)
   | LZ_vector l =>
       match update_zlexp_subexps xs l with
       | (Some l, n :: xs) => (Some (LE_aux (LE_vector l n) annot), xs)
@@ -152,7 +146,6 @@ Proof with reflexivity.
   intros A l.
   induction l using lexp_ind_g.
   all: try reflexivity.
-  - cbn; intros; rewrite take_drop_app...
   - induction ls as [| l ls].
     + reflexivity.
     + rewrite Forall_cons_iff in H.

--- a/src/sail_coq_backend/pretty_print_coq.ml
+++ b/src/sail_coq_backend/pretty_print_coq.ml
@@ -3244,7 +3244,6 @@ let all_ids pexp =
           IdSet.add id (IdSet.union ids1 (IdSet.union ids2 (IdSet.union ids3 ids4)))
         );
       le_id = IdSet.singleton;
-      le_app = (fun (id, ids) -> List.fold_left IdSet.union (IdSet.singleton id) ids);
       le_typ = (fun (_, id) -> IdSet.singleton id);
       pat_alg =
         {


### PR DESCRIPTION
Rewrite directly into E_app during desugaring.

Rename the abstraction function for lattices.