### PR TITLE
Add a feature to allow stripping JSON comments from configuration files

### DIFF
--- a/doc/asciidoc/usage.adoc
+++ b/doc/asciidoc/usage.adoc
@@ -124,17 +124,27 @@ generated SystemVerilog, see `sail --help` for more details.
 
 
 <<<
-=== Automatic formatting (Experimental)
+=== Automatic formatting
 
-CAUTION: This feature is new and experimental, so be sure to inspect
-changes to source made by the tool and use at your own risk!
+NOTE: The tool does check that the resulting syntax tree is equivalent
+to the input syntax tree, and it also runs the formatting multiple
+times to ensure a formatting fixed point is reached, which should
+provide some guarantee that it is both stable and does not change the
+meaning of the code. However, it is still somewhat experimental so
+we suggest taking care to inspect changes made to the code.
 
 Sail supports automatic code formatting similar to tools like `go fmt`
 or `rustfmt`. This is built into Sail itself, and can be used via the
-`--fmt` flag. To format a file `my_file.sail`, we would use the command:
+`--fmt` or `--tool` flag. To format a file `my_file.sail`, we would
+use the command:
 [source,sh]
 ----
 sail --fmt my_file.sail
+----
+or
+[source,sh]
+----
+sail --tool format my_file.sail
 ----
 
 Note that Sail does not attempt to type-check files when formatting
@@ -147,27 +157,33 @@ so:
 sail --fmt file1.sail file2.sail file3.sail
 ----
 
-The one exception is if a file uses a custom infix operator, then the
-file that declares that operator must be passed before any file that
-uses it. So if `my_file.sail` uses an operator declared in
-`operator.sail` (otherwise it would not be able to parenthesize infix
-expressions correctly), we would be required to do:
+This will format all three files. If we want to avoid formatting
+`file2.sail`, we could either use `--fmt-skip`, like so:
 [source,sh]
 ----
-sail --fmt operator.sail my_file.sail
-----
-This will format both files. If we want to avoid formatting
-`operator.sail`, we could either use `--fmt-skip`, like so:
-[source,sh]
-----
-sail --fmt-skip operator.sail --fmt operator.sail my_file.sail
+sail --fmt file1.sail file2.sail file3.sail --fmt-skip file2.sail
 ----
 or the `--fmt-only` option, like so:
 [source,sh]
 ----
-sail --fmt-only my_file.sail --fmt operator.sail my_file.sail
+sail --fmt file1.sail file2.sail file3.sail --fmt-only file1.sail --fmt-only file3.sail
 ----
-Both of these options can be passed multiple times if required.
+Both of these options can be passed multiple times as required.
+
+They, and other formatting specific options (See `sail --fmt --help`)
+must be passed after the `--fmt`/`--tool` flag.
+
+An entire Sail project can be formatted by passing the `.sail_project` file:
+[source,sh]
+----
+sail --fmt file.sail_project
+----
+if we want to set any variables in the project, they must be passed
+prior to the `--fmt`/`--tool` flag, for example:
+[source,sh]
+----
+sail --variable "FOO=true" --fmt file.sail_project
+----
 
 Formatting configuration is done using a JSON configuration file:
 as:
@@ -175,7 +191,7 @@ as:
 ----
 include::../../test/format/default/config.json[]
 ----
-which is passed to sail with the `--config` flag.
+which is passed to sail with the `--sail-config` flag.
 
 The various keys supported under the `"fmt"` key are as follows:
 

--- a/src/bin/sail.ml
+++ b/src/bin/sail.ml
@@ -69,15 +69,11 @@ let opt_project_files : string list ref = ref []
 let opt_variable_assignments : string list ref = ref []
 let opt_model_config_file : string option ref = ref None
 let opt_sail_config_file : string option ref = ref None
-let opt_format = ref false
-let opt_format_backup : string option ref = ref None
-let opt_format_only : string list ref = ref []
-let opt_format_emit : string ref = ref "file"
-let opt_format_skip : string list ref = ref []
-let opt_format_debug : bool ref = ref false
 let opt_slice_instantiation_types : bool ref = ref false
 let opt_output_schema_file : string option ref = ref None
 let opt_warn_error : bool ref = ref false
+let opt_tool : (Yojson.Safe.t option -> string list -> string list -> int) option ref = ref None
+let opt_tool_help : string ref = ref ""
 
 let is_bytecode = Sys.backend_type = Bytecode
 
@@ -187,6 +183,16 @@ let version_full =
   let open Manifest in
   Printf.sprintf "Sail %s (%s @ %s)" version_string branch commit
 
