### PR TITLE
Sail LSP formatting

### DIFF
--- a/src/lib/chunk_ast.ml
+++ b/src/lib/chunk_ast.ml
@@ -1535,6 +1535,10 @@ let rec chunk_def skip source last_line_span comments chunks (DEF_aux (def, l)) 
       Queue.add (Spacer (false, 1)) chunks;
       let skip = has_skip_attr skip attrs in
       chunk_def skip source last_line_span comments chunks def
+  | DEF_private def ->
+      pop_comments comments chunks l;
+      chunk_keyword "private" chunks;
+      chunk_def skip source line_span comments chunks def
   | def ->
       if skip then raw_source ()
       else (

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -276,6 +276,17 @@ module PPrintWrapper = struct
       )
       lines
 
+  (* True if the document contains a hardline that will be printed even
+     when the document is flattened, i.e. any group containing it can
+     never be laid out on a single line. Note that we only need to look
+     at the flat branch of an ifflat. *)
+  let rec forces_hardline = function
+    | Hardline _ -> true
+    | Cat (doc1, doc2) -> forces_hardline doc1 || forces_hardline doc2
+    | Group doc | Nest (_, doc) | Align doc -> forces_hardline doc
+    | Ifflat (flat, _) -> forces_hardline flat
+    | Empty | Weak_space | Char _ | Lineup_char _ | String _ | Utf8string _ -> false
+
   (* TODO: maybe save line_number in ast *)
   let is_single_line_block_comment s =
     let lines = String.split_on_char '\n' s in
@@ -881,10 +892,19 @@ module Make (Config : CONFIG) = struct
     match pexp.guard with
     | None ->
         group (typq ^^ paren_args (doc_chunks ~ungroup_tuple:true opts pexp.pat) ^^ return_typ)
-        ^^ string "="
         ^^
-        if is_block pexp.body || hanging then space ^^ doc_chunks opts pexp.body
-        else nest indent (hardline ^^ doc_chunks opts pexp.body)
+        let body = doc_chunks opts pexp.body in
+        string "="
+        ^^
+        if is_block pexp.body then space ^^ body
+        else if hanging then
+          (* The body was on the same line as the header in the source, so
+             we try to keep it there. However, if the body is not something
+             that will lay itself out over multiple lines anyway (like a
+             block or a match), we allow it to be pushed onto the next line
+             rather than forcing it to break internally. *)
+          if forces_hardline body then space ^^ body else group (nest indent (break 1 ^^ body))
+        else nest indent (hardline ^^ body)
     | Some guard ->
         typq
         ^^ parens (separate space [doc_chunks opts pexp.pat; string "if"; doc_chunks opts guard])

--- a/src/lib/format_sail.ml
+++ b/src/lib/format_sail.ml
@@ -1096,14 +1096,13 @@ module Make (Config : CONFIG) = struct
     let f2 = format_defs_once ~debug filename f1 comments defs in
     let comments, defs = parse_file_from_string f2 in
     let f3 = format_defs_once ~debug filename f2 comments defs in
