### PR TITLE
Lean: add support for ArchSem

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -287,6 +287,9 @@
   (%{workspace_root}/src/sail_lean_backend/Sail/FakeReal.lean
    as
    src/sail_lean_backend/Sail/FakeReal.lean)
-  (%{workspace_root}/src/sail_lean_backend/Sail/Specialization.lean
+  (%{workspace_root}/src/sail_lean_backend/Sail/SpecializationV1.lean
    as
-   src/sail_lean_backend/Sail/Specialization.lean)))
+   src/sail_lean_backend/Sail/SpecializationV1.lean)
+  (%{workspace_root}/src/sail_lean_backend/Sail/SpecializationArchSem.lean
+   as
+   src/sail_lean_backend/Sail/SpecializationArchSem.lean)))

--- a/src/sail_lean_backend/Sail/SpecializationArchSem.lean
+++ b/src/sail_lean_backend/Sail/SpecializationArchSem.lean
@@ -1,0 +1,81 @@
+import Sail
+import THE_MODULE_NAME.Defs
+
+open Sail ArchSem
+
+namespace THE_MODULE_NAME
+
+open Defs
+
+@[simp_sail]
+def sailTryCatch (e : SailM α) (h : exception → SailM α) : SailM α := PreSail.sailTryCatch e h
+
+@[simp_sail]
+def sailThrow (e : exception) : SailM α := PreSail.sailThrow e
+
+abbrev undefined_unit (_ : Unit) : SailM Unit := PreSail.undefined_unit ()
+abbrev undefined_bit (_ : Unit) : SailM (BitVec 1) := PreSail.undefined_bit ()
+abbrev undefined_bool (_ : Unit) : SailM Bool := PreSail.undefined_bool ()
+abbrev undefined_range (low high : Int) : SailM Int := PreSail.undefined_range low high
+abbrev undefined_bitvector (n : Nat) : SailM (BitVec n) := PreSail.undefined_bitvector n
+abbrev undefined_int (_ : Unit) : SailM Int := PreSail.undefined_int ()
+abbrev undefined_nat (_ : Unit) : SailM Nat := PreSail.undefined_nat ()
+abbrev undefined_string (_ : Unit) : SailM String := PreSail.undefined_string ()
+abbrev undefined_vector (n : Nat) (a : α) : SailM (Vector α n) := PreSail.undefined_vector n a
+
+abbrev internal_pick {α : Type} : List α → SailM α := PreSail.internal_pick
+
+abbrev writeReg (reg : Register) (v : RegisterType reg) : SailM PUnit := PreSail.writeReg reg v
+
+abbrev readReg (reg : Register) : SailM (RegisterType reg) := PreSail.readReg reg
+
+abbrev RegisterRef := @Sail.ArchSem.RegisterRef
+
+abbrev readRegRef (reg_ref : RegisterRef α) : SailM α := PreSail.readRegRef reg_ref
+
+abbrev writeRegRef (reg_ref : RegisterRef α) (a : α) : SailM Unit := PreSail.writeRegRef reg_ref a
+
+abbrev reg_deref (reg_ref : RegisterRef α) : SailM α := PreSail.reg_deref reg_ref
+
+abbrev assert (p : Bool) (s : String) : SailM Unit := PreSail.assert p s
+
+namespace ArchSem
+
+abbrev sail_mem_read (req : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) :
+    SailM (Result ((Vector (BitVec 8) n) × (Vector Bool nt)) Arch.abort) :=
+  PreSail.sail_mem_read req
+
+def sail_mem_write (req : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) (valueBytes : Vector (BitVec 8) n) (tags : Vector Bool nt) :
+    SailM (Result (Option Bool) Arch.abort) := do
+  PreSail.sail_mem_write req valueBytes tags
+
+abbrev sail_sys_reg_read (id : Arch.sys_reg_id) (r : RegisterRef α) : SailM α :=
+  PreSail.sail_sys_reg_read id r
+
+abbrev sail_sys_reg_write (id : Arch.sys_reg_id) (r : RegisterRef α) (v : α) : SailM Unit :=
+  PreSail.sail_sys_reg_write id r v
+
+abbrev sail_mem_address_announce (ann : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) : SailM Unit :=
+  PreSail.sail_mem_address_announce ann
+
+abbrev sail_barrier (b : Arch.barrier) : SailM Unit := PreSail.sail_barrier b
+abbrev sail_cache_op (op : Arch.cache_op) : SailM Unit := PreSail.sail_cache_op op
+abbrev sail_tlbi (op : Arch.tlbi) : SailM Unit := PreSail.sail_tlbi op
+abbrev sail_translation_start (ts : Arch.trans_start) : SailM Unit := PreSail.sail_translation_start ts
+abbrev sail_translation_end (te : Arch.trans_end) : SailM Unit := PreSail.sail_translation_end te
+abbrev sail_take_exception (f : Arch.exn) : SailM Unit := PreSail.sail_take_exception f
+abbrev sail_return_exception (a : Unit) : SailM Unit := PreSail.sail_return_exception a
+
+end ArchSem
+
+abbrev cycle_count (a : Unit) : SailM Unit := PreSail.cycle_count a
+abbrev get_cycle_count (a : Unit) : SailM Nat := PreSail.get_cycle_count a
+abbrev print_effect (str : String) : SailM Unit := PreSail.print_effect str
+abbrev print_int_effect (str : String) (n : Int) : SailM Unit := PreSail.print_int_effect str n
+abbrev print_bits_effect {w : Nat} (str : String) (x : BitVec w) : SailM Unit := PreSail.print_bits_effect str x
+abbrev print_endline_effect (str : String) : SailM Unit := PreSail.print_endline_effect str
+
+def SailME.run (m : SailME α α) : SailM α := PreSail.PreSailME.run m
+def SailME.throw (e : α) : SailME α β := PreSail.PreSailME.throw e
+abbrev sailTryCatchE (e : SailME β α) (h : exception → SailME β α) : SailME β α := PreSail.sailTryCatchE e h
+def unwrapValue [Inhabited α] (x : SailM α) := PreSail.unwrapValue x

