### PR TITLE
Refactor how undefined_* primitives are set up

### DIFF
--- a/lib/core/corelib.sail
+++ b/lib/core/corelib.sail
@@ -61,3 +61,39 @@ val gteq_int = pure { coq: "Z.geb", lean: "_lean_ge", _: "gteq" } : forall 'n 'm
 val lt_int = pure { coq: "Z.ltb", lean: "_lean_lt", _: "lt" } : forall 'n 'm. (int('n), int('m)) -> bool('n < 'm)
 
 val gt_int = pure { coq: "Z.gtb", lean: "_lean_gt", _: "gt" } : forall 'n 'm. (int('n), int('m)) -> bool('n > 'm)
+
+$[never_fold]
+val internal_pick = impure "internal_pick" : forall ('a:Type). list('a) -> 'a
+
+$[never_fold]
+val undefined_bool = impure "undefined_bool" : unit -> bool
+
+$[never_fold]
+val undefined_bit = impure "undefined_bit" : unit -> bitvector(1)
+
+$[never_fold]
+val undefined_int = impure "undefined_int" : unit -> int
+
+$[never_fold]
+val undefined_nat = impure "undefined_nat" : unit -> nat
+
+$[never_fold]
+val undefined_real = impure "undefined_real" : unit -> real
+
+$[never_fold]
+val undefined_string = impure "undefined_string" : unit -> string
+
+$[never_fold]
+val undefined_list = impure "undefined_list" : forall 'a. 'a -> list('a)
+
+$[never_fold]
+val undefined_range = impure "undefined_range" : forall 'n 'm. (int('n), int('m)) -> range('n, 'm)
+
+$[never_fold]
+val undefined_vector = impure "undefined_vector" : forall 'n 'a. (int('n), 'a) -> vector('n, 'a)
+
+$[never_fold]
+val undefined_bitvector = impure "undefined_bitvector" : forall 'n. int('n) -> bitvector('n)
+
+$[never_fold]
+val undefined_unit = impure "undefined_unit" : unit -> unit

--- a/src/lib/constant_propagation.ml
+++ b/src/lib/constant_propagation.ml
@@ -47,6 +47,7 @@
 open Ast
 open Ast_compare
 open Ast_util
+open Ast_defs
 open Spec_analysis
 open Type_check
 
@@ -261,6 +262,18 @@ and typ_arg_has_existential (A_aux (a, _)) =
 module StringSet = Set.Make (String)
 module StringMap = Map.Make (String)
 
+let never_fold_ids ast =
+  List.fold_left
+    (fun ids def ->
+      match def with
+      | DEF_aux (DEF_val vs, def_annot) -> (
+          let id = id_of_val_spec vs in
+          match get_def_attribute "never_fold" def_annot with Some _ -> IdSet.add id ids | None -> ids
+        )
+      | _ -> ids
+    )
+    IdSet.empty ast.defs
+
 (* This is set up so that a partially applied version can be used multiple
    times, reducing start up time. *)
 
@@ -269,11 +282,10 @@ let const_props target env ast =
   let interpreter_istate =
     (* Do not interpret undefined_X functions *)
     let open Interpreter in
-    let undefined_builtin_ids = ids_of_defs (Initial_check.undefined_builtin_val_specs ()) in
     let remove_primop id = StringMap.remove (string_of_id id) in
-    let remove_undefined_primops = IdSet.fold remove_primop undefined_builtin_ids in
+    let remove_never_fold = IdSet.fold remove_primop (never_fold_ids ast) in
     let lstate, gstate = Constant_fold.initial_state ast env in
-    (lstate, { gstate with primops = remove_undefined_primops gstate.primops })
+    (lstate, { gstate with primops = remove_never_fold gstate.primops })
   in
   let const_fold exp =
     try

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -363,9 +363,7 @@ let load_modules ?target default_sail_dir options env proj root_mod_ids =
       mods
   in
   let processed =
-    [ProcessedGenerated (Initial_check.generate_undefineds vs_ids)]
-    @ List.concat processed
-    @ [ProcessedGenerated (Initial_check.generate_initialize_registers vs_ids regs)]
+    List.concat processed @ [ProcessedGenerated (Initial_check.generate_initialize_registers vs_ids regs)]
   in
 
   let t = Profile.start () in
@@ -395,11 +393,7 @@ let load_files ?(no_core = false) ?target default_sail_dir options env files =
   let (ctx, vs_ids, regs), processed =
     process_files ~target_name ~default_sail_dir ~options Initial_check.initial_ctx IdSet.empty [] parsed_files
   in
-  let processed =
-    [ProcessedGenerated (Initial_check.generate_undefineds vs_ids)]
-    @ processed
-    @ [ProcessedGenerated (Initial_check.generate_initialize_registers vs_ids regs)]
-  in
+  let processed = processed @ [ProcessedGenerated (Initial_check.generate_initialize_registers vs_ids regs)] in
 
   let t = Profile.start () in
   let env, checked = check_files env processed in

--- a/src/lib/initial_check.ml
+++ b/src/lib/initial_check.ml
@@ -2554,28 +2554,8 @@ let generate_undefined_enum id ids =
       ];
   ]
 
