### PR TITLE
Remove polymorphic comparisons and physical inequality checks

### DIFF
--- a/src/lib/ast_compare.ml
+++ b/src/lib/ast_compare.ml
@@ -99,14 +99,16 @@ let rec nexp_compare (Nexp_aux (nexp1, _)) (Nexp_aux (nexp2, _)) =
   | Nexp_app (op1, args1), Nexp_app (op2, args2) ->
       let lex1 = Id.compare op1 op2 in
       let lex2 = List.length args1 - List.length args2 in
-      let lex3 = if lex2 = 0 then List.fold_left2 (fun l n1 n2 -> lex_ord (l, compare n1 n2)) 0 args1 args2 else 0 in
+      let lex3 =
+        if lex2 = 0 then List.fold_left2 (fun l n1 n2 -> lex_ord (l, nexp_compare n1 n2)) 0 args1 args2 else 0
+      in
       lex_ord (lex1, lex_ord (lex2, lex3))
   | Nexp_times (n1a, n1b), Nexp_times (n2a, n2b)
   | Nexp_sum (n1a, n1b), Nexp_sum (n2a, n2b)
   | Nexp_minus (n1a, n1b), Nexp_minus (n2a, n2b) ->
-      lex_ord (compare n1a n2a, compare n1b n2b)
-  | Nexp_exp n1, Nexp_exp n2 -> compare n1 n2
-  | Nexp_neg n1, Nexp_neg n2 -> compare n1 n2
+      lex_ord (nexp_compare n1a n2a, nexp_compare n1b n2b)
+  | Nexp_exp n1, Nexp_exp n2 -> nexp_compare n1 n2
+  | Nexp_neg n1, Nexp_neg n2 -> nexp_compare n1 n2
   | Nexp_if (i1, t1, e1), Nexp_if (i2, t2, e2) ->
       let lex1 = nc_compare i1 i2 in
       let lex2 = nexp_compare t1 t2 in

--- a/src/lib/callgraph.ml
+++ b/src/lib/callgraph.ml
@@ -104,7 +104,7 @@ module Node = struct
   type t = node
   let compare n1 n2 =
     let lex_ord c1 c2 = if c1 = 0 then c2 else c1 in
-    lex_ord (compare (node_kind n1) (node_kind n2)) (Id.compare (node_id n1) (node_id n2))
+    lex_ord (Int.compare (node_kind n1) (node_kind n2)) (Id.compare (node_id n1) (node_id n2))
 end
 
 module NodeSet = Set.Make (Node)