-    if f2 <> f3 then (
-      prerr_endline f2;
-      prerr_endline f3;
-      raise (Reporting.err_general Parse_ast.Unknown filename)
-    );
+    if not (String.equal f2 f3) then
+      raise
+        (Reporting.err_general Parse_ast.Unknown
+           (Printf.sprintf "Did not reach a fixed point when formatting %s" filename)
+        );
     ( match diff_list ~at:Parse_ast.Unknown diff_def starting_defs defs with
     | Some difference ->
-        prerr_endline f3;
         raise
           (Reporting.err_general difference
              (Printf.sprintf "Found difference in syntax tree here after formatting %s" filename)

--- a/src/sail_lsp/README.md
+++ b/src/sail_lsp/README.md
@@ -6,8 +6,45 @@ sail_lsp
 This is a minimal (and highly WIP) LSP server for Sail.
 
 Currently supports syntax highlighting, code folding, hover
-type-at-cursor, go-to-definition, and reporting type-error
-diagnostics as you type.
+type-at-cursor, go-to-definition, automatic formatting, and reporting
+type-error diagnostics as you type.
+
+### Configuration
+
+Semantic highlighting and folding are off by default. Either can be
+turned on with a command line flag (`--highlight` and `--folding`, plus
+the matching `--no-` flags), or in the configuration file, which is
+read from `$XDG_CONFIG_HOME/sail_lsp/config.json`
+(`%APPDATA%\sail_lsp\config.json` on Windows). A flag on the command
+line overrides the file.
+
+```json
+{
+    "sail_dir": "/path/to/sail",
+    "highlight": true,
+    "fmt": {
+        "indent": 4,
+        "line_width": 120
+    }
+}
+```
+
+The `fmt` section holds the formatting options, and takes the same
+keys as the `fmt` section of a Sail configuration file passed to `sail
+-fmt`.
+
+Formatting works on whole documents and on selections. A selection is
+formatted a definition at a time: every definition the selection
+touches is reformatted, so putting the cursor in a definition and
+formatting the selection reformats just that definition. Whatever lies
+between definitions — a comment on a line of its own, say — belongs to
+no definition, and is left as written.
+
+Either way the whole buffer has to parse, because a definition is
+formatted by formatting the document it belongs to and keeping the part
+that corresponds to it. A document that does not parse cannot be
+formatted, and the server responds with an error explaining why rather
+than silently leaving the buffer alone.
 
 No editor modes are currently provided, but it is particularly easy to
 set up in neovim for testing with just the following lua:

--- a/src/sail_lsp/formatting.ml
+++ b/src/sail_lsp/formatting.ml
@@ -1,0 +1,172 @@
+(****************************************************************************)
+(*     Sail                                                                 *)
+(*                                                                          *)
+(*  Sail and the Sail architecture models here, comprising all files and    *)
+(*  directories except the ASL-derived Sail code in the aarch64 directory,  *)
+(*  are subject to the BSD two-clause licence below.                        *)
+(*                                                                          *)
+(*  The ASL derived parts of the ARMv8.3 specification in                   *)
+(*  aarch64/no_vector and aarch64/full are copyright ARM Ltd.               *)
+(*                                                                          *)
+(*  Copyright (c) 2013-2021                                                 *)
+(*    Kathyrn Gray                                                          *)
+(*    Shaked Flur                                                           *)
+(*    Stephen Kell                                                          *)
+(*    Gabriel Kerneis                                                       *)
+(*    Robert Norton-Wright                                                  *)
+(*    Christopher Pulte                                                     *)
+(*    Peter Sewell                                                          *)
+(*    Alasdair Armstrong                                                    *)
+(*    Brian Campbell                                                        *)
+(*    Thomas Bauereiss                                                      *)
+(*    Anthony Fox                                                           *)
+(*    Jon French                                                            *)
+(*    Dominic Mulligan                                                      *)
+(*    Stephen Kell                                                          *)
+(*    Mark Wassell                                                          *)
+(*    Alastair Reid (Arm Ltd)                                               *)
+(*                                                                          *)
+(*  All rights reserved.                                                    *)
+(*                                                                          *)
+(*  This work was partially supported by EPSRC grant EP/K008528/1 <a        *)
+(*  href="http://www.cl.cam.ac.uk/users/pes20/rems">REMS: Rigorous          *)
+(*  Engineering for Mainstream Systems</a>, an ARM iCASE award, EPSRC IAA   *)
+(*  KTF funding, and donations from Arm.  This project has received         *)
+(*  funding from the European Research Council (ERC) under the European     *)
+(*  Union’s Horizon 2020 research and innovation programme (grant           *)
+(*  agreement No 789108, ELVER).                                            *)
+(*                                                                          *)
+(*  This software was developed by SRI International and the University of  *)
+(*  Cambridge Computer Laboratory (Department of Computer Science and       *)
+(*  Technology) under DARPA/AFRL contracts FA8650-18-C-7809 ("CIFV")        *)
+(*  and FA8750-10-C-0237 ("CTSRD").                                         *)
+(*                                                                          *)
+(*  SPDX-License-Identifier: BSD-2-Clause                                   *)
+(****************************************************************************)
+
+open Libsail
+open Log
+
+(* Parse and format the buffer. Raises [Reporting.Fatal_error] if the buffer does
+   not parse, or if the formatter rejects its own output. *)
+let format_buffer ~config handle =
+  let module Formatter = Format_sail.Make (struct
+    let config = config
+  end) in
+  let filename = Sail_file.Path.to_string (Sail_file.to_path handle) in
+  let source = Sail_file.contents handle in
+  let comments, defs = Initial_check.parse_file_from_string source in
+  (source, defs, Formatter.format_defs filename source comments defs)
+
+(* An LSP position for a position within [source]. The parse that produced it is
+   of a string rather than of a file in the editor's view of the world, so the
+   conversion to editor coordinates - a line plus an offset in UTF-16 code units
+   - is done here against the same string, rather than by [Sail_file]. *)
+let editor_position source (p : Sail_file.position) =
+  let open Sail_file.Position in
+  let bol = min p.pos_bol (String.length source) in
+  let cnum = min (max p.pos_cnum bol) (String.length source) in
+  Lsp.Types.Position.create ~line:(p.pos_lnum - 1)
+    ~character:(Sail_file.utf16_length (String.sub source bol (cnum - bol)))
+
+(* The end of the buffer as an LSP position. [Sail_file.contents] joins the lines
+   with '\n', so the last element of the split is the final line. *)
+let end_position source =
+  let rec last = function [] -> "" | [line] -> line | _ :: lines -> last lines in
+  let lines = String.split_on_char '\n' source in
+  Lsp.Types.Position.create ~line:(List.length lines - 1) ~character:(Sail_file.utf16_length (last lines))
+
+let whole_document source =
+  Lsp.Types.Range.create ~start:(Lsp.Types.Position.create ~line:0 ~character:0) ~end_:(end_position source)
+
+let compute ~config handle =
+  match format_buffer ~config handle with
+  | exception Reporting.Fatal_error err -> Error err
+  (* An unchanged buffer means no edits, rather than an edit that rewrites the
+     whole document with what it already contains. *)
+  | source, _, formatted when String.equal formatted source -> Ok []
+  | source, _, formatted -> Ok [Lsp.Types.TextEdit.create ~newText:formatted ~range:(whole_document source)]
+
+let def_loc (Parse_ast.DEF_aux (_, l)) = l
+
+(* The extent of a definition in the source it was parsed from. A definition with
+   attributes, a doc comment or a [private] marker attached to it is a definition
+   wrapped in another one, and the wrapper's location spans only the wrapper
+   itself - the [$[attr]] and not what it is attached to - so the extent has to
+   be stitched together from the wrapper and the definition inside it. *)
+let rec def_extent (Parse_ast.DEF_aux (aux, l)) =
+  let wrapper = Reporting.simp_loc l in
+  match aux with
+  | Parse_ast.DEF_private def | Parse_ast.DEF_attribute (_, def) | Parse_ast.DEF_doc (_, def) -> (
+      match (wrapper, def_extent def) with
+      | Some (p1, _), Some (_, p2) -> Some (p1, p2)
+      | Some _, None -> wrapper
+      | None, extent -> extent
+    )
+  | _ -> wrapper
+
+(* Whether a definition is one the request selected. Definitions start on a line
+   of their own, so whole lines are the right granularity: a request touching any
+   part of a line selects the definition that line belongs to, which makes an
+   empty range - a bare cursor - select the definition it sits in. *)
+let selected (range : Lsp.Types.Range.t) (p1 : Sail_file.position) (p2 : Sail_file.position) =
+  let open Sail_file.Position in
+  (* Lexing lines are 1-based, editor lines are 0-based. *)
+  p1.pos_lnum - 1 <= range.end_.line && range.start.line <= p2.pos_lnum - 1
+
+(* The text of a definition, cut out of the string it was parsed from. *)
+let def_text source p1 p2 =
+  let open Sail_file.Position in
+  String.sub source p1.pos_cnum (p2.pos_cnum - p1.pos_cnum)
+
+(* Replace each selected definition with its formatted counterpart. The edits do
+   not overlap - definitions do not - and are all relative to the buffer as it
+   stands, as LSP requires. *)
+let def_edits ~range source formatted defs formatted_defs =
+  let edit (def, formatted_def) =
+    match (def_extent def, def_extent formatted_def) with
+    (* A definition without a usable source range is one we cannot place an edit
+       against, e.g. one that came from a $include rather than from the buffer. *)
+    | Some (p1, p2), Some (f1, f2) when selected range p1 p2 ->
+        (* The formatter promises the syntax tree survives formatting, so the two
+           definitions must be the same one. If they ever are not, replacing the
+           text of one with the text of the other would silently corrupt the
+           buffer, so refuse rather than guess. *)
+        if Option.is_some (Parse_ast_diff.diff_def def formatted_def) then
+          Error
+            (Reporting.Err_general
+               (def_loc def, "Formatting changed this definition, so it cannot be formatted on its own")
+            )
+        else (
+          let source_text = def_text source p1 p2 in
+          let formatted_text = def_text formatted f1 f2 in
+          if String.equal source_text formatted_text then Ok None
+          else (
+            let range = Lsp.Types.Range.create ~start:(editor_position source p1) ~end_:(editor_position source p2) in
+            Ok (Some (Lsp.Types.TextEdit.create ~newText:formatted_text ~range))
+          )
+        )
+    | _ -> Ok None
+  in
+  let rec collect edits = function
+    | [] -> Ok (List.rev edits)
+    | pair :: pairs -> (
+        match edit pair with
+        | Error _ as err -> err
+        | Ok None -> collect edits pairs
+        | Ok (Some edit) -> collect (edit :: edits) pairs
+      )
+  in
+  collect [] (List.combine defs formatted_defs)
+
+let compute_range ~config ~range handle =
+  match
+    let source, defs, formatted = format_buffer ~config handle in
+    let _, formatted_defs = Initial_check.parse_file_from_string formatted in
+    (source, defs, formatted, formatted_defs)
+  with
+  | exception Reporting.Fatal_error err -> Error err
+  | source, defs, formatted, formatted_defs ->
+      if List.compare_lengths defs formatted_defs <> 0 then
+        Error (Reporting.Err_general (Parse_ast.Unknown, "Formatting changed the number of definitions in the file"))
+      else def_edits ~range source formatted defs formatted_defs

--- a/src/sail_lsp/formatting.mli
+++ b/src/sail_lsp/formatting.mli
@@ -44,14 +44,22 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-open Printf
+open Libsail
 
-let opt_file = ref None
+(** Automatic formatting for the LSP (the [textDocument/formatting] and [textDocument/rangeFormatting] requests). *)
 
-let log fmt args =
-  let chan = Option.value ~default:stdout !opt_file in
-  fprintf chan "[sail_lsp] %s\n%!" (sprintf fmt args)
+(** Format an entire document using the same formatter as [sail -fmt], returning the edits that turn the buffer into its
+    formatted form: a single whole-document replacement, or no edits at all when the buffer is already formatted.
+    Formatting requires the buffer to parse, so a document with a syntax error - or one the formatter rejects - returns
+    the error explaining why it could not be formatted. *)
+val compute : config:Format_sail.config -> Sail_file.handle -> (Lsp.Types.TextEdit.t list, Reporting.error) Result.t
 
-let log_error fmt args =
-  let chan = Option.value ~default:stdout !opt_file in
-  fprintf chan "[sail_lsp] Error: %s\n%!" (sprintf fmt args)
+(** Format the definitions a range touches, one edit per definition, leaving the rest of the document alone. A range
+    that selects no definition - a cursor in a comment sitting between two of them, say - yields no edits. The whole
+    buffer still has to parse, as it does for [compute], because a definition is formatted by formatting the document it
+    belongs to and keeping the part of the result that corresponds to it. *)
+val compute_range :
+  config:Format_sail.config ->
+  range:Lsp.Types.Range.t ->
+  Sail_file.handle ->
+  (Lsp.Types.TextEdit.t list, Reporting.error) Result.t

--- a/src/sail_lsp/handler.ml
+++ b/src/sail_lsp/handler.ml
@@ -118,6 +118,7 @@ let error_diagnostic (err : Reporting.error) =
     | Reporting.Err_unreachable (l, _, _, msg) -> (l, msg)
     | Reporting.Err_type (l, hint, msg) -> (l, match hint with Some h -> msg ^ "\n" ^ h | None -> msg)
     | Reporting.Err_syntax (p, msg) | Reporting.Err_lex (p, msg) -> (Parse_ast.Range (p, p), msg)
+    | Reporting.Err_warning (l, short, msg) -> (l, short ^ ":\n" ^ msg)
   in
   let range =
     match
@@ -157,16 +158,21 @@ let diagnostics_for_handle file handle =
   in
   Lsp.Server_notification.PublishDiagnostics params
 
-let on_initialize _params =
+let on_initialize ~(config : Server_config.t) _params =
   let server_info = Lsp.Types.InitializeResult.create_serverInfo ~name:"sail_lsp" () in
   let sync =
     Lsp.Types.TextDocumentSyncOptions.create ~openClose:true ~change:Lsp.Types.TextDocumentSyncKind.Incremental
       ~save:(`Bool true) ()
   in
-  let semantic_tokens = Lsp.Types.SemanticTokensOptions.create ~legend:Highlight.legend ~full:(`Bool true) () in
+  let semantic_tokens =
+    if config.highlight then
+      Some
+        (`SemanticTokensOptions (Lsp.Types.SemanticTokensOptions.create ~legend:Highlight.legend ~full:(`Bool true) ()))
+    else None
+  in
   let capabilities =
     Lsp.Types.ServerCapabilities.create ~hoverProvider:(`Bool true) ~textDocumentSync:(`TextDocumentSyncOptions sync)
