### PR TITLE
Minimal Sail language server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ libsail_coverage:
 extraction:
 	$(MAKE) -C src/rocq extraction
 
+lsp:
+	$(MAKE) -C src/sail_lsp
+
+lsp_install:
+	$(MAKE) -C src/sail_lsp install
+
 # Build binary tarball. The lib directory is very large and not needed
 # for running the compiler. Z3_EXE can be used to bundle a z3 binary.
 # GMP_DLL can be used to bundle a libgmp DLL (this is only used on Windows currently).

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -635,7 +635,7 @@ let run_sail_format (config : Yojson.Safe.t option) =
 let feature_check () =
   match !opt_have_feature with
   | None -> ()
-  | Some symbol -> if Preprocess.have_default_symbol symbol then exit 0 else exit 2
+  | Some symbol -> if Preprocess.have_symbol symbol (Preprocess.get_default_symbols ()) then exit 0 else exit 2
 
 let get_plugin_dir () =
   match Sys.getenv_opt "SAIL_PLUGIN_DIR" with

--- a/src/dune
+++ b/src/dune
@@ -1,1 +1,1 @@
-(dirs :standard \ rocq)
+(dirs :standard \ rocq sail_lsp)

--- a/src/lib/frontend.ml
+++ b/src/lib/frontend.ml
@@ -218,6 +218,8 @@ module type FILE_HANDLER = sig
     processed * Preprocess.symbol_set * Initial_check.ctx
 
   val check : Type_check.Env.t -> processed -> Type_check.typed_ast * Type_check.Env.t
+
+  val check_lazy : Type_check.Env.t -> processed -> Type_check.typed_lazy_ast * Type_check.Env.t
 end
 
 module SailHandler : FILE_HANDLER = struct
@@ -240,6 +242,8 @@ module SailHandler : FILE_HANDLER = struct
     ({ ast with comments = [(filename, comments)] }, symbols, ctx)
 
   let check env ast = Type_error.check env ast
+
+  let check_lazy env ast = Type_check.check_lazy env ast
 end
 
 let handlers : (string, (module FILE_HANDLER)) Hashtbl.t = Hashtbl.create 8

--- a/src/lib/frontend.mli
+++ b/src/lib/frontend.mli
@@ -113,11 +113,15 @@ module type FILE_HANDLER = sig
     processed * Preprocess.symbol_set * Initial_check.ctx
 
   val check : Type_check.Env.t -> processed -> Type_check.typed_ast * Type_check.Env.t
+
+  val check_lazy : Type_check.Env.t -> processed -> Type_check.typed_lazy_ast * Type_check.Env.t
 end
 
 (** Register a file handler module. The extension should be the extension for the file type we want to handle, e.g.
     ".json". *)
 val register_file_handler : extension:string -> (module FILE_HANDLER) -> unit
+
+val get_handler : path:Sail_file.path -> string -> (module FILE_HANDLER)
 
 val load_files :
   ?no_core:bool ->

--- a/src/lib/preprocess.ml
+++ b/src/lib/preprocess.ml
@@ -82,8 +82,6 @@ let get_default_symbols () = !default_symbols
 
 let add_default_symbol str = default_symbols := StringSet.add str !default_symbols
 
-let have_default_symbol str = StringSet.mem str !default_symbols
-
 let have_symbol str set = StringSet.mem str set
 
 let cond_pragma l defs =

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -107,7 +107,7 @@ val start_loc : Parse_ast.l -> Parse_ast.l
 
     Note that all these errors are intended to be fatal, so should not be caught other than by the top-level function.
 *)
-type error = private
+type error =
   | Err_general of Parse_ast.l * string  (** General errors, used for multi purpose. If you are unsure, use this one. *)
   | Err_unreachable of Parse_ast.l * (string * int * int * int) * Printexc.raw_backtrace * string
       (** Unreachable errors should never be thrown. They represent an internal Sail error. *)

--- a/src/lib/sail_file.ml
+++ b/src/lib/sail_file.ml
@@ -110,12 +110,54 @@ let count_newlines s =
   String.iter (fun c -> if c = '\n' then incr n) s;
   !n
 
+(* LSP positions count characters in UTF-16 code units, whereas Sail's lexer
+   works in bytes. A UTF-8 code point in the basic multilingual plane is a
+   single UTF-16 code unit; one outside it (a four-byte UTF-8 sequence) is
+   encoded as a surrogate pair and so counts as two. These helpers convert
+   between byte and UTF-16 offsets within a single (UTF-8 encoded) line. *)
+
+(* The number of UTF-8 bytes and UTF-16 code units of the character whose
+   leading byte is [c]. *)
+let utf8_char_size c = if c < 0x80 then (1, 1) else if c < 0xe0 then (2, 1) else if c < 0xf0 then (3, 1) else (4, 2)
+
+(* Byte offset into [line] of its [utf16]th UTF-16 code unit. An offset past the
+   end of the line clamps to its byte length. *)
+let utf16_offset_to_byte line utf16 =
+  let len = String.length line in
+  let byte = ref 0 in
+  let units = ref 0 in
+  while !units < utf16 && !byte < len do
+    let nbytes, nunits = utf8_char_size (Char.code line.[!byte]) in
+    byte := !byte + nbytes;
+    units := !units + nunits
+  done;
+  min !byte len
+
+(* UTF-16 code-unit offset into [line] corresponding to the byte offset [byte].
+   An offset past the end of the line clamps to its UTF-16 length. *)
+let byte_offset_to_utf16 line byte =
+  let target = min byte (String.length line) in
+  let b = ref 0 in
+  let units = ref 0 in
+  while !b < target do
+    let nbytes, nunits = utf8_char_size (Char.code line.[!b]) in
+    b := !b + nbytes;
+    units := !units + nunits
+  done;
+  !units
+
+(* The length of [s] in UTF-16 code units. *)
+let utf16_length s = byte_offset_to_utf16 s (String.length s)
+
+(* Text edits are stored in editor (UTF-16 code-unit) coordinates, so measure
+   the inserted text in the same units to keep the position arithmetic in
+   [update_position]/[revert_position] consistent. *)
 let measure_edit edit =
   let newlines = count_newlines edit.text in
-  if newlines = 0 then Single_line (String.length edit.text)
+  if newlines = 0 then Single_line (utf16_length edit.text)
   else (
-    let pre = String.index_from edit.text 0 '\n' in
-    let post = String.rindex_from edit.text (String.length edit.text - 1) '\n' in
+    let pre = byte_offset_to_utf16 edit.text (String.index_from edit.text 0 '\n') in
+    let post = byte_offset_to_utf16 edit.text (String.rindex_from edit.text (String.length edit.text - 1) '\n') in
     Multiple_lines { pre; newlines; post }
   )
 
@@ -293,10 +335,21 @@ let editor_position p =
   let path = Path.canonicalize (Path.Actual p.pos_fname) in
   match Hashtbl.find_opt opened path with
   | Some handle ->
+      let info = Hashtbl.find files handle in
+      (* Lexing/AST lines are 1-based; editor lines are 0-based. *)
+      let line = p.pos_lnum - 1 in
+      let byte_character = p.pos_cnum - p.pos_bol in
+      (* The Lexing position is a byte offset into the base contents; editor
+         positions are UTF-16 code units, so convert against the base line
+         before replaying the pending edits (which are in editor coordinates). *)
+      let character =
+        if line >= 0 && line < Array.length info.contents then byte_offset_to_utf16 info.contents.(line) byte_character
+        else byte_character
+      in
       fold_edits_first_to_last
         (fun edit size pos_opt -> match pos_opt with None -> None | Some p -> update_position edit size p)
         handle
-        (Some { line = p.pos_lnum; character = p.pos_cnum - p.pos_bol })
+        (Some { line; character })
   | None -> None
 
 let lexing_position handle p =
@@ -313,8 +366,60 @@ let lexing_position handle p =
       for i = 0 to p.line - 1 do
         bol := !bol + String.length info.contents.(i) + 1
       done;
+      (* [p.character] is a UTF-16 code-unit offset into the base contents;
+         convert it to a byte offset for the Sail lexing position. *)
+      let character =
+        if p.line >= 0 && p.line < Array.length info.contents then
+          utf16_offset_to_byte info.contents.(p.line) p.character
+        else p.character
+      in
+      (* Editor lines are 0-based; Lexing/AST lines are 1-based. *)
       Some