--- a/src/lib/interpreter.ml
+++ b/src/lib/interpreter.ml
@@ -393,7 +393,7 @@ let rec eval_frame' = function
             )
           )
           else (
-            let arg = if List.length args != 1 then tuple_value args else List.hd args in
+            let arg = if Util.is_singleton_list args then List.hd args else tuple_value args in
             try
               let body = exp_of_fundef (Bindings.find id gstate.fundefs) arg in
               Step (lazy (string_of_exp body), (initial_lstate, gstate), Monad.pure body, (out, lstate, cont) :: stack)
@@ -481,7 +481,7 @@ let default_effect_interp out state stack eff =
         else failwith ("Write of nonexistent register: " ^ string_of_id id)
       else failwith ("Register write disallowed by allow_registers setting: " ^ string_of_id id)
   | Outcome (id, vals, cont) -> (
-      let arg = if List.length vals != 1 then tuple_value vals else List.hd vals in
+      let arg = if Util.is_singleton_list vals then List.hd vals else tuple_value vals in
       match Bindings.find_opt id gstate.fundefs with
       | Some fundef ->
           let body = exp_of_fundef fundef arg in

--- a/src/lib/jib_optimize.ml
+++ b/src/lib/jib_optimize.ml
@@ -689,7 +689,7 @@ let remove_tuples cdefs ctx =
         let sorted_tuples =
           CTSet.elements tuples
           |> List.map (fun ctyp -> (tuple_depth ctyp, ctyp))
-          |> List.sort (fun (d1, _) (d2, _) -> compare d2 d1)
+          |> List.sort (fun (d1, _) (d2, _) -> Int.compare d2 d1)
           |> List.map snd
         in
         let ctx_updates, structs = List.map to_struct sorted_tuples |> List.split in

--- a/src/lib/jib_ssa.ml
+++ b/src/lib/jib_ssa.ml
@@ -49,10 +49,7 @@ open Jib
 open Jib_util
 
 module IntSet = Util.IntSet
-module IntMap = Map.Make (struct
-  type t = int
-  let compare = compare
-end)
+module IntMap = Util.IntMap
 
 let ssa_name i = function
   | Gen (v1, v2, _) -> Gen (v1, v2, i)

--- a/src/lib/jib_util.ml
+++ b/src/lib/jib_util.ml
@@ -81,14 +81,14 @@ module Name = struct
         let c1 = Id.compare x y in
         if c1 = 0 then Int.compare n m else c1
     | Abstract x, Abstract y -> Id.compare x y
-    | Have_exception n, Have_exception m -> compare n m
-    | Current_exception n, Current_exception m -> compare n m
-    | Return n, Return m -> compare n m
-    | Memory_writes n, Memory_writes m -> compare n m
+    | Have_exception n, Have_exception m -> Int.compare n m
+    | Current_exception n, Current_exception m -> Int.compare n m
+    | Return n, Return m -> Int.compare n m
+    | Memory_writes n, Memory_writes m -> Int.compare n m
     | Channel (c1, n), Channel (c2, m) -> (
         match (c1, c2) with
-        | Chan_stdout, Chan_stdout -> compare n m
-        | Chan_stderr, Chan_stderr -> compare n m
+        | Chan_stdout, Chan_stdout -> Int.compare n m
+        | Chan_stderr, Chan_stderr -> Int.compare n m
         | Chan_stdout, Chan_stderr -> 1
         | Chan_stderr, Chan_stdout -> -1
       )
@@ -504,16 +504,16 @@ let rec ctyp_compare ctyp1 ctyp2 =
   | CT_lint, CT_lint -> 0
   | CT_lint, _ -> 1
   | _, CT_lint -> -1
-  | CT_fint n, CT_fint m -> compare n m
+  | CT_fint n, CT_fint m -> Int.compare n m
   | CT_fint _, _ -> 1
   | _, CT_fint _ -> -1
   | CT_constant n, CT_constant m -> Big_int.compare n m
   | CT_constant _, _ -> 1
   | _, CT_constant _ -> -1
-  | CT_fbits n, CT_fbits m -> compare n m
+  | CT_fbits n, CT_fbits m -> Int.compare n m
   | CT_fbits _, _ -> 1
   | _, CT_fbits _ -> -1
-  | CT_sbits n, CT_sbits m -> compare n m
+  | CT_sbits n, CT_sbits m -> Int.compare n m
   | CT_sbits _, _ -> 1
   | _, CT_sbits _ -> -1
   | CT_lbits, CT_lbits -> 0
@@ -525,7 +525,7 @@ let rec ctyp_compare ctyp1 ctyp2 =
   | CT_real, CT_real -> 0
   | CT_real, _ -> 1
   | _, CT_real -> -1
-  | CT_float n, CT_float m -> compare n m
+  | CT_float n, CT_float m -> Int.compare n m
   | CT_float _, _ -> 1
   | _, CT_float _ -> -1
   | CT_poly kid1, CT_poly kid2 -> Kid.compare kid1 kid2
@@ -552,7 +552,7 @@ let rec ctyp_compare ctyp1 ctyp2 =
   | CT_vector ctyp1, CT_vector ctyp2 -> ctyp_compare ctyp1 ctyp2
   | CT_vector _, _ -> 1
   | _, CT_vector _ -> -1
-  | CT_fvector (n1, ctyp1), CT_fvector (n2, ctyp2) -> lex_ord (compare n1 n2) (ctyp_compare ctyp1 ctyp2)
+  | CT_fvector (n1, ctyp1), CT_fvector (n2, ctyp2) -> lex_ord (Int.compare n1 n2) (ctyp_compare ctyp1 ctyp2)
   | CT_fvector _, _ -> 1
   | _, CT_fvector _ -> -1
   | CT_tup ctyps1, CT_tup ctyps2 -> Util.lex_ord_list ctyp_compare ctyps1 ctyps2

--- a/src/lib/monomorphise.ml
+++ b/src/lib/monomorphise.ml
@@ -1711,7 +1711,7 @@ module Analysis = struct
     type t = id * int
     let compare (id, i) (id', i') =
       let x = Id.compare id id' in
-      if x <> 0 then x else compare i i'
+      if x <> 0 then x else Int.compare i i'
   end)
 
   (* Type variables that we should look at in callers *)
@@ -1725,10 +1725,7 @@ module Analysis = struct
     type t = Parse_ast.l
     let compare = compare
   end)