--- a/src/sail_lean_backend/Sail/SpecializationV1.lean
+++ b/src/sail_lean_backend/Sail/SpecializationV1.lean
@@ -1,7 +1,7 @@
 import Sail
 import THE_MODULE_NAME.Defs
 
-open Sail
+open Sail ConcurrencyInterfaceV1
 
 namespace THE_MODULE_NAME
 
@@ -14,21 +14,13 @@ def sailTryCatch (e : SailM α) (h : exception → SailM α) : SailM α := PreSa
 def sailThrow (e : exception) : SailM α := PreSail.sailThrow e
 
 abbrev undefined_unit (_ : Unit) : SailM Unit := PreSail.undefined_unit ()
-
 abbrev undefined_bit (_ : Unit) : SailM (BitVec 1) := PreSail.undefined_bit ()
-
 abbrev undefined_bool (_ : Unit) : SailM Bool := PreSail.undefined_bool ()
-
 abbrev undefined_int (_ : Unit) : SailM Int := PreSail.undefined_int ()
-
 abbrev undefined_range (low high : Int) : SailM Int := PreSail.undefined_range low high
-
 abbrev undefined_nat (_ : Unit) : SailM Nat := PreSail.undefined_nat ()
-
 abbrev undefined_string (_ : Unit) : SailM String := PreSail.undefined_string ()
-
 abbrev undefined_bitvector (n : Nat) : SailM (BitVec n) := PreSail.undefined_bitvector n
-
 abbrev undefined_vector (n : Nat) (a : α) : SailM (Vector α n) := PreSail.undefined_vector n a
 
 abbrev internal_pick {α : Type} : List α → SailM α := PreSail.internal_pick
@@ -37,7 +29,7 @@ abbrev writeReg (reg : Register) (v : RegisterType reg) : SailM PUnit := PreSail
 
 abbrev readReg (reg : Register) : SailM (RegisterType reg) := PreSail.readReg reg
 
-abbrev RegisterRef := @PreSail.RegisterRef Register RegisterType
+abbrev RegisterRef := @Sail.ConcurrencyInterfaceV1.RegisterRef Register RegisterType
 
 abbrev readRegRef (reg_ref : RegisterRef α) : SailM α := PreSail.readRegRef reg_ref
 
@@ -52,56 +44,25 @@ namespace ConcurrencyInterfaceV1
 open Sail.ConcurrencyInterfaceV1
 
 abbrev sail_mem_write [Arch] (req : Mem_write_request n vasize (BitVec pa_size) ts arch) : SailM (Result (Option Bool) Arch.abort) :=
-  PreSail.ConcurrencyInterfaceV1.sail_mem_write req
+  PreSail.sail_mem_write req
 
 abbrev write_ram (addr_size data_size : Nat) (_hex_ram addr : BitVec addr_size) (value : BitVec (8 * data_size)) :
     SailM Unit := PreSail.write_ram addr_size data_size _hex_ram addr value
 
-abbrev sail_mem_read [Arch] (req : Mem_read_request n vasize (BitVec pa_size) ts arch) : SailM (Result ((BitVec (8 * n)) × (Option Bool)) Arch.abort) := PreSail.ConcurrencyInterfaceV1.sail_mem_read req
+abbrev sail_mem_read [Arch] (req : Mem_read_request n vasize (BitVec pa_size) ts arch) : SailM (Result ((BitVec (8 * n)) × (Option Bool)) Arch.abort) := PreSail.sail_mem_read req
 
 abbrev read_ram (addr_size data_size : Nat) (_hex_ram addr : BitVec addr_size) : SailM (BitVec (8 * data_size)) := PreSail.read_ram addr_size data_size _hex_ram addr
 
