### PR TITLE
Fix issue with unions allowing additional keys in configuration file schemas

### DIFF
--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -356,6 +356,7 @@ end = struct
               ("properties", `Assoc properties);
               ("minProperties", `Int 1);
               ("maxProperties", `Int 1);
+              ("additionalProperties", `Bool false);
             ]
           in
           Some (`Assoc variant_schema)


### PR DESCRIPTION
Unions did not have `"additionalProperties": false` in the generated JSON schema for the configuration, allowing extra keys that are not valid constructors of the union.