-  module StringSet = Set.Make (struct
-    type t = string
-    let compare = compare
-  end)
+  module StringSet = Util.StringSet
 
   (* When we've obviously got a tuple, keep the elements separate *)
   type dependencies =

--- a/src/lib/partial_eval.ml
+++ b/src/lib/partial_eval.ml
@@ -1013,7 +1013,7 @@ module Make (Lattice : SAIL_VALUE) = struct
                 let is_extern = Type_check.Env.is_extern id gstate.typecheck_env "interpreter" in
                 if has_fundef && (not is_extern) && Type_check.Env.is_outcome id gstate.typecheck_env then (
                   let fdef = Bindings.find id gstate.fundefs in
-                  let arg = if List.length args != 1 then Lattice.mk_tuple args' else List.hd args' in
+                  let arg = if Util.is_singleton_list args' then List.hd args' else Lattice.mk_tuple args' in
                   let arms, annot = arms_of_fundef fdef in
                   Stack.push cont stack;
                   {
@@ -1057,7 +1057,7 @@ module Make (Lattice : SAIL_VALUE) = struct
                   )
                 )
                 else (
-                  let arg = if List.length args != 1 then Lattice.mk_tuple args' else List.hd args' in
+                  let arg = if Util.is_singleton_list args then List.hd args' else Lattice.mk_tuple args' in
                   let fdef = match Bindings.find_opt id gstate.fundefs with Some fdef -> Some fdef | None -> None in
                   match fdef with
                   | None -> (

--- a/src/lib/sail_lib.ml
+++ b/src/lib/sail_lib.ml
@@ -74,7 +74,7 @@ let cycle_count () = incr cycle_count_var
 
 let cycle_limit_reached () =
   incr cycle_count_var;
-  !opt_cycle_limit != 0 && !cycle_count_var >= !opt_cycle_limit
+  (not (Int.equal !opt_cycle_limit 0)) && !cycle_count_var >= !opt_cycle_limit
 
 let sail_call (type t) (f : _ -> t) =
   let module M = struct
@@ -136,7 +136,7 @@ let xor_vec (xs, ys) =
   assert (List.length xs = List.length ys);
   List.map2 (fun x y -> xor_bit (x, y)) xs ys
 
-let xor_bool (b1, b2) = (b1 || b2) && b1 != b2
+let xor_bool (b1, b2) = (b1 || b2) && b1 <> b2
 
 let undefined_bit () = if !random then if Random.bool () then B0 else B1 else B0
 

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -183,6 +183,8 @@ let rec equal_list f l1 l2 =
   | [], _ -> false
   | x :: l1, y :: l2 -> f x y && equal_list f l1 l2
 
+let is_singleton_list = function [_] -> true | _ -> false
+
 let update_first f = function [] -> [] | x :: xs -> f x :: xs
 
 let rec update_last f = function [] -> [] | [x] -> [f x] | x :: xs -> x :: update_last f xs
@@ -352,8 +354,11 @@ module StringSet = Set.Make (String)
 module StringMap = Map.Make (String)
 
 module IntIntSet = Set.Make (struct
-  let compare = Stdlib.compare
   type t = int * int
+
+  let compare x y =
+    let c = Int.compare (fst x) (fst y) in
+    if c = 0 then Int.compare (snd x) (snd y) else c
 end)
 
 let copy_file src dst =

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -187,6 +187,8 @@ val compare_list : ('a -> 'b -> int) -> 'a list -> 'b list -> int
 
 val equal_list : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 
+val is_singleton_list : 'a list -> bool
+
 val take : int -> 'a list -> 'a list
 val drop : int -> 'a list -> 'a list
 

--- a/src/sail_lem_backend/gen_lem_monad.ml
+++ b/src/sail_lem_backend/gen_lem_monad.ml
@@ -59,7 +59,7 @@ open Callgraph
 
 let outcome_spec_of_def = function DEF_outcome (OV_aux (outcome, _), _) -> Some outcome | _ -> None
 
-let outcome_specs_of_ast ast = Util.map_filter outcome_spec_of_def ast.defs
+let outcome_specs_of_ast ast = List.filter_map outcome_spec_of_def ast.defs
 
 let id_of_outcome (OV_outcome (id, _, _)) = id
 


### PR DESCRIPTION
Removes usages of polymorphic `compare` replacing it with more specific version (often `Int.compare`). Only remaining use is comparing locations in monomorphisation.

Also find and remove usages of physical inequality `!=` as these are most likely bugs where `<>` was intended.

These instances were found using `ocamlgrep`, which could be useful as a linting tool to prevent these kinds of constructs from being introduced in the first place.