### PR TITLE
Update Windows dependencies installation in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,10 @@ jobs:
 
     - name: System dependencies (Windows)
       if: runner.os == 'Windows'
-      run: vcpkg install gmp
+      run: |
+        vcpkg update
+        vcpkg upgrade
+        vcpkg install gmp
 
     - name: Setup Z3
       id: z3


### PR DESCRIPTION
Make sure we have the latest versions of windows packages, otherwise CI fails whenever an old package gets removed from the vcpkg mirrors.