-      ~semanticTokensProvider:(`SemanticTokensOptions semantic_tokens) ~foldingRangeProvider:(`Bool true)
+      ?semanticTokensProvider:semantic_tokens ~foldingRangeProvider:(`Bool config.folding)
       ~definitionProvider:(`Bool true) ()
   in
   Lsp.Types.InitializeResult.create ~capabilities ~serverInfo:server_info ()
@@ -234,12 +240,13 @@ let on_definition ({ position = { line; character }; textDocument = { uri } } : 
       Some (`Location [loc])
   | _ -> None
 
-let refresh_project ~default_sail_dir file =
+let refresh_project ~(config : Server_config.t) file =
   match find_sail_project file with
-  | Some project_file -> state := Some (Server_state.load_project ~default_sail_dir [project_file])
+  | Some project_file ->
+      state := Some (Server_state.load_project ~default_sail_dir:config.default_sail_dir [project_file])
   | None -> state := None
 
-let on_notification ~default_sail_dir notif =
+let on_notification ~config notif =
   let open Lsp.Types in
   match notif with
   | Lsp.Client_notification.Exit -> exit 0
@@ -250,11 +257,11 @@ let on_notification ~default_sail_dir notif =
       let handle = Sail_file.editor_take_file ~contents:text file in
       register_handle file handle;
       ( match !state with
-      | None -> refresh_project ~default_sail_dir file
+      | None -> refresh_project ~config file
       | Some s -> (
           match Server_state.invalidate s handle with
           | Some s' -> state := Some s'
-          | None -> refresh_project ~default_sail_dir file
+          | None -> refresh_project ~config file
         )
       );
       [diagnostics_for_handle file handle]

--- a/src/sail_lsp/handler.ml
+++ b/src/sail_lsp/handler.ml
@@ -107,19 +107,21 @@ module CursorScanner = Ast_util.Scanner (struct
   let categorize_pat = function P_id id -> Some (Scan_id id) | _ -> None
 end)
 
+(* Split a [Reporting.error] into the location it points at and its message. *)
+let error_loc_and_message (err : Reporting.error) =
+  match err with
+  | Reporting.Err_general (l, msg) | Reporting.Err_todo (l, msg) | Reporting.Err_syntax_loc (l, msg) -> (l, msg)
+  | Reporting.Err_unreachable (l, _, _, msg) -> (l, msg)
+  | Reporting.Err_type (l, hint, msg) -> (l, match hint with Some h -> msg ^ "\n" ^ h | None -> msg)
+  | Reporting.Err_syntax (p, msg) | Reporting.Err_lex (p, msg) -> (Parse_ast.Range (p, p), msg)
+  | Reporting.Err_warning (l, short, msg) -> (l, short ^ ":\n" ^ msg)
+
 (* Turn a [Reporting.error] into an LSP diagnostic. Every error carries a message
    and a location; when the location can't be resolved to an editor range (e.g. an
    unknown or generated location) we fall back to the start of the file so the
    diagnostic is still valid and shown. *)
 let error_diagnostic (err : Reporting.error) =
-  let loc, message =
-    match err with
-    | Reporting.Err_general (l, msg) | Reporting.Err_todo (l, msg) | Reporting.Err_syntax_loc (l, msg) -> (l, msg)
-    | Reporting.Err_unreachable (l, _, _, msg) -> (l, msg)
-    | Reporting.Err_type (l, hint, msg) -> (l, match hint with Some h -> msg ^ "\n" ^ h | None -> msg)
-    | Reporting.Err_syntax (p, msg) | Reporting.Err_lex (p, msg) -> (Parse_ast.Range (p, p), msg)
-    | Reporting.Err_warning (l, short, msg) -> (l, short ^ ":\n" ^ msg)
-  in
+  let loc, message = error_loc_and_message err in
   let range =
     match
       Option.bind (Reporting.simp_loc loc) (fun (p1, p2) ->
@@ -173,7 +175,8 @@ let on_initialize ~(config : Server_config.t) _params =
   let capabilities =
     Lsp.Types.ServerCapabilities.create ~hoverProvider:(`Bool true) ~textDocumentSync:(`TextDocumentSyncOptions sync)
       ?semanticTokensProvider:semantic_tokens ~foldingRangeProvider:(`Bool config.folding)
-      ~definitionProvider:(`Bool true) ()
+      ~definitionProvider:(`Bool true) ~documentFormattingProvider:(`Bool true)
+      ~documentRangeFormattingProvider:(`Bool true) ()
   in
   Lsp.Types.InitializeResult.create ~capabilities ~serverInfo:server_info ()
 
@@ -196,6 +199,43 @@ let on_folding_range (params : Lsp.Types.FoldingRangeParams.t) =
       log "foldingRange: no handle for %s" file;
       None
   | Some handle -> Some (Folding.compute handle)
+
+(* The two formatting requests differ only in which edits they ask for; finding
+   the document and reporting a failure are the same for both. Unlike the other
+   requests, a failure here is worth telling the user about - they asked for
+   something to be reformatted and it was not - so we report why rather than
+   silently returning no edits. *)
+let formatting_edits ~request uri edits_of_handle =
+  let file = Lsp.Types.DocumentUri.to_path uri in
+  log "%s" (request ^ ": " ^ file);
+  match Hashtbl.find_opt file_to_handle file with
+  | None ->
+      log "%s" (request ^ ": no handle for " ^ file);
+      Error (Printf.sprintf "%s is not open" file)
+  | Some handle -> (
+      match edits_of_handle handle with
+      | Ok edits -> Ok edits
+      | Error err ->
+          let loc, message = error_loc_and_message err in
+          (* The formatter parses the buffer rather than the file on disk, so the
+             error's file is a scratch handle; only its line number is useful. *)
+          let where =
+            match Reporting.simp_loc loc with
+            | Some (p1, _) -> Printf.sprintf " on line %d" p1.Sail_file.Position.pos_lnum
+            | None -> ""
+          in
+          log_error "%s" (request ^ ": " ^ message);
+          Error (Printf.sprintf "Could not format %s%s: %s" (Filename.basename file) where message)
+    )
+
+let on_formatting ~(config : Server_config.t) (params : Lsp.Types.DocumentFormattingParams.t) =
+  formatting_edits ~request:"formatting" params.textDocument.uri (Formatting.compute ~config:config.fmt)
+
+(* Formatting a selection reformats the definitions it touches, so a cursor
+   anywhere in a definition reformats that definition. *)
+let on_range_formatting ~(config : Server_config.t) (params : Lsp.Types.DocumentRangeFormattingParams.t) =
+  formatting_edits ~request:"rangeFormatting" params.textDocument.uri
+    (Formatting.compute_range ~config:config.fmt ~range:params.range)
 
 let on_hover ({ position = { line; character }; textDocument = { uri } } : Lsp.Types.HoverParams.t) =
   let open Lsp.Types in

--- a/src/sail_lsp/handler.mli
+++ b/src/sail_lsp/handler.mli
@@ -44,7 +44,7 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-val on_initialize : Lsp.Types.InitializeParams.t -> Lsp.Types.InitializeResult.t
+val on_initialize : config:Server_config.t -> Lsp.Types.InitializeParams.t -> Lsp.Types.InitializeResult.t
 
 val on_shutdown : unit -> unit
 
@@ -56,4 +56,4 @@ val on_hover : Lsp.Types.HoverParams.t -> Lsp.Types.Hover.t option
 
 val on_definition : Lsp.Types.DefinitionParams.t -> Lsp.Types.Locations.t option
 
-val on_notification : default_sail_dir:string -> Lsp.Client_notification.t -> Lsp.Server_notification.t list
+val on_notification : config:Server_config.t -> Lsp.Client_notification.t -> Lsp.Server_notification.t list

--- a/src/sail_lsp/handler.mli
+++ b/src/sail_lsp/handler.mli
@@ -52,6 +52,15 @@ val on_semantic_tokens_full : Lsp.Types.SemanticTokensParams.t -> Lsp.Types.Sema
 
 val on_folding_range : Lsp.Types.FoldingRangeParams.t -> Lsp.Types.FoldingRange.t list option
 
+(** Format a whole document, returning either the edits that reformat it (none if it is already formatted) or a message
+    explaining why it could not be formatted, to be sent back as a request error. *)
+val on_formatting :
+  config:Server_config.t -> Lsp.Types.DocumentFormattingParams.t -> (Lsp.Types.TextEdit.t list, string) Result.t
+
+(** Format the definitions the given range touches, reporting a failure as [on_formatting] does. *)
+val on_range_formatting :
+  config:Server_config.t -> Lsp.Types.DocumentRangeFormattingParams.t -> (Lsp.Types.TextEdit.t list, string) Result.t
+
 val on_hover : Lsp.Types.HoverParams.t -> Lsp.Types.Hover.t option
 
 val on_definition : Lsp.Types.DefinitionParams.t -> Lsp.Types.Locations.t option

--- a/src/sail_lsp/log.mli
+++ b/src/sail_lsp/log.mli
@@ -44,6 +44,8 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
+val opt_file : out_channel option ref
+
 val log : ('a -> string, unit, string) format -> 'a -> unit
 
 val log_error : ('a -> string, unit, string) format -> 'a -> unit

--- a/src/sail_lsp/sail_lsp.ml
+++ b/src/sail_lsp/sail_lsp.ml
@@ -56,7 +56,10 @@ let toggle_option name desc opt =
   ]
 
 let speclist =
-  [("--stdio", Arg.Unit (fun () -> ()), " Use stdin/stdout for IO (default).")]
+  [
+    ("--stdio", Arg.Unit (fun () -> ()), " Use stdin/stdout for IO (default).");
+    ("--log-file", Arg.String (fun s -> Log.opt_file := Some (open_out s)), " Log to a file rather than stderr");
+  ]
   @ toggle_option "highlight" "full semantic highlighting" opt_highlight
   @ toggle_option "folding" "code folding" opt_folding
 

--- a/src/sail_lsp/sail_lsp.ml
+++ b/src/sail_lsp/sail_lsp.ml
@@ -46,7 +46,19 @@
 
 open Libsail
 
-let speclist = [("--stdio", Arg.Unit (fun () -> ()), " Use stdin/stdout for IO (default).")]
+let opt_highlight = ref (Server_config.Implicit false)
+let opt_folding = ref (Server_config.Implicit false)
+
+let toggle_option name desc opt =
+  [
+    ("--" ^ name, Arg.Unit (fun () -> opt := Server_config.Explicit true), " Enable " ^ desc ^ ".");
+    ("--no-" ^ name, Arg.Unit (fun () -> opt := Server_config.Explicit false), " Disable " ^ desc ^ ".");
+  ]
+
+let speclist =
+  [("--stdio", Arg.Unit (fun () -> ()), " Use stdin/stdout for IO (default).")]
+  @ toggle_option "highlight" "full semantic highlighting" opt_highlight
+  @ toggle_option "folding" "code folding" opt_folding
 
 let anon_fun _ = ()
 
@@ -55,8 +67,8 @@ let main () =
 
   Util.opt_colors := false;
 
-  match Server_config.get_config () with
-  | Ok config -> Server.run ~default_sail_dir:config.default_sail_dir ()
+  match Server_config.get_config ~highlight:!opt_highlight ~folding:!opt_folding with
+  | Ok config -> Server.run ~config ()
   | Error msg ->
       prerr_endline msg;
       exit 1

--- a/src/sail_lsp/server.ml
+++ b/src/sail_lsp/server.ml
@@ -101,6 +101,16 @@ let handle_request ~config oc (req : Jsonrpc.Request.t) =
               Ok (Lsp.Client_request.yojson_of_result r (Handler.on_hover params))
           | Lsp.Client_request.TextDocumentDefinition params ->
               Ok (Lsp.Client_request.yojson_of_result r (Handler.on_definition params))
+          | Lsp.Client_request.TextDocumentFormatting params -> (
+              match Handler.on_formatting ~config params with
+              | Ok edits -> Ok (Lsp.Client_request.yojson_of_result r (Some edits))
+              | Error message -> Error (Response.Error.make ~code:Response.Error.Code.RequestFailed ~message ())
+            )
+          | Lsp.Client_request.TextDocumentRangeFormatting params -> (
+              match Handler.on_range_formatting ~config params with
+              | Ok edits -> Ok (Lsp.Client_request.yojson_of_result r (Some edits))
+              | Error message -> Error (Response.Error.make ~code:Response.Error.Code.RequestFailed ~message ())
+            )
           | _ ->
               Error (Response.Error.make ~code:Response.Error.Code.MethodNotFound ~message:"method not implemented" ())
         in

--- a/src/sail_lsp/server.ml
+++ b/src/sail_lsp/server.ml
@@ -80,7 +80,7 @@ module LspIo = Lsp.Io.Make (Io) (Chan)
 
 let send oc packet = LspIo.write oc packet
 
-let handle_request oc (req : Jsonrpc.Request.t) =
+let handle_request ~config oc (req : Jsonrpc.Request.t) =
   let open Jsonrpc in
   let resp =
     match Lsp.Client_request.of_jsonrpc req with
@@ -89,7 +89,7 @@ let handle_request oc (req : Jsonrpc.Request.t) =
         let result =
           match r with
           | Lsp.Client_request.Initialize params ->
-              Ok (Lsp.Client_request.yojson_of_result r (Handler.on_initialize params))
+              Ok (Lsp.Client_request.yojson_of_result r (Handler.on_initialize ~config params))
           | Lsp.Client_request.Shutdown ->
               Handler.on_shutdown ();
               Ok (Lsp.Client_request.yojson_of_result r ())
@@ -109,13 +109,14 @@ let handle_request oc (req : Jsonrpc.Request.t) =
   in
   send oc (Packet.Response resp)
 
-let rec run ~default_sail_dir () =
+let rec run ~config () =
   match LspIo.read stdin with
   | None -> ()
   | Some packet ->
       ( match packet with
       | Jsonrpc.Packet.Request req -> (
-          try handle_request stdout req with exn -> log_error "request handler raised: %s" (Printexc.to_string exn)
+          try handle_request ~config stdout req
+          with exn -> log_error "request handler raised: %s" (Printexc.to_string exn)
         )
       | Jsonrpc.Packet.Notification n -> (
           match Lsp.Client_notification.of_jsonrpc n with
@@ -126,11 +127,11 @@ let rec run ~default_sail_dir () =
                     let jsonrpc_notif = Lsp.Server_notification.to_jsonrpc server_notif in
                     send stdout (Jsonrpc.Packet.Notification jsonrpc_notif)
                   )
-                  (Handler.on_notification ~default_sail_dir notif)
+                  (Handler.on_notification ~config notif)
               with exn -> log_error "notification handler raised: %s" (Printexc.to_string exn)
             )
           | Error msg -> log_error "failed to decode notification: %s" msg
         )
       | _ -> ()
       );
-      run ~default_sail_dir ()
+      run ~config ()

--- a/src/sail_lsp/server.mli
+++ b/src/sail_lsp/server.mli
@@ -44,4 +44,4 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-val run : default_sail_dir:string -> unit -> unit
+val run : config:Server_config.t -> unit -> unit

--- a/src/sail_lsp/server_config.ml
+++ b/src/sail_lsp/server_config.ml
@@ -102,7 +102,7 @@ let read_process_stdout cmd =
 
 let get_sail_dir_from_sail () = Result.map String.trim (read_process_stdout "sail --dir")
 
-type t = { default_sail_dir : string; highlight : bool; folding : bool }
+type t = { default_sail_dir : string; highlight : bool; folding : bool; fmt : Format_sail.config }
 
 module From_json = struct
   let assoc msg = function `Assoc obj -> Ok obj | _ -> Error (Printf.sprintf "Expected JSON object %s" msg)
@@ -124,20 +124,39 @@ module From_json = struct
         let* v = boolean ("as " ^ name ^ " value") json in
         Ok (Some v)
     | None -> Ok None
+
+  (* The formatting options are shared with [sail -fmt], so they are read by the
+     same code, which reports a malformed section by raising rather than by
+     returning a result like the rest of this module. *)
+  let fmt json =
+    let* obj = assoc "at root" json in
+    match List.assoc_opt "fmt" obj with
+    | Some json -> (
+        try Ok (Format_sail.config_from_json json)
+        with Reporting.Fatal_error (Reporting.Err_general (_, msg)) -> Error msg
+      )
+    | None -> Ok Format_sail.default_config
 end
 
 let config_from_json ~highlight ~folding json =
   let* default_sail_dir = From_json.sail_dir json in
   let* highlight = with_flag highlight (From_json.optional_toggle "highlight") json in
   let* folding = with_flag folding (From_json.optional_toggle "folding") json in
-  Ok { default_sail_dir; highlight; folding }
+  let* fmt = From_json.fmt json in
+  Ok { default_sail_dir; highlight; folding; fmt }
 
 let get_config ~highlight ~folding =
   let* cfg_dir = get_config_dir () in
   let cfg_file = Filename.concat cfg_dir "config.json" in
   if not (Sys.file_exists cfg_file) then
     let* sail_dir = get_sail_dir_from_sail () in
-    Ok { default_sail_dir = sail_dir; highlight = unwrap_flag_setting highlight; folding = unwrap_flag_setting folding }
+    Ok
+      {
+        default_sail_dir = sail_dir;
+        highlight = unwrap_flag_setting highlight;
+        folding = unwrap_flag_setting folding;
+        fmt = Format_sail.default_config;
+      }
   else (
     let json = Yojson.Safe.from_file ~fname:"config.json" cfg_file in
     config_from_json ~highlight ~folding json

--- a/src/sail_lsp/server_config.ml
+++ b/src/sail_lsp/server_config.ml
@@ -47,6 +47,18 @@
 open Libsail
 open Util.Result_monad
 
+type 'a flag_setting = Explicit of 'a | Implicit of 'a
+
+let unwrap_flag_setting = function Explicit v -> v | Implicit v -> v
+
+let with_flag flg get cfg =
+  match flg with
+  | Explicit v -> Ok v
+  | Implicit v -> (
+      let* res = get cfg in
+      match res with Some cfg_v -> Ok cfg_v | None -> Ok v
+    )
+
 let get_home_dir () =
   match Sys.getenv_opt "HOME" with
   | Some h -> Ok h
@@ -90,31 +102,43 @@ let read_process_stdout cmd =
 
 let get_sail_dir_from_sail () = Result.map String.trim (read_process_stdout "sail --dir")
 
-type t = { default_sail_dir : string }
+type t = { default_sail_dir : string; highlight : bool; folding : bool }
 
 module From_json = struct
   let assoc msg = function `Assoc obj -> Ok obj | _ -> Error (Printf.sprintf "Expected JSON object %s" msg)
 
   let string msg = function `String str -> Ok str | _ -> Error (Printf.sprintf "Expected JSON string %s" msg)
 
+  let boolean msg = function `Bool b -> Ok b | _ -> Error (Printf.sprintf "Expected JSON boolean %S" msg)
+
   let sail_dir json =
     let* obj = assoc "at root" json in
     match List.assoc_opt "sail_dir" obj with
     | Some json -> string "as sail_dir value" json
     | None -> get_sail_dir_from_sail ()
+
+  let optional_toggle name json =
+    let* obj = assoc "at root" json in
+    match List.assoc_opt name obj with
+    | Some json ->
+        let* v = boolean ("as " ^ name ^ " value") json in
+        Ok (Some v)
+    | None -> Ok None
 end
 
-let config_from_json json =
+let config_from_json ~highlight ~folding json =
   let* default_sail_dir = From_json.sail_dir json in
-  Ok { default_sail_dir }
+  let* highlight = with_flag highlight (From_json.optional_toggle "highlight") json in
+  let* folding = with_flag folding (From_json.optional_toggle "folding") json in
+  Ok { default_sail_dir; highlight; folding }
 
-let get_config () =
+let get_config ~highlight ~folding =
   let* cfg_dir = get_config_dir () in
   let cfg_file = Filename.concat cfg_dir "config.json" in
   if not (Sys.file_exists cfg_file) then
     let* sail_dir = get_sail_dir_from_sail () in
-    Ok { default_sail_dir = sail_dir }
+    Ok { default_sail_dir = sail_dir; highlight = unwrap_flag_setting highlight; folding = unwrap_flag_setting folding }
   else (
     let json = Yojson.Safe.from_file ~fname:"config.json" cfg_file in
-    config_from_json json
+    config_from_json ~highlight ~folding json
   )

--- a/src/sail_lsp/server_config.mli
+++ b/src/sail_lsp/server_config.mli
@@ -44,6 +44,8 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
-type t = { default_sail_dir : string }
+type 'a flag_setting = Explicit of 'a | Implicit of 'a
 
-val get_config : unit -> (t, string) Result.t
+type t = { default_sail_dir : string; highlight : bool; folding : bool }
+
+val get_config : highlight:bool flag_setting -> folding:bool flag_setting -> (t, string) Result.t

--- a/src/sail_lsp/server_config.mli
+++ b/src/sail_lsp/server_config.mli
@@ -44,8 +44,15 @@
 (*  SPDX-License-Identifier: BSD-2-Clause                                   *)
 (****************************************************************************)
 
+open Libsail
+
 type 'a flag_setting = Explicit of 'a | Implicit of 'a
 
-type t = { default_sail_dir : string; highlight : bool; folding : bool }
+type t = {
+  default_sail_dir : string;
+  highlight : bool;
+  folding : bool;
+  fmt : Format_sail.config;  (** The formatting options, read from the [fmt] section as for [sail -fmt]. *)
+}
 
 val get_config : highlight:bool flag_setting -> folding:bool flag_setting -> (t, string) Result.t

--- a/test/format/default/long_funcl_clause.expect
+++ b/test/format/default/long_funcl_clause.expect
@@ -1,0 +1,4 @@
+default Order dec
+
+function pma_atomicity_support_gt(x : AtomicSupport, y : AtomicSupport) -> bool =
+    long_long_extra_num_of_AtomicSupport(x) > num_of_AtomicSupport(y)

--- a/test/format/default/private.expect
+++ b/test/format/default/private.expect
@@ -1,0 +1,13 @@
+default Order dec
+
+private val g : int -> int
+
+private function foo() -> unit = ()
+
+/*! A documented private function */
+private function bar() -> unit = ()
+
+$[attr]
+private val h : int -> int
+
+private function baz() -> unit = ()

--- a/test/format/long_funcl_clause.sail
+++ b/test/format/long_funcl_clause.sail
@@ -1,0 +1,3 @@
+default Order dec
+
+function pma_atomicity_support_gt(x : AtomicSupport, y : AtomicSupport) -> bool = long_long_extra_num_of_AtomicSupport(x) > num_of_AtomicSupport(y)

--- a/test/format/lw80_preserve/long_funcl_clause.expect
+++ b/test/format/lw80_preserve/long_funcl_clause.expect
@@ -1,0 +1,4 @@
+default Order dec
+
+function pma_atomicity_support_gt(x : AtomicSupport, y : AtomicSupport) -> bool =
+  long_long_extra_num_of_AtomicSupport(x) > num_of_AtomicSupport(y)

--- a/test/format/lw80_preserve/private.expect
+++ b/test/format/lw80_preserve/private.expect
@@ -1,0 +1,13 @@
+default Order dec
+
+private val g : int -> int
+
+private function foo() -> unit = ()
+
+/*! A documented private function */
+private function bar() -> unit = ()
+
+$[attr]
+private val h : int -> int
+
+private function baz() -> unit = ()

--- a/test/format/private.sail
+++ b/test/format/private.sail
@@ -1,0 +1,14 @@
+default Order dec
+
+private val  g : int -> int
+
+private   function  foo() -> unit = ()
+
+/*! A documented private function */
+private function  bar() -> unit = ()
+
+$[attr]
+private val  h : int -> int
+
+private
+function  baz() -> unit = ()

--- a/test/lsp/README.md
+++ b/test/lsp/README.md
@@ -47,7 +47,9 @@ Sail test suites); the runner exits non-zero if any test fails.
   request/notification helpers, and the document lifecycle (didOpen,
   didChange, didSave, didClose). Documents must exist on disk because the
   server canonicalises paths with `realpath`; use the `Workspace` helper to
