### PR TITLE
Refactor warnings and scattered definitions

### DIFF
--- a/src/lib/pattern_completeness.ml
+++ b/src/lib/pattern_completeness.ml
@@ -999,10 +999,11 @@ module Make (C : Config) = struct
     )
     ^ terminator
 
-  let is_complete_wildcarded ?(keyword = "match") ?(remove_redundant = false) l ctx cases head_exp_typ =
+  let is_complete_wildcarded ?(keyword = "match") ?(remove_redundant = false) ?(allow_redundant = false) l ctx cases
+      head_exp_typ =
     try
       match cases_to_pats ctx 0 ~have_guard:false ~have_mapping:false cases with
-      (* The type-checker can prune some case armms early, if it determines the pattern would introduce a
+      (* The type-checker can prune some case arms early, if it determines the pattern would introduce a
          false/impossible flow typing constraint. If this happens we can get an empty list here. *)
       | have_guard, have_mapping, [] ->
           Reporting.warn Version.v0_20_2 "Incomplete pattern match statement at" (shrink_loc keyword l)
@@ -1033,12 +1034,13 @@ module Make (C : Config) = struct
               Reporting.unreachable l __POS__ "Got unmatched pattern matrix without witness" [@coverage off]
           | Complete cinfo ->
               let wildcarded_pats = List.map (fun (_, pat) -> insert_wildcards cinfo pat) pats in
-              List.iter
-                (fun (idx, _) ->
-                  if IntSet.mem idx.num cinfo.redundant then
-                    Reporting.warn Version.v0_20_2 "Redundant case" idx.loc "This match case is never used"
-                )
-                (rows_to_list matrix);
+              if not allow_redundant then
+                List.iter
+                  (fun (idx, _) ->
+                    if IntSet.mem idx.num cinfo.redundant then
+                      Reporting.warn Version.v0_20_2 "Redundant case" idx.loc "This match case is never used"
+                  )
+                  (rows_to_list matrix);
               let result = update_cases l wildcarded_pats cases in
               if remove_redundant then Some (filter_out cinfo.redundant result) else Some result
           | Completeness_unknown -> None
@@ -1049,10 +1051,13 @@ module Make (C : Config) = struct
     | Reporting.Fatal_error (Err_warning _) as exn -> raise exn
     | _ -> None
 
-  let is_complete_funcls_wildcarded ?(keyword = "match") ?(remove_redundant = false) l ctx funcls head_exp_typ =
+  let is_complete_funcls_wildcarded ?(remove_redundant = false) ?(allow_redundant = false) l ctx funcls head_exp_typ =
     let destruct_funcl (FCL_aux (FCL_funcl (id, pexp), annot)) = ((id, annot), pexp) in
     let cases = List.map destruct_funcl funcls in
-    match is_complete_wildcarded ~keyword l ctx (List.map snd cases) head_exp_typ with
+    match
+      is_complete_wildcarded ~keyword:"function" ~remove_redundant ~allow_redundant l ctx (List.map snd cases)
+        head_exp_typ
+    with
     | Some pexps -> Some (List.map2 (fun ((id, annot), _) pexp -> FCL_aux (FCL_funcl (id, pexp), annot)) cases pexps)
     | None -> None
 

--- a/src/lib/pattern_completeness.mli
+++ b/src/lib/pattern_completeness.mli
@@ -71,8 +71,22 @@ end
 
 module Make (C : Config) : sig
   val is_complete_wildcarded :
-    ?keyword:string -> ?remove_redundant:bool -> Parse_ast.l -> ctx -> C.t pexp list -> typ -> C.t pexp list option
+    ?keyword:string ->
+    ?remove_redundant:bool ->
+    ?allow_redundant:bool ->
+    Parse_ast.l ->
+    ctx ->
+    C.t pexp list ->
+    typ ->
+    C.t pexp list option
+
   val is_complete_funcls_wildcarded :
-    ?keyword:string -> ?remove_redundant:bool -> Parse_ast.l -> ctx -> C.t funcl list -> typ -> C.t funcl list option
+    ?remove_redundant:bool ->
+    ?allow_redundant:bool ->
+    Parse_ast.l ->
+    ctx ->
+    C.t funcl list ->
+    typ ->
+    C.t funcl list option
   val is_complete : ?keyword:string -> Parse_ast.l -> ctx -> C.t pexp list -> typ -> bool
 end

--- a/src/lib/preprocess.ml
+++ b/src/lib/preprocess.ml
@@ -161,6 +161,12 @@ let get_argv_position ~plus =
 let target_set_contains (target_set : string) (target : string) : bool =
   String.split_on_char ' ' target_set |> List.mem target
 
+let rec find_warnings_off = function
+  | DEF_aux (DEF_pragma ("suppress_warnings", Pragma_line ("off", _)), l) :: _ ->
+      Option.map snd (Reporting.simp_loc (pragma_loc l))
+  | def :: defs -> find_warnings_off defs
+  | [] -> None
+
 let preprocess ~default_sail_dir ~target_name ~options ~symbols defs =
   let module P = Parse_ast in
   let symbols = ref symbols in
@@ -183,6 +189,9 @@ let preprocess ~default_sail_dir ~target_name ~options ~symbols defs =
             format_message message (buffer_formatter b);
             raise (Reporting.err_general l (Buffer.contents b))
       )