-abbrev sail_barrier (a : α) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_barrier a
+abbrev sail_barrier (a : α) : SailM Unit := PreSail.sail_barrier a
 
-abbrev sail_cache_op [Arch] (op : Arch.cache_op) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_cache_op op
-abbrev sail_tlbi [Arch] (op : Arch.tlb_op) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_tlbi op
-abbrev sail_translation_start [Arch] (ts : Arch.trans_start) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_translation_start ts
-abbrev sail_translation_end [Arch] (te : Arch.trans_end) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_translation_end te
-abbrev sail_take_exception [Arch] (f : Arch.fault) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_take_exception f
-abbrev sail_return_exception [Arch] (a : Arch.pa) : SailM Unit := PreSail.ConcurrencyInterfaceV1.sail_return_exception a
+abbrev sail_cache_op [Arch] (op : Arch.cache_op) : SailM Unit := PreSail.sail_cache_op op
+abbrev sail_tlbi [Arch] (op : Arch.tlb_op) : SailM Unit := PreSail.sail_tlbi op
+abbrev sail_translation_start [Arch] (ts : Arch.trans_start) : SailM Unit := PreSail.sail_translation_start ts
+abbrev sail_translation_end [Arch] (te : Arch.trans_end) : SailM Unit := PreSail.sail_translation_end te
+abbrev sail_take_exception [Arch] (f : Arch.fault) : SailM Unit := PreSail.sail_take_exception f
+abbrev sail_return_exception [Arch] (a : Arch.pa) : SailM Unit := PreSail.sail_return_exception a
 
 end ConcurrencyInterfaceV1
-
-namespace ConcurrencyInterfaceV2
-
-open Sail.ConcurrencyInterfaceV2
-
-abbrev sail_mem_read [Arch] (req : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) :
-    SailM (Result ((Vector (BitVec 8) n) × (Vector Bool nt)) Arch.abort) :=
-  PreSail.ConcurrencyInterfaceV2.sail_mem_read req
-
-def sail_mem_write [Arch] (req : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) (valueBytes : Vector (BitVec 8) n) (tags : Vector Bool nt) :
-    SailM (Result (Option Bool) Arch.abort) := do
-  PreSail.ConcurrencyInterfaceV2.sail_mem_write req valueBytes tags
-
-abbrev sail_sys_reg_read [Arch] (id : Arch.sys_reg_id) (r : RegisterRef α) : SailM α :=
-  PreSail.ConcurrencyInterfaceV2.sail_sys_reg_read id r
-
-abbrev sail_sys_reg_write [Arch] (id : Arch.sys_reg_id) (r : RegisterRef α) (v : α) : SailM Unit :=
-  PreSail.ConcurrencyInterfaceV2.sail_sys_reg_write id r v
-
-abbrev sail_mem_address_announce [Arch] (ann : Mem_request n nt Arch.addr_size Arch.addr_space Arch.mem_acc) : SailM Unit :=
-  PreSail.ConcurrencyInterfaceV2.sail_mem_address_announce ann
-
-abbrev sail_barrier [Arch] (b : Arch.barrier) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_barrier b
-abbrev sail_cache_op [Arch] (op : Arch.cache_op) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_cache_op op
-abbrev sail_tlbi [Arch] (op : Arch.tlbi) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_tlbi op
-abbrev sail_translation_start [Arch] (ts : Arch.trans_start) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_translation_start ts
-abbrev sail_translation_end [Arch] (te : Arch.trans_end) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_translation_end te
-abbrev sail_take_exception [Arch] (f : Arch.exn) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_take_exception f
-abbrev sail_return_exception (a : Unit) : SailM Unit := PreSail.ConcurrencyInterfaceV2.sail_return_exception a
-
-end ConcurrencyInterfaceV2
 
 abbrev cycle_count (a : Unit) : SailM Unit := PreSail.cycle_count a
 

--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1445,7 +1445,15 @@ let type_enum ctx registers =
       empty;
     ]
 