-  create throwaway files.
+  create throwaway files. Features that the server has off by default are
+  enabled by passing the flag to the server, as in
+  `LspClient(args=["--highlight"])`.
 - `run_tests.py` — the test cases and runner.
 
 ## Adding a test

--- a/test/lsp/lsp_harness.py
+++ b/test/lsp/lsp_harness.py
@@ -86,7 +86,10 @@ class LspError(Exception):
 class LspClient:
     """Drives a sail_lsp subprocess over stdio."""
 
-    def __init__(self, server=None, timeout=15.0):
+    def __init__(self, server=None, timeout=15.0, args=None):
+        """Spawn the server. ``args`` are extra command line flags, appended
+        after ``--stdio``; features that are off by default (``--highlight``,
+        ``--folding``) have to be enabled that way."""
         self.server = server or find_server()
         self.timeout = timeout
         self._next_id = 0
@@ -94,7 +97,7 @@ class LspClient:
         self._notifications = queue.Queue()
         self._stderr_lines = []
         self._proc = subprocess.Popen(
-            [self.server, "--stdio"],
+            [self.server, "--stdio"] + list(args or []),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -149,7 +152,9 @@ class LspClient:
     def notify(self, method, params=None):
         self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
 
-    def request(self, method, params=None):
+    def request(self, method, params=None, expect_error=False):
+        """Send a request and return its result. With ``expect_error`` the
+        request must fail, and the JSON-RPC error object is returned instead."""
         self._next_id += 1
         request_id = self._next_id
         self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}})