+    | DEF_aux (DEF_pragma ("warn", Pragma_line (msg, _)), l) :: defs ->
+        Reporting.warn Version.v0_20_2 "Directive" (pragma_loc l) msg;
+        aux includes acc defs
     | (DEF_aux (DEF_pragma ("option", Pragma_line (command, ltrim)), l) as opt_pragma) :: defs ->
         let l = pragma_loc l in
         let first_line err_msg =
@@ -258,10 +267,22 @@ let preprocess ~default_sail_dir ~target_name ~options ~symbols defs =
           Reporting.warn Version.v0_20_2 "" (pragma_loc l) ("Skipping bad $include " ^ file ^ ". " ^ help);
           aux includes acc defs
         )
-    | DEF_aux (DEF_pragma ("suppress_warnings", _), l) :: defs ->
+    | DEF_aux (DEF_pragma ("suppress_warnings", arg), l) :: defs ->
         ( match Reporting.simp_loc l with
         | None -> () (* This shouldn't happen, but if it does just continue *)
-        | Some (p, _) -> Reporting.suppress_warnings_for_file p.pos_fname
+        | Some (p, _) -> (
+            match arg with
+            | Pragma_line ("on", _) -> (
+                match find_warnings_off defs with
+                | None ->
+                    raise
+                      (Reporting.err_general (pragma_loc l) "Could not find matching '$suppress_warnings off' directive")
+                | Some p_end -> Reporting.suppress_warnings_for_span p p_end
+              )
+            | Pragma_line ("off", _) -> ()
+            | Pragma_line ("", _) -> Reporting.suppress_warnings_for_file p.pos_fname
+            | _ -> raise (Reporting.err_general (pragma_loc l) "Unknown argument for suppress_warnings directive")
+          )
         );
         aux includes acc defs
     (* Filter file_start and file_end out of the AST so when we

--- a/src/lib/reporting.ml
+++ b/src/lib/reporting.ml
@@ -282,11 +282,33 @@ end
 
 module RangeMap = Map.Make (Range)
 
-let ignored_files = ref Sail_file.HandleSet.empty
+let ignored_locations = ref Sail_file.HandleMap.empty
 
-let suppress_warnings_for_file f = ignored_files := Sail_file.HandleSet.add f !ignored_files
+let suppress_warnings_for_file f = ignored_locations := Sail_file.HandleMap.add f None !ignored_locations
 
-let ignore_file p = Sail_file.(HandleSet.mem p.Position.pos_fname !ignored_files)
+let suppress_warnings_for_span p_start p_end =
+  let open Sail_file.Position in
+  if Sail_file.handle_equal p_start.pos_fname p_end.pos_fname then (
+    match Sail_file.HandleMap.find_opt p_start.pos_fname !ignored_locations with
+    | None ->
+        ignored_locations :=
+          Sail_file.HandleMap.add p_start.pos_fname
+            (Some (Util.IntIntSet.singleton (p_start.pos_cnum, p_end.pos_cnum)))
+            !ignored_locations
+    | Some None -> () (* Already ignoring whole file. *)
+    | Some (Some spans) ->
+        ignored_locations :=
+          Sail_file.HandleMap.add p_start.pos_fname
+            (Some (Util.IntIntSet.add (p_start.pos_cnum, p_end.pos_cnum) spans))
+            !ignored_locations
+  )
+
+let ignore_position p =
+  let open Sail_file.Position in
+  match Sail_file.HandleMap.find_opt p.pos_fname !ignored_locations with
+  | None -> false
+  | Some None -> true
+  | Some (Some spans) -> Util.IntIntSet.exists (fun (s, e) -> s <= p.pos_cnum && p.pos_cnum <= e) spans
 
 let seen_warnings = ref RangeMap.empty
 let once_from_warnings = ref StringSet.empty
@@ -297,7 +319,7 @@ let suppressed_warning_info () =
     prerr_endline
       (Util.("Warning" |> yellow |> clear)
       ^ ": " ^ string_of_int !suppressed_warnings
-      ^ " warnings have been suppressed. Use --all-warnings to display them."
+      ^ " warnings have been automatically suppressed. Use --all-warnings to display them."
       );
     suppressed_warnings := 0
   )
@@ -340,11 +362,13 @@ let format_warn ?once_from ?(force_show = false) version short_str l explanation
   in
   if (!opt_warnings && not already_shown) || force_show then (
     match simp_loc l with
-    | Some (p1, p2) when not (ignore_file p1) ->
-        let shorts = RangeMap.find_opt (p1, p2) !seen_warnings |> Option.value ~default:[] in
-        if not (List.exists (fun s -> s = short_str) shorts) then (
-          print_warning ~fatal short_str l explanation;
-          seen_warnings := RangeMap.add (p1, p2) (short_str :: shorts) !seen_warnings
+    | Some (p1, p2) ->
+        if not (ignore_position p1) then (
+          let shorts = RangeMap.find_opt (p1, p2) !seen_warnings |> Option.value ~default:[] in
+          if not (List.exists (fun s -> s = short_str) shorts) then (
+            print_warning ~fatal short_str l explanation;
+            seen_warnings := RangeMap.add (p1, p2) (short_str :: shorts) !seen_warnings
+          )
         )
     | _ -> print_warning ~fatal short_str l explanation
   )

--- a/src/lib/reporting.mli
+++ b/src/lib/reporting.mli
@@ -44,7 +44,7 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-(** Sail error reporting
+(** Sail error reporting and warnings
 
     [Reporting] contains functions to report errors and warnings. It contains functions to print locations
     ([Parse_ast.l] and [Ast.l]) and lexing positions.
@@ -53,7 +53,9 @@
     internally and reported via [report_error]. There are several predefined types of errors which all cause different
     error messages. If none of these fit, [Err_general] can be used. *)
 
-(** If this is false, Sail will never generate any warnings *)
+(** {1 Options} *)
+
+(** If this is false, Sail will never generate any warnings (except when marked as [~force_show]) *)
 val opt_warnings : bool ref
 
 (** If this is true, we will print all warnings, even if generated with [~once_from]. *)
@@ -65,7 +67,7 @@ val opt_warn_error : Version.t option ref
 (** How many backtrace entries to show for unreachable code errors *)
 val opt_backtrace_length : int ref
 
-(** {2 Auxiliary Functions} *)
+(** {1 Auxiliary Functions} *)
 
 (** [loc_to_string] prints a location as a string, including source code *)
 val loc_to_string : Parse_ast.l -> string
@@ -104,12 +106,12 @@ val print_err : Parse_ast.l -> string -> string -> unit
 (** Reduce all spans in a location to just their starting characters *)
 val start_loc : Parse_ast.l -> Parse_ast.l
 
-(** {2 The error type} *)
+(** {1 The error type} *)
 
 (** Errors stop execution and print a message; they typically have a location and message.
 
-    Note that all these errors are intended to be fatal, so should not be caught other than by the top-level function.
-*)
+    Note that all these errors are intended to be fatal, so should not typically be caught other than by the top-level
+    function. *)
 type error =
   | Err_general of Parse_ast.l * string  (** General errors, used for multi purpose. If you are unsure, use this one. *)
   | Err_unreachable of Parse_ast.l * (string * int * int * int) * Printexc.raw_backtrace * string
@@ -151,10 +153,31 @@ val print_type_error : ?hint:string -> Parse_ast.l -> string -> unit
 (** This function transforms all errors raised by the provided function into internal [Err_unreachable] errors *)
 val forbid_errors : string * int * int * int -> ('a -> 'b) -> 'a -> 'b
 
-(** Print a warning message. The first string is printed before the location, the second after. *)
+(** {1 Warnings} *)
+
+(** Print a warning message. The first string argument is a short string identifying the type of warning (e.g.
+    "Deprecated") and is printed before the location, the second is a longer description printed after.
+
+    The combination of the short string and the location are used to uniquely identify any warning. Subsequent warnings
+    that share both will not be shown.
+
+    The version argument is used for promoting warnings to errors. Each warning, has a specified version where it was
+    introduced (see [Version]). Any warning with an introduced version less than or equal to the [opt_warn_error]
+    version will become an error. This means that new warnings can be introduced without breaking downstream CI builds
+    that want to treat warnings as errors.
+
+    @param once_from
+      This parameter is always set to the OCaml builtin [__POS__] binding. If used, this ensures that that instance of
+      [warn] only ever happens once, provided [opt_all_warnings] isn't set. This is useful when a warning, if triggered,
+      would likely trigger many more times (on different parts of the input source). As an example, this is often used
+      for deprecated constructs, as we want to notify that is deprecated via a warning, but not print hundreds or
+      warnings for every use.
+
+    @param force_show This parameter if true forces the warning to always be shown. *)
 val warn :
   ?once_from:string * int * int * int -> ?force_show:bool -> Version.t -> string -> Parse_ast.l -> string -> unit
 
+(** Print a formatted warning message. See [warn] for details of the arguments. *)
 val format_warn :
   ?once_from:string * int * int * int ->
   ?force_show:bool ->
@@ -164,15 +187,26 @@ val format_warn :
   Error_format.message ->
   unit
 
-(** Print information about suppressed warnings *)
+(** Print information about suppressed warnings. These are specifically warnings that would be shown if
+    [opt_all_warnings] was used.
+
+    Internally we can consider warnings that are not shown as falling into three categories:
+
+    - Suppressed by [once_from]
+    - Ignored by directives ([$suppress_warnings])
+    - Duplicate, already shown
+
+    This function prints information about the first only. *)
 val suppressed_warning_info : unit -> unit
 
 (** Print a simple one-line warning without a location. *)
 val simple_warn : Version.t -> string -> unit
 
-(** Will suppress all warnings for a given (Sail) file handle. Used by $suppress_warnings directive in process_file.ml
-*)
+(** Will suppress all warnings for a given (Sail) file handle. Used by the $suppress_warnings directive in
+    process_file.ml *)
 val suppress_warnings_for_file : Sail_file.handle -> unit
+
+val suppress_warnings_for_span : Sail_file.position -> Sail_file.position -> unit
 
 val get_sail_dir : string -> string
 

--- a/src/lib/sail_file.ml
+++ b/src/lib/sail_file.ml
@@ -64,7 +64,14 @@ type handle = int
 
 let handle_compare h1 h2 = Int.compare h1 h2
 
+let handle_equal h1 h2 = Int.equal h1 h2
+
 module HandleSet = Set.Make (struct
+  type t = handle
+  let compare = handle_compare
+end)
+
+module HandleMap = Map.Make (struct
   type t = handle
   let compare = handle_compare
 end)

--- a/src/lib/sail_file.mli
+++ b/src/lib/sail_file.mli
@@ -77,8 +77,14 @@ type handle = private int
 
 val handle_compare : handle -> handle -> int
 
+val handle_equal : handle -> handle -> bool
+
 module HandleSet : sig
   include Set.S with type elt = handle
+end
+
+module HandleMap : sig
+  include Map.S with type key = handle
 end
 
 (** Open a file and return a [handle] to it's contents. Note that the file is not actually held open -- we read the

--- a/src/lib/scattered.ml
+++ b/src/lib/scattered.ml
@@ -53,13 +53,24 @@ let funcl_id (FCL_aux (FCL_funcl (id, _), _)) = id
 
 let rec last_scattered_funcl id = function
   | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, _)), _) :: _ when Id.compare (funcl_id funcl) id = 0 -> false