-let inhabit_enum ctx typ_map =
+let inhabit_enum_v2 ctx typ_map =
+  separate_map hardline
+    (fun (_, (id, typ)) ->
+      string "instance : Inhabited (RegisterRef "
+      ^^ doc_typ ctx typ ^^ string ") where" ^^ hardline ^^ string "  default := .Reg " ^^ doc_id_ctor id
+    )
+    typ_map
+
+let inhabit_enum_v1 ctx typ_map =
   separate_map hardline
     (fun (_, (id, typ)) ->
       string "instance : Inhabited (RegisterRef RegisterType "
@@ -1455,11 +1463,9 @@ let inhabit_enum ctx typ_map =
 
 let doc_reg_info env global registers =
   let ctx = context_init env global in
-  let type_map = List.fold_left add_reg_typ Bindings.empty registers in
-  let type_map = Bindings.bindings type_map in
-  separate hardline [register_enums registers; type_enum ctx registers; inhabit_enum ctx type_map; empty]
+  separate hardline [register_enums registers; type_enum ctx registers; empty]
 
-let doc_monad_abbrev defs (has_registers : bool) =
+let doc_monad_abbrev ~version defs =
   let find_exc_typ defs =
     let is_exc_typ_def = function
       | DEF_aux (DEF_type td, _) -> string_of_id (id_of_type_def td) = "exception"
@@ -1468,89 +1474,96 @@ let doc_monad_abbrev defs (has_registers : bool) =
     if List.exists is_exc_typ_def defs then empty else string "abbrev exception := Unit\n"
   in
   let excdef = find_exc_typ defs in
-  let pp_register_type = string "PreSailM RegisterType trivialChoiceSource exception" in
-  let pp_register_type_e = string "PreSailME RegisterType trivialChoiceSource exception" in
+  let pp_register_type =
+    if version = 1 then string "PreSailM RegisterType trivialChoiceSource exception" else string "PreSailM exception"
+  in
+  let pp_register_type_e =
+    if version = 1 then string "PreSailME RegisterType trivialChoiceSource exception" else string "PreSailME exception"
+  in
   let monad = separate space [string "abbrev"; string "SailM"; coloneq; pp_register_type] in
   let monad_e =
     separate space [string "abbrev"; string "SailME"; coloneq; pp_register_type_e] ^^ hardline ^^ hardline
   in
   separate hardline (remove_empties [excdef; monad; monad_e])
 
-let doc_instantiations_v1 ctx env =
+let doc_instantiations_v1 ctx env defs registers =
   let params = Monad_params.find_monad_parameters env in
-  match params with
-  | None -> empty
-  | Some params ->
-      nest 2
-        (separate hardline
-           [
-             string "instance : Arch where";
-             string "va_size := 64";
-             string "pa := " ^^ doc_typ ctx params.pa_type;
-             string "abort := " ^^ doc_typ ctx params.abort_type;
-             string "translation := " ^^ doc_typ ctx params.translation_summary_type;
-             string "trans_start := " ^^ doc_typ ctx params.trans_start_type;
-             string "trans_end := " ^^ doc_typ ctx params.trans_end_type;
-             string "fault := " ^^ doc_typ ctx params.fault_type;
-             string "tlb_op := " ^^ doc_typ ctx params.tlbi_type;
-             string "cache_op := " ^^ doc_typ ctx params.cache_op_type;
-             string "barrier := " ^^ doc_typ ctx params.barrier_type;
-             string "arch_ak := " ^^ doc_typ ctx params.arch_ak_type;
-             string "sys_reg_id := " ^^ doc_typ ctx params.sys_reg_id_type ^^ hardline;
-           ]
-        )
-      ^^ hardline
+  let arch =
+    match params with
+    | None -> empty
+    | Some params ->
+        nest 2
+          (separate hardline
+             [
+               string "instance : Arch where";
+               string "va_size := 64";
+               string "pa := " ^^ doc_typ ctx params.pa_type;
+               string "abort := " ^^ doc_typ ctx params.abort_type;
+               string "translation := " ^^ doc_typ ctx params.translation_summary_type;
+               string "trans_start := " ^^ doc_typ ctx params.trans_start_type;
+               string "trans_end := " ^^ doc_typ ctx params.trans_end_type;
+               string "fault := " ^^ doc_typ ctx params.fault_type;
+               string "tlb_op := " ^^ doc_typ ctx params.tlbi_type;
+               string "cache_op := " ^^ doc_typ ctx params.cache_op_type;
+               string "barrier := " ^^ doc_typ ctx params.barrier_type;
+               string "arch_ak := " ^^ doc_typ ctx params.arch_ak_type;
+               string "sys_reg_id := " ^^ doc_typ ctx params.sys_reg_id_type ^^ hardline;
+             ]
+          )
+        ^^ hardline
+  in
+  let type_map = List.fold_left add_reg_typ Bindings.empty registers in
+  let type_map = Bindings.bindings type_map in
+  separate hardline [arch; empty; doc_monad_abbrev ~version:1 defs; empty; inhabit_enum_v1 ctx type_map]
 
-let doc_instantiations_v2 ctx ast =
-  let type_substs, id_substs = Monad_params.find_instantiations ast in
+let doc_instantiations_v2 ctx defs registers =
+  let has_regs = registers != [] in
+  let type_substs, id_substs = Monad_params.find_instantiations defs in
   let ts x d = KBindings.find_opt (mk_kid x) type_substs |> Option.fold ~none:(string d) ~some:(doc_typ_app ctx) in
   let is x = Bindings.find_opt (mk_id x) id_substs |> Option.fold ~none:(string "fun _ => false") ~some:doc_id_ctor in
   let pr ?(d = "Unit") x = string (x ^ " := ") ^^ ts x d in
   let fn x = string (x ^ " := ") ^^ is x in
-  string "@[reducible]" ^^ hardline
-  ^^ nest 2
-       (separate hardline
-          [
-            string "instance : Arch where";
-            pr "addr_size" ~d:"64";
-            pr "addr_space";
-            pr "CHERI" ~d:"false";
-            pr "cap_size_log" ~d:"0";
-            pr "mem_acc";
-            fn "mem_acc_is_explicit";
-            fn "mem_acc_is_ifetch";
-            fn "mem_acc_is_ttw";
-            fn "mem_acc_is_relaxed";
-            fn "mem_acc_is_rel_acq_rcpc";
-            fn "mem_acc_is_rel_acq_rcsc";
-            fn "mem_acc_is_standalone";
-            fn "mem_acc_is_exclusive";
-            fn "mem_acc_is_atomic_rmw";
-            pr "trans_start";
-            pr "trans_end";
-            pr "abort";
-            pr "barrier";
-            pr "cache_op";
-            pr "tlbi";
-            pr "exn";
-            pr "sys_reg_id";
-          ]
-       )
-(*
-  mem_acc_is_explicit : mem_acc -> Bool
-  mem_acc_is_ifetch : mem_acc -> Bool
-  mem_acc_is_ttw : mem_acc -> Bool
-  mem_acc_is_relaxed : mem_acc -> Bool
-  mem_acc_is_rel_acq_rcpc : mem_acc -> Bool
-  mem_acc_is_rel_acq_rcsc : mem_acc -> Bool
-  mem_acc_is_standalone : mem_acc -> Bool
-  mem_acc_is_exclusive : mem_acc -> Bool
-  mem_acc_is_atomic_rmw : mem_acc -> Bool
-*)
+  let arch =
+    string "@[reducible]" ^^ hardline
+    ^^ nest 2
+         (separate hardline
+            [
+              string "instance : Arch where";
+              pr "addr_size" ~d:"64";
+              pr "addr_space";
+              pr "CHERI" ~d:"false";
+              pr "cap_size_log" ~d:"0";
+              pr "register" ~d:"Register";
+              pr "register_type" ~d:"RegisterType";
+              pr "mem_acc";
+              fn "mem_acc_is_explicit";
+              fn "mem_acc_is_ifetch";
+              fn "mem_acc_is_ttw";
+              fn "mem_acc_is_relaxed";
+              fn "mem_acc_is_rel_acq_rcpc";
+              fn "mem_acc_is_rel_acq_rcsc";
+              fn "mem_acc_is_standalone";
+              fn "mem_acc_is_exclusive";
+              fn "mem_acc_is_atomic_rmw";
+              pr "trans_start";
+              pr "trans_end";
+              pr "abort";
+              pr "barrier";
+              pr "cache_op";
+              pr "tlbi";
+              pr "exn";
+              pr "sys_reg_id";
+            ]
+         )
+  in
+  let type_map = List.fold_left add_reg_typ Bindings.empty registers in
+  let type_map = Bindings.bindings type_map in
+  separate hardline [arch; empty; doc_monad_abbrev ~version:2 defs; empty; inhabit_enum_v2 ctx type_map]
+(* let doc_monad_abbrev env global registers defs (has_registers : bool) = *)
 
-let doc_instantiations symbols ctx env ast =
-  if Preprocess.have_symbol "CONCURRENCY_INTERFACE_V2" symbols then doc_instantiations_v2 ctx ast
-  else doc_instantiations_v1 ctx env
+let doc_instantiations symbols ctx env defs regs =
+  if Preprocess.have_symbol "CONCURRENCY_INTERFACE_V2" symbols then doc_instantiations_v2 ctx defs regs
+  else doc_instantiations_v1 ctx env defs regs
 
 let main_function_stub effect_info has_registers =
   let open Effects in
@@ -1630,13 +1643,12 @@ let pp_ast_lean symbols (env : Type_check.env) effect_info ({ defs; _ } as ast :
   let instantiation_deps =
     match instantiation_deps with [x] -> x | _ -> failwith "expected a single block of instantiation defs"
   in
-  let instantiations = doc_instantiations symbols ctx env defs in
+  let instantiations = doc_instantiations symbols ctx env defs regs in
   let has_registers = List.length regs > 0 in
   let register_refs =
     if has_registers then doc_reg_info env global regs
     else string "abbrev Register := PEmpty\nabbrev RegisterType : Register -> Type := PEmpty.elim\n\n"
   in
-  let monad = doc_monad_abbrev defs has_registers in
   let types, all_fundefss = doc_defs ctx defs in
   let imp_fundefss, main_fundefs =
     if imp_funcs_files = [] then ([], concat all_fundefss) else (Util.butlast all_fundefss, Util.last all_fundefss)
@@ -1650,7 +1662,7 @@ let pp_ast_lean symbols (env : Type_check.env) effect_info ({ defs; _ } as ast :
     else []
   in
   let opens = IdSet.fold (fun id doc -> string "open " ^^ doc_id_ctor id ^^ hardline ^^ doc) !opens empty in
-  print types_file (types ^^ register_refs ^^ monad ^^ instantiation_deps ^^ instantiations);
+  print types_file (types ^^ register_refs ^^ instantiation_deps ^^ instantiations);
   let _ =
     List.map2
       (fun file defs -> print file (separate hardline (remove_empties [opens; defs])))

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -97,7 +97,7 @@ let opt_disable_matchbv : bool ref = ref true
 let lean_version : string = "lean4:v4.29.0"
 let mathlib_version : string = "v4.29.0"
 let lib_default_git : string = "https://github.com/rems-project/lean-sail"
-let lib_default_rev : string = "v4"
+let lib_default_rev : string = "v5"
 
 let lean_options =
   [
@@ -256,6 +256,8 @@ let file_to_module (filename : string) =
   let base = Filename.basename filename in
   Filename.chop_extension base
 
+let interface_module interface_v = if interface_v = 1 then "ConcurrencyInterfaceV1" else "ArchSem"
+
 let file_prelude version namespace =
   let non_computable = if !opt_lean_noncomputable then "noncomputable section\n" else "" in
   Printf.sprintf
@@ -265,12 +267,12 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open Sail.ConcurrencyInterfaceV%d
+open Sail.%s
 
 %snamespace %s
 
 |}
-    version non_computable namespace
+    (interface_module version) non_computable namespace
 
 let path_to_static_library sail_dir str = Filename.quote (sail_dir ^ "/src/sail_lean_backend/Sail/" ^ str ^ ".lean")
 
@@ -293,7 +295,7 @@ let print_function_file_prelude interface_v file out_name_camel (imp_refs : stri
     | ns -> List.iter (fun n -> output_string file ("import " ^ out_name_camel ^ "." ^ n ^ "\n")) ns
   in
   output_string file ("\n" ^ file_prelude interface_v out_name_camel);
-  Printf.fprintf file "open ConcurrencyInterfaceV%d\n\n" interface_v;
+  Printf.fprintf file "open %s\n\n" (interface_module interface_v);
   output_string file "open Defs\n";
   output_string file "namespace Functions\n\n"
 
@@ -325,7 +327,8 @@ let start_lean_output interface_v (out_name : string) (import_names : string lis
     else "/src/sail_lean_backend/Sail/FakeReal.lean"
   in
   opt_lean_import_files := (sail_dir ^ real_numbers_file) :: !opt_lean_import_files;
-  opt_lean_import_files := (sail_dir ^ "/src/sail_lean_backend/Sail/Specialization.lean") :: !opt_lean_import_files;
+  let specialization_file = if interface_v = 1 then "SpecializationV1.lean" else "SpecializationArchSem.lean" in
+  opt_lean_import_files := (sail_dir ^ "/src/sail_lean_backend/Sail/" ^ specialization_file) :: !opt_lean_import_files;
   List.iter
     (fun filename ->
       let filepath = Filename.concat lean_src_dir (file_to_module filename) in

--- a/test/lean/SailTinyArm.expected.lean
+++ b/test/lean/SailTinyArm.expected.lean
@@ -473,13 +473,6 @@ abbrev RegisterType : Register → Type
   | .R30 => (BitVec 64)
   | ._PC => (BitVec 64)
 
-instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
-  default := .Reg _PC
-abbrev exception := Unit
-
-abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
-abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
-
 def pa_bits (bv : (BitVec 56)) : (BitVec 64) :=
   (Sail.BitVec.zeroExtend bv 64)
 
@@ -498,11 +491,21 @@ instance : Arch where
   sys_reg_id := Unit
 
 
+
+abbrev exception := Unit
+
+abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
+
+
+
+instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
+  default := .Reg _PC
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/SailTinyArmV2.expected.lean
+++ b/test/lean/SailTinyArmV2.expected.lean
@@ -7,7 +7,7 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open Sail.ConcurrencyInterfaceV2
+open Sail.ArchSem
 
 namespace Out
 
@@ -403,13 +403,6 @@ abbrev RegisterType : Register → Type
   | .R30 => (BitVec 64)
   | ._PC => (BitVec 64)
 
-instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
-  default := .Reg _PC
-abbrev exception := Unit
-
-abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
-abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
-
 def mem_acc_is_explicit (acc : AccessDescriptor) : Bool :=
   (BEq.beq acc.acctype AccessType_GPR)
 
@@ -443,6 +436,8 @@ instance : Arch where
   addr_space := addr_space
   CHERI := false
   cap_size_log := 0
+  register := Register
+  register_type := RegisterType
   mem_acc := AccessDescriptor
   mem_acc_is_explicit := mem_acc_is_explicit
   mem_acc_is_ifetch := mem_acc_is_ifetch
@@ -461,11 +456,21 @@ instance : Arch where
   tlbi := Unit
   exn := Unit
   sys_reg_id := Unit
+
+abbrev exception := Unit
+
+abbrev SailM := PreSailM exception
+abbrev SailME := PreSailME exception
+
+
+
+instance : Inhabited (RegisterRef (BitVec 64)) where
+  default := .Reg _PC
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationArchSem
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000
@@ -474,11 +479,11 @@ set_option linter.unusedVariables false
 set_option match.ignoreUnusedAlts true
 
 open Sail
-open Sail.ConcurrencyInterfaceV2
+open Sail.ArchSem
 
 namespace Out
 
-open ConcurrencyInterfaceV2
+open ArchSem
 
 open Defs
 namespace Functions

--- a/test/lean/append.expected.lean
+++ b/test/lean/append.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/atom_bool.expected.lean
+++ b/test/lean/atom_bool.expected.lean
@@ -16,17 +16,21 @@ namespace Defs
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/bitfield.expected.lean
+++ b/test/lean/bitfield.expected.lean
@@ -34,19 +34,22 @@ open Register
 abbrev RegisterType : Register → Type
   | .R => (BitVec 8)
 
-instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
-  default := .Reg R
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType (BitVec 8)) where
+  default := .Reg R
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/bitvec_operation.expected.lean
+++ b/test/lean/bitvec_operation.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/early_return.expected.lean
+++ b/test/lean/early_return.expected.lean
@@ -42,21 +42,24 @@ abbrev RegisterType : Register → Type
   | .r_B => E
   | .r_A => E
 
-instance : Inhabited (RegisterRef RegisterType E) where
-  default := .Reg r_A
-instance : Inhabited (RegisterRef RegisterType Nat) where
-  default := .Reg r
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType E) where
+  default := .Reg r_A
+instance : Inhabited (RegisterRef RegisterType Nat) where
+  default := .Reg r
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/enum.expected.lean
+++ b/test/lean/enum.expected.lean
@@ -31,17 +31,21 @@ inductive E where | A | B | C
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/errors.expected.lean
+++ b/test/lean/errors.expected.lean
@@ -32,19 +32,22 @@ open Register
 abbrev RegisterType : Register → Type
   | .dummy => (BitVec 1)
 
-instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
-  default := .Reg dummy
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
+  default := .Reg dummy
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/extern.expected.lean
+++ b/test/lean/extern.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/extern_bitvec.expected.lean
+++ b/test/lean/extern_bitvec.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/guardedmatch.expected.lean
+++ b/test/lean/guardedmatch.expected.lean
@@ -29,17 +29,21 @@ abbrev xlen : Int := 32
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/implicit.expected.lean
+++ b/test/lean/implicit.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/ite.expected.lean
+++ b/test/lean/ite.expected.lean
@@ -34,21 +34,24 @@ abbrev RegisterType : Register → Type
   | .B => Bool
   | .R => Nat
 
-instance : Inhabited (RegisterRef RegisterType Bool) where
-  default := .Reg B
-instance : Inhabited (RegisterRef RegisterType Nat) where
-  default := .Reg R
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType Bool) where
+  default := .Reg B
+instance : Inhabited (RegisterRef RegisterType Nat) where
+  default := .Reg R
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/let.expected.lean
+++ b/test/lean/let.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/loop.expected.lean
+++ b/test/lean/loop.expected.lean
@@ -32,19 +32,22 @@ open Register
 abbrev RegisterType : Register → Type
   | .r => Nat
 
-instance : Inhabited (RegisterRef RegisterType Nat) where
-  default := .Reg r
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType Nat) where
+  default := .Reg r
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/map_tactics.expected.lean
+++ b/test/lean/map_tactics.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/mapping.expected.lean
+++ b/test/lean/mapping.expected.lean
@@ -31,17 +31,21 @@ inductive word_width where | BYTE | HALF | WORD | DOUBLE
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/match.expected.lean
+++ b/test/lean/match.expected.lean
@@ -40,19 +40,22 @@ abbrev RegisterType : Register → Type
   | .r_B => E
   | .r_A => E
 
-instance : Inhabited (RegisterRef RegisterType E) where
-  default := .Reg r_A
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType E) where
+  default := .Reg r_A
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/match_bv.expected.lean
+++ b/test/lean/match_bv.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/option.expected.lean
+++ b/test/lean/option.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/range.expected.lean
+++ b/test/lean/range.expected.lean
@@ -27,17 +27,21 @@ inductive option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/register_vector.expected.lean
+++ b/test/lean/register_vector.expected.lean
@@ -96,19 +96,22 @@ abbrev RegisterType : Register → Type
   | .R30 => (BitVec 64)
   | ._PC => (BitVec 64)
 
-instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
-  default := .Reg _PC
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
+  default := .Reg _PC
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/registers.expected.lean
+++ b/test/lean/registers.expected.lean
@@ -47,6 +47,15 @@ abbrev RegisterType : Register → Type
   | .R1 => (BitVec 64)
   | .R0 => (BitVec 64)
 
+
+
+abbrev exception := Unit
+
+abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
+abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
+
+
+
 instance : Inhabited (RegisterRef RegisterType (BitVec 1)) where
   default := .Reg BIT
 instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
@@ -57,17 +66,11 @@ instance : Inhabited (RegisterRef RegisterType Int) where
   default := .Reg INT
 instance : Inhabited (RegisterRef RegisterType Nat) where
   default := .Reg NAT
-abbrev exception := Unit
-
-abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
-abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
-
-
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/riscv_duopod.expected.lean
+++ b/test/lean/riscv_duopod.expected.lean
@@ -54,21 +54,24 @@ abbrev RegisterType : Register → Type
   | .nextPC => (BitVec 64)
   | .PC => (BitVec 64)
 
-instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
-  default := .Reg PC
-instance : Inhabited (RegisterRef RegisterType (Vector (BitVec 64) 32)) where
-  default := .Reg Xs
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType (BitVec 64)) where
+  default := .Reg PC
+instance : Inhabited (RegisterRef RegisterType (Vector (BitVec 64) 32)) where
+  default := .Reg Xs
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/string.expected.lean
+++ b/test/lean/string.expected.lean
@@ -18,17 +18,21 @@ abbrev bit := (BitVec 1)
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/struct.expected.lean
+++ b/test/lean/struct.expected.lean
@@ -53,19 +53,22 @@ open Register
 abbrev RegisterType : Register → Type
   | .r => Int
 