@@ -161,6 +166,10 @@ class LspClient:
             raise LspError("server exited while waiting for response to {!r}\n{}".format(method, self.stderr()))
         if response.get("id") != request_id:
             raise LspError("response id {} did not match request id {}".format(response.get("id"), request_id))
+        if expect_error:
+            if "error" not in response:
+                raise LspError("request {!r} unexpectedly succeeded: {}".format(method, response.get("result")))
+            return response["error"]
         if "error" in response:
             raise LspError("request {!r} returned error: {}".format(method, response["error"]))
         return response.get("result")
@@ -226,6 +235,27 @@ class LspClient:
 
     def folding_range(self, uri):
         return self.request("textDocument/foldingRange", {"textDocument": {"uri": uri}})
+
+    def formatting(self, uri, tab_size=4, insert_spaces=True, expect_error=False):
+        return self.request(
+            "textDocument/formatting",
+            {"textDocument": {"uri": uri}, "options": {"tabSize": tab_size, "insertSpaces": insert_spaces}},
+            expect_error=expect_error,
+        )
+
+    def range_formatting(self, uri, start_line, start_char, end_line, end_char, tab_size=4, expect_error=False):
+        return self.request(
+            "textDocument/rangeFormatting",
+            {
+                "textDocument": {"uri": uri},
+                "range": {
+                    "start": {"line": start_line, "character": start_char},
+                    "end": {"line": end_line, "character": end_char},
+                },
+                "options": {"tabSize": tab_size, "insertSpaces": True},
+            },
+            expect_error=expect_error,
+        )
 
     def definition(self, uri, line, character):
         return self.request(

--- a/test/lsp/run_tests.py
+++ b/test/lsp/run_tests.py
@@ -205,7 +205,7 @@ def semantic_tokens_legend(init_result):
 
 def test_semantic_tokens_capability():
     """The server advertises a semanticTokens provider with a full legend."""
-    with LspClient() as client:
+    with LspClient(args=["--highlight"]) as client:
         provider = semantic_tokens_legend(client.initialize())
         check(provider.get("full") is True, "full semantic tokens not advertised: {}".format(provider))
         types = provider["legend"]["tokenTypes"]
@@ -218,7 +218,7 @@ def test_semantic_tokens_capability():
 def test_semantic_tokens_full():
     """semanticTokens/full lexes the buffer into typed, positioned tokens."""
     code = 'val x = 0xFF // hi\n"str"\n'
-    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+    with Workspace({"m.sail": code}) as ws, LspClient(args=["--highlight"]) as client:
         types = semantic_tokens_legend(client.initialize(ws.root_uri()))["legend"]["tokenTypes"]
         client.initialized()
         uri = ws.uri("m.sail")
@@ -242,7 +242,7 @@ def test_semantic_tokens_unicode():
     """Token positions and lengths are reported in UTF-16 code units."""
     # The string literal "ππ" is 6 UTF-8 bytes but 4 UTF-16 code units.
     code = 'let x = "ππ"\n'
-    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+    with Workspace({"m.sail": code}) as ws, LspClient(args=["--highlight"]) as client:
         types = semantic_tokens_legend(client.initialize(ws.root_uri()))["legend"]["tokenTypes"]
         client.initialized()
         uri = ws.uri("m.sail")
@@ -256,7 +256,7 @@ def test_semantic_tokens_unicode():
 def test_semantic_tokens_multiline():
     """A token spanning several lines is split into one token per line."""
     code = "/* a\n b */\nval x\n"
-    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+    with Workspace({"m.sail": code}) as ws, LspClient(args=["--highlight"]) as client:
         types = semantic_tokens_legend(client.initialize(ws.root_uri()))["legend"]["tokenTypes"]
         client.initialized()
         uri = ws.uri("m.sail")
@@ -271,7 +271,7 @@ def test_semantic_tokens_multiline():
 
 def test_folding_range_capability():
     """The server advertises a folding-range provider."""
-    with LspClient() as client:
+    with LspClient(args=["--folding"]) as client:
         result = client.initialize()
         provider = result["capabilities"].get("foldingRangeProvider")
         check(provider is True, "foldingRangeProvider not advertised: {}".format(provider))
@@ -291,7 +291,7 @@ def test_folding_range():
         "}\n"                 # 6  '}' closes here
         "// tail\n"           # 7  line comment: not foldable
     )
