### PR TITLE
Lean: avoid V1 main wrapper for ArchSem models

### DIFF
--- a/src/sail_lean_backend/pretty_print_lean.ml
+++ b/src/sail_lean_backend/pretty_print_lean.ml
@@ -1665,6 +1665,7 @@ let compute_ctor_renames (env : Type_check.env) =
 
 let pp_ast_lean symbols (env : Type_check.env) effect_info ({ defs; _ } as ast : Libsail.Type_check.typed_ast)
     out_name_camel types_file imp_funcs_files funcs_file =
+  let is_concurrency_interface_v2 = Preprocess.have_symbol "CONCURRENCY_INTERFACE_V2" symbols in
   let regs = State.find_registers defs in
   let fun_args = populate_fun_args defs in
   let ctor_renames = compute_ctor_renames env in
@@ -1689,8 +1690,10 @@ let pp_ast_lean symbols (env : Type_check.env) effect_info ({ defs; _ } as ast :
     if imp_funcs_files = [] then ([], concat all_fundefss) else (Util.butlast all_fundefss, Util.last all_fundefss)
   in
   let main_fundefs = main_fundefs ^^ string ("end " ^ out_name_camel ^ ".Functions") ^^ hardline in
+  (* ArchSem effects require a model-specific interpreter, so its Sail main cannot use the V1 IO wrapper. *)
+  let generate_main = !the_main_function_has_been_seen && not is_concurrency_interface_v2 in
   let main_function =
-    if !the_main_function_has_been_seen then (
+    if generate_main then (
       let stub = main_function_stub effect_info has_registers in
       [string ("open " ^ out_name_camel); string ("open " ^ out_name_camel ^ ".Functions\n\n") ^^ stub]
     )
@@ -1704,4 +1707,4 @@ let pp_ast_lean symbols (env : Type_check.env) effect_info ({ defs; _ } as ast :
       imp_funcs_files imp_fundefss
   in
   print ~len:!opt_line_width funcs_file (separate hardline (remove_empties ([opens; main_fundefs] @ main_function)));
-  !the_main_function_has_been_seen
+  generate_main

--- a/src/sail_lean_backend/sail_plugin_lean.ml
+++ b/src/sail_lean_backend/sail_plugin_lean.ml
@@ -416,6 +416,9 @@ let rec dedup_files (files : string list) (acc : string list) =
 let output (out_name : string) symbols env effect_info ({ defs; _ } as ast : Libsail.Type_check.typed_ast)
     default_sail_dir single_file noncomputable =
   let interface_v = if Preprocess.have_symbol "CONCURRENCY_INTERFACE_V2" symbols then 2 else 1 in
+  if !opt_lean_executable && interface_v = 2 then
+    Reporting.warn ~force_show:true Version.v0_20_2 "Lean executable" Parse_ast.Unknown
+      "`--lean-executable` is not supported for ArchSem models; provide a model-specific interpreter and `main` instead";
   let cg = Callgraph.graph_of_ast ast in
   let files, import_sets, main_import_set =
     if single_file then ([], [], [])


### PR DESCRIPTION
## Summary

Fixes #1730

`main_of_sail_main` is provided only by `Sail.ConcurrencyInterfaceV1`. ArchSem models use `CONCURRENCY_INTERFACE_V2`, so generating this wrapper leaves an unknown identifier in the Lean output and causes the build to fail. 

- skip the V1-specific `main_of_sail_main` wrapper and `lean_exe` target for ArchSem models
- warn when `--lean-executable` is requested for an ArchSem model

