### PR TITLE
Add missing libsail build dependency on sail_maker

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -50,6 +50,7 @@ been used for several papers, available from
 http://www.cl.cam.ac.uk/~pes20/sail/.
 ")
   (depends
+    (sail_maker (and (= :version) :build))
     (dune-site (>= 3.0.2))
     (bisect_ppx (and :dev (>= "2.5.0")))
     (menhir (and (>= 20240715) :build))

--- a/libsail.opam
+++ b/libsail.opam
@@ -31,6 +31,7 @@ homepage: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
   "dune" {>= "3.21"}
+  "sail_maker" {= version & build}
   "dune-site" {>= "3.0.2"}
   "bisect_ppx" {dev & >= "2.5.0"}
   "menhir" {>= "20240715" & build}


### PR DESCRIPTION
Prevents build failures, e.g., when upgrading opam might decide to install the new sail_maker after libsail without the dependency.