+let set_tool options tool_name =
+  opt_tool_help := " --tool " ^ tool_name;
+  let action =
+    match tool_name with
+    | "strip_json" -> Tools.load (module Tools.Strip_json_comments) fix_options options
+    | "format" -> Tools.load (module Tools.Format) fix_options options
+    | _ -> raise (Arg.Bad "unknown tool")
+  in
+  opt_tool := Some action
+
 let usage_msg = "Sail " ^ version_string ^ "\nusage: sail <options> <file1.sail> ... <fileN.sail>\n"
 
 let help options = raise (Arg.Help (Arg.usage_string options usage_msg))
@@ -242,27 +248,14 @@ let rec options =
         Arg.String (fun sep -> Frontend.opt_list_files := Some sep),
         " list files used in all project files, with a provided separator"
       );
+      ("-tool", Arg.String (fun s -> set_tool options s), "<name> run a builtin utility");
       ("-config", Arg.String (fun file -> opt_model_config_file := Some file), "<file> model configuration file");
       ("-sail_config", Arg.String (fun file -> opt_sail_config_file := Some file), "<file> sail configuration file");
       ( "-output-schema",
         Arg.String (fun file -> opt_output_schema_file := Some file),
         "<file> output configuration schema"
       );
-      ("-fmt", Arg.Set opt_format, " format input source code");
-      ( "-fmt_backup",
-        Arg.String (fun suffix -> opt_format_backup := Some suffix),
-        "<suffix> create backups of formatted files as 'file.suffix'"
-      );
-      ("-fmt_only", Arg.String (fun file -> opt_format_only := file :: !opt_format_only), "<file> format only this file");
-      ( "-fmt_emit",
-        Arg.String (fun output -> opt_format_emit := output),
-        "[file(default)|stdout] update target file or just output to stdout"
-      );
-      ( "-fmt_skip",
-        Arg.String (fun file -> opt_format_skip := file :: !opt_format_skip),
-        "<file> skip formatting this file"
-      );
-      ("-fmt_debug", Arg.Bool (fun debug -> opt_format_debug := debug), "<bool> debug mode");
+      ("-fmt", Arg.Unit (fun () -> set_tool options "format"), " format input source code");
       ( "-slice_instantiation_types",
         Arg.Tuple [Arg.Set Type_check.opt_no_bitfield_expansion; Arg.Set opt_slice_instantiation_types],
         " (experimental) produce a Sail file containing all of the types that are used in instantiations"
@@ -543,78 +536,6 @@ let run_sail (config : Yojson.Safe.t option) tgt =
 
   (symbols, ctx, ast, env, effect_info)
 
-let run_sail_format (config : Yojson.Safe.t option) =
-  let is_format_file f =
-    match !opt_format_only with [] -> true | files -> List.exists (fun f' -> Sail_file.Path.to_string f = f') files
-  in
-  let is_skipped_file f =
-    match !opt_format_skip with [] -> false | files -> List.exists (fun f' -> Sail_file.Path.to_string f = f') files
-  in
-  let module Config = struct
-    let config =
-      match config with
-      | Some (`Assoc keys) ->
-          List.assoc_opt "fmt" keys |> Option.map Format_sail.config_from_json
-          |> Option.value ~default:Format_sail.default_config
-      | Some _ -> raise (Reporting.err_general Parse_ast.Unknown "Invalid configuration file (must be a json object)")
-      | None -> Format_sail.default_config
-  end in
-  let module Formatter = Format_sail.Make (Config) in
-  let project_files, files =
-    List.partition (fun free -> Filename.check_suffix free ".sail_project") !opt_free_arguments
-  in
-
-  (* Get all the files references by project files *)
-  let referenced_files =
-    List.map
-      (fun project_file ->
-        let root_directory = Filename.dirname project_file in
-        let defs = Project.mk_root root_directory :: Initial_check.parse_project (Sail_file.Path.actual project_file) in
-
-        let variables = ref Util.StringMap.empty in
-        List.iter
-          (fun assignment ->
-            if not (Project.parse_assignment ~variables assignment) then
-              raise (Reporting.err_general Parse_ast.Unknown ("Could not parse assignment " ^ assignment))
-          )
-          !opt_variable_assignments;
-        let proj = Project.initialize_project_structure ~variables defs in
-        Project.all_files proj
-      )
-      project_files
-    |> List.concat |> List.map fst
-  in
-
-  let parsed_files =
-    List.map (fun f -> (f, Initial_check.parse_file f)) (List.map Sail_file.Path.actual files @ referenced_files)
-  in
-  List.iter
-    (fun (f, (comments, parse_ast)) ->
-      let source = Sail_file.contents (Sail_file.open_file f) in
-      if is_format_file f && not (is_skipped_file f) then (
-        let formatted =
-          Formatter.format_defs ~debug:!opt_format_debug (Sail_file.Path.to_string f) source comments parse_ast
-        in
-        ( match !opt_format_backup with
-        | Some suffix ->
-            let out_chan = open_out (Sail_file.Path.to_string f ^ "." ^ suffix) in
-            output_string out_chan source;
-            close_out out_chan
-        | None -> ()
-        );
-        match !opt_format_emit with
-        | "file" ->
-            let file_info = Util.open_output_with_check (Sail_file.Path.to_string f) in
-            output_string file_info.channel formatted;
-            Util.close_output_with_check file_info
-        | "stdout" ->
-            output_string stdout formatted;
-            flush stdout
-        | _ -> raise (Failure "unknown format_emit option")
-      )
-    )
-    parsed_files
-
 let feature_check () =
   match !opt_have_feature with
   | None -> ()
@@ -678,7 +599,7 @@ let main () =
   ( try Arg.parse_argv_dynamic argv options (fun s -> opt_free_arguments := !opt_free_arguments @ [s]) usage_msg with
   | Arg.Bad _ ->
       prerr_endline usage_msg;
-      prerr_endline "Use 'sail --help' for a list of available arguments.";
+      Printf.eprintf "Use 'sail%s --help' for a list of available arguments.\n%!" !opt_tool_help;
       exit 1
   | Arg.Help msg ->
       prerr_endline msg;
@@ -714,10 +635,7 @@ let main () =
     exit 0
   );
 
-  if !opt_format then (
-    run_sail_format config;
-    exit 0
-  );
+  (match !opt_tool with None -> () | Some action -> exit (action config !opt_variable_assignments !opt_free_arguments));
 
   let default_target = register_default_target () in
 

--- a/src/bin/tools.ml
+++ b/src/bin/tools.ml
@@ -1,0 +1,188 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Libsail
+
+module type TOOL = sig
+  val options : (Arg.key * Arg.spec * Arg.doc) list
+
+  val run : Yojson.Safe.t option -> string list -> string list -> int
+end
+
+module Strip_json_comments : TOOL = struct
+  let opt_output : string option ref = ref None
+  let opt_compact : bool ref = ref false
+
+  let options =
+    [
+      ("-o", Arg.String (fun filename -> opt_output := Some filename), "<file> output file (stdout if not provided)");
+      ("-compact", Arg.Set opt_compact, " use compact JSON output");
+    ]
+
+  let run _ _ = function
+    | [file] ->
+        let json =
+          try Yojson.Safe.from_file ~fname:file ~lnum:0 file
+          with Yojson.Json_error message ->
+            raise (Reporting.err_general Parse_ast.Unknown (Printf.sprintf "Failed to parse JSON:\n%s" message))
+        in
+        let close, chan =
+          match !opt_output with None -> (false, stdout) | Some out_file -> (true, open_out out_file)
+        in
+        if !opt_compact then Yojson.Safe.to_channel ~std:true chan json
+        else Yojson.Safe.pretty_to_channel ~std:true chan json;
+        if close then close_out chan;
+        0
+    | files ->
+        raise
+          (Reporting.err_general Parse_ast.Unknown
+             (Printf.sprintf "Expected a single input file, got %d" (List.length files))
+          )
+end
+
+module Format : TOOL = struct
+  let opt_format_backup : string option ref = ref None
+  let opt_format_only : string list ref = ref []
+  let opt_format_emit : string ref = ref "file"
+  let opt_format_skip : string list ref = ref []
+  let opt_format_debug : bool ref = ref false
+
+  let options =
+    [
+      ( "-fmt_backup",
+        Arg.String (fun suffix -> opt_format_backup := Some suffix),
+        "<suffix> create backups of formatted files as 'file.suffix'"
+      );
+      ("-fmt_only", Arg.String (fun file -> opt_format_only := file :: !opt_format_only), "<file> format only this file");
+      ( "-fmt_emit",
+        Arg.String (fun output -> opt_format_emit := output),
+        "[file(default)|stdout] update target file or just output to stdout"
+      );
+      ( "-fmt_skip",
+        Arg.String (fun file -> opt_format_skip := file :: !opt_format_skip),
+        "<file> skip formatting this file"
+      );
+      ("-fmt_debug", Arg.Bool (fun debug -> opt_format_debug := debug), "<bool> debug mode");
+    ]
+
+  let run config variable_assignments frees =
+    let is_format_file f =
+      match !opt_format_only with [] -> true | files -> List.exists (fun f' -> Sail_file.Path.to_string f = f') files
+    in
+    let is_skipped_file f =
+      match !opt_format_skip with [] -> false | files -> List.exists (fun f' -> Sail_file.Path.to_string f = f') files
+    in
+    let module Config = struct
+      let config =
+        match config with
+        | Some (`Assoc keys) ->
+            List.assoc_opt "fmt" keys |> Option.map Format_sail.config_from_json
+            |> Option.value ~default:Format_sail.default_config
+        | Some _ -> raise (Reporting.err_general Parse_ast.Unknown "Invalid configuration file (must be a json object)")
+        | None -> Format_sail.default_config
+    end in
+    let module Formatter = Format_sail.Make (Config) in
+    let project_files, files = List.partition (fun free -> Filename.check_suffix free ".sail_project") frees in
+
+    (* Get all the files references by project files *)
+    let referenced_files =
+      List.map
+        (fun project_file ->
+          let root_directory = Filename.dirname project_file in
+          let defs =
+            Project.mk_root root_directory :: Initial_check.parse_project (Sail_file.Path.actual project_file)
+          in
+
+          let variables = ref Util.StringMap.empty in
+          List.iter
+            (fun assignment ->
+              if not (Project.parse_assignment ~variables assignment) then
+                raise (Reporting.err_general Parse_ast.Unknown ("Could not parse assignment " ^ assignment))
+            )
+            variable_assignments;
+          let proj = Project.initialize_project_structure ~variables defs in
+          Project.all_files proj
+        )
+        project_files
+      |> List.concat |> List.map fst
+    in
+
+    let parsed_files =
+      List.map (fun f -> (f, Initial_check.parse_file f)) (List.map Sail_file.Path.actual files @ referenced_files)
+    in
+    List.iter
+      (fun (f, (comments, parse_ast)) ->
+        let source = Sail_file.contents (Sail_file.open_file f) in
+        if is_format_file f && not (is_skipped_file f) then (
+          let formatted =
+            Formatter.format_defs ~debug:!opt_format_debug (Sail_file.Path.to_string f) source comments parse_ast
+          in
+          ( match !opt_format_backup with
+          | Some suffix ->
+              let out_chan = open_out (Sail_file.Path.to_string f ^ "." ^ suffix) in
+              output_string out_chan source;
+              close_out out_chan
+          | None -> ()
+          );
+          match !opt_format_emit with
+          | "file" ->
+              let file_info = Util.open_output_with_check (Sail_file.Path.to_string f) in
+              output_string file_info.channel formatted;
+              Util.close_output_with_check file_info
+          | "stdout" ->
+              output_string stdout formatted;
+              flush stdout
+          | _ -> raise (Failure "unknown format_emit option")
+        )
+      )
+      parsed_files;
+    0
+end
+
+let load t fix_options opts =
+  let module T = (val t : TOOL) in
+  opts := fix_options T.options;
+  T.run

--- a/src/bin/tools.mli
+++ b/src/bin/tools.mli
@@ -1,0 +1,66 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Libsail
+
+module type TOOL = sig
+  val options : (Arg.key * Arg.spec * Arg.doc) list
+
+  val run : Yojson.Safe.t option -> string list -> string list -> int
+end
+
+module Strip_json_comments : TOOL
+
+module Format : TOOL
+
+val load :
+  (module TOOL) ->
+  ((Arg.key * Arg.spec * Arg.doc) list -> 'a) ->
+  'a ref ->
+  Yojson.Safe.t option ->
+  string list ->
+  string list ->
+  int


### PR DESCRIPTION
More generally, this PR adds a generic way for a Sail command line flag to invoke some other behaviour than the default compilation pipeline - each of which we refer to as a separate 'tool'. So to reformat JSON, for example:
```
sail --tool strip_json --compact file.json
```
The Sail formatter has also been refactored to use this mechanism, so rather than `sail --fmt`, it can also be invoked as:
```
sail --tool format file.sail --fmt-skip other_file.sail
```

Each tool is implemented by implementing the OCaml `TOOL` module signature in `tools.ml`, and then setting the `opt_tool` flag in the Sail main module to invoke it.

This is a slightly breaking change, as it means that the way options are handled has changed slightly. Options after the `--tool` flag are entirely custom, and specific to that tool, so
```
sail --tool strip_json --help
```
will only print options for stripping JSON, such as the aforementioned `--compact` flag. This means that tool options cannot be passed before the flag, which affects the Sail formatting tool as previously they were just regular options.

Right now this is implemented in the `sail` executable, rather than in Libsail, but it might be worth moving to Libsail so such tools can be registered with a `register_tool` function and then be implemented by Sail plugins.