+  | DEF_aux (DEF_scattered (SD_aux (SD_end fid, _)), _) :: _ when Id.compare fid id = 0 -> false
   | _ :: defs -> last_scattered_funcl id defs
   | [] -> true
 
 let rec last_scattered_mapcl id = function
   | DEF_aux (DEF_scattered (SD_aux (SD_mapcl (mid, _), _)), _) :: _ when Id.compare mid id = 0 -> false
+  | DEF_aux (DEF_scattered (SD_aux (SD_end mid, _)), _) :: _ when Id.compare mid id = 0 -> false
   | _ :: defs -> last_scattered_mapcl id defs
   | [] -> true
+
+let scattered_function_end aux funcls defs =
+  match aux with
+  | SD_end id -> Bindings.mem id funcls
+  | SD_funcl funcl -> last_scattered_funcl (funcl_id funcl) defs
+  | _ -> false
+
+let scattered_mapping_end aux mapcls defs =
+  match aux with SD_end id -> Bindings.mem id mapcls | SD_mapcl (id, _) -> last_scattered_mapcl id defs | _ -> false
 
 (* Nothing cares about these and the AST should be changed *)
 let fake_rec_opt l = Rec_aux (Rec_nonrec, gen_loc l)
@@ -96,97 +107,131 @@ let patch_funcl_loc def_annot (FCL_aux (aux, (_, tannot))) =
 let patch_mapcl_annot def_annot (MCL_aux (aux, (_, tannot))) =
   MCL_aux (aux, (Type_check.strip_def_annot def_annot, tannot))
 