-    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+    with Workspace({"m.sail": code}) as ws, LspClient(args=["--folding"]) as client:
         client.initialize(ws.root_uri())
         client.initialized()
         uri = ws.uri("m.sail")
@@ -359,6 +359,223 @@ def test_definition_absent():
         client.exit()
 
 
+def test_formatting_capability():
+    """The server advertises a formatting provider."""
+    with LspClient() as client:
+        provider = client.initialize()["capabilities"].get("documentFormattingProvider")
+        check(provider is True, "documentFormattingProvider not advertised: {}".format(provider))
+        client.shutdown()
+        client.exit()
+
+
+def test_formatting():
+    """Formatting a badly laid out document returns one whole-document edit."""
+    code = "default   Order    dec\nval  main :  unit->unit\nfunction  main()  =  ()\n"
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        edits = client.formatting(uri)
+        check(len(edits) == 1, "expected a single whole-document edit, got {}".format(edits))
+        edit = edits[0]
+        start, end = edit["range"]["start"], edit["range"]["end"]
+        check(start == {"line": 0, "character": 0}, "edit does not start at the top of the file: {}".format(start))
+        # The document has a trailing newline, so its last line is line 3 and empty.
+        check(end == {"line": 3, "character": 0}, "edit does not cover the whole file: {}".format(end))
+        formatted = edit["newText"]
+        check("val main : unit -> unit" in formatted, "run-together spacing not fixed: {!r}".format(formatted))
+
+        # Formatting is idempotent: the formatted text needs no further edits.
+        client.did_change(uri, full_change(formatted))
+        client.wait_notification("textDocument/publishDiagnostics")
+        check(client.formatting(uri) == [], "formatted document was not left alone")
+        client.shutdown()
+        client.exit()
+
+
+def test_formatting_unicode():
+    """The replaced range ends at the end of the buffer, in UTF-16 code units."""
+    # The last line holds two multi-byte characters: 12 UTF-16 code units, 14 bytes.
+    # It deliberately has no trailing newline, so the last line is not empty.
+    code = 'default   Order dec\nlet x = "ππ"'
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        edits = client.formatting(uri)
+        check(len(edits) == 1, "expected a single whole-document edit, got {}".format(edits))
+        end = edits[0]["range"]["end"]
+        check(end == {"line": 1, "character": 12}, "end position is not in UTF-16 code units: {}".format(end))
+        client.shutdown()
+        client.exit()
+
+
+def test_formatting_syntax_error():
+    """A document that does not parse cannot be formatted, and says so."""
+    code = "default Order dec\nfoo bar baz\n"
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        error = client.formatting(uri, expect_error=True)
+        check("m.sail" in error["message"], "error does not name the file: {}".format(error))
+        check("line 2" in error["message"], "error does not locate the problem: {}".format(error))
+        # The server must still be serving requests afterwards.
+        check(client.shutdown() is None, "server did not survive a formatting failure")
+        client.exit()
+
+
+def test_range_formatting_capability():
+    """The server advertises a range-formatting provider."""
+    with LspClient() as client:
+        provider = client.initialize()["capabilities"].get("documentRangeFormattingProvider")
+        check(provider is True, "documentRangeFormattingProvider not advertised: {}".format(provider))
+        client.shutdown()
+        client.exit()
+
+
+# Two badly spaced definitions, separated by a comment and blank lines that
+# belong to no definition. The first line is already formatted.
+RANGE_CODE = (
+    "default Order dec\n"    # 0
+    "\n"                     # 1
+    "// a comment\n"         # 2
+    "val  f : int -> int\n"  # 3
+    "\n"                     # 4
+    "val  g : int -> int\n"  # 5
+)
+
+
+def test_range_formatting():
+    """Formatting a range reformats the definitions it touches, and nothing else."""
+    with Workspace({"m.sail": RANGE_CODE}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, RANGE_CODE)
+
+        # An empty range - a bare cursor - selects the definition it sits in.
+        edits = client.range_formatting(uri, 5, 4, 5, 4)
+        check(len(edits) == 1, "expected one edit for the definition at the cursor, got {}".format(edits))
+        check(edits[0]["newText"] == "val g : int -> int", "definition not reformatted: {}".format(edits[0]))
+        check(
+            edits[0]["range"] == {"start": {"line": 5, "character": 0}, "end": {"line": 5, "character": 19}},
+            "edit does not cover exactly the definition: {}".format(edits[0]["range"]),
+        )
+
+        # A selection spanning both definitions yields one edit each. The already
+        # formatted first line is not among them: it needs no edit.
+        edits = client.range_formatting(uri, 3, 0, 5, 19)
+        check(
+            [e["newText"] for e in edits] == ["val f : int -> int", "val g : int -> int"],
+            "expected an edit per selected definition, got {}".format(edits),
+        )
+        check([e["range"]["start"]["line"] for e in edits] == [3, 5], "edits on the wrong lines: {}".format(edits))
+        client.shutdown()
+        client.exit()
+
+
+def test_range_formatting_outside_definition():
+    """A range touching no definition produces no edits."""
+    with Workspace({"m.sail": RANGE_CODE}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, RANGE_CODE)
+        for line, what in [(2, "a comment"), (4, "a blank line")]:
+            edits = client.range_formatting(uri, line, 0, line, 0)
+            check(edits == [], "expected no edits for {}, got {}".format(what, edits))
+        client.shutdown()
+        client.exit()
+
+
+def test_range_formatting_multiline():
+    """A definition spanning several lines is replaced whole, and its neighbour is untouched."""
+    code = (
+        "function  main()  = {\n"        # 0
+        "let  x  =  1;   // trailing\n"  # 1
+        "      ()\n"                     # 2
+        "}\n"                            # 3
+        "\n"                             # 4
+        "val  g : int -> int\n"          # 5
+    )
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+        edits = client.range_formatting(uri, 1, 2, 1, 2)
+        check(len(edits) == 1, "expected one edit for the enclosing definition, got {}".format(edits))
+        edit = edits[0]
+        check(
+            edit["range"] == {"start": {"line": 0, "character": 0}, "end": {"line": 3, "character": 1}},
+            "edit does not cover the whole definition: {}".format(edit["range"]),
+        )
+        check(
+            edit["newText"] == "function main() = {\n    let x = 1; // trailing\n    ()\n}",
+            "definition not reformatted as expected: {!r}".format(edit["newText"]),
+        )
+        client.shutdown()
+        client.exit()
+
+
+def test_range_formatting_attributes():
+    """A definition with an attribute or a doc comment is formatted along with it."""
+    # Attributes, doc comments and `private` wrap the definition they are
+    # attached to in another definition whose location spans only the wrapper,
+    # so the extent of such a definition has to be stitched back together.
+    code = (
+        "$[attr]\n"                      # 0
+        "val  f : int -> int\n"          # 1
+        "\n"                             # 2
+        "/*! documented */\n"            # 3
+        "$[complete]\n"                  # 4
+        "function  main()  = ()\n"       # 5
+        "\n"                             # 6
+        "private val  g : int -> int\n"  # 7
+    )
+    with Workspace({"m.sail": code}) as ws, LspClient() as client:
+        client.initialize(ws.root_uri())
+        client.initialized()
+        uri = ws.uri("m.sail")
+        client.did_open(uri, code)
+
+        # Whether the cursor is on the attribute or on the definition it is
+        # attached to, both are reformatted as one.
+        for line, character in [(0, 0), (1, 4)]:
+            edits = client.range_formatting(uri, line, character, line, character)
+            check(len(edits) == 1, "expected one edit at {}:{}, got {}".format(line, character, edits))
+            check(
+                edits[0]["newText"] == "$[attr]\nval f : int -> int",
+                "attribute and definition not reformatted together: {!r}".format(edits[0]["newText"]),
+            )
+            check(
+                edits[0]["range"] == {"start": {"line": 0, "character": 0}, "end": {"line": 1, "character": 19}},
+                "edit does not span the attribute and the definition: {}".format(edits[0]["range"]),
+            )
+
+        # A doc comment stacked on top of an attribute is covered too.
+        edits = client.range_formatting(uri, 5, 4, 5, 4)
+        check(len(edits) == 1, "expected one edit for the documented definition, got {}".format(edits))
+        check(
+            edits[0]["range"]["start"] == {"line": 3, "character": 0},
+            "edit does not start at the doc comment: {}".format(edits[0]["range"]),
+        )
+
+        # `private` is the third wrapper of this kind.
+        edits = client.range_formatting(uri, 7, 12, 7, 12)
+        check(len(edits) == 1, "expected one edit for the private definition, got {}".format(edits))
+        check(
+            edits[0]["newText"] == "private val g : int -> int",
+            "private definition not reformatted: {!r}".format(edits[0]["newText"]),
+        )
+        client.shutdown()
+        client.exit()
+
+
 def test_error_diagnostic():
     """A file with an error yields a diagnostic with a valid, correctly located range."""
     # The syntax error is on line 1 (zero-based); LSP positions are zero-based.
@@ -419,6 +636,15 @@ TESTS = [
     test_definition_capability,
     test_definition,
     test_definition_absent,
+    test_formatting_capability,
+    test_formatting,
+    test_formatting_unicode,
+    test_formatting_syntax_error,
+    test_range_formatting_capability,
+    test_range_formatting,
+    test_range_formatting_outside_definition,
+    test_range_formatting_multiline,
+    test_range_formatting_attributes,
     test_error_diagnostic,
     test_valid_file_has_no_diagnostics,
 ]


### PR DESCRIPTION
Automatic formatting support for sail_lsp (both whole file and per-definition).

Improved formatting for some edge cases around hanging expressions.