-        { pos_fname = Path.to_string info.given_path; pos_lnum = p.line; pos_bol = !bol; pos_cnum = !bol + p.character }
+        {
+          pos_fname = Path.to_string info.given_path;
+          pos_lnum = p.line + 1;
+          pos_bol = !bol;
+          pos_cnum = !bol + character;
+        }
+
+(* Apply a single text edit to a line array, returning the updated array. The
+   edit's character offsets are UTF-16 code units, so convert them to byte
+   offsets into the (UTF-8) lines they index before slicing. The half-open
+   range [s, e) is replaced by [edit.text], which may itself span several
+   lines. Line numbers are clamped to be in-bounds so that malformed client
+   input cannot raise; [utf16_offset_to_byte] already clamps the columns. *)
+let apply_edit contents edit =
+  let contents = if Array.length contents = 0 then [| "" |] else contents in
+  let n = Array.length contents in
+  let s, e = edit.range in
+  let clamp lo hi x = if x < lo then lo else if x > hi then hi else x in
+  let sl = clamp 0 (n - 1) s.line in
+  let el = clamp 0 (n - 1) e.line in
+  let sc = utf16_offset_to_byte contents.(sl) s.character in
+  let ec = utf16_offset_to_byte contents.(el) e.character in
+  let before = String.sub contents.(sl) 0 sc in
+  let after = String.sub contents.(el) ec (String.length contents.(el) - ec) in
+  let replacement = Array.of_list (String.split_on_char '\n' (before ^ edit.text ^ after)) in
+  Array.concat [Array.sub contents 0 sl; replacement; Array.sub contents (el + 1) (n - (el + 1))]
+
+(* The current editor view of a file: its base contents with every queued edit
+   applied, in order. Does not mutate the stored contents or the edit queue. *)
+let current_contents info =
+  let contents = ref info.contents in
+  for i = 0 to info.next_edit - 1 do
+    let edit, _ = Option.get info.edits.(i) in
+    contents := apply_edit !contents edit
+  done;
+  !contents
+
+(* Bake the queued edits into the file's contents, bringing them in sync with
+   the editor, and clear the queue. After this the base contents equals the
+   editor view, so no pending position translation remains. *)
+let apply_edits handle =
+  let info = Hashtbl.find files handle in
+  info.contents <- current_contents info;
+  Array.fill info.edits 0 info.next_edit None;
+  info.next_edit <- 0
 
 let file_to_line_array filename =
   let chan = open_in filename in

--- a/src/lib/sail_file.mli
+++ b/src/lib/sail_file.mli
@@ -161,7 +161,9 @@ val editor_take_file : contents:string -> string -> handle
 (** The LSP can stop editing a file using the DidCloseTextDocument message, in which case we need to manage the file. *)
 val editor_drop_file : handle -> unit
 
-(** The LSP protocol uses line + character offsets as positions. *)
+(** The LSP protocol uses line + character offsets as positions. Both are zero-based, and [character] is counted in
+    UTF-16 code units (as the LSP protocol specifies), not bytes. The conversion to the byte offsets Sail's lexer uses
+    happens lazily, when edits are applied and in [editor_position] and [lexing_position]. *)
 type editor_position = { line : int; character : int }
 
 type editor_range = editor_position * editor_position
@@ -183,6 +185,14 @@ val editor_position : Lexing.position -> editor_position option
 (** Take a cursor position in the editor, and map it to a position in the Sail AST. Returns None if the cursor position
     is within a pending edit that has not yet been processed by Sail. *)
 val lexing_position : handle -> editor_position -> Lexing.position option