+let scattered_id = function
+  | SD_function (id, _) -> id
+  | SD_funcl funcl -> funcl_id funcl
+  | SD_variant (id, _) -> id
+  | SD_unioncl (id, _) -> id
+  | SD_internal_unioncl_record (id, _, _, _) -> id
+  | SD_mapping (id, _) -> id
+  | SD_mapcl (id, _) -> id
+  | SD_enum id -> id
+  | SD_enumcl (id, _) -> id
+  | SD_end id -> id
+
+let final_funcl = function SD_funcl funcl -> Some funcl | _ -> None
+
+let final_mapcl = function SD_mapcl (_, mapcl) -> Some mapcl | _ -> None
+
 let rec descatter' global_env annots accumulator funcls mapcls = function
-  (* For scattered functions we collect all the seperate function
-     clauses until we find the last one, then we turn that function
-     clause into a DEF_fundef containing all the clauses. *)
-  | DEF_aux (DEF_scattered (SD_aux (SD_function (id, _), _)), def_annot) :: defs ->
-      descatter' global_env (Bindings.add id def_annot annots) accumulator funcls mapcls defs
-  | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, (l, tannot))), def_annot) :: defs
-    when last_scattered_funcl (funcl_id funcl) defs ->
-      let funcl = patch_funcl_loc def_annot funcl in
-      let clauses =
-        match Bindings.find_opt (funcl_id funcl) funcls with
-        | Some clauses -> List.rev (funcl :: clauses)
-        | None -> [funcl]
-      in
-      let clauses, update_attr =
-        Type_check.(check_funcls_complete ~global_env l (env_of_tannot tannot) clauses (typ_of_tannot tannot))
-      in
-      let def_annot =
-        Option.value ~default:(mk_def_annot (gen_loc l) def_annot.env) (Bindings.find_opt (funcl_id funcl) annots)
-      in
-      let accumulator =
-        DEF_aux
-          ( DEF_fundef (FD_aux (FD_function (fake_rec_opt l, no_tannot_opt l, clauses), (gen_loc l, tannot))),
-            update_attr def_annot
-          )
-        :: accumulator
-      in
-      descatter' global_env annots accumulator funcls mapcls defs
-  | DEF_aux (DEF_scattered (SD_aux (SD_funcl funcl, _)), def_annot) :: defs -> (
-      let id = funcl_id funcl in
-      let funcl = patch_funcl_loc def_annot funcl in
-      match Bindings.find_opt id funcls with
-      | Some clauses -> descatter' global_env annots accumulator (Bindings.add id (funcl :: clauses) funcls) mapcls defs
-      | None -> descatter' global_env annots accumulator (Bindings.add id [funcl] funcls) mapcls defs
-    )
-  (* Scattered mappings are handled the same way as scattered functions *)
-  | DEF_aux (DEF_scattered (SD_aux (SD_mapping (id, _), _)), def_annot) :: defs ->
-      descatter' global_env (Bindings.add id def_annot annots) accumulator funcls mapcls defs
-  | DEF_aux (DEF_scattered (SD_aux (SD_mapcl (id, mapcl), (l, tannot))), def_annot) :: defs
-    when last_scattered_mapcl id defs ->
-      let mapcl = patch_mapcl_annot def_annot mapcl in
-      let clauses =
-        match Bindings.find_opt id mapcls with Some clauses -> List.rev (mapcl :: clauses) | None -> [mapcl]
-      in
-      let def_annot = Option.value ~default:(mk_def_annot (gen_loc l) def_annot.env) (Bindings.find_opt id annots) in
-      let accumulator =
-        DEF_aux (DEF_mapdef (MD_aux (MD_mapping (id, no_tannot_opt l, clauses), (gen_loc l, tannot))), def_annot)
-        :: accumulator
-      in
-      descatter' global_env annots accumulator funcls mapcls defs
-  | DEF_aux (DEF_scattered (SD_aux (SD_mapcl (id, mapcl), _)), def_annot) :: defs -> (
-      let mapcl = patch_mapcl_annot def_annot mapcl in
-      match Bindings.find_opt id mapcls with
-      | Some clauses -> descatter' global_env annots accumulator funcls (Bindings.add id (mapcl :: clauses) mapcls) defs
-      | None -> descatter' global_env annots accumulator funcls (Bindings.add id [mapcl] mapcls) defs
-    )
-  (* For scattered unions, when we find a union declaration we
-     immediately grab all the future clauses and turn it into a
-     regular union declaration. *)
-  | DEF_aux (DEF_scattered (SD_aux (SD_variant (id, typq), (l, _))), def_annot) :: defs -> (
-      let tus = get_scattered_union_clauses id defs in
-      let records = get_union_records id [] defs in
-      match tus with
-      | [] -> raise (Reporting.err_general l "No clauses found for scattered union type")
-      | _ ->
+  | DEF_aux (DEF_scattered (SD_aux (aux, (l, tannot))), def_annot) :: defs -> (
+      match aux with
+      | SD_function (id, _) ->
+          (* For scattered functions we collect all the seperate
+             function clauses until we find the last one (or SD_end),
+             then we turn that function clause into a DEF_fundef
+             containing all the clauses. *)
+          descatter' global_env (Bindings.add id def_annot annots) accumulator funcls mapcls defs
+      | _ when scattered_function_end aux funcls defs ->
+          let id = scattered_id aux in
+          let funcl = Option.fold ~none:[] ~some:(fun funcl -> [patch_funcl_loc def_annot funcl]) (final_funcl aux) in
+          let clauses =
+            match Bindings.find_opt id funcls with Some clauses -> List.rev (funcl @ clauses) | None -> funcl
+          in
+          let clauses, update_attr =
+            Type_check.(
+              check_funcls_complete ~global_env ~allow_redundant:true l (env_of_tannot tannot) clauses
+                (typ_of_tannot tannot)
+            )
+          in
+          let def_annot =
+            Option.value ~default:(mk_def_annot (gen_loc l) def_annot.env) (Bindings.find_opt id annots)
+          in
           let accumulator =
             DEF_aux
-              (DEF_type (TD_aux (TD_variant (id, typq, tus, false), (gen_loc l, Type_check.empty_tannot))), def_annot)
-            :: records
-            @ accumulator
-          in
-          descatter' global_env annots accumulator funcls mapcls (filter_union_clauses id defs)
-    )
-  (* Therefore we should never see SD_unioncl... *)
-  | DEF_aux (DEF_scattered (SD_aux (SD_unioncl _, (l, _))), _) :: _ ->
-      raise (Reporting.err_unreachable l __POS__ "Found union clause during de-scattering")
-  | DEF_aux (DEF_scattered (SD_aux (SD_enum id, (l, _))), def_annot) :: defs -> (
-      let members = get_scattered_enum_clauses id defs in
-      match members with
-      | [] -> raise (Reporting.err_general l "No clauses found for scattered enum type")
-      | _ ->
-          let def_annot =
-            def_annot
-            |> add_def_attribute (gen_loc l) "no_enum_number_conversions" None
-            |> add_def_attribute (gen_loc l) "undefined_gen" (Some (AD_aux (AD_string "forbid", gen_loc l)))
-          in
-          let accumulator =
-            DEF_aux (DEF_type (TD_aux (TD_enum (id, members, false), (gen_loc l, Type_check.empty_tannot))), def_annot)
+              ( DEF_fundef (FD_aux (FD_function (fake_rec_opt l, no_tannot_opt l, clauses), (gen_loc l, tannot))),
+                update_attr def_annot
+              )
             :: accumulator
           in
-          descatter' global_env annots accumulator funcls mapcls (filter_enum_clauses id defs)
+          descatter' global_env annots accumulator funcls mapcls defs
+      | SD_funcl funcl -> (
+          let id = funcl_id funcl in
+          let funcl = patch_funcl_loc def_annot funcl in
+          match Bindings.find_opt id funcls with
+          | Some clauses ->
+              descatter' global_env annots accumulator (Bindings.add id (funcl :: clauses) funcls) mapcls defs
+          | None -> descatter' global_env annots accumulator (Bindings.add id [funcl] funcls) mapcls defs
+        )
+      | SD_mapping (id, _) ->
+          (* Scattered mappings are handled the same way as scattered functions *)
+          descatter' global_env (Bindings.add id def_annot annots) accumulator funcls mapcls defs
+      | _ when scattered_mapping_end aux mapcls defs ->
+          let id = scattered_id aux in
+          let mapcl = Option.fold ~none:[] ~some:(fun mapcl -> [patch_mapcl_annot def_annot mapcl]) (final_mapcl aux) in
+          let clauses =
+            match Bindings.find_opt id mapcls with Some clauses -> List.rev (mapcl @ clauses) | None -> mapcl
+          in
+          let def_annot =
+            Option.value ~default:(mk_def_annot (gen_loc l) def_annot.env) (Bindings.find_opt id annots)
+          in
+          let accumulator =
+            DEF_aux (DEF_mapdef (MD_aux (MD_mapping (id, no_tannot_opt l, clauses), (gen_loc l, tannot))), def_annot)
+            :: accumulator
+          in
+          descatter' global_env annots accumulator funcls mapcls defs
+      | SD_mapcl (id, mapcl) -> (
+          let mapcl = patch_mapcl_annot def_annot mapcl in
+          match Bindings.find_opt id mapcls with
+          | Some clauses ->
+              descatter' global_env annots accumulator funcls (Bindings.add id (mapcl :: clauses) mapcls) defs
+          | None -> descatter' global_env annots accumulator funcls (Bindings.add id [mapcl] mapcls) defs
+        )
+      | SD_variant (id, typq) -> (
+          (* For scattered unions, when we find a union declaration we
+             immediately grab all the future clauses and turn it into
+             a regular union declaration. *)
+          let tus = get_scattered_union_clauses id defs in
+          let records = get_union_records id [] defs in
+          match tus with
+          | [] -> raise (Reporting.err_general l "No clauses found for scattered union type")
+          | _ ->
+              let accumulator =
+                DEF_aux
+                  ( DEF_type (TD_aux (TD_variant (id, typq, tus, false), (gen_loc l, Type_check.empty_tannot))),
+                    def_annot
+                  )
+                :: records
+                @ accumulator
+              in
+              descatter' global_env annots accumulator funcls mapcls (filter_union_clauses id defs)
+        )
+      | SD_unioncl _ ->
+          (* Therefore we should never see SD_unioncl... *)
+          raise (Reporting.err_unreachable l __POS__ "Found union clause during de-scattering")
+      | SD_enum id -> (
+          let members = get_scattered_enum_clauses id defs in
+          match members with
+          | [] -> raise (Reporting.err_general l "No clauses found for scattered enum type")
+          | _ ->
+              let def_annot =
+                def_annot
+                |> add_def_attribute (gen_loc l) "no_enum_number_conversions" None
+                |> add_def_attribute (gen_loc l) "undefined_gen" (Some (AD_aux (AD_string "forbid", gen_loc l)))
+              in
+              let accumulator =
+                DEF_aux
+                  (DEF_type (TD_aux (TD_enum (id, members, false), (gen_loc l, Type_check.empty_tannot))), def_annot)
+                :: accumulator
+              in
+              descatter' global_env annots accumulator funcls mapcls (filter_enum_clauses id defs)
+        )
+      | SD_enumcl _ ->
+          (* Like with SD_unioncl, we should never see SD_enumcl... *)
+          raise (Reporting.err_unreachable l __POS__ "Found enum clause during de-scattering")
+      | SD_end _ -> raise (Reporting.err_general l "Found ending for scattered definition that had no start")
+      | SD_internal_unioncl_record _ ->
+          raise (Reporting.err_unreachable l __POS__ "Internal union clause record found during descattering")
     )
   | def :: defs -> descatter' global_env annots (def :: accumulator) funcls mapcls defs
   | [] -> List.rev accumulator

--- a/src/lib/type_check.ml
+++ b/src/lib/type_check.ml
@@ -4734,7 +4734,7 @@ let check_termination_measure_decl env def_annot (id, pat, exp) =
   let tpat, texp = check_termination_measure env arg_typs pat exp in
   DEF_aux (DEF_measure (id, tpat, texp), def_annot)
 
-let check_funcls_complete ?global_env l env funcls typ =
+let check_funcls_complete ?global_env ?(allow_redundant = false) l env funcls typ =
   let typ_arg, _, env = bind_funcl_arg_typ l env typ in
   let ctx =
     match global_env with
@@ -4743,7 +4743,7 @@ let check_funcls_complete ?global_env l env funcls typ =
         let ctx = pattern_completeness_ctx genv in
         { ctx with constraints = Env.get_constraints env; is_open = (fun _ -> false) }
   in
-  match PC.is_complete_funcls_wildcarded ~keyword:"function" l ctx funcls typ_arg with
+  match PC.is_complete_funcls_wildcarded ~allow_redundant l ctx funcls typ_arg with
   | Some funcls -> (funcls, add_def_attribute (gen_loc l) "complete" None)
   | None -> (funcls, add_def_attribute (gen_loc l) "incomplete" None)
 

--- a/src/lib/type_check.mli
+++ b/src/lib/type_check.mli
@@ -358,6 +358,7 @@ val assert_constraint : Env.t -> bool -> tannot exp -> n_constraint option
     type definitions will be considered as closed. *)
 val check_funcls_complete :
   ?global_env:Env.t ->
+  ?allow_redundant:bool ->
   Parse_ast.l ->
   Env.t ->
   tannot funcl list ->


### PR DESCRIPTION
Slightly changes how scattered definitions are descattered - if an `end` is present, clauses will be moved there rather than the with final clause.

Add a `$suppress_warnings on` and `$suppress_warnings off` directive to locally disable warnings within a portion of a file.