-instance : Inhabited (RegisterRef RegisterType Int) where
-  default := .Reg r
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+instance : Inhabited (RegisterRef RegisterType Int) where
+  default := .Reg r
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/struct_of_enum.expected.lean
+++ b/test/lean/struct_of_enum.expected.lean
@@ -35,17 +35,21 @@ structure s_test where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/termination.expected.lean
+++ b/test/lean/termination.expected.lean
@@ -31,17 +31,21 @@ inductive E where | A | B | C
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/trivial.expected.lean
+++ b/test/lean/trivial.expected.lean
@@ -16,17 +16,21 @@ namespace Defs
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/tuples.expected.lean
+++ b/test/lean/tuples.expected.lean
@@ -16,17 +16,21 @@ namespace Defs
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/type_kid.expected.lean
+++ b/test/lean/type_kid.expected.lean
@@ -16,17 +16,21 @@ namespace Defs
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/typedef.expected.lean
+++ b/test/lean/typedef.expected.lean
@@ -37,17 +37,21 @@ abbrev my_bits k_n := (BitVec k_n)
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/typquant.expected.lean
+++ b/test/lean/typquant.expected.lean
@@ -32,17 +32,21 @@ inductive virtaddr where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/undefined.expected.lean
+++ b/test/lean/undefined.expected.lean
@@ -18,17 +18,21 @@ abbrev bit := (BitVec 1)
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000

--- a/test/lean/union.expected.lean
+++ b/test/lean/union.expected.lean
@@ -38,17 +38,21 @@ inductive my_option (k_a : Type) where
 abbrev Register := PEmpty
 abbrev RegisterType : Register -> Type := PEmpty.elim
 
+
+
 abbrev exception := Unit
 
 abbrev SailM := PreSailM RegisterType trivialChoiceSource exception
 abbrev SailME := PreSailME RegisterType trivialChoiceSource exception
 
 
+
+
 XXXXXXXXX
 
 import Sail
 import Out.Defs
-import Out.Specialization
+import Out.SpecializationV1
 import Out.FakeReal
 
 set_option maxHeartbeats 1_000_000_000


### PR DESCRIPTION
The main change is that we carry *two* specialization files, depending on whether we are using concurrency interface v1 or ArchSem. This is controled by the macro `CONCURRENCY_INTERFACE_V2`.