+
+(** Bake the queued edits (see [edit_file]) into the file's contents, bringing them in sync with the editor, and clear
+    the queue. This is where the UTF-16 code-unit offsets carried by edits are resolved to byte offsets. *)
+val apply_edits : handle -> unit
+
+(** The length of a UTF-8 string in UTF-16 code units. LSP character offsets and lengths are counted in UTF-16 code
+    units, so this converts a byte length (or, applied to a substring, a byte offset) into the LSP's units. *)
+val utf16_length : string -> int
 
 (** {1 Channel interface} *)
 

--- a/src/lib/token.ml
+++ b/src/lib/token.ml
@@ -166,3 +166,55 @@ type token =
   | When
   | While
   | With
+
+module Highlight = struct
+  type t =
+    | H_id
+    | H_keyword
+    | H_kind
+    | H_comment
+    | H_string
+    | H_pragma
+    | H_internal
+    | H_operator
+    | H_literal
+    | H_ty_var
+    | H_bracket
+    | H_punctuation
+
+  let to_class = function
+    | H_id -> "sail-id"
+    | H_keyword -> "sail-keyword"
+    | H_kind -> "sail-kind"
+    | H_comment -> "sail-comment"
+    | H_string -> "sail-string"
+    | H_pragma -> "sail-pragma"
+    | H_internal -> "sail-internal"
+    | H_operator -> "sail-operator"
+    | H_literal -> "sail-literal"
+    | H_ty_var -> "sail-ty-var"
+    | H_bracket -> "sail-bracket"
+    | H_punctuation -> "sail-punctuation"
+
+  let classify = function
+    | Eof -> None
+    | Id _ -> Some H_id
+    | INT | NAT | BOOL | TYPE | ORDER -> Some H_kind
+    | String _ | MultilineString _ -> Some H_string
+    | DocLine _ | DocBlock _ -> Some H_comment
+    | And | As | Assert | By | Match | Clause | Dec | Op | Default | Effect | End | Enum | Else | Exit | Cast | Forall
+    | Foreach | Function_ | Mapping | Overload | Throw | Try | Catch | If_ | In | Inc | Var | Ref | Pure | Impure
+    | Monadic | Register | Return | Scattered | Sizeof | Constraint | Constant | Struct | Then | Typedef | Union
+    | Newtype | With | Val | Outcome | Instantiation | Impl | Private | Repeat | Until | While | Do | Mutual | Config
+    | Configuration | TerminationMeasure | Forwards | Backwards | Let_ | Bitfield | When | To | Downto | From ->
+        Some H_keyword
+    | StructuredPragma _ | Pragma _ | Attribute _ | Fixity _ -> Some H_pragma
+    | InternalPLet | InternalReturn | InternalAssume -> Some H_internal
+    | OpId _ | Star | ColonColon | Bar | Caret | Minus -> Some H_operator
+    | Hex _ | Bin _ | Undefined | True | False | Bitzero | Bitone | Num _ | Real _ -> Some H_literal
+    | TyVar _ -> Some H_ty_var
+    | Lcurly | Rcurly | LcurlyBar | RcurlyBar | Lsquare | Rsquare | LsquareBar | RsquareBar | Lparen | Rparen ->
+        Some H_bracket
+    | Under | Colon _ | Dot | DotDot | EqGt _ | At | Unit _ | Bidir | Semi | Comma | Eq _ | TwoCaret | MinusGt ->
+        Some H_punctuation
+end

--- a/src/sail_doc_backend/html_source.ml
+++ b/src/sail_doc_backend/html_source.ml
@@ -49,21 +49,7 @@ open Libsail
 open Ast
 open Ast_defs
 
-module Highlight = struct
-  type t = Id | Keyword | Kind | Comment | String | Pragma | Internal | Operator | Literal | TyVar
-
-  let to_class = function
-    | Id -> "sail-id"
-    | Keyword -> "sail-keyword"
-    | Kind -> "sail-kind"
-    | Comment -> "sail-comment"
-    | String -> "sail-string"
-    | Pragma -> "sail-pragma"
-    | Internal -> "sail-internal"
-    | Operator -> "sail-operator"
-    | Literal -> "sail-literal"
-    | TyVar -> "sail-ty-var"
-end
+module Highlight = Token.Highlight
 
 let highlights path =
   let handle, lexbuf = Initial_check.get_lexbuf path in
@@ -72,49 +58,17 @@ let highlights path =
   let mark h = Queue.add (h, lexbuf.lex_start_p.pos_cnum, lexbuf.lex_curr_p.pos_cnum) highlights in
   let rec go () =
     let open Token in
-    match Lexer.token handle comments lexbuf with
-    | Eof -> ()
-    | Id _ ->
-        mark Highlight.Id;
-        go ()
-    | INT | NAT | BOOL | TYPE | ORDER ->
-        mark Highlight.Kind;
-        go ()
-    | String _ | MultilineString _ ->
-        mark Highlight.String;
-        go ()
-    | DocLine _ | DocBlock _ ->
-        mark Highlight.Comment;
-        go ()
-    | And | As | Assert | By | Match | Clause | Dec | Op | Default | Effect | End | Enum | Else | Exit | Cast | Forall
-    | Foreach | Function_ | Mapping | Overload | Throw | Try | Catch | If_ | In | Inc | Var | Ref | Pure | Impure
-    | Monadic | Register | Return | Scattered | Sizeof | Constraint | Constant | Struct | Then | Typedef | Union
-    | Newtype | With | Val | Outcome | Instantiation | Impl | Private | Repeat | Until | While | Do | Mutual | Config
-    | Configuration | TerminationMeasure | Forwards | Backwards | Let_ | Bitfield | When | To | Downto | From ->
-        mark Highlight.Keyword;
-        go ()
-    | StructuredPragma _ | Pragma _ | Attribute _ | Fixity _ ->
-        mark Highlight.Pragma;
-        go ()
-    | InternalPLet | InternalReturn | InternalAssume ->
-        mark Highlight.Internal;
-        go ()
-    | OpId _ | Star | ColonColon | Bar | Caret | Minus ->
-        mark Highlight.Operator;
-        go ()
-    | Hex _ | Bin _ | Undefined | True | False | Bitzero | Bitone | Num _ | Real _ ->
-        mark Highlight.Literal;
-        go ()
-    | TyVar _ ->
-        mark Highlight.TyVar;
-        go ()
-    | Under | Colon _ | Lcurly | Rcurly | LcurlyBar | RcurlyBar | Lsquare | Rsquare | LsquareBar | RsquareBar | Lparen
-    | Rparen | Dot | DotDot | EqGt _ | At | Unit _ | Bidir | Semi | Comma | Eq _ | TwoCaret | MinusGt ->
+    let tok = Lexer.token handle comments lexbuf in
+    match Highlight.classify tok with
+    | None -> ()
+    | Some (H_punctuation | H_bracket) -> go ()
+    | Some h ->
+        mark h;
         go ()
   in
   go ();
   List.iter
-    (function Lexer.Comment (_, s, e, _) -> Queue.add (Highlight.Comment, s.pos_cnum, e.pos_cnum) highlights)
+    (function Lexer.Comment (_, s, e, _) -> Queue.add (Highlight.H_comment, s.pos_cnum, e.pos_cnum) highlights)
     !comments;
   let highlights = Array.init (Queue.length highlights) (fun _ -> Queue.take highlights) in
   Array.stable_sort (fun (_, s1, _) (_, s2, _) -> Int.compare s1 s2) highlights;

--- a/src/sail_doc_backend/html_source.mli
+++ b/src/sail_doc_backend/html_source.mli
@@ -48,18 +48,17 @@ open Libsail
 
 open Ast_defs
 
-module Highlight : sig
-  type t = Id | Keyword | Kind | Comment | String | Pragma | Internal | Operator | Literal | TyVar
-
-  val to_class : t -> string
-end
-
-val highlights : Sail_file.path -> (Highlight.t * int * int) array
+val highlights : Sail_file.path -> (Token.Highlight.t * int * int) array
 
 val hyperlink_targets : ('a, 'b) ast -> Sail_file.position Callgraph.NodeMap.t
 
 val hyperlinks_for_file : filename:string -> Type_check.typed_ast -> (Callgraph.node * int * int) array
 
-type file_info = { filename : string; prefix : string; contents : string; highlights : (Highlight.t * int * int) array }
+type file_info = {
+  filename : string;
+  prefix : string;
+  contents : string;
+  highlights : (Token.Highlight.t * int * int) array;
+}
 
 val output_html : ?css:string -> file_info:file_info -> hyperlinks:(string * int * int) array -> out_channel -> unit

--- a/src/sail_lsp/.ocamlformat
+++ b/src/sail_lsp/.ocamlformat
@@ -1,0 +1,9 @@
+profile = default
+version = 0.29.0
+margin = 120
+exp-grouping = parens
+parens-ite = true
+space-around-lists = false
+indicate-multiline-delimiters = closing-on-separate-line
+module-item-spacing = preserve
+doc-comments = before

--- a/src/sail_lsp/Makefile
+++ b/src/sail_lsp/Makefile
@@ -1,0 +1,8 @@
+.PHONY: sail_lsp install
+
+# --release implies --root .
+sail_lsp:
+	dune build --release
+
+install: sail_lsp
+	dune install --root .

--- a/src/sail_lsp/README.md
+++ b/src/sail_lsp/README.md
@@ -1,0 +1,45 @@
+sail_lsp
+========
+
+### Usage
+
+This is a minimal (and highly WIP) LSP server for Sail.
+
+Currently supports syntax highlighting and reporting type-error
+diagnostics as you type.
+
+No editor modes are currently provided, but it is particularly easy to
+set up in neovim for testing with just the following lua:
+
+```lua
+
+vim.lsp.config['sail_lsp'] = {
+    cmd = { 'sail_lsp', '--stdio' },
+    filetypes = { 'sail' },
+    root_markers = { '.git' },
+    settings = {}
+}
+
+vim.lsp.enable('sail_lsp')
+
+vim.filetype.add({
+    extension = {
+        sail = "sail",
+    },
+})
+```
+
+### Build
+
+Use `make lsp` or `make lsp_install` from the repository root.
+Currently the LSP is set up as a separate dune-project, so it will use
+the _installed_ version of `Libsail`.
+
+### Testing
+
+There is a python script (mostly vibe-coded) that can drive the LSP
+protocol for testing, and tests in `test/lsp` at the repository root.
+
+For testing the UTF-16 support in Libsail, there are also unit tests
+in `test/unit` which are gated behind setting the
+`SAIL_UNIT_TESTS=true` enviroment variable.

--- a/src/sail_lsp/dune
+++ b/src/sail_lsp/dune
@@ -1,0 +1,5 @@
+(executable
+ (name sail_lsp)
+ (modes native byte)
+ (public_name sail_lsp)
+ (libraries libsail lsp))

--- a/src/sail_lsp/dune-project
+++ b/src/sail_lsp/dune-project
@@ -1,0 +1,8 @@
+(lang dune 3.21)
+
+(package
+ (name sail_lsp)
+ (synopsis "Sail LSP server")
+ (depends
+  (lsp (>= 1.25.0))
+  (jsonrpc (>= 1.25.0))))

--- a/src/sail_lsp/handler.ml
+++ b/src/sail_lsp/handler.ml
@@ -1,0 +1,236 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Libsail
+
+open Log
+
+let file_to_handle : (string, Sail_file.handle) Hashtbl.t = Hashtbl.create 16
+let handle_to_file : (Sail_file.handle, string) Hashtbl.t = Hashtbl.create 16
+
+let register_handle file handle =
+  Hashtbl.replace file_to_handle file handle;
+  Hashtbl.replace handle_to_file handle file
+
+let unregister_handle handle =
+  (match Hashtbl.find_opt handle_to_file handle with Some file -> Hashtbl.remove file_to_handle file | None -> ());
+  Hashtbl.remove handle_to_file handle
+
+(* Search the directory containing [file] and its ancestors for the closest
+   file with a [.sail_project] extension, returning its path if one is found. *)
+let find_sail_project file =
+  let rec search dir =
+    let entries = try Sys.readdir dir with Sys_error _ -> [||] in
+    Array.sort compare entries;
+    match Array.find_opt (fun entry -> Filename.extension entry = ".sail_project") entries with
+    | Some entry -> Some (Filename.concat dir entry)
+    | None ->
+        let parent = Filename.dirname dir in
+        (* [Filename.dirname] is idempotent at the filesystem root, so stop there. *)
+        if parent = dir then None else search parent
+  in
+  search (Filename.dirname file)
+
+let state : Server_state.state option ref = ref None
+
+(* Convert a Sail source position to its zero-based, UTF-16 editor coordinates.
+   [Sail_file.editor_position] resolves the file from the position's path, so we
+   re-attach the handle's path to the (path-less) [Lexing] position first. *)
+let editor_position_of (p : Sail_file.position) =
+  let { Sail_file.Position.pos_fname = handle; _ } = p in
+  Sail_file.editor_position
+    { (Sail_file.Position.to_lexing p) with Lexing.pos_fname = Sail_file.Path.to_string (Sail_file.to_path handle) }
+
+(* Turn a [Reporting.error] into an LSP diagnostic. Every error carries a message
+   and a location; when the location can't be resolved to an editor range (e.g. an
+   unknown or generated location) we fall back to the start of the file so the
+   diagnostic is still valid and shown. *)
+let error_diagnostic (err : Reporting.error) =
+  let loc, message =
+    match err with
+    | Reporting.Err_general (l, msg) | Reporting.Err_todo (l, msg) | Reporting.Err_syntax_loc (l, msg) -> (l, msg)
+    | Reporting.Err_unreachable (l, _, _, msg) -> (l, msg)
+    | Reporting.Err_type (l, hint, msg) -> (l, match hint with Some h -> msg ^ "\n" ^ h | None -> msg)
+    | Reporting.Err_syntax (p, msg) | Reporting.Err_lex (p, msg) -> (Parse_ast.Range (p, p), msg)
+  in
+  let range =
+    match
+      Option.bind (Reporting.simp_loc loc) (fun (p1, p2) ->
+          match (editor_position_of p1, editor_position_of p2) with Some s, Some e -> Some (s, e) | _ -> None
+      )
+    with
+    | Some (s, e) ->
+        let { Sail_file.line = sl; character = sc } = s in
+        let { Sail_file.line = el; character = ec } = e in
+        Lsp.Types.Range.create
+          ~start:(Lsp.Types.Position.create ~line:sl ~character:sc)
+          ~end_:(Lsp.Types.Position.create ~line:el ~character:ec)
+    | None ->
+        let zero = Lsp.Types.Position.create ~line:0 ~character:0 in
+        Lsp.Types.Range.create ~start:zero ~end_:zero
+  in
+  Lsp.Types.Diagnostic.create ~range ~severity:Lsp.Types.DiagnosticSeverity.Error ~source:"sail"
+    ~message:(`String message) ()
+
+let diagnostics_for_handle file handle =
+  let diags =
+    match !state with
+    | Some s -> (
+        match Server_state.check_up_to s handle with
+        | Ok s' ->
+            state := Some s';
+            []
+        | Error err -> [error_diagnostic err]
+      )
+    | None -> []
+  in
+  let params =
+    Lsp.Types.PublishDiagnosticsParams.create ~uri:(Lsp.Types.DocumentUri.of_path file) ~diagnostics:diags ()
+  in
+  Lsp.Server_notification.PublishDiagnostics params
+
+let on_initialize _params =
+  let server_info = Lsp.Types.InitializeResult.create_serverInfo ~name:"sail_lsp" () in
+  let sync =
+    Lsp.Types.TextDocumentSyncOptions.create ~openClose:true ~change:Lsp.Types.TextDocumentSyncKind.Incremental
+      ~save:(`Bool true) ()
+  in
+  let semantic_tokens = Lsp.Types.SemanticTokensOptions.create ~legend:Highlight.legend ~full:(`Bool true) () in
+  let capabilities =
+    Lsp.Types.ServerCapabilities.create ~textDocumentSync:(`TextDocumentSyncOptions sync)
+      ~semanticTokensProvider:(`SemanticTokensOptions semantic_tokens) ()
+  in
+  Lsp.Types.InitializeResult.create ~capabilities ~serverInfo:server_info ()
+
+let on_shutdown () = ()
+
+let on_semantic_tokens_full (params : Lsp.Types.SemanticTokensParams.t) =
+  let file = Lsp.Types.DocumentUri.to_path params.textDocument.uri in
+  log "semanticTokens/full: %s" file;
+  match Hashtbl.find_opt file_to_handle file with
+  | None ->
+      log "semanticTokens/full: no handle for %s" file;
+      None
+  | Some handle -> Some (Highlight.compute handle)
+
+let refresh_project file =
+  match find_sail_project file with
+  | Some project_file ->
+      state := Some (Server_state.load_project ~default_sail_dir:"/Users/alasdair/sail" [project_file])
+  | None -> state := None
+
+let on_notification notif =
+  let open Lsp.Types in
+  match notif with
+  | Lsp.Client_notification.Exit -> exit 0
+  | Lsp.Client_notification.TextDocumentDidOpen params ->
+      let file = DocumentUri.to_path params.textDocument.uri in
+      log "didOpen: %s" file;
+      let text = params.textDocument.text in
+      let handle = Sail_file.editor_take_file ~contents:text file in
+      register_handle file handle;
+      ( match !state with
+      | None -> refresh_project file
+      | Some s -> (
+          match Server_state.invalidate s handle with Some s' -> state := Some s' | None -> refresh_project file
+        )
+      );
+      [diagnostics_for_handle file handle]
+  | Lsp.Client_notification.TextDocumentDidChange params -> (
+      let file = DocumentUri.to_path params.textDocument.uri in
+      log "didChange: %s" file;
+      match Hashtbl.find_opt file_to_handle file with
+      | None ->
+          log "didChange: no handle for %s" file;
+          []
+      | Some handle ->
+          List.iter
+            (fun (change : TextDocumentContentChangeEvent.t) ->
+              match change with
+              | { range = Some range; text; _ } ->
+                  (* LSP positions are UTF-16 code-unit offsets; store them as-is. The
+                     conversion to byte offsets happens when the edits are applied. *)
+                  let startp = { Sail_file.line = range.start.line; character = range.start.character } in
+                  let endp = { Sail_file.line = range.end_.line; character = range.end_.character } in
+                  Sail_file.edit_file handle { Sail_file.range = (startp, endp); text }
+              | { range = None; text; _ } -> ignore (Sail_file.editor_take_file ~contents:text file)
+            )
+            params.contentChanges;
+          Sail_file.apply_edits handle;
+          ( match !state with
+          | Some s -> (
+              match Server_state.invalidate s handle with Some s' -> state := Some s' | None -> ()
+            )
+          | None -> ()
+          );
+          [diagnostics_for_handle file handle]
+    )
+  | Lsp.Client_notification.DidSaveTextDocument params -> (
+      let file = DocumentUri.to_path params.textDocument.uri in
+      log "didSave: %s" file;
+      match Hashtbl.find_opt file_to_handle file with
+      | None -> []
+      | Some handle ->
+          Sail_file.apply_edits handle;
+          ( match !state with
+          | Some s -> (
+              match Server_state.invalidate s handle with Some s' -> state := Some s' | None -> ()
+            )
+          | None -> ()
+          );
+          [diagnostics_for_handle file handle]
+    )
+  | Lsp.Client_notification.TextDocumentDidClose params ->
+      let file = DocumentUri.to_path params.textDocument.uri in
+      log "didClose: %s" file;
+      ( match Hashtbl.find_opt file_to_handle file with
+      | None -> ()
+      | Some handle ->
+          Sail_file.editor_drop_file handle;
+          unregister_handle handle
+      );
+      []
+  | _ -> []

--- a/src/sail_lsp/handler.mli
+++ b/src/sail_lsp/handler.mli
@@ -44,22 +44,10 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type symbol_set
+val on_initialize : Lsp.Types.InitializeParams.t -> Lsp.Types.InitializeResult.t
 
-val add_default_symbol : string -> unit
+val on_shutdown : unit -> unit
 
-val get_default_symbols : unit -> symbol_set
+val on_semantic_tokens_full : Lsp.Types.SemanticTokensParams.t -> Lsp.Types.SemanticTokens.t option
 
-val have_symbol : string -> symbol_set -> bool
-
-val create_argv_array : offset:int -> current:int ref -> Ast.l -> string -> string list * (unit -> unit)
-
-val get_argv_position : plus:int -> Sail_file.position option
-
-val preprocess :
-  default_sail_dir:string ->
-  target_name:string option ->
-  options:(Arg.key * Arg.spec * Arg.doc) list ->
-  symbols:symbol_set ->
-  Parse_ast.def list ->
-  Parse_ast.def list * symbol_set
+val on_notification : Lsp.Client_notification.t -> Lsp.Server_notification.t list

--- a/src/sail_lsp/log.ml
+++ b/src/sail_lsp/log.ml
@@ -44,22 +44,8 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type symbol_set
+open Printf
 
-val add_default_symbol : string -> unit
+let log fmt args = eprintf "[sail_lsp] %s\n%!" (sprintf fmt args)
 
-val get_default_symbols : unit -> symbol_set
-
-val have_symbol : string -> symbol_set -> bool
-
-val create_argv_array : offset:int -> current:int ref -> Ast.l -> string -> string list * (unit -> unit)
-
-val get_argv_position : plus:int -> Sail_file.position option
-
-val preprocess :
-  default_sail_dir:string ->
-  target_name:string option ->
-  options:(Arg.key * Arg.spec * Arg.doc) list ->
-  symbols:symbol_set ->
-  Parse_ast.def list ->
-  Parse_ast.def list * symbol_set
+let log_error fmt args = eprintf "[sail_lsp] Error: %s\n%!" (sprintf fmt args)

--- a/src/sail_lsp/log.mli
+++ b/src/sail_lsp/log.mli
@@ -44,22 +44,6 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type symbol_set
+val log : ('a -> string, unit, string) format -> 'a -> unit
 
-val add_default_symbol : string -> unit
-
-val get_default_symbols : unit -> symbol_set
-
-val have_symbol : string -> symbol_set -> bool
-
-val create_argv_array : offset:int -> current:int ref -> Ast.l -> string -> string list * (unit -> unit)
-
-val get_argv_position : plus:int -> Sail_file.position option
-
-val preprocess :
-  default_sail_dir:string ->
-  target_name:string option ->
-  options:(Arg.key * Arg.spec * Arg.doc) list ->
-  symbols:symbol_set ->
-  Parse_ast.def list ->
-  Parse_ast.def list * symbol_set
+val log_error : ('a -> string, unit, string) format -> 'a -> unit

--- a/src/sail_lsp/sail_lsp.ml
+++ b/src/sail_lsp/sail_lsp.ml
@@ -44,22 +44,19 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type symbol_set
+let speclist = [("--stdio", Arg.Unit (fun () -> ()), " Use stdin/stdout for IO (default).")]
 
-val add_default_symbol : string -> unit
+let anon_fun _ = ()
 
-val get_default_symbols : unit -> symbol_set
+let main () =
+  Arg.parse_argv Sys.argv speclist anon_fun "sail_lsp [--stdio]";
+  Server.run ()
 
-val have_symbol : string -> symbol_set -> bool
-
-val create_argv_array : offset:int -> current:int ref -> Ast.l -> string -> string list * (unit -> unit)
-
-val get_argv_position : plus:int -> Sail_file.position option
-
-val preprocess :
-  default_sail_dir:string ->
-  target_name:string option ->
-  options:(Arg.key * Arg.spec * Arg.doc) list ->
-  symbols:symbol_set ->
-  Parse_ast.def list ->
-  Parse_ast.def list * symbol_set
+let () =
+  try Libsail.Parmap.toplevel_handler main with
+  | Arg.Bad msg ->
+      prerr_endline msg;
+      exit 1
+  | Arg.Help msg ->
+      print_endline msg;
+      exit 0

--- a/src/sail_lsp/server.ml
+++ b/src/sail_lsp/server.ml
@@ -44,22 +44,87 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type symbol_set
+open Log
 
-val add_default_symbol : string -> unit
+module Io = struct
+  type 'a t = 'a
 
-val get_default_symbols : unit -> symbol_set
+  let return x = x
+  let raise = raise
 
-val have_symbol : string -> symbol_set -> bool
+  module O = struct
+    let ( let+ ) x f = f x
+    let ( let* ) x f = f x
+  end
+end
 
-val create_argv_array : offset:int -> current:int ref -> Ast.l -> string -> string list * (unit -> unit)
+module Chan = struct
+  type input = in_channel
+  type output = out_channel
 
-val get_argv_position : plus:int -> Sail_file.position option
+  let read_line ic = try Some (input_line ic) with End_of_file -> None
 
-val preprocess :
-  default_sail_dir:string ->
-  target_name:string option ->
-  options:(Arg.key * Arg.spec * Arg.doc) list ->
-  symbols:symbol_set ->
-  Parse_ast.def list ->
-  Parse_ast.def list * symbol_set
+  let read_exactly ic n =
+    let buf = Bytes.create n in
+    try
+      really_input ic buf 0 n;
+      Some (Bytes.to_string buf)
+    with End_of_file -> None
+
+  let write oc parts =
+    List.iter (output_string oc) parts;
+    flush oc
+end
+
+module LspIo = Lsp.Io.Make (Io) (Chan)
+
+let send oc packet = LspIo.write oc packet
+
+let handle_request oc (req : Jsonrpc.Request.t) =
+  let open Jsonrpc in
+  let resp =
+    match Lsp.Client_request.of_jsonrpc req with
+    | Error msg -> Response.error req.id (Response.Error.make ~code:Response.Error.Code.InvalidRequest ~message:msg ())
+    | Ok (Lsp.Client_request.E r) -> (
+        let result =
+          match r with
+          | Lsp.Client_request.Initialize params ->
+              Ok (Lsp.Client_request.yojson_of_result r (Handler.on_initialize params))
+          | Lsp.Client_request.Shutdown ->
+              Handler.on_shutdown ();
+              Ok (Lsp.Client_request.yojson_of_result r ())
+          | Lsp.Client_request.SemanticTokensFull params ->
+              Ok (Lsp.Client_request.yojson_of_result r (Handler.on_semantic_tokens_full params))
+          | _ ->
+              Error (Response.Error.make ~code:Response.Error.Code.MethodNotFound ~message:"method not implemented" ())
+        in
+        match result with Ok json -> Response.ok req.id json | Error err -> Response.error req.id err
+      )
+  in
+  send oc (Packet.Response resp)
+
+let rec run () =
+  match LspIo.read stdin with
+  | None -> ()
+  | Some packet ->
+      ( match packet with
+      | Jsonrpc.Packet.Request req -> (
+          try handle_request stdout req with exn -> log_error "request handler raised: %s" (Printexc.to_string exn)
+        )
+      | Jsonrpc.Packet.Notification n -> (
+          match Lsp.Client_notification.of_jsonrpc n with
+          | Ok notif -> (
+              try
+                List.iter
+                  (fun server_notif ->
+                    let jsonrpc_notif = Lsp.Server_notification.to_jsonrpc server_notif in
+                    send stdout (Jsonrpc.Packet.Notification jsonrpc_notif)
+                  )
+                  (Handler.on_notification notif)
+              with exn -> log_error "notification handler raised: %s" (Printexc.to_string exn)
+            )
+          | Error msg -> log_error "failed to decode notification: %s" msg
+        )
+      | _ -> ()
+      );
+      run ()

--- a/src/sail_lsp/server.mli
+++ b/src/sail_lsp/server.mli
@@ -44,22 +44,4 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type symbol_set
-
-val add_default_symbol : string -> unit
-
-val get_default_symbols : unit -> symbol_set
-
-val have_symbol : string -> symbol_set -> bool
-
-val create_argv_array : offset:int -> current:int ref -> Ast.l -> string -> string list * (unit -> unit)
-
-val get_argv_position : plus:int -> Sail_file.position option
-
-val preprocess :
-  default_sail_dir:string ->
-  target_name:string option ->
-  options:(Arg.key * Arg.spec * Arg.doc) list ->
-  symbols:symbol_set ->
-  Parse_ast.def list ->
-  Parse_ast.def list * symbol_set
+val run : unit -> unit

--- a/test/lsp/README.md
+++ b/test/lsp/README.md
@@ -1,0 +1,67 @@
+# LSP tests
+
+Black-box tests for the Sail language server (`sail_lsp`). They spawn the
+server as a subprocess and drive it over stdio using the JSON-RPC / LSP
+`Content-Length` framing, asserting on the protocol-level behaviour.
+
+## Running
+
+Build the server first:
+
+```
+make lsp        # from the repository root
+```
+
+Then run the suite:
+
+```
+cd test/lsp
+./run_tests.py
+```
+
+The harness locates the server binary in this order:
+
+1. the `SAIL_LSP` environment variable, if set;
+2. the binary produced by `make lsp`
+   (`src/sail_lsp/_build/default/sail_lsp.exe`);
+3. `sail_lsp` on `PATH`.
+
+To test an installed server (`make lsp_install`) or a specific build:
+
+```
+SAIL_LSP=$(command -v sail_lsp) ./run_tests.py
+```
+
+Run a subset by naming the test functions:
+
+```
+./run_tests.py test_initialize test_incremental_edits
+```
+
+Results are written to `tests.xml` (the JUnit format shared with the other
+Sail test suites); the runner exits non-zero if any test fails.
+
+## Layout
+
+- `lsp_harness.py` — a minimal LSP client: process spawning, message framing,
+  request/notification helpers, and the document lifecycle (didOpen,
+  didChange, didSave, didClose). Documents must exist on disk because the
+  server canonicalises paths with `realpath`; use the `Workspace` helper to
+  create throwaway files.
+- `run_tests.py` — the test cases and runner.
+
+## Adding a test
+
+Add a function named `test_*` to `run_tests.py` and list it in `TESTS`. A test
+constructs an `LspClient` (and usually a `Workspace`), performs a protocol
+exchange, and uses `check(...)` for assertions. Each test should
+`shutdown()`/`exit()` the server it starts. For example:
+
+```python
+def test_initialize():
+    with LspClient() as client:
+        result = client.initialize()
+        check(result["serverInfo"]["name"] == "sail_lsp", "unexpected serverInfo")
+        client.shutdown()
+        client.exit()
+```

--- a/test/lsp/lsp_harness.py
+++ b/test/lsp/lsp_harness.py
@@ -1,0 +1,276 @@
+"""A minimal Language Server Protocol client for driving the Sail LSP server.
+
+The server (``sail_lsp``) speaks JSON-RPC 2.0 over stdin/stdout using the
+standard LSP ``Content-Length`` framing.  This module spawns the server as a
+subprocess and provides just enough of a client to write black-box tests
+against it:
+
+  * request / notify with automatic framing,
+  * a background reader thread that separates responses from notifications,
+  * helpers for the document lifecycle (didOpen / didChange / ...),
+  * discovery of the server binary via the ``SAIL_LSP`` environment variable.
+
+The Sail server canonicalises paths with ``realpath`` when a document is
+opened, so documents passed to :meth:`LspClient.did_open` must refer to files
+that actually exist on disk.  Use :func:`workspace` to create throwaway files.
+"""
+
+import json
+import os
+import pathlib
+import queue
+import shutil
+import subprocess
+import tempfile
+import threading
+
+
+def find_server():
+    """Locate the sail_lsp binary.
+
+    Preference order: the ``SAIL_LSP`` environment variable, then the binary
+    produced by ``make lsp`` in the source tree, then ``sail_lsp`` on PATH.
+    """
+    env = os.environ.get("SAIL_LSP")
+    if env:
+        return env
+
+    here = os.path.dirname(os.path.realpath(__file__))
+    built = os.path.realpath(os.path.join(here, "..", "..", "src", "sail_lsp", "_build", "default", "sail_lsp.exe"))
+    if os.path.exists(built):
+        return built
+
+    return "sail_lsp"
+
+
+def uri_of_path(path):
+    return pathlib.Path(path).resolve().as_uri()
+
+
+class Workspace:
+    """A temporary directory of Sail source files, cleaned up on exit."""
+
+    def __init__(self, files):
+        self.dir = tempfile.mkdtemp(prefix="sail_lsp_test_")
+        self.paths = {}
+        for name, contents in files.items():
+            path = os.path.join(self.dir, name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(contents)
+            self.paths[name] = path
+
+    def path(self, name):
+        return self.paths[name]
+
+    def uri(self, name):
+        return uri_of_path(self.paths[name])
+
+    def root_uri(self):
+        return uri_of_path(self.dir)
+
+    def cleanup(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.cleanup()
+
+
+class LspError(Exception):
+    pass
+
+
+class LspClient:
+    """Drives a sail_lsp subprocess over stdio."""
+
+    def __init__(self, server=None, timeout=15.0):
+        self.server = server or find_server()
+        self.timeout = timeout
+        self._next_id = 0
+        self._responses = queue.Queue()
+        self._notifications = queue.Queue()
+        self._stderr_lines = []
+        self._proc = subprocess.Popen(
+            [self.server, "--stdio"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        self._stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_reader.start()
+
+    # -- low level IO --------------------------------------------------------
+
+    def _read_loop(self):
+        out = self._proc.stdout
+        try:
+            while True:
+                headers = {}
+                while True:
+                    line = out.readline()
+                    if not line:
+                        raise EOFError
+                    line = line.decode("utf-8").rstrip("\r\n")
+                    if line == "":
+                        break
+                    key, _, value = line.partition(":")
+                    headers[key.strip().lower()] = value.strip()
+                length = int(headers["content-length"])
+                body = out.read(length)
+                message = json.loads(body.decode("utf-8"))
+                if "id" in message and ("result" in message or "error" in message):
+                    self._responses.put(message)
+                elif "method" in message:
+                    self._notifications.put(message)
+                # else: server->client responses we didn't send; ignore.
+        except (EOFError, ValueError, KeyError):
+            # Stream closed (server exited), a truncated read, or a malformed
+            # frame; wake up any waiters with a sentinel so they don't block.
+            self._responses.put(None)
+            self._notifications.put(None)
+
+    def _stderr_loop(self):
+        for line in iter(self._proc.stderr.readline, b""):
+            self._stderr_lines.append(line.decode("utf-8", "replace").rstrip())
+
+    def _send(self, message):
+        body = json.dumps(message).encode("utf-8")
+        header = "Content-Length: {}\r\n\r\n".format(len(body)).encode("ascii")
+        self._proc.stdin.write(header + body)
+        self._proc.stdin.flush()
+
+    # -- public API ----------------------------------------------------------
+
+    def notify(self, method, params=None):
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def request(self, method, params=None):
+        self._next_id += 1
+        request_id = self._next_id
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
+        try:
+            response = self._responses.get(timeout=self.timeout)
+        except queue.Empty:
+            raise LspError("timed out waiting for response to {!r}\n{}".format(method, self.stderr()))
+        if response is None:
+            raise LspError("server exited while waiting for response to {!r}\n{}".format(method, self.stderr()))
+        if response.get("id") != request_id:
+            raise LspError("response id {} did not match request id {}".format(response.get("id"), request_id))
+        if "error" in response:
+            raise LspError("request {!r} returned error: {}".format(method, response["error"]))
+        return response.get("result")
+
+    def wait_notification(self, method=None, timeout=None):
+        """Return the next notification, optionally waiting for a given method."""
+        deadline_timeout = self.timeout if timeout is None else timeout
+        while True:
+            try:
+                notification = self._notifications.get(timeout=deadline_timeout)
+            except queue.Empty:
+                raise LspError(
+                    "timed out waiting for notification {!r}\n{}".format(method, self.stderr())
+                )
+            if notification is None:
+                raise LspError(
+                    "server exited while waiting for notification {!r}\n{}".format(method, self.stderr())
+                )
+            if method is None or notification.get("method") == method:
+                return notification
+
+    def expect_no_notification(self, timeout=0.5):
+        """Assert that no notification arrives within the given window."""
+        try:
+            notification = self._notifications.get(timeout=timeout)
+        except queue.Empty:
+            return
+        if notification is None:
+            return
+        raise LspError("unexpected notification: {}".format(json.dumps(notification)))
+
+    # -- lifecycle helpers ---------------------------------------------------
+
+    def initialize(self, root_uri=None):
+        return self.request(
+            "initialize",
+            {"processId": os.getpid(), "rootUri": root_uri, "capabilities": {}},
+        )
+
+    def initialized(self):
+        self.notify("initialized", {})
+
+    def did_open(self, uri, text, language_id="sail", version=1):
+        self.notify(
+            "textDocument/didOpen",
+            {"textDocument": {"uri": uri, "languageId": language_id, "version": version, "text": text}},
+        )
+
+    def did_change(self, uri, changes, version=2):
+        self.notify(
+            "textDocument/didChange",
+            {"textDocument": {"uri": uri, "version": version}, "contentChanges": changes},
+        )
+
+    def did_save(self, uri):
+        self.notify("textDocument/didSave", {"textDocument": {"uri": uri}})
+
+    def did_close(self, uri):
+        self.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+
+    def semantic_tokens_full(self, uri):
+        return self.request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+
+    def shutdown(self):
+        return self.request("shutdown")
+
+    def exit(self, expected_code=0, timeout=None):
+        self.notify("exit")
+        code = self.wait_for_exit(timeout=timeout)
+        if expected_code is not None and code != expected_code:
+            raise LspError("server exited with code {}, expected {}".format(code, expected_code))
+        return code
+
+    def wait_for_exit(self, timeout=None):
+        try:
+            return self._proc.wait(timeout=self.timeout if timeout is None else timeout)
+        except subprocess.TimeoutExpired:
+            raise LspError("server did not exit\n{}".format(self.stderr()))
+
+    def stderr(self):
+        return "\n".join(self._stderr_lines)
+
+    def close(self):
+        if self._proc.poll() is None:
+            self._proc.kill()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def full_change(text):
+    """A whole-document content change (no range)."""
+    return [{"text": text}]
+
+
+def incremental_change(start_line, start_char, end_line, end_char, text):
+    """A ranged (incremental) content change using LSP line/UTF-16 offsets."""
+    return [
+        {
+            "range": {
+                "start": {"line": start_line, "character": start_char},
+                "end": {"line": end_line, "character": end_char},
+            },
+            "text": text,
+        }
+    ]

--- a/test/lsp/run_tests.py
+++ b/test/lsp/run_tests.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+
+"""Black-box test suite for the Sail LSP server (``sail_lsp``).
+
+Each test drives a fresh server subprocess over stdio using the client in
+``lsp_harness.py`` and asserts on the protocol-level behaviour.  Run directly:
+
+    ./run_tests.py                 # use the binary built by `make lsp`
+    SAIL_LSP=/path/to/sail_lsp ./run_tests.py
+
+Results are written to ``tests.xml`` in the JUnit format used by the other
+Sail test suites, and a non-zero exit code is returned if anything fails.
+"""
+
+import datetime
+import html
+import os
+import sys
+import traceback
+
+from lsp_harness import LspClient, Workspace, full_change, incremental_change
+
+
+class color:
+    NOTICE = "\033[94m"
+    PASS = "\033[92m"
+    FAIL = "\033[91m"
+    END = "\033[0m"
+
+
+HELLO = "default Order dec\n\nval main : unit -> unit\n\nfunction main() = ()\n"
+
+# A file with multi-byte UTF-8 characters, to exercise the UTF-16 offset path.
+UNICODE = "// π ≈ 3.14  — comment with wide chars\ndefault Order dec\n"
+
+# A single-module project referencing m.sail; needed for the server to actually
+# type-check a file and report diagnostics (without a project it stays idle).
+PROJECT = "M {\n  files m.sail\n}\n"
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def diagnostics_uri(notification):
+    check(
+        notification.get("method") == "textDocument/publishDiagnostics",
+        "expected publishDiagnostics, got {}".format(notification.get("method")),
+    )
+    return notification["params"]["uri"]
+
+
+# -- test cases --------------------------------------------------------------
+
+
+def test_initialize():
+    """initialize advertises the server name and document-sync capabilities."""
+    with LspClient() as client:
+        result = client.initialize()
+        info = result.get("serverInfo", {})
+        check(info.get("name") == "sail_lsp", "unexpected serverInfo: {}".format(info))
+
+        sync = result["capabilities"]["textDocumentSync"]
+        check(sync["openClose"] is True, "openClose not advertised: {}".format(sync))
+        # 2 == TextDocumentSyncKind.Incremental
+        check(sync["change"] == 2, "expected incremental sync, got {}".format(sync["change"]))
+        check(bool(sync["save"]), "save not advertised: {}".format(sync))
+
+        client.shutdown()
+        client.exit()
+
+
+def test_shutdown_exit():
+    """A shutdown request returns null and exit terminates with code 0."""
+    with LspClient() as client:
+        client.initialize()
+        result = client.shutdown()
+        check(result is None, "shutdown should return null, got {}".format(result))
+        client.exit(expected_code=0)
+
+
+def test_did_change_publishes_diagnostics():
+    """Editing an open document yields a publishDiagnostics for that document."""
+    with Workspace({"m.sail": HELLO}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        client.did_open(ws.uri("m.sail"), HELLO)
+        client.did_change(ws.uri("m.sail"), incremental_change(0, 0, 0, 0, "// edit\n"))
+        notification = client.wait_notification("textDocument/publishDiagnostics")
+        check(
+            diagnostics_uri(notification) == ws.uri("m.sail"),
+            "diagnostics for wrong uri: {}".format(diagnostics_uri(notification)),
+        )
+        client.shutdown()
+        client.exit()
+
+
+def test_did_save_publishes_diagnostics():
+    """Saving an open document yields a publishDiagnostics for that document."""
+    with Workspace({"m.sail": HELLO}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        client.did_open(ws.uri("m.sail"), HELLO)
+        client.did_save(ws.uri("m.sail"))
+        notification = client.wait_notification("textDocument/publishDiagnostics")
+        check(diagnostics_uri(notification) == ws.uri("m.sail"), "diagnostics for wrong uri")
+        client.shutdown()
+        client.exit()
+
+
+def test_incremental_edits():
+    """A sequence of incremental edits keeps the server responsive."""
+    with Workspace({"m.sail": HELLO}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, HELLO)
+
+        edits = [
+            incremental_change(0, 0, 0, 0, "// header\n"),   # insert a line at the top
+            incremental_change(1, 0, 1, 0, "// second\n"),   # insert another line
+            incremental_change(0, 0, 1, 0, ""),              # delete the first line
+            full_change("default Order dec\n"),              # whole-document replace
+        ]
+        for version, change in enumerate(edits, start=2):
+            client.did_change(uri, change, version=version)
+            notification = client.wait_notification("textDocument/publishDiagnostics")
+            check(diagnostics_uri(notification) == uri, "diagnostics for wrong uri")
+
+        # Server is still healthy and responds to a request.
+        check(client.shutdown() is None, "shutdown failed after edits")
+        client.exit()
+
+
+def test_unicode_offsets():
+    """Edits expressed in UTF-16 offsets over multi-byte text don't crash the server."""
+    with Workspace({"u.sail": UNICODE}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("u.sail")
+        client.did_open(uri, UNICODE)
+        # Insert after the multi-byte characters on line 0. LSP character
+        # offsets are counted in UTF-16 code units, not bytes.
+        client.did_change(uri, incremental_change(0, 12, 0, 12, "X"))
+        notification = client.wait_notification("textDocument/publishDiagnostics")
+        check(diagnostics_uri(notification) == uri, "diagnostics for wrong uri")
+        client.shutdown()
+        client.exit()
+
+
+def test_open_close_reopen():
+    """Closing then reopening a document leaves the server healthy."""
+    with Workspace({"m.sail": HELLO}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, HELLO)
+        client.did_close(uri)
+        # didOpen/didClose produce no notifications of their own.
+        client.expect_no_notification()
+        client.did_open(uri, HELLO)
+        client.did_change(uri, incremental_change(0, 0, 0, 0, "// again\n"))
+        notification = client.wait_notification("textDocument/publishDiagnostics")
+        check(diagnostics_uri(notification) == uri, "diagnostics for wrong uri")
+        client.shutdown()
+        client.exit()
+
+
+def test_missing_file_does_not_crash():
+    """Opening a non-existent document must not take the server down."""
+    with LspClient() as client:
+        client.initialize()
+        client.initialized()
+        # This path does not exist on disk; the server logs an error but must
+        # keep serving requests.
+        client.did_open("file:///no/such/sail/file.sail", "default Order dec\n")
+        check(client.shutdown() is None, "server did not survive a bad didOpen")
+        client.exit()
+
+
+def decode_semantic_tokens(data, token_types):
+    """Decode the LSP delta-encoded semantic token array into a list of
+    (line, start_char, length, type_name) tuples, all zero-based and in UTF-16
+    code units."""
+    tokens = []
+    line = 0
+    char = 0
+    for i in range(0, len(data), 5):
+        delta_line, delta_start, length, type_index, _modifiers = data[i : i + 5]
+        line += delta_line
+        char = delta_start if delta_line else char + delta_start
+        tokens.append((line, char, length, token_types[type_index]))
+    return tokens
+
+
+def semantic_tokens_legend(init_result):
+    provider = init_result["capabilities"].get("semanticTokensProvider")
+    check(provider is not None, "semanticTokensProvider not advertised")
+    return provider
+
+
+def test_semantic_tokens_capability():
+    """The server advertises a semanticTokens provider with a full legend."""
+    with LspClient() as client:
+        provider = semantic_tokens_legend(client.initialize())
+        check(provider.get("full") is True, "full semantic tokens not advertised: {}".format(provider))
+        types = provider["legend"]["tokenTypes"]
+        for expected in ("keyword", "comment", "string", "number"):
+            check(expected in types, "legend missing {!r}: {}".format(expected, types))
+        client.shutdown()
+        client.exit()
+
+
+def test_semantic_tokens_full():
+    """semanticTokens/full lexes the buffer into typed, positioned tokens."""
+    code = 'val x = 0xFF // hi\n"str"\n'
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        types = semantic_tokens_legend(client.initialize(ws.root_uri()))["legend"]["tokenTypes"]
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        result = client.semantic_tokens_full(uri)
+        check(result is not None, "no semantic tokens returned")
+        tokens = decode_semantic_tokens(result["data"], types)
+        expected = [
+            (0, 0, 3, "keyword"),  # val
+            (0, 8, 4, "number"),  # 0xFF
+            (0, 13, 5, "comment"),  # // hi
+            (1, 0, 5, "string"),  # "str"
+        ]
+        for token in expected:
+            check(token in tokens, "expected token {} not found in {}".format(token, tokens))
+        client.shutdown()
+        client.exit()
+
+
+def test_semantic_tokens_unicode():
+    """Token positions and lengths are reported in UTF-16 code units."""
+    # The string literal "ππ" is 6 UTF-8 bytes but 4 UTF-16 code units.
+    code = 'let x = "ππ"\n'
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        types = semantic_tokens_legend(client.initialize(ws.root_uri()))["legend"]["tokenTypes"]
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        tokens = decode_semantic_tokens(client.semantic_tokens_full(uri)["data"], types)
+        check((0, 8, 4, "string") in tokens, "UTF-16 string token not found in {}".format(tokens))
+        client.shutdown()
+        client.exit()
+
+
+def test_semantic_tokens_multiline():
+    """A token spanning several lines is split into one token per line."""
+    code = "/* a\n b */\nval x\n"
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        types = semantic_tokens_legend(client.initialize(ws.root_uri()))["legend"]["tokenTypes"]
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        tokens = decode_semantic_tokens(client.semantic_tokens_full(uri)["data"], types)
+        # The block comment covers "/* a" on line 0 and " b */" on line 1.
+        for token in [(0, 0, 4, "comment"), (1, 0, 5, "comment")]:
+            check(token in tokens, "expected comment token {} not found in {}".format(token, tokens))
+        client.shutdown()
+        client.exit()
+
+
+def test_error_diagnostic():
+    """A file with an error yields a diagnostic with a valid, correctly located range."""
+    # The syntax error is on line 1 (zero-based); LSP positions are zero-based.
+    code = "default Order dec\nfoo bar baz\n"
+    with Workspace({"proj.sail_project": PROJECT, "m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        note = client.wait_notification("textDocument/publishDiagnostics")
+        check(diagnostics_uri(note) == uri, "diagnostics for wrong uri")
+        diags = note["params"]["diagnostics"]
+        check(len(diags) >= 1, "expected at least one diagnostic, got {}".format(diags))
+        d = diags[0]
+        check(d.get("severity") == 1, "expected Error severity (1), got {}".format(d.get("severity")))
+        check(d.get("source") == "sail", "expected source 'sail', got {}".format(d.get("source")))
+        message = d.get("message")
+        check(isinstance(message, str) and message.strip() != "", "expected a non-empty message, got {!r}".format(message))
+        start, end = d["range"]["start"], d["range"]["end"]
+        check(start["line"] == 1, "expected diagnostic on line 1, got {}".format(start))
+        # A well-formed range: start no later than end, both zero-based.
+        check(start["character"] >= 0 and (end["line"], end["character"]) >= (start["line"], start["character"]),
+              "malformed range {}".format(d["range"]))
+        client.shutdown()
+        client.exit()
+
+
+def test_valid_file_has_no_diagnostics():
+    """A well-formed file under a project produces an empty diagnostics list."""
+    code = "default Order dec\n"
+    with Workspace({"proj.sail_project": PROJECT, "m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        note = client.wait_notification("textDocument/publishDiagnostics")
+        diags = note["params"]["diagnostics"]
+        check(diags == [], "expected no diagnostics for a valid file, got {}".format(diags))
+        client.shutdown()
+        client.exit()
+
+
+TESTS = [
+    test_initialize,
+    test_shutdown_exit,
+    test_did_change_publishes_diagnostics,
+    test_did_save_publishes_diagnostics,
+    test_incremental_edits,
+    test_unicode_offsets,
+    test_open_close_reopen,
+    test_missing_file_does_not_crash,
+    test_semantic_tokens_capability,
+    test_semantic_tokens_full,
+    test_semantic_tokens_unicode,
+    test_semantic_tokens_multiline,
+    test_error_diagnostic,
+    test_valid_file_has_no_diagnostics,
+]
+
+
+# -- runner ------------------------------------------------------------------
+
+
+def main():
+    only = sys.argv[1:]
+    tests = [t for t in TESTS if not only or t.__name__ in only]
+
+    passes = 0
+    failures = 0
+    xml = ""
+
+    for test in tests:
+        name = test.__name__
+        label = "{} ".format(name).ljust(48, ".")
+        try:
+            test()
+        except Exception as exc:
+            failures += 1
+            message = "{}: {}".format(type(exc).__name__, exc)
+            print("{} {}FAIL{}".format(label, color.FAIL, color.END))
+            print(traceback.format_exc())
+            qmsg = html.escape(message)
+            xml += '    <testcase name="{}">\n      <error message="{}">{}</error>\n    </testcase>\n'.format(
+                name, qmsg, qmsg
+            )
+        else:
+            passes += 1
+            print("{} {}ok{}".format(label, color.PASS, color.END))
+            xml += '    <testcase name="{}"/>\n'.format(name)
+
+    print(
+        "{}{} passes and {} failures{}".format(
+            color.NOTICE, passes, failures, color.END
+        )
+    )
+
+    timestamp = datetime.datetime.utcnow()
+    suite = '<testsuites>\n  <testsuite name="lsp" tests="{}" failures="{}" timestamp="{}">\n{}  </testsuite>\n</testsuites>\n'
+    with open(os.path.join(os.path.dirname(__file__), "tests.xml"), "w") as f:
+        f.write(suite.format(passes + failures, failures, timestamp, xml))
+
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -1,0 +1,37 @@
+# Unit tests
+
+Unit tests for the public `libsail` interface, written with
+[Alcotest](https://github.com/mirage/alcotest). They exercise the
+library the same way an external consumer would through the public
+`Libsail` module interfaces.
+
+## Running
+
+```
+SAIL_UNIT_TESTS=true dune runtest test/unit
+```
+
+The `SAIL_UNIT_TESTS` environment variable gates the tests: without
+it, a plain `dune build` (and `make sail`) does not compile these
+tests, so Alcotest is not required for the normal build. The tests are
+part of the main dune project, so they link the in-tree `libsail` and
+test working-tree changes and not an installed copy.
+
+To run a single test group or case, pass Alcotest's filter arguments
+after `--`:
+
+```
+SAIL_UNIT_TESTS=true dune exec test/unit/test_libsail.exe -- test Sail_file.utf16_to_byte
+```
+
+## Layout
+
+- `test_libsail.ml` — the runner. It collects the `suites` from each
+  per-file module and passes them to `Alcotest.run`.
+- `test_<file>.ml` — one module per Libsail file under test (e.g.
+  `test_sail_file.ml` for `Sail_file`), each exposing
+  `val suites : unit Alcotest.test list`.
+
+To test a new Libsail file, add a `test_<file>.ml` module exposing a
+`suites` value and append `Test_<file>.suites` to the list in
+`test_libsail.ml`.

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,0 +1,5 @@
+(test
+ (name test_libsail)
+ (libraries libsail alcotest)
+ (enabled_if
+  (= %{env:SAIL_UNIT_TESTS=false} true)))

--- a/test/unit/test_libsail.ml
+++ b/test/unit/test_libsail.ml
@@ -1,0 +1,8 @@
+(* Entry point for the libsail unit tests.
+
+   Each Libsail file under test has its own [test_<file>] module exposing a
+   [suites] value (a list of named Alcotest suites). Collect them all here so a
+   single run covers the whole library. To test a new file, add a
+   [test_<file>.ml] module and append its [suites] below. *)
+
+let () = Alcotest.run "libsail" (List.concat [Test_sail_file.suites])

--- a/test/unit/test_sail_file.ml
+++ b/test/unit/test_sail_file.ml
@@ -1,0 +1,142 @@
+(* Unit tests for the public Sail_file interface.
+
+   To keep the tests hermetic they build file handles with
+   [add_virtual_file], which does not touch the filesystem, rather
+   than [editor_take_file], which canonicalises paths with realpath
+   and hence needs a real file on disk.
+
+   The [suites] value at the bottom is collected by the [test_libsail] runner. *)
+
+open Libsail
+
+let counter = ref 0
+
+(* A fresh file handle initialised with [contents]. Each handle gets a unique
+   virtual name so tests do not interfere with one another. *)
+let handle_of contents =
+  incr counter;
+  let _, handle = Sail_file.add_virtual_file ~contents (Printf.sprintf "sail_file_test_%d.sail" !counter) in
+  handle
+
+let pos line character = { Sail_file.line; character }
+
+let edit start_ end_ text = { Sail_file.range = (start_, end_); text }
+
+(* -- Sail_file.contents round-trips the initial file ---------------------- *)
+
+let contents_tests =
+  let roundtrip name input () =
+    let handle = handle_of input in
+    Alcotest.(check string) name input (Sail_file.contents handle)
+  in
+  [
+    Alcotest.test_case "single line" `Quick (roundtrip "single line" "default Order dec");
+    Alcotest.test_case "trailing newline" `Quick (roundtrip "trailing newline" "a\nb\n");
+    Alcotest.test_case "no trailing newline" `Quick (roundtrip "no trailing newline" "a\nb");
+    Alcotest.test_case "empty" `Quick (roundtrip "empty" "");
+  ]
+
+(* -- Sail_file.lexing_position (UTF-16 -> byte conversion) ---------------- *)
+
+(* Editor positions carry UTF-16 code-unit character offsets; Sail lexing
+   positions carry byte offsets. With no pending edits, [lexing_position] just
+   converts the offset against the addressed line, so we can use it to exercise
+   the UTF-16 -> byte conversion through the public API. The multi-byte
+   characters used below (given as explicit UTF-8 byte escapes) are:
+     beta   U+03B2  "\xce\xb2"          2 bytes, 1 UTF-16 unit
+     approx U+2248  "\xe2\x89\x88"      3 bytes, 1 UTF-16 unit
+     grin   U+1F600 "\xf0\x9f\x98\x80"  4 bytes, 2 UTF-16 units (surrogate pair) *)
+
+(* Byte offset within its line of the editor position [(line, utf16)]. *)
+let byte_offset handle line utf16 =
+  match Sail_file.lexing_position handle (pos line utf16) with
+  | Some p -> p.Lexing.pos_cnum - p.Lexing.pos_bol
+  | None -> Alcotest.failf "lexing_position returned None for (%d, %d)" line utf16
+
+let lexing_position_tests =
+  let case name ?(line = 0) contents utf16 expected =
+    Alcotest.test_case name `Quick (fun () ->
+        let handle = handle_of contents in
+        Alcotest.(check int) name expected (byte_offset handle line utf16)
+    )
+  in
+  [
+    (* Plain ASCII: UTF-16 offset equals the byte offset. *)
+    case "ascii start" "hello" 0 0;
+    case "ascii middle" "hello" 3 3;
+    case "ascii end" "hello" 5 5;
+    case "ascii past end clamps to byte length" "hello" 99 5;
+    (* Two-byte character: "a<beta>c". *)
+    case "two-byte: before" "a\xce\xb2c" 1 1;
+    case "two-byte: after" "a\xce\xb2c" 2 3;
+    case "two-byte: end" "a\xce\xb2c" 3 4;
+    (* Three-byte character: "a<approx>c". *)
+    case "three-byte: before" "a\xe2\x89\x88c" 1 1;
+    case "three-byte: after" "a\xe2\x89\x88c" 2 4;
+    case "three-byte: end" "a\xe2\x89\x88c" 3 5;
+    (* Four-byte (astral) character counts as two UTF-16 units: "a<grin>b". *)
+    case "astral: before" "a\xf0\x9f\x98\x80b" 1 1;
+    case "astral: after (2 units)" "a\xf0\x9f\x98\x80b" 3 5;
+    case "astral: end" "a\xf0\x9f\x98\x80b" 4 6;
+    (* Offsets are per-line, and the byte offset is relative to the line. *)
+    case "second line" ~line:1 "aa\nb\xce\xb2b" 2 3;
+  ]
+
+(* -- Sail_file.edit_file / apply_edits ----------------------------------- *)
+
+(* Apply a batch of edits (each [(start, end, text)]) to [contents] and check
+   the resulting buffer. Character offsets are UTF-16 code units (what the LSP
+   handler stores); [apply_edits] resolves them to byte offsets against the
+   lines being edited. Edits in a batch are applied in order, each relative to
+   the state produced by the previous. *)
+let apply_case name contents edits expected =
+  Alcotest.test_case name `Quick (fun () ->
+      let handle = handle_of contents in
+      List.iter (fun (s, e, text) -> Sail_file.edit_file handle (edit s e text)) edits;
+      Sail_file.apply_edits handle;
+      Alcotest.(check string) name expected (Sail_file.contents handle)
+  )
+
+let apply_edits_tests =
+  [
+    apply_case "insert single character" "hello world" [(pos 0 5, pos 0 5, ",")] "hello, world";
+    apply_case "delete a range" "abcdef" [(pos 0 1, pos 0 4, "")] "aef";
+    apply_case "replace within a line" "abcdef" [(pos 0 1, pos 0 4, "XYZ")] "aXYZef";
+    apply_case "insert splits a line" "abcd" [(pos 0 2, pos 0 2, "\n")] "ab\ncd";
+    apply_case "prepend a whole line" "first\nsecond" [(pos 0 0, pos 0 0, "// header\n")] "// header\nfirst\nsecond";
+    apply_case "delete across lines joins them" "one\ntwo" [(pos 0 3, pos 1 0, "")] "onetwo";
+    apply_case "multi-line replacement" "one\ntwo\nthree" [(pos 0 1, pos 2 2, "X\nY\nZ")] "oX\nY\nZree";
+    apply_case "append at end of file" "abc\n" [(pos 1 0, pos 1 0, "def")] "abc\ndef";
+    (* Second edit's offsets refer to the buffer after the first edit. *)
+    apply_case "sequential edits in one batch" "abc" [(pos 0 0, pos 0 0, "X"); (pos 0 4, pos 0 4, "Y")] "XabcY";
+    (* An empty queue leaves the buffer untouched. *)
+    apply_case "no pending edits" "unchanged" [] "unchanged";
+    (* Offsets are UTF-16 code units, so they must be resolved against the
+       multi-byte contents. "a<beta>c" has units a=0, beta=1, c=2. *)
+    apply_case "insert after a two-byte char" "a\xce\xb2c" [(pos 0 2, pos 0 2, "X")] "a\xce\xb2Xc";
+    apply_case "delete a two-byte char" "a\xce\xb2c" [(pos 0 1, pos 0 2, "")] "ac";
+    (* "a<grin>b" spans units a=0, grin=1..2 (surrogate pair), b=3. *)
+    apply_case "insert after an astral char" "a\xf0\x9f\x98\x80b" [(pos 0 3, pos 0 3, "X")] "a\xf0\x9f\x98\x80Xb";
+    apply_case "replace an astral char" "a\xf0\x9f\x98\x80b" [(pos 0 1, pos 0 3, "Y")] "aYb";
+  ]
+
+(* apply_edits should clear the queue, so applying twice is not the same as
+   applying an edit twice. *)
+let idempotence_tests =
+  [
+    Alcotest.test_case "apply_edits clears the queue" `Quick (fun () ->
+        let handle = handle_of "abc" in
+        Sail_file.edit_file handle (edit (pos 0 0) (pos 0 0) "X");
+        Sail_file.apply_edits handle;
+
+        Sail_file.apply_edits handle;
+        Alcotest.(check string) "second apply is a no-op" "Xabc" (Sail_file.contents handle)
+    );
+  ]
+
+let suites : unit Alcotest.test list =
+  [
+    ("Sail_file.contents", contents_tests);
+    ("Sail_file.lexing_position", lexing_position_tests);
+    ("Sail_file.apply_edits", apply_edits_tests @ idempotence_tests);
+  ]


### PR DESCRIPTION
Currently provides code highlighting using LSP semantic tokens support and inline type-error diagnostics as you type. This is currently set up as a separate dune-project in src/sail_lsp

In order for it to understand the structure of any Sail project a `.sail_project` file is a hard requirement for the LSP to do anything other than the most basic syntax highlighting.

The biggest part of this PR other than the server itself is the testing setup. It's unsuited to our standard end-to-end test approach, so instead there is a python script in `test/lsp` that can send the jsonrpc messages to fake being an editor and test the interactions with the server. The UTF-16 handling is also fiddly, so there are now Libsail unit tests in `test/unit` targetting this. The unit tests should not pull any dependencies into the main build as they are gated behind setting the SAIL_UNIT_TESTS variable to true.