### PR TITLE
C++: Output a storage type for enums.

### DIFF
--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1664,8 +1664,10 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           string (Printf.sprintf "static enum %s UNDEFINED(%s)(unit u) { return %s; }" name name (sgen_id first_id))
         in
         (* Conservatively use the smallest size of int to guard specifying storage size.  This assumes C++11,
-           but could also be done for C23.*)
-        let enum_type = if Config.cpp && List.length ids < 65536 then ": int" else "" in
+           but could also be done for C23. *)
+        let enum_type =
+          if Config.cpp && List.length ids < 65536 then space ^^ colon ^^ space ^^ string "int" else empty
+        in
         [
           TypeDeclaration
             (string (Printf.sprintf "// enum %s" (string_of_id id))
@@ -1673,8 +1675,7 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
             ^^ separate space
                  [
                    string "enum";
-                   codegen_id id;
-                   string enum_type;
+                   codegen_id id ^^ enum_type;
                    lbrace;
                    separate_map (comma ^^ space) codegen_id ids;
                    rbrace ^^ semi;

--- a/src/sail_c_backend/c_backend.ml
+++ b/src/sail_c_backend/c_backend.ml
@@ -1663,12 +1663,22 @@ module Codegen (Config : CODEGEN_CONFIG) = struct
           let name = sgen_id id in
           string (Printf.sprintf "static enum %s UNDEFINED(%s)(unit u) { return %s; }" name name (sgen_id first_id))
         in
+        (* Conservatively use the smallest size of int to guard specifying storage size.  This assumes C++11,
+           but could also be done for C23.*)
+        let enum_type = if Config.cpp && List.length ids < 65536 then ": int" else "" in
         [
           TypeDeclaration
             (string (Printf.sprintf "// enum %s" (string_of_id id))
             ^^ hardline
             ^^ separate space
-                 [string "enum"; codegen_id id; lbrace; separate_map (comma ^^ space) codegen_id ids; rbrace ^^ semi]
+                 [
+                   string "enum";
+                   codegen_id id;
+                   string enum_type;
+                   lbrace;
+                   separate_map (comma ^^ space) codegen_id ids;
+                   rbrace ^^ semi;
+                 ]
             );
           StaticFunctionDefinition enum_eq;
           StaticFunctionDefinition enum_undefined;


### PR DESCRIPTION
This enables forward declarations of enums for C++11 and later. This is also possible for C23 and later, but isn't done here since C23 may still be relatively new.