-let undefined_builtin_val_specs () =
-  [
-    extern_of_string initial_ctx (mk_id "internal_pick") "forall ('a:Type). list('a) -> 'a";
-    extern_of_string initial_ctx (mk_id "undefined_bool") "unit -> bool";
-    extern_of_string initial_ctx (mk_id "undefined_bit") "unit -> bitvector(1)";
-    extern_of_string initial_ctx (mk_id "undefined_int") "unit -> int";
-    extern_of_string initial_ctx (mk_id "undefined_nat") "unit -> nat";
-    extern_of_string initial_ctx (mk_id "undefined_real") "unit -> real";
-    extern_of_string initial_ctx (mk_id "undefined_string") "unit -> string";
-    extern_of_string initial_ctx (mk_id "undefined_list") "forall ('a:Type). 'a -> list('a)";
-    extern_of_string initial_ctx (mk_id "undefined_range") "forall 'n 'm. (atom('n), atom('m)) -> range('n,'m)";
-    extern_of_string initial_ctx (mk_id "undefined_vector")
-      "forall 'n ('a:Type) ('ord : Order). (atom('n), 'a) -> vector('n, 'ord,'a)";
-    extern_of_string initial_ctx (mk_id "undefined_bitvector") "forall 'n. atom('n) -> bitvector('n)";
-    extern_of_string initial_ctx (mk_id "undefined_unit") "unit -> unit";
-  ]
-
 let make_global (DEF_aux (def, def_annot)) =
   DEF_aux (def, add_def_attribute (gen_loc def_annot.loc) "global" None def_annot)
-
-let generate_undefineds vs_ids =
-  List.filter (fun def -> IdSet.is_empty (IdSet.inter vs_ids (ids_of_def def))) (undefined_builtin_val_specs ())
 
 let rec get_uninitialized_registers = function
   | DEF_aux (DEF_register (DEC_aux (DEC_reg (typ, id, None), _)), _) :: defs -> (
@@ -2714,11 +2694,6 @@ let generate_enum_number_conversions defs =
 let process_ast ctx ast =
   let ast, ctx = to_ast ctx ast in
   ({ ast with defs = generate_enum_number_conversions ast.defs }, ctx)
-
-let generate ast =
-  let vs_ids = val_spec_ids ast.defs in
-  let regs = get_uninitialized_registers ast.defs in
-  { ast with defs = generate_undefineds vs_ids @ ast.defs @ generate_initialize_registers vs_ids regs }
 
 let ast_of_def_string_with ?inline ocaml_pos ctx f str =
   let lexbuf = Lexing.from_string str in

--- a/src/lib/initial_check.mli
+++ b/src/lib/initial_check.mli
@@ -85,17 +85,9 @@ val generate_undefined_record : id -> typquant -> ((id * typ) * unit def_annot) 
 
 val generate_undefined_enum : id -> id list -> untyped_def list
 
-(** Val specs of undefined functions for builtin types that get added to the AST by generate_undefinds (minus those
-    functions that already exist in the AST). *)
-val undefined_builtin_val_specs : unit -> untyped_def list
-
-val generate_undefineds : IdSet.t -> untyped_def list
-
 val generate_initialize_registers : IdSet.t -> (id * typ) list -> untyped_def list
 
 val generate_enum_number_conversions : untyped_def list -> untyped_def list
-
-val generate : untyped_ast -> untyped_ast
 
 val process_ast : ctx -> Parse_ast.defs -> untyped_ast * ctx
 


### PR DESCRIPTION
This is technically a slightly breaking change, as it means these definitions can no longer be overridden in the same way, but it is significantly simpler and makes the LSP implementation much more straightforward (as which definitions are available